### PR TITLE
(feat) Adding Claude Opus 4.7 Support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,6 +33,8 @@ OPENROUTER_API_KEY=
 GOOGLE_SITE_VERIFICATION=
 
 # Optional overrides (defaults are used if unset)
+# Claude Opus 4.7 adaptive thinking effort: low | medium | high | max
+ANTHROPIC_OPUS_4_7_EFFORT=max
 # Claude Opus 4.6 adaptive thinking effort: low | medium | high | max
 ANTHROPIC_OPUS_4_6_EFFORT=max
 # Claude Sonnet 4.6 adaptive thinking effort: low | medium | high (max is unsupported)

--- a/components/sandbox/SandboxLive.tsx
+++ b/components/sandbox/SandboxLive.tsx
@@ -1086,7 +1086,7 @@ export function SandboxLive({ initialPrompt }: { initialPrompt?: string }) {
                           value={customModel.modelId}
                           onChange={(e) => updateCustomModel({ modelId: e.target.value })}
                           disabled={running}
-                          placeholder="aws/anthropic/bedrock-claude-opus-4-6"
+                          placeholder="aws/anthropic/bedrock-claude-opus-4-7"
                         />
                       </label>
                       <label className="flex flex-col gap-1">

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -98,6 +98,7 @@ Copy `.env.example` to `.env` and set what you need.
 ### Optional Provider and Runtime Tuning
 
 - `MINEBENCH_ALLOW_SERVER_KEYS=1` (production opt-in for server env keys in `/api/generate`)
+- `ANTHROPIC_OPUS_4_7_EFFORT=low|medium|high|max`
 - `ANTHROPIC_OPUS_4_6_EFFORT=low|medium|high|max`
 - `ANTHROPIC_SONNET_4_6_EFFORT=low|medium|high|max` (runtime falls back automatically if provider rejects `max`)
 - `ANTHROPIC_STREAM_RESPONSES=1`

--- a/lib/ai/generateVoxelBuild.ts
+++ b/lib/ai/generateVoxelBuild.ts
@@ -49,6 +49,12 @@ function maxOutputTokenCapForModel(modelId: string): number | undefined {
   // gpt-5-pro alias remaining at 272k.
   if (modelId === "gpt-5-pro") return 272_000;
   if (modelId.startsWith("gpt-5")) return 128_000;
+  if (
+    modelId.startsWith("claude-opus-4-7") ||
+    modelId === "anthropic/claude-opus-4.7"
+  ) {
+    return 128_000;
+  }
   // MiniMax M2.7's OpenAI-compatible route rejects the larger MineBench default
   // output budgets. Keep a lower completion budget so the prompt plus output
   // stays within the model's effective request limit.

--- a/lib/ai/modelCatalog.ts
+++ b/lib/ai/modelCatalog.ts
@@ -28,6 +28,7 @@ export type ModelKey =
   | "anthropic_claude_4_6_sonnet"
   | "anthropic_claude_4_5_opus"
   | "anthropic_claude_4_6_opus"
+  | "anthropic_claude_4_7_opus"
   | "gemini_3_0_pro"
   | "gemini_3_1_pro"
   | "gemini_3_0_flash"
@@ -194,6 +195,14 @@ export const MODEL_CATALOG: ModelCatalogEntry[] = [
     displayName: "Claude 4.6 Opus",
     enabled: true,
     openRouterModelId: "anthropic/claude-opus-4.6",
+  },
+  {
+    key: "anthropic_claude_4_7_opus",
+    provider: "anthropic",
+    modelId: "claude-opus-4-7",
+    displayName: "Claude 4.7 Opus",
+    enabled: true,
+    openRouterModelId: "anthropic/claude-opus-4.7",
   },
   {
     key: "gemini_3_0_pro",

--- a/lib/ai/providers/anthropic.ts
+++ b/lib/ai/providers/anthropic.ts
@@ -122,6 +122,10 @@ function isLegacyManualThinkingModel(modelId: string): boolean {
   return modelId.startsWith("claude-sonnet-4-5") || modelId.startsWith("claude-opus-4-5");
 }
 
+function isOpus47(modelId: string): boolean {
+  return modelId.startsWith("claude-opus-4-7");
+}
+
 function isOpus46(modelId: string): boolean {
   return modelId.startsWith("claude-opus-4-6");
 }
@@ -131,10 +135,17 @@ function isSonnet46(modelId: string): boolean {
 }
 
 function isAdaptiveThinkingModel(modelId: string): boolean {
-  return isOpus46(modelId) || isSonnet46(modelId);
+  return isOpus47(modelId) || isOpus46(modelId) || isSonnet46(modelId);
 }
 
 function parseAdaptiveEfforts(modelId: string): AnthropicEffort[] {
+  if (isOpus47(modelId)) {
+    const preferred = parseEffortEnv("ANTHROPIC_OPUS_4_7_EFFORT", {
+      defaultEffort: "max",
+      allowMax: true,
+    });
+    return effortFallbacks(preferred, { allowMax: true });
+  }
   if (isOpus46(modelId)) {
     const preferred = parseEffortEnv("ANTHROPIC_OPUS_4_6_EFFORT", {
       defaultEffort: "max",

--- a/lib/ai/reasoningProfiles.ts
+++ b/lib/ai/reasoningProfiles.ts
@@ -58,7 +58,9 @@ export function anthropicAdaptiveEffortAttempts(
   override?: string,
 ): AnthropicAdaptiveEffort[] | undefined {
   const isAdaptiveModel =
-    modelId.startsWith("claude-opus-4-6") || modelId.startsWith("claude-sonnet-4-6");
+    modelId.startsWith("claude-opus-4-7") ||
+    modelId.startsWith("claude-opus-4-6") ||
+    modelId.startsWith("claude-sonnet-4-6");
   if (!isAdaptiveModel) {
     const normalized = normalizeReasoningOverride(override);
     if (normalized) {
@@ -129,6 +131,7 @@ export function openRouterReasoningEffortAttempts(
     return descendingAttempts(label, ["xhigh", "high"], override);
   }
   if (
+    modelId === "anthropic/claude-opus-4.7" ||
     modelId === "anthropic/claude-sonnet-4.6" ||
     modelId === "anthropic/claude-opus-4.6"
   ) {

--- a/scripts/uploadsCatalog.ts
+++ b/scripts/uploadsCatalog.ts
@@ -50,6 +50,7 @@ export const MODEL_SLUG: Record<ModelKey, string> = {
   anthropic_claude_4_6_sonnet: "sonnet-4-6",
   anthropic_claude_4_5_opus: "opus",
   anthropic_claude_4_6_opus: "opus-4-6",
+  anthropic_claude_4_7_opus: "opus-4-7",
   gemini_3_0_pro: "gemini-pro",
   gemini_3_1_pro: "gemini-3-1-pro",
   gemini_3_0_flash: "gemini-flash",


### PR DESCRIPTION
## What does this PR do?

Adds Claude Opus 4.7 as a first-class MineBench model across the normal onboarding paths.

- Adds `anthropic_claude_4_7_opus` to the model catalog
- Wires the canonical Anthropic-hosted model ID: `claude-opus-4-7`
- Adds OpenRouter fallback support via `anthropic/claude-opus-4.7`
- Adds the uploads slug mapping for batch generation/import flows
- Applies the highest supported reasoning default for Claude Opus 4.7:
  - direct Anthropic route: adaptive effort starts at `max`
  - OpenRouter route: reasoning effort starts at `max`
- Caps Opus 4.7 sync output budget at 128k so requests start inside the documented limit instead of over-requesting and stepping down
- Updates the env/docs surfaces and sandbox custom-model placeholder to reflect the new model

## Why?

Anthropic released Claude Opus 4.7 as its latest generally available flagship model, and MineBench should expose it through the same first-class catalog and fallback paths as the other current model entries.

This keeps the integration consistent with the existing MineBench model-onboarding pattern while matching the provider’s documented defaults and limits. In particular, Opus 4.7 should default to the highest supported reasoning setting, and its synchronous output budget should respect the current 128k limit.

## How to test

1. Run `pnpm lint`
2. Verify the catalog entry resolves correctly:
   - `npx tsx -e "import { getModelByKey } from './lib/ai/modelCatalog.ts'; console.log(getModelByKey('anthropic_claude_4_7_opus'))"`
3. Verify the reasoning ladders resolve to the highest supported defaults:
   - `npx tsx -e "import { anthropicAdaptiveEffortAttempts, openRouterReasoningEffortAttempts } from './lib/ai/reasoningProfiles.ts'; console.log('direct', anthropicAdaptiveEffortAttempts('claude-opus-4-7')); console.log('openrouter', openRouterReasoningEffortAttempts('anthropic/claude-opus-4.7'));"`
4. Run `pnpm build`
5. Test direct generation with an Anthropic key:
   - `pnpm batch:generate --model opus-4-7 --concurrency 1 --generate`
6. Test OpenRouter fallback:
   - `pnpm batch:generate --model opus-4-7 --concurrency 1 --generate --openrouter`

## Checklist

- [x] `pnpm lint` passes
- [x] Tested locally
- [x] Updated README or docs if needed
_(PR Body Written by Codex)_