### PR TITLE
(feat) add deepseek v4 pro support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -44,6 +44,7 @@ ANTHROPIC_STREAM_RESPONSES=1
 # Stream OpenAI responses when the caller consumes live deltas (UI paths).
 # Batch generation uses non-streamed Responses JSON for reliability.
 OPENAI_STREAM_RESPONSES=1
+# DeepSeek V4 Pro defaults to thinking=max and uses up to 384000 output tokens unless MINEBENCH_MAX_OUTPUT_TOKENS lowers it.
 # Use OpenAI background mode for long-running Responses API models (default true for gpt-5* when not streaming deltas)
 OPENAI_USE_BACKGROUND_MODE=1
 # Poll interval (ms) while waiting on background Responses jobs

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -108,6 +108,7 @@ Copy `.env.example` to `.env` and set what you need.
 - `OPENAI_BACKGROUND_POLL_MS=2000` (poll interval for background mode)
 - `ANTHROPIC_ENABLE_1M_CONTEXT_BETA=1`
 - `ANTHROPIC_THINKING_BUDGET` (legacy/manual thinking models)
+- DeepSeek V4 Pro uses the native DeepSeek API with JSON Output mode, defaults to `thinking=max` and `max_tokens=384000`; use `pnpm batch:generate --reasoning high` only when intentionally lowering effort.
 - `OPENROUTER_BASE_URL`, `MOONSHOT_BASE_URL`, `DEEPSEEK_BASE_URL`, `MINIMAX_BASE_URL`, `XAI_BASE_URL`
 - `AI_DEBUG=1` (logs raw model output on failures)
 - `MINEBENCH_TOOL_OUTPUT_DIR`, `MINEBENCH_TOOL_TIMEOUT_MS`, `MINEBENCH_TOOL_MAX_*` (advanced `voxel.exec` controls)

--- a/lib/ai/generateVoxelBuild.ts
+++ b/lib/ai/generateVoxelBuild.ts
@@ -16,6 +16,8 @@ import { xaiGenerateText } from "@/lib/ai/providers/xai";
 import {
   AnthropicAdaptiveEffort,
   anthropicAdaptiveEffortAttempts,
+  DeepSeekThinkingConfig,
+  deepseekThinkingConfigForModel,
   GeminiThinkingConfig,
   geminiThinkingConfigForModel,
   MoonshotThinkingConfig,
@@ -39,12 +41,24 @@ import {
 
 const INT_ENV_MAX_OUTPUT_TOKENS = "MINEBENCH_MAX_OUTPUT_TOKENS";
 
-function parseIntEnvVar(name: string, fallback: number): number {
+function parseOptionalIntEnvVar(name: string): number | undefined {
   const raw = process.env[name];
-  if (!raw) return fallback;
+  if (!raw) return undefined;
   const parsed = Number.parseInt(raw, 10);
-  if (!Number.isFinite(parsed) || Number.isNaN(parsed) || parsed <= 0) return fallback;
+  if (!Number.isFinite(parsed) || Number.isNaN(parsed) || parsed <= 0) return undefined;
   return Math.floor(parsed);
+}
+
+function defaultOutputTokenRequestForModel(modelId: string): number | undefined {
+  if (
+    modelId === "deepseek-v4-pro" ||
+    modelId === "deepseek-v4-flash" ||
+    modelId === "deepseek/deepseek-v4-pro" ||
+    modelId === "deepseek/deepseek-v4-flash"
+  ) {
+    return 384_000;
+  }
+  return undefined;
 }
 
 function maxOutputTokenCapForModel(modelId: string): number | undefined {
@@ -54,6 +68,15 @@ function maxOutputTokenCapForModel(modelId: string): number | undefined {
   // gpt-5-pro alias remaining at 272k.
   if (modelId === "gpt-5-pro") return 272_000;
   if (modelId.startsWith("gpt-5")) return 128_000;
+  if (
+    modelId === "deepseek-v4-pro" ||
+    modelId === "deepseek-v4-flash" ||
+    modelId === "deepseek/deepseek-v4-pro" ||
+    modelId === "deepseek/deepseek-v4-flash"
+  ) {
+    return 384_000;
+  }
+  if (modelId === "deepseek/deepseek-v3.2") return 65_536;
   if (modelId === "glm-5.1" || modelId === "glm-5") return 131_072;
   if (
     modelId.startsWith("claude-opus-4-7") ||
@@ -76,7 +99,10 @@ function maxOutputTokenCapForModel(modelId: string): number | undefined {
 }
 
 function defaultMaxOutputTokens(_gridSize: 64 | 256 | 512, modelId: string): number {
-  const requested = parseIntEnvVar(INT_ENV_MAX_OUTPUT_TOKENS, DEFAULT_MAX_OUTPUT_TOKENS);
+  const requested =
+    parseOptionalIntEnvVar(INT_ENV_MAX_OUTPUT_TOKENS) ??
+    defaultOutputTokenRequestForModel(modelId) ??
+    DEFAULT_MAX_OUTPUT_TOKENS;
   const cap = maxOutputTokenCapForModel(modelId);
   return typeof cap === "number" ? Math.min(requested, cap) : requested;
 }
@@ -116,6 +142,7 @@ function describeRequestedThinkingMode(opts: {
   adaptiveEffortAttempts?: AnthropicAdaptiveEffort[];
   geminiThinkingConfig?: GeminiThinkingConfig;
   moonshotThinkingConfig?: MoonshotThinkingConfig;
+  deepseekThinkingConfig?: DeepSeekThinkingConfig;
 }): string {
   if (opts.route === "openrouter") {
     if (opts.reasoningEffortAttempts && opts.reasoningEffortAttempts.length > 0) {
@@ -137,7 +164,11 @@ function describeRequestedThinkingMode(opts: {
     return "default";
   }
 
-  if (opts.provider === "deepseek") return "thinking=enabled";
+  if (opts.provider === "deepseek") {
+    if (!opts.deepseekThinkingConfig) return "default";
+    if (opts.deepseekThinkingConfig.type === "disabled") return "thinking=disabled";
+    return `thinking=${opts.deepseekThinkingConfig.reasoningEffort ?? "high"}`;
+  }
   if (opts.provider === "xai") return "automatic";
   if (opts.provider === "moonshot") {
     return opts.moonshotThinkingConfig
@@ -185,13 +216,18 @@ function providerRequestTraceLine(opts: {
   adaptiveEffortAttempts?: AnthropicAdaptiveEffort[];
   geminiThinkingConfig?: GeminiThinkingConfig;
   moonshotThinkingConfig?: MoonshotThinkingConfig;
+  deepseekThinkingConfig?: DeepSeekThinkingConfig;
 }): string {
   const thinkingMode =
     opts.route === "openrouter" && opts.openRouterReasoningEnabled
       ? "enabled"
       : describeRequestedThinkingMode(opts);
   const temperature =
-    opts.route === "direct" && opts.provider === "moonshot"
+    opts.route === "direct" &&
+    opts.provider === "deepseek" &&
+    opts.deepseekThinkingConfig?.type === "enabled"
+      ? "n/a"
+      : opts.route === "direct" && opts.provider === "moonshot"
       ? opts.modelId === "kimi-k2.6" || opts.modelId === "kimi-k2.5"
         ? opts.moonshotThinkingConfig?.type === "disabled"
           ? 0.6
@@ -421,6 +457,7 @@ async function callDirectProvider(args: {
   adaptiveEffortAttempts?: AnthropicAdaptiveEffort[];
   geminiThinkingConfig?: GeminiThinkingConfig;
   moonshotThinkingConfig?: MoonshotThinkingConfig;
+  deepseekThinkingConfig?: DeepSeekThinkingConfig;
   signal?: AbortSignal;
   onDelta?: (delta: string) => void;
   onTrace?: (message: string) => void;
@@ -496,7 +533,9 @@ async function callDirectProvider(args: {
       system: args.system,
       user: args.user,
       maxOutputTokens: args.maxOutputTokens,
+      thinkingConfig: args.deepseekThinkingConfig,
       temperature: DEFAULT_TEMPERATURE,
+      jsonSchema: args.jsonSchema,
       signal: args.signal,
       onDelta: args.onDelta,
       onTrace: args.onTrace,
@@ -652,6 +691,10 @@ async function providerGenerateText(args: {
       model.provider === "moonshot"
         ? moonshotThinkingConfigForModel(model.modelId, args.reasoning)
         : undefined;
+    const directDeepSeekThinkingConfig =
+      model.provider === "deepseek"
+        ? deepseekThinkingConfigForModel(model.modelId, args.reasoning)
+        : undefined;
     if (model.provider === "xai") {
       xaiAutomaticReasoningForModel(model.modelId, args.reasoning);
     }
@@ -667,6 +710,7 @@ async function providerGenerateText(args: {
           adaptiveEffortAttempts: directAnthropicAdaptiveEffortAttempts,
           geminiThinkingConfig: directGeminiThinkingConfig,
           moonshotThinkingConfig: directMoonshotThinkingConfig,
+          deepseekThinkingConfig: directDeepSeekThinkingConfig,
         }),
     );
     try {
@@ -684,6 +728,7 @@ async function providerGenerateText(args: {
         adaptiveEffortAttempts: directAnthropicAdaptiveEffortAttempts,
         geminiThinkingConfig: directGeminiThinkingConfig,
         moonshotThinkingConfig: directMoonshotThinkingConfig,
+        deepseekThinkingConfig: directDeepSeekThinkingConfig,
         signal: args.signal,
         onDelta: args.onDelta,
         onTrace: args.onProviderTrace,

--- a/lib/ai/modelCatalog.ts
+++ b/lib/ai/modelCatalog.ts
@@ -38,6 +38,7 @@ export type ModelKey =
   | "moonshot_kimi_k2"
   | "moonshot_kimi_k2_6"
   | "moonshot_kimi_k2_5"
+  | "deepseek_v4_pro"
   | "deepseek_v3_2"
   | "xai_grok_4_1"
   | "xai_grok_4_20"
@@ -281,12 +282,20 @@ export const MODEL_CATALOG: ModelCatalogEntry[] = [
     forceOpenRouter: true,
   },
   {
+    key: "deepseek_v4_pro",
+    provider: "deepseek",
+    modelId: "deepseek-v4-pro",
+    displayName: "DeepSeek V4 Pro",
+    enabled: true,
+  },
+  {
     key: "deepseek_v3_2",
     provider: "deepseek",
-    modelId: "deepseek-reasoner",
+    modelId: "deepseek/deepseek-v3.2",
     displayName: "DeepSeek V3.2",
     enabled: true,
     openRouterModelId: "deepseek/deepseek-v3.2",
+    forceOpenRouter: true,
   },
   {
     key: "xai_grok_4_1",

--- a/lib/ai/providers/deepseek.ts
+++ b/lib/ai/providers/deepseek.ts
@@ -1,17 +1,34 @@
 import { attachAbortSignal } from "@/lib/ai/providers/abort";
 import { consumeSseStream } from "@/lib/ai/providers/sse";
 import { tokenBudgetCandidates } from "@/lib/ai/tokenBudgets";
+import type { DeepSeekThinkingConfig } from "@/lib/ai/reasoningProfiles";
 
 type DeepSeekChatResponse = {
-  choices?: { message?: { content?: unknown } }[];
+  choices?: {
+    message?: {
+      content?: unknown;
+      tool_calls?: { function?: { arguments?: unknown } }[];
+    };
+  }[];
 };
 
 type DeepSeekChatStreamChunk = {
-  choices?: { delta?: { content?: unknown } }[];
+  choices?: {
+    delta?: {
+      content?: unknown;
+      reasoning_content?: unknown;
+      tool_calls?: { function?: { arguments?: unknown } }[];
+    };
+  }[];
 };
 
 function extractTextFromChat(data: DeepSeekChatResponse): string {
-  const content = data.choices?.[0]?.message?.content;
+  const message = data.choices?.[0]?.message;
+  const toolArguments = message?.tool_calls?.[0]?.function?.arguments;
+  if (typeof toolArguments === "string") return toolArguments;
+  if (toolArguments && typeof toolArguments === "object") return JSON.stringify(toolArguments);
+
+  const content = message?.content;
   if (typeof content === "string") return content;
   if (Array.isArray(content)) return content.map((c) => String(c ?? "")).join("");
   return "";
@@ -37,13 +54,25 @@ function withMaxOutputTokens(message: string, maxOutputTokens: number): string {
   return `${trimmed}; max_output_tokens=${budget}.`;
 }
 
+function describeThinkingConfig(config: DeepSeekThinkingConfig): string {
+  if (config.type === "disabled") return "disabled";
+  return config.reasoningEffort ?? "high";
+}
+
+function normalizeBaseUrl(raw: string | undefined): string {
+  const trimmed = raw?.trim();
+  return (trimmed || "https://api.deepseek.com").replace(/\/+$/, "");
+}
+
 export async function deepseekGenerateText(params: {
   modelId: string;
   apiKey?: string;
   system: string;
   user: string;
   maxOutputTokens?: number;
+  thinkingConfig?: DeepSeekThinkingConfig;
   temperature?: number;
+  jsonSchema?: Record<string, unknown>;
   signal?: AbortSignal;
   onDelta?: (delta: string) => void;
   onTrace?: (message: string) => void;
@@ -51,8 +80,9 @@ export async function deepseekGenerateText(params: {
   const apiKey = params.apiKey ?? process.env.DEEPSEEK_API_KEY;
   if (!apiKey) throw new Error("Missing DEEPSEEK_API_KEY");
 
-  const baseUrl = (process.env.DEEPSEEK_BASE_URL ?? "https://api.deepseek.com").replace(/\/+$/, "");
+  const baseUrl = normalizeBaseUrl(process.env.DEEPSEEK_BASE_URL);
   const url = `${baseUrl}/v1/chat/completions`;
+  const useJsonOutput = Boolean(params.jsonSchema);
 
   const controller = new AbortController();
   const detachAbort = attachAbortSignal(controller, params.signal);
@@ -61,6 +91,7 @@ export async function deepseekGenerateText(params: {
   let res: Response | null = null;
   let lastBody = "";
   const maxTokens = params.maxOutputTokens ?? 65536;
+  const thinkingConfig = params.thinkingConfig ?? { type: "enabled", reasoningEffort: "max" };
   let selectedTokenBudget: number | null = null;
   try {
     for (const tok of tokenBudgetCandidates(maxTokens)) {
@@ -79,9 +110,15 @@ export async function deepseekGenerateText(params: {
             { role: "user", content: params.user },
           ],
           stream: Boolean(params.onDelta),
-          temperature: params.temperature ?? 0.2,
           max_tokens: tok,
-          thinking: { type: "enabled" },
+          thinking: { type: thinkingConfig.type },
+          ...(thinkingConfig.type === "enabled" && thinkingConfig.reasoningEffort
+            ? { reasoning_effort: thinkingConfig.reasoningEffort }
+            : {}),
+          ...(useJsonOutput ? { response_format: { type: "json_object" } } : {}),
+          ...(thinkingConfig.type === "disabled"
+            ? { temperature: params.temperature ?? 0.2 }
+            : {}),
         }),
       });
       if (res.ok) {
@@ -116,7 +153,12 @@ export async function deepseekGenerateText(params: {
   }
 
   const budget = selectedTokenBudget ?? maxTokens;
-  params.onTrace?.(withMaxOutputTokens("DeepSeek reasoning mode in use: enabled.", budget));
+  params.onTrace?.(
+    withMaxOutputTokens(
+      `DeepSeek reasoning mode in use: ${describeThinkingConfig(thinkingConfig)}; structured_output=${useJsonOutput ? "json_object" : "none"}.`,
+      budget,
+    ),
+  );
 
   if (params.onDelta) {
     let text = "";
@@ -128,7 +170,13 @@ export async function deepseekGenerateText(params: {
       } catch {
         return;
       }
-      const chunk = parsed?.choices?.[0]?.delta?.content;
+      const delta = parsed?.choices?.[0]?.delta;
+      const chunk =
+        typeof delta?.content === "string"
+          ? delta.content
+          : typeof delta?.tool_calls?.[0]?.function?.arguments === "string"
+            ? delta.tool_calls[0].function.arguments
+            : null;
       if (typeof chunk === "string" && chunk) {
         text += chunk;
         params.onDelta?.(chunk);

--- a/lib/ai/reasoningProfiles.ts
+++ b/lib/ai/reasoningProfiles.ts
@@ -9,6 +9,11 @@ export type MoonshotThinkingConfig = {
   type: "enabled" | "disabled";
 };
 
+export type DeepSeekThinkingConfig = {
+  type: "enabled" | "disabled";
+  reasoningEffort?: "high" | "max";
+};
+
 function normalizeReasoningOverride(value?: string): string | undefined {
   const normalized = value?.trim().toLowerCase();
   return normalized ? normalized : undefined;
@@ -144,6 +149,55 @@ export function moonshotThinkingConfigForModel(
 
   throw new Error(
     `Moonshot model ${modelId} does not support reasoning '${override}'. Supported values: enabled, disabled.`,
+  );
+}
+
+export function deepseekThinkingConfigForModel(
+  modelId: string,
+  override?: string,
+): DeepSeekThinkingConfig | undefined {
+  const normalized = normalizeReasoningOverride(override);
+  const supportsThinking =
+    modelId === "deepseek-v4-pro" ||
+    modelId === "deepseek-v4-flash" ||
+    modelId === "deepseek-reasoner";
+
+  if (!supportsThinking) {
+    if (normalized) {
+      throw new Error(`DeepSeek model ${modelId} does not expose a thinking override.`);
+    }
+    return undefined;
+  }
+
+  if (
+    !normalized ||
+    normalized === "default" ||
+    normalized === "enabled" ||
+    normalized === "on" ||
+    normalized === "true" ||
+    normalized === "max" ||
+    normalized === "xhigh"
+  ) {
+    return { type: "enabled", reasoningEffort: "max" };
+  }
+
+  if (normalized === "high") {
+    return { type: "enabled", reasoningEffort: "high" };
+  }
+
+  if (
+    normalized === "disabled" ||
+    normalized === "off" ||
+    normalized === "false" ||
+    normalized === "none" ||
+    normalized === "non-think" ||
+    normalized === "nonthinking"
+  ) {
+    return { type: "disabled" };
+  }
+
+  throw new Error(
+    `DeepSeek model ${modelId} does not support reasoning '${override}'. Supported values: max, high, disabled.`,
   );
 }
 

--- a/scripts/uploadsCatalog.ts
+++ b/scripts/uploadsCatalog.ts
@@ -60,6 +60,7 @@ export const MODEL_SLUG: Record<ModelKey, string> = {
   moonshot_kimi_k2: "kimi-k2",
   moonshot_kimi_k2_6: "kimi-k2-6",
   moonshot_kimi_k2_5: "kimi-k2-5",
+  deepseek_v4_pro: "deepseek-v4-pro",
   deepseek_v3_2: "deepseek-v3-2",
   xai_grok_4_1: "grok-4-1",
   xai_grok_4_20: "grok-4-20",


### PR DESCRIPTION
## What does this PR do?

Adds DeepSeek V4 Pro as a first-class MineBench model, wires the native DeepSeek provider path for `deepseek-v4-pro`, and adds the upload slug/reasoning/output-budget plumbing needed for benchmark generation.

It routes V4 Pro through DeepSeek's native API instead of OpenRouter so benchmark runs use the intended provider surface. The direct route requests DeepSeek JSON Output mode with thinking enabled, `reasoning_effort=max`, and the documented 384000-token output ceiling, while MineBench still validates the returned `voxel.exec` JSON locally before accepting a build.

It also keeps the existing DeepSeek V3.2 catalog row on OpenRouter, since the current native `deepseek-reasoner` compatibility alias now maps to the V4 thinking backend rather than the older V3.2 model.

## Why?

DeepSeek V4 Pro needs full benchmark wiring to be benchmarkable in MineBench.

The current DeepSeek docs list `deepseek-v4-pro` and `deepseek-v4-flash`, with V4 Pro supporting thinking mode and `reasoning_effort=max`. OpenRouter exposes V4 Pro too, but its routed endpoint rejected MineBench's strict structured-output parameter set, and the native DeepSeek thinking backend rejects forced tool calls. Using the native DeepSeek JSON Output route keeps the benchmark on the correct provider path while preserving MineBench's local schema validation and retry loop.

## How to test

- `pnpm lint`
- `pnpm build`
- `pnpm batch:status --model deepseek-v4-pro`
- mocked native DeepSeek request smoke check confirming `deepseek-v4-pro`, `reasoning_effort=max`, `max_tokens=384000`, and `response_format={ type: "json_object" }`
- `DEEPSEEK_API_KEY=... pnpm batch:generate --generate --model deepseek-v4-pro`

## Checklist

- [x] `pnpm lint` passes
- [x] `pnpm build` passes
- [x] Tested locally
- [x] Updated README or docs if needed

_(PR Body written by Codex)_
