### PR TITLE
(feat) add grok 4.20 support + xai routing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -56,6 +56,7 @@ ANTHROPIC_ENABLE_1M_CONTEXT_BETA=1
 MOONSHOT_BASE_URL="https://api.moonshot.ai"
 DEEPSEEK_BASE_URL="https://api.deepseek.com"
 MINIMAX_BASE_URL="https://api.minimax.io/v1"
+XAI_BASE_URL="https://api.x.ai/v1"
 OPENROUTER_BASE_URL="https://openrouter.ai/api"
 
 # Arena large-build loading controls

--- a/app/api/admin/seed/route.ts
+++ b/app/api/admin/seed/route.ts
@@ -59,6 +59,7 @@ function providerKeyStatus() {
     moonshot: Boolean(process.env.MOONSHOT_API_KEY),
     deepseek: Boolean(process.env.DEEPSEEK_API_KEY),
     minimax: Boolean(process.env.MINIMAX_API_KEY),
+    xai: Boolean(process.env.XAI_API_KEY),
     openrouter: Boolean(process.env.OPENROUTER_API_KEY),
   };
 }
@@ -69,7 +70,7 @@ function isModelGeneratable(args: { modelKey: string; provider: string }) {
   const canUseOpenRouter = Boolean(status.openrouter && catalog?.openRouterModelId);
 
   if (catalog?.forceOpenRouter) return canUseOpenRouter;
-  if (args.provider === "xai") return canUseOpenRouter;
+  if (args.provider === "xai") return status.xai || canUseOpenRouter;
 
   if (args.provider === "openai") return status.openai || canUseOpenRouter;
   if (args.provider === "anthropic") return status.anthropic || canUseOpenRouter;
@@ -211,7 +212,7 @@ export async function POST(req: Request) {
       done: true,
       seeded: 0,
       error:
-        "No enabled models found. Set at least one API key (OPENROUTER_API_KEY, OPENAI_API_KEY, ANTHROPIC_API_KEY, GOOGLE_AI_API_KEY, MINIMAX_API_KEY, etc.) or enable models for configured providers.",
+        "No enabled models found. Set at least one API key (OPENROUTER_API_KEY, OPENAI_API_KEY, ANTHROPIC_API_KEY, GOOGLE_AI_API_KEY, MINIMAX_API_KEY, XAI_API_KEY, etc.) or enable models for configured providers.",
       promptCount: prompts.length,
       modelCount: 0,
       settings: ARENA_SETTINGS,
@@ -274,7 +275,7 @@ export async function POST(req: Request) {
       done: true,
       seeded: 0,
       error:
-        "No API keys are configured, so no builds can be generated automatically. Use generateBuilds=0 to seed prompts/models only, or set OPENROUTER_API_KEY / provider API keys to generate builds.",
+        "No API keys are configured, so no builds can be generated automatically. Use generateBuilds=0 to seed prompts/models only, or set OPENROUTER_API_KEY / provider API keys such as XAI_API_KEY to generate builds.",
       promptCount: prompts.length,
       modelCount: modelsAll.length,
       modelCountGeneratable: 0,

--- a/app/api/generate/route.ts
+++ b/app/api/generate/route.ts
@@ -15,6 +15,7 @@ const providerKeysSchema = z
     moonshot: z.string().trim().min(1).max(4000).optional(),
     deepseek: z.string().trim().min(1).max(4000).optional(),
     minimax: z.string().trim().min(1).max(4000).optional(),
+    xai: z.string().trim().min(1).max(4000).optional(),
     openrouter: z.string().trim().min(1).max(4000).optional(),
     custom: z.string().trim().min(1).max(4000).optional(),
   })
@@ -116,7 +117,7 @@ export async function POST(req: Request) {
     return NextResponse.json(
       {
         error:
-          "No API keys provided. Add an OpenRouter key or a provider key (OpenAI/Anthropic/Gemini/Moonshot/DeepSeek/MiniMax/etc.) in Sandbox settings.",
+          "No API keys provided. Add an OpenRouter key or a provider key (OpenAI/Anthropic/Gemini/Moonshot/DeepSeek/MiniMax/xAI/etc.) in Sandbox settings.",
       },
       { status: 401 }
     );

--- a/components/sandbox/SandboxLive.tsx
+++ b/components/sandbox/SandboxLive.tsx
@@ -585,6 +585,7 @@ export function SandboxLive({ initialPrompt }: { initialPrompt?: string }) {
       setKey("moonshot", providerKeys.moonshot);
       setKey("deepseek", providerKeys.deepseek);
       setKey("minimax", providerKeys.minimax);
+      setKey("xai", providerKeys.xai);
       setKey("custom", providerKeys.custom);
 
       const res = await fetch("/api/generate", {
@@ -1209,6 +1210,19 @@ export function SandboxLive({ initialPrompt }: { initialPrompt?: string }) {
                       autoComplete="off"
                       spellCheck={false}
                       placeholder="Paste your MiniMax key"
+                    />
+                  </label>
+
+                  <label className="flex flex-col gap-1">
+                    <div className="text-xs font-medium text-muted">xAI</div>
+                    <input
+                      className="mb-field h-10 w-full"
+                      type={showKeys ? "text" : "password"}
+                      value={providerKeys.xai ?? ""}
+                      onChange={(e) => setProviderKeys((prev) => ({ ...prev, xai: e.target.value }))}
+                      autoComplete="off"
+                      spellCheck={false}
+                      placeholder="Paste your xAI key"
                     />
                   </label>
                 </div>

--- a/components/sandbox/SandboxLive.tsx
+++ b/components/sandbox/SandboxLive.tsx
@@ -133,6 +133,7 @@ function loadProviderKeysFromStorage(): ProviderApiKeys {
     set("moonshot");
     set("deepseek");
     set("minimax");
+    set("xai");
     set("custom");
     return keys;
   } catch {

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -64,7 +64,7 @@ To generate fresh builds in `/sandbox`:
 2. Switch to `Live Generate`
 3. Enter either:
    - an `OpenRouter` key, or
-   - provider-specific keys (OpenAI, Anthropic, Gemini, Moonshot, DeepSeek, MiniMax)
+   - provider-specific keys (OpenAI, Anthropic, Gemini, Moonshot, DeepSeek, MiniMax, xAI)
 4. Pick 2 models and click `Generate`
 
 Notes:
@@ -93,6 +93,7 @@ Copy `.env.example` to `.env` and set what you need.
 - `MOONSHOT_API_KEY`
 - `DEEPSEEK_API_KEY`
 - `MINIMAX_API_KEY`
+- `XAI_API_KEY`
 - `OPENROUTER_API_KEY`
 
 ### Optional Provider and Runtime Tuning
@@ -107,7 +108,7 @@ Copy `.env.example` to `.env` and set what you need.
 - `OPENAI_BACKGROUND_POLL_MS=2000` (poll interval for background mode)
 - `ANTHROPIC_ENABLE_1M_CONTEXT_BETA=1`
 - `ANTHROPIC_THINKING_BUDGET` (legacy/manual thinking models)
-- `OPENROUTER_BASE_URL`, `MOONSHOT_BASE_URL`, `DEEPSEEK_BASE_URL`, `MINIMAX_BASE_URL`
+- `OPENROUTER_BASE_URL`, `MOONSHOT_BASE_URL`, `DEEPSEEK_BASE_URL`, `MINIMAX_BASE_URL`, `XAI_BASE_URL`
 - `AI_DEBUG=1` (logs raw model output on failures)
 - `MINEBENCH_TOOL_OUTPUT_DIR`, `MINEBENCH_TOOL_TIMEOUT_MS`, `MINEBENCH_TOOL_MAX_*` (advanced `voxel.exec` controls)
 

--- a/lib/ai/generateVoxelBuild.ts
+++ b/lib/ai/generateVoxelBuild.ts
@@ -835,6 +835,7 @@ export async function generateVoxelBuild(
     maxBlocks: MAX_BLOCKS_BY_GRID[params.gridSize],
     minBlocks,
     palette: params.palette,
+    enableTools,
   });
   const system = enableTools
     ? baseSystem +

--- a/lib/ai/generateVoxelBuild.ts
+++ b/lib/ai/generateVoxelBuild.ts
@@ -12,6 +12,7 @@ import { moonshotGenerateText } from "@/lib/ai/providers/moonshot";
 import { openAiCompatibleGenerateText } from "@/lib/ai/providers/nvidia";
 import { openaiGenerateText } from "@/lib/ai/providers/openai";
 import { openrouterGenerateText } from "@/lib/ai/providers/openrouter";
+import { xaiGenerateText } from "@/lib/ai/providers/xai";
 import {
   AnthropicAdaptiveEffort,
   anthropicAdaptiveEffortAttempts,
@@ -20,7 +21,9 @@ import {
   MoonshotThinkingConfig,
   moonshotThinkingConfigForModel,
   openAiReasoningEffortAttempts,
+  openRouterReasoningEnabledForModel,
   openRouterReasoningEffortAttempts as openRouterReasoningEffortAttemptsForModel,
+  xaiAutomaticReasoningForModel,
 } from "@/lib/ai/reasoningProfiles";
 import { parseVoxelBuildSpec, validateVoxelBuild } from "@/lib/voxel/validate";
 import type { VoxelBuild } from "@/lib/voxel/types";
@@ -61,6 +64,13 @@ function maxOutputTokenCapForModel(modelId: string): number | undefined {
   // output budgets. Keep a lower completion budget so the prompt plus output
   // stays within the model's effective request limit.
   if (modelId === "MiniMax-M2.7") return 131_072;
+  if (
+    modelId === "grok-4-1-fast" ||
+    modelId === "grok-4-1-fast-reasoning" ||
+    modelId === "x-ai/grok-4.1-fast"
+  ) {
+    return 30_000;
+  }
   return undefined;
 }
 
@@ -127,6 +137,7 @@ function describeRequestedThinkingMode(opts: {
   }
 
   if (opts.provider === "deepseek") return "thinking=enabled";
+  if (opts.provider === "xai") return "automatic";
   if (opts.provider === "moonshot") {
     return opts.moonshotThinkingConfig
       ? `thinking=${opts.moonshotThinkingConfig.type}`
@@ -245,6 +256,7 @@ type ProviderKeyName =
   | "moonshot"
   | "deepseek"
   | "minimax"
+  | "xai"
   | "openrouter"
   | "custom";
 
@@ -262,6 +274,8 @@ function envVarForProviderKey(provider: ProviderKeyName): string {
       return "DEEPSEEK_API_KEY";
     case "minimax":
       return "MINIMAX_API_KEY";
+    case "xai":
+      return "XAI_API_KEY";
     case "openrouter":
       return "OPENROUTER_API_KEY";
     case "custom":
@@ -283,6 +297,8 @@ function envVarForDirectProvider(provider: DirectProvider): string | null {
       return envVarForProviderKey("deepseek");
     case "minimax":
       return envVarForProviderKey("minimax");
+    case "xai":
+      return envVarForProviderKey("xai");
     case "custom":
       return envVarForProviderKey("custom");
     default:
@@ -301,7 +317,7 @@ function effectiveApiKey(opts: {
   allowServerKeys: boolean;
 }): string | null {
   const provider = opts.provider;
-  if (provider === "xai" || provider === "zai" || provider === "qwen" || provider === "meta") return null; // only supported via OpenRouter fallback
+  if (provider === "zai" || provider === "qwen" || provider === "meta") return null; // only supported via OpenRouter fallback
 
   const directKey = normalizeApiKey(
     provider === "openrouter"
@@ -318,6 +334,8 @@ function effectiveApiKey(opts: {
                 ? opts.providerKeys?.deepseek
                 : provider === "minimax"
                   ? opts.providerKeys?.minimax
+                  : provider === "xai"
+                    ? opts.providerKeys?.xai
                   : provider === "custom"
                     ? opts.providerKeys?.custom
                   : undefined,
@@ -333,6 +351,7 @@ function effectiveApiKey(opts: {
   if (provider === "moonshot") return serverApiKey("moonshot");
   if (provider === "deepseek") return serverApiKey("deepseek");
   if (provider === "minimax") return serverApiKey("minimax");
+  if (provider === "xai") return serverApiKey("xai");
   if (provider === "custom") return serverApiKey("custom");
 
   return null;
@@ -500,7 +519,18 @@ async function callDirectProvider(args: {
   }
 
   if (args.provider === "xai") {
-    throw new Error("xAI direct API not supported; use OpenRouter fallback");
+    return xaiGenerateText({
+      modelId: args.modelId,
+      apiKey: args.apiKey,
+      system: args.system,
+      user: args.user,
+      maxOutputTokens: args.maxOutputTokens,
+      temperature: DEFAULT_TEMPERATURE,
+      jsonSchema: args.jsonSchema,
+      signal: args.signal,
+      onDelta: args.onDelta,
+      onTrace: args.onTrace,
+    });
   }
 
   // Z.AI models are currently OpenRouter-only in MineBench
@@ -621,6 +651,9 @@ async function providerGenerateText(args: {
       model.provider === "moonshot"
         ? moonshotThinkingConfigForModel(model.modelId, args.reasoning)
         : undefined;
+    if (model.provider === "xai") {
+      xaiAutomaticReasoningForModel(model.modelId, args.reasoning);
+    }
     args.onProviderTrace?.(
       `Routing via direct ${model.provider} provider (${model.modelId}). ` +
         providerRequestTraceLine({
@@ -669,13 +702,18 @@ async function providerGenerateText(args: {
   const openRouterUsesThinkingToggle =
     model.openRouterModelId === "moonshotai/kimi-k2.6" ||
     model.openRouterModelId === "moonshotai/kimi-k2.5";
+  const xaiOpenRouterReasoningEnabled = openRouterReasoningEnabledForModel(
+    model.openRouterModelId,
+    args.reasoning,
+  );
   const openRouterReasoningEnabled =
-    openRouterUsesThinkingToggle
+    xaiOpenRouterReasoningEnabled ??
+    (openRouterUsesThinkingToggle
       ? !normalizedReasoning ||
         normalizedReasoning === "enabled" ||
         normalizedReasoning === "default" ||
         normalizedReasoning === "on"
-      : false;
+      : false);
   if (
     openRouterUsesThinkingToggle &&
     normalizedReasoning &&
@@ -686,7 +724,7 @@ async function providerGenerateText(args: {
     );
   }
   const openRouterReasoningEffortAttempts =
-    openRouterUsesThinkingToggle
+    xaiOpenRouterReasoningEnabled !== undefined || openRouterUsesThinkingToggle
       ? undefined
       : openRouterReasoningEffortAttemptsForModel(
           model.openRouterModelId,
@@ -797,7 +835,6 @@ export async function generateVoxelBuild(
     maxBlocks: MAX_BLOCKS_BY_GRID[params.gridSize],
     minBlocks,
     palette: params.palette,
-    enableTools,
   });
   const system = enableTools
     ? baseSystem +

--- a/lib/ai/modelCatalog.ts
+++ b/lib/ai/modelCatalog.ts
@@ -40,6 +40,7 @@ export type ModelKey =
   | "moonshot_kimi_k2_5"
   | "deepseek_v3_2"
   | "xai_grok_4_1"
+  | "xai_grok_4_20"
   | "zai_glm_5"
   | "zai_glm_4_7"
   | "qwen_qwen3_max_thinking"
@@ -289,10 +290,18 @@ export const MODEL_CATALOG: ModelCatalogEntry[] = [
   {
     key: "xai_grok_4_1",
     provider: "xai",
-    modelId: "grok-4.1-fast",
-    displayName: "Grok 4.1",
+    modelId: "grok-4-1-fast-reasoning",
+    displayName: "Grok 4.1 Fast",
     enabled: true,
     openRouterModelId: "x-ai/grok-4.1-fast",
+  },
+  {
+    key: "xai_grok_4_20",
+    provider: "xai",
+    modelId: "grok-4.20-0309-reasoning",
+    displayName: "Grok 4.20",
+    enabled: true,
+    openRouterModelId: "x-ai/grok-4.20",
   },
   {
     key: "zai_glm_5",

--- a/lib/ai/providers/nvidia.ts
+++ b/lib/ai/providers/nvidia.ts
@@ -471,15 +471,17 @@ export async function openAiCompatibleGenerateText(params: {
   maxOutputTokens?: number;
   temperature?: number;
   jsonSchema?: Record<string, unknown>;
+  serviceLabel?: string;
   signal?: AbortSignal;
   onDelta?: (delta: string) => void;
   onTrace?: (message: string) => void;
 }): Promise<{ text: string }> {
+  const serviceLabel = params.serviceLabel ?? "Custom API";
   const apiKey = params.apiKey ?? process.env.CUSTOM_API_KEY;
-  if (!apiKey) throw new Error("Missing custom API key");
+  if (!apiKey) throw new Error(`Missing ${serviceLabel} API key`);
 
   const rawBaseUrl = params.baseUrl ?? process.env.CUSTOM_API_BASE_URL;
-  if (!rawBaseUrl) throw new Error("Missing custom API server URL");
+  if (!rawBaseUrl) throw new Error(`Missing ${serviceLabel} API server URL`);
   const target = await resolveCustomApiTarget(rawBaseUrl);
   const controller = new AbortController();
   const detachAbort = attachAbortSignal(controller, params.signal);
@@ -537,11 +539,11 @@ export async function openAiCompatibleGenerateText(params: {
     }
   } catch (err) {
     if (err instanceof Error && err.name === "AbortError") {
-      throw new Error("Custom API request timed out");
+      throw new Error(`${serviceLabel} request timed out`);
     }
-    console.error("Custom API network error:", err);
+    console.error(`${serviceLabel} network error:`, err);
     const cause = err instanceof Error && err.cause ? ` (cause: ${String(err.cause)})` : "";
-    throw new Error(`Custom API request failed: ${err instanceof Error ? err.message : String(err)}${cause}`);
+    throw new Error(`${serviceLabel} request failed: ${err instanceof Error ? err.message : String(err)}${cause}`);
   } finally {
     detachAbort();
     if (timeout) clearTimeout(timeout);
@@ -554,15 +556,15 @@ export async function openAiCompatibleGenerateText(params: {
   if (res.status < 200 || res.status >= 300) {
     const body = lastBody || (await readResponseText(res.body).catch(() => ""));
     const rid = requestIdFromHeaders(res.headers);
-    throw new Error(`Custom API error ${res.status}${rid ? ` (request ${rid})` : ""}: ${body}`);
+    throw new Error(`${serviceLabel} error ${res.status}${rid ? ` (request ${rid})` : ""}: ${body}`);
   }
 
   const budget = selectedTokenBudget ?? maxTokens;
   params.onTrace?.(
     withMaxOutputTokens(
       useStructuredOutput
-        ? "Custom API chat completions in use with structured output."
-        : "Custom API chat completions in use without structured output.",
+        ? `${serviceLabel} chat completions in use with structured output.`
+        : `${serviceLabel} chat completions in use without structured output.`,
       budget,
     ),
   );

--- a/lib/ai/providers/xai.ts
+++ b/lib/ai/providers/xai.ts
@@ -1,0 +1,34 @@
+import { openAiCompatibleGenerateText } from "@/lib/ai/providers/nvidia";
+
+export async function xaiGenerateText(params: {
+  modelId: string;
+  apiKey?: string;
+  system: string;
+  user: string;
+  maxOutputTokens?: number;
+  temperature?: number;
+  jsonSchema?: Record<string, unknown>;
+  signal?: AbortSignal;
+  onDelta?: (delta: string) => void;
+  onTrace?: (message: string) => void;
+}): Promise<{ text: string }> {
+  const apiKey = params.apiKey ?? process.env.XAI_API_KEY;
+  if (!apiKey) throw new Error("Missing XAI_API_KEY");
+
+  const baseUrl = process.env.XAI_BASE_URL ?? "https://api.x.ai/v1";
+
+  return openAiCompatibleGenerateText({
+    modelId: params.modelId,
+    apiKey,
+    baseUrl,
+    system: params.system,
+    user: params.user,
+    maxOutputTokens: params.maxOutputTokens,
+    temperature: params.temperature,
+    jsonSchema: params.jsonSchema,
+    serviceLabel: "xAI",
+    signal: params.signal,
+    onDelta: params.onDelta,
+    onTrace: params.onTrace,
+  });
+}

--- a/lib/ai/reasoningProfiles.ts
+++ b/lib/ai/reasoningProfiles.ts
@@ -147,6 +147,41 @@ export function moonshotThinkingConfigForModel(
   );
 }
 
+export function xaiAutomaticReasoningForModel(
+  modelId: string,
+  override?: string,
+): "automatic" | undefined {
+  const normalized = normalizeReasoningOverride(override);
+  const label = `xAI model ${modelId}`;
+  const isAutomaticReasoningModel =
+    modelId === "grok-4.20-0309-reasoning" ||
+    modelId === "grok-4.20-reasoning" ||
+    modelId === "grok-4-1-fast-reasoning" ||
+    modelId === "grok-4-1-fast";
+
+  if (!isAutomaticReasoningModel) {
+    if (normalized) {
+      throw new Error(`${label} does not expose a reasoning override.`);
+    }
+    return undefined;
+  }
+
+  if (
+    !normalized ||
+    normalized === "automatic" ||
+    normalized === "auto" ||
+    normalized === "enabled" ||
+    normalized === "on" ||
+    normalized === "true"
+  ) {
+    return "automatic";
+  }
+
+  throw new Error(
+    `${label} reasons automatically and does not support reasoning overrides like '${override}'.`,
+  );
+}
+
 export function openRouterReasoningEffortAttempts(
   modelId: string,
   override?: string,
@@ -206,4 +241,40 @@ export function openRouterReasoningEffortAttempts(
     throw new Error(`${label} does not expose a reasoning-effort override.`);
   }
   return undefined;
+}
+
+export function openRouterReasoningEnabledForModel(
+  modelId: string,
+  override?: string,
+): boolean | undefined {
+  const normalized = normalizeReasoningOverride(override);
+  const label = `OpenRouter model ${modelId}`;
+  const isBooleanReasoningModel =
+    modelId === "x-ai/grok-4.20" ||
+    modelId === "x-ai/grok-4.1-fast";
+
+  if (!isBooleanReasoningModel) {
+    return undefined;
+  }
+
+  if (!normalized) return true;
+  if (
+    normalized === "enabled" ||
+    normalized === "on" ||
+    normalized === "true"
+  ) {
+    return true;
+  }
+  if (
+    normalized === "disabled" ||
+    normalized === "off" ||
+    normalized === "false" ||
+    normalized === "none"
+  ) {
+    return false;
+  }
+
+  throw new Error(
+    `${label} does not support reasoning '${override}'. Supported values: enabled, disabled.`,
+  );
 }

--- a/lib/ai/types.ts
+++ b/lib/ai/types.ts
@@ -10,6 +10,7 @@ export type ProviderApiKeys = {
   moonshot?: string;
   deepseek?: string;
   minimax?: string;
+  xai?: string;
   openrouter?: string;
   custom?: string;
 };

--- a/scripts/uploadsCatalog.ts
+++ b/scripts/uploadsCatalog.ts
@@ -62,6 +62,7 @@ export const MODEL_SLUG: Record<ModelKey, string> = {
   moonshot_kimi_k2_5: "kimi-k2-5",
   deepseek_v3_2: "deepseek-v3-2",
   xai_grok_4_1: "grok-4-1",
+  xai_grok_4_20: "grok-4-20",
   zai_glm_5: "glm-5",
   zai_glm_4_7: "glm-4-7",
   qwen_qwen3_max_thinking: "qwen3-max-thinking",


### PR DESCRIPTION
## What does this PR do?

Adds Grok 4.20 as a first-class MineBench model, wires direct xAI provider support, and audits the existing Grok 4.1 path so it uses the reasoning model slug and the correct completion cap.

It also enables the Grok-specific OpenRouter reasoning toggle for `x-ai/grok-4.20` and `x-ai/grok-4.1-fast`, while preserving strict JSON-schema structured output routing for schema requests.

## Why?

Grok 4.20 needs full native + OpenRouter wiring to be benchmarkable in MineBench.

The existing Grok integration was incomplete: MineBench did not have a native xAI provider path where Grok 4.1 was not using the older fast slug instead of the reasoning slug, and Grok's OpenRouter reasoning controls are a boolean enable/disable toggle rather than the effort-ladder path used by most of our other OpenRouter reasoning models.

## How to test

- `pnpm lint`
- `npm run build`
- `pnpm batch:generate --generate --model grok-4-20`
- `pnpm batch:generate --generate --model grok-4-20 --openrouter`

## Checklist

- [x] `pnpm lint` passes
- [x] Tested locally
- [x] Updated README or docs if needed

_(PR Body written by Codex)_