### PR TITLE
(feat) Adding Gemma 4 31B Model Support

### DIFF
--- a/lib/ai/modelCatalog.ts
+++ b/lib/ai/modelCatalog.ts
@@ -33,6 +33,7 @@ export type ModelKey =
   | "gemini_3_0_flash"
   | "gemini_3_1_flash_lite"
   | "gemini_2_5_pro"
+  | "gemma_4_31b"
   | "moonshot_kimi_k2"
   | "moonshot_kimi_k2_5"
   | "deepseek_v3_2"
@@ -232,6 +233,14 @@ export const MODEL_CATALOG: ModelCatalogEntry[] = [
     displayName: "Gemini 2.5 Pro",
     enabled: true,
     openRouterModelId: "google/gemini-2.5-pro",
+  },
+  {
+    key: "gemma_4_31b",
+    provider: "gemini",
+    modelId: "gemma-4-31b-it",
+    displayName: "Gemma 4 31B",
+    enabled: true,
+    openRouterModelId: "google/gemma-4-31b-it",
   },
   {
     key: "moonshot_kimi_k2",

--- a/lib/ai/providers/gemini.ts
+++ b/lib/ai/providers/gemini.ts
@@ -14,6 +14,10 @@ function bestThinkingConfigForModel(modelId: string): GeminiThinkingConfig | und
     return { thinkingLevel: "high" };
   }
 
+  if (modelId.startsWith("gemma-4")) {
+    return { thinkingLevel: "high" };
+  }
+
   if (modelId.startsWith("gemini-2.5-pro")) {
     // Use adaptive/dynamic reasoning budget for 2.5 Pro.
     return { thinkingBudget: -1 };

--- a/lib/ai/reasoningProfiles.ts
+++ b/lib/ai/reasoningProfiles.ts
@@ -90,6 +90,15 @@ export function geminiThinkingConfigForModel(
     return { thinkingLevel: normalized };
   }
 
+  if (modelId.startsWith("gemma-4")) {
+    if (!normalized || normalized === "high") {
+      return { thinkingLevel: "high" };
+    }
+    throw new Error(
+      `Gemini model ${modelId} does not support reasoning '${override}'. Supported values: high.`,
+    );
+  }
+
   if (modelId.startsWith("gemini-2.5-pro")) {
     if (!normalized || normalized === "dynamic" || normalized === "adaptive") {
       return { thinkingBudget: -1 };
@@ -134,6 +143,9 @@ export function openRouterReasoningEffortAttempts(
   }
   if (modelId.startsWith("google/gemini-3")) {
     return descendingAttempts(label, ["high", "medium", "low", "minimal"], override);
+  }
+  if (modelId === "google/gemma-4-31b-it") {
+    return descendingAttempts(label, ["high"], override);
   }
   if (
     modelId === "qwen/qwen3-max-thinking" ||

--- a/scripts/uploadsCatalog.ts
+++ b/scripts/uploadsCatalog.ts
@@ -55,6 +55,7 @@ export const MODEL_SLUG: Record<ModelKey, string> = {
   gemini_3_0_flash: "gemini-flash",
   gemini_3_1_flash_lite: "gemini-3-1-flash-lite",
   gemini_2_5_pro: "gemini-2-5-pro",
+  gemma_4_31b: "gemma-4-31b",
   moonshot_kimi_k2: "kimi-k2",
   moonshot_kimi_k2_5: "kimi-k2-5",
   deepseek_v3_2: "deepseek-v3-2",


### PR DESCRIPTION
  ## What does this PR do?

  Adds Gemma 4 31B as a first-class MineBench model across the normal onboarding paths.

  - Adds `gemma_4_31b` to the model catalog
  - Wires the canonical Google-hosted model ID: `gemma-4-31b-it`
  - Adds OpenRouter fallback support via `google/gemma-4-31b-it`
  - Adds the uploads slug mapping for batch generation/import flows
  - Applies the highest supported thinking default for Gemma 4:
    - direct Google route: `thinkingLevel: "high"`
    - OpenRouter route: `reasoning.effort = high`

  ## Why?

  Issue #13 asked for Gemma 4 support as a recent open-weight Google model.

  This keeps the integration consistent with the current MineBench model-onboarding pattern and reasoning-policy layout, while avoiding unsupported config assumptions. Gemma
  4 does not expose the same broader thinking ladder as Gemini 3.x, so this PR keeps the implementation strict to the documented `high` setting instead of inventing extra
  modes.

  ## How to test

  1. Run `pnpm lint`
  2. Verify the catalog entry resolves correctly:
     - `npx tsx -e "import { getModelByKey } from './lib/ai/modelCatalog.ts'; console.log(getModelByKey('gemma_4_31b'))"`
  3. Test direct generation with a Google key:
     - `pnpm batch:generate --model gemma --concurrency 1 --generate`
  4. Test OpenRouter fallback:
     - `pnpm batch:generate --model gemma --concurrency 1 --generate --openrouter`
  5. Optionally verify the reasoning override path stays constrained to the supported max:
     - `pnpm batch:generate --model gemma --concurrency 1 --generate --openrouter --reasoning high`

  ## Checklist

  - [x] `pnpm lint` passes
  - [x] Tested locally
  - [x] Updated README or docs if needed
_(PR Body Written by Codex)_