### PR TITLE
(feat) add glm 5.1 support

### DIFF
--- a/lib/ai/generateVoxelBuild.ts
+++ b/lib/ai/generateVoxelBuild.ts
@@ -54,6 +54,7 @@ function maxOutputTokenCapForModel(modelId: string): number | undefined {
   // gpt-5-pro alias remaining at 272k.
   if (modelId === "gpt-5-pro") return 272_000;
   if (modelId.startsWith("gpt-5")) return 128_000;
+  if (modelId === "glm-5.1" || modelId === "glm-5") return 131_072;
   if (
     modelId.startsWith("claude-opus-4-7") ||
     modelId === "anthropic/claude-opus-4.7"

--- a/lib/ai/modelCatalog.ts
+++ b/lib/ai/modelCatalog.ts
@@ -41,6 +41,7 @@ export type ModelKey =
   | "deepseek_v3_2"
   | "xai_grok_4_1"
   | "xai_grok_4_20"
+  | "zai_glm_5_1"
   | "zai_glm_5"
   | "zai_glm_4_7"
   | "qwen_qwen3_max_thinking"
@@ -302,6 +303,15 @@ export const MODEL_CATALOG: ModelCatalogEntry[] = [
     displayName: "Grok 4.20",
     enabled: true,
     openRouterModelId: "x-ai/grok-4.20",
+  },
+  {
+    key: "zai_glm_5_1",
+    provider: "zai",
+    modelId: "glm-5.1",
+    displayName: "Z.AI GLM 5.1",
+    enabled: true,
+    openRouterModelId: "z-ai/glm-5.1",
+    forceOpenRouter: true,
   },
   {
     key: "zai_glm_5",

--- a/lib/ai/reasoningProfiles.ts
+++ b/lib/ai/reasoningProfiles.ts
@@ -207,7 +207,10 @@ export function openRouterReasoningEffortAttempts(
       override,
     );
   }
-  if (modelId === "z-ai/glm-5") {
+  if (
+    modelId === "z-ai/glm-5.1" ||
+    modelId === "z-ai/glm-5"
+  ) {
     return descendingAttempts(label, ["xhigh", "high", "medium", "low"], override);
   }
   if (modelId.startsWith("google/gemini-3")) {

--- a/scripts/uploadsCatalog.ts
+++ b/scripts/uploadsCatalog.ts
@@ -63,6 +63,7 @@ export const MODEL_SLUG: Record<ModelKey, string> = {
   deepseek_v3_2: "deepseek-v3-2",
   xai_grok_4_1: "grok-4-1",
   xai_grok_4_20: "grok-4-20",
+  zai_glm_5_1: "glm-5-1",
   zai_glm_5: "glm-5",
   zai_glm_4_7: "glm-4-7",
   qwen_qwen3_max_thinking: "qwen3-max-thinking",


### PR DESCRIPTION
## What does this PR do?

Adds GLM 5.1 as a first-class MineBench model, wires the existing OpenRouter-based GLM catalog/slug/reasoning path for `z-ai/glm-5.1`, and applies the documented 131072-token output ceiling for the new model.

It keeps GLM 5.1 aligned with the current GLM 5 benchmark route in MineBench: OpenRouter-only today, with the same reasoning effort fallback ladder used for routed GLM reasoning requests.

## Why?

GLM 5.1 needs full benchmark wiring to be benchmarkable in MineBench.

The official Z.AI docs describe GLM 5.1 as a thinking model with thinking enabled by default, and they document a 131072-token maximum output limit (also summarized as 128K in the model overview). OpenRouter exposes the model as `z-ai/glm-5.1`, so MineBench needs the new catalog entry, slug mapping, reasoning profile, and output cap to route it consistently with the existing GLM benchmark path.

## How to test

- `pnpm lint`
- `npm run build`
- `pnpm batch:generate --model glm-5-1`
- `pnpm batch:generate --generate --model glm-5-1 --openrouter`

## Checklist

- [x] `pnpm lint` passes
- [x] Tested locally
- [x] Updated README or docs if needed

_(PR Body written by Codex)_