### PR TITLE
(feat) add gpt 5.5 models

### DIFF
--- a/components/sandbox/SandboxBenchmark.tsx
+++ b/components/sandbox/SandboxBenchmark.tsx
@@ -113,8 +113,8 @@ type CachedBuild = {
   serverValidated: boolean;
 };
 
-const DEFAULT_MODEL_A = "openai_gpt_5_4";
-const DEFAULT_MODEL_B = "openai_gpt_5_4_pro";
+const DEFAULT_MODEL_A = "openai_gpt_5_5";
+const DEFAULT_MODEL_B = "openai_gpt_5_5_pro";
 const SNAPSHOT_FETCH_TIMEOUT_MS = Number.parseInt(
   process.env.NEXT_PUBLIC_ARENA_SNAPSHOT_TIMEOUT_MS ?? "12000",
   10,

--- a/lib/ai/modelCatalog.ts
+++ b/lib/ai/modelCatalog.ts
@@ -11,6 +11,8 @@ export type Provider =
   | "meta";
 
 export type ModelKey =
+  | "openai_gpt_5_5"
+  | "openai_gpt_5_5_pro"
   | "openai_gpt_5_4"
   | "openai_gpt_5_4_pro"
   | "openai_gpt_5_4_mini"
@@ -63,6 +65,22 @@ export type ModelCatalogEntry = {
 };
 
 export const MODEL_CATALOG: ModelCatalogEntry[] = [
+  {
+    key: "openai_gpt_5_5",
+    provider: "openai",
+    modelId: "gpt-5.5-2026-04-23",
+    displayName: "GPT 5.5",
+    enabled: true,
+    openRouterModelId: "openai/gpt-5.5",
+  },
+  {
+    key: "openai_gpt_5_5_pro",
+    provider: "openai",
+    modelId: "gpt-5.5-pro-2026-04-23",
+    displayName: "GPT 5.5 Pro",
+    enabled: true,
+    openRouterModelId: "openai/gpt-5.5-pro",
+  },
   {
     key: "openai_gpt_5_4",
     provider: "openai",

--- a/lib/ai/providers/openai.ts
+++ b/lib/ai/providers/openai.ts
@@ -447,18 +447,24 @@ export async function openaiGenerateText(params: {
   const isGptOssFamily = params.modelId.startsWith("gpt-oss-");
   // Some models are Responses-only (or otherwise not supported in chat/completions).
   // For these, don't fall back to chat/completions because it hides the real failure cause.
+  const isGpt55Pro = params.modelId.startsWith("gpt-5.5-pro");
   const isResponsesOnlyModel =
     params.modelId === "gpt-5.2-pro" ||
+    isGpt55Pro ||
     params.modelId.startsWith("gpt-5.4-pro") ||
     params.modelId === "gpt-5-pro" ||
     params.modelId === "gpt-5.2-codex" ||
     params.modelId === "gpt-5.3-codex";
   const defaultReasoningEffortAttempts: string[] = isGpt5Family
-    ? params.modelId.startsWith("gpt-5.4-pro")
+    ? isGpt55Pro
       ? ["xhigh", "high", "medium"]
-      : params.modelId === "gpt-5-pro"
-        ? ["high"]
-        : ["xhigh", "high"]
+      : params.modelId.startsWith("gpt-5.5")
+        ? ["xhigh", "high", "medium", "low", "none"]
+        : params.modelId.startsWith("gpt-5.4-pro")
+          ? ["xhigh", "high", "medium"]
+          : params.modelId === "gpt-5-pro"
+            ? ["high"]
+            : ["xhigh", "high"]
     : isGptOssFamily
       ? ["xhigh", "high", "medium", "low"]
       : [];
@@ -478,9 +484,9 @@ export async function openaiGenerateText(params: {
   // For non-interactive callers (e.g. batch generation), use non-streaming
   // Responses JSON to avoid SSE event-shape drift causing empty text payloads.
   const streamResponses =
-    Boolean(params.onDelta) && parseBooleanEnv("OPENAI_STREAM_RESPONSES", true);
+    !isGpt55Pro && Boolean(params.onDelta) && parseBooleanEnv("OPENAI_STREAM_RESPONSES", true);
   const useBackgroundMode =
-    !params.onDelta &&
+    (isGpt55Pro || !params.onDelta) &&
     parseBooleanEnv("OPENAI_USE_BACKGROUND_MODE", isGpt5Family);
   const backgroundPollIntervalMs = parseIntEnv("OPENAI_BACKGROUND_POLL_MS", 15_000);
   const streamForRequest = useBackgroundMode ? false : streamResponses;

--- a/lib/ai/reasoningProfiles.ts
+++ b/lib/ai/reasoningProfiles.ts
@@ -37,6 +37,12 @@ export function openAiReasoningEffortAttempts(
   override?: string,
 ): string[] | undefined {
   const label = `OpenAI model ${modelId}`;
+  if (modelId.startsWith("gpt-5.5-pro")) {
+    return descendingAttempts(label, ["xhigh", "high", "medium"], override);
+  }
+  if (modelId.startsWith("gpt-5.5")) {
+    return descendingAttempts(label, ["xhigh", "high", "medium", "low", "none"], override);
+  }
   if (modelId.startsWith("gpt-5.4-pro")) {
     return descendingAttempts(label, ["xhigh", "high", "medium"], override);
   }
@@ -187,6 +193,12 @@ export function openRouterReasoningEffortAttempts(
   override?: string,
 ): string[] | undefined {
   const label = `OpenRouter model ${modelId}`;
+  if (modelId === "openai/gpt-5.5-pro") {
+    return descendingAttempts(label, ["xhigh", "high", "medium"], override);
+  }
+  if (modelId === "openai/gpt-5.5") {
+    return descendingAttempts(label, ["xhigh", "high", "medium", "low", "none"], override);
+  }
   if (modelId === "openai/gpt-5.4-pro") {
     return descendingAttempts(label, ["xhigh", "high", "medium"], override);
   }

--- a/scripts/uploadsCatalog.ts
+++ b/scripts/uploadsCatalog.ts
@@ -33,6 +33,8 @@ export const PROMPT_MAP: Record<string, string> = {
 
 // Model key to short filename slug.
 export const MODEL_SLUG: Record<ModelKey, string> = {
+  openai_gpt_5_5: "gpt-5-5",
+  openai_gpt_5_5_pro: "gpt-5-5-pro",
   openai_gpt_5_4: "gpt-5-4",
   openai_gpt_5_4_pro: "gpt-5-4-pro",
   openai_gpt_5_4_mini: "gpt-5-4-mini",


### PR DESCRIPTION
## What does this PR do?

- Adds `GPT 5.5` and `GPT 5.5 Pro` to the MineBench model catalog using the dated OpenAI snapshots `gpt-5.5-2026-04-23` and `gpt-5.5-pro-2026-04-23`.
- Adds upload slugs for batch/import flows: `gpt-5-5` and `gpt-5-5-pro`.
- Updates the sandbox benchmark default pair to compare GPT 5.5 against GPT 5.5 Pro.
- Wires direct OpenAI and OpenRouter reasoning-effort fallbacks so GPT 5.5 starts at `xhigh`; GPT 5.5 supports `xhigh -> high -> medium -> low -> none`, and GPT 5.5 Pro starts at `xhigh -> high -> medium`.
- Keeps GPT 5.5 Pro on the Responses/background path and disables streaming for it to match its long-running, non-streaming API behavior.

## Why?

OpenAI's current docs list GPT 5.5 as the flagship complex-reasoning/coding model, with `none`, `low`, `medium`, `high`, and `xhigh` reasoning effort support, a 1,050,000-token context window, and 128,000 max output tokens. GPT 5.5 Pro is documented with the same 1,050,000-token context window and 128,000 max output tokens, supports structured outputs, and is designed for slower long-running Responses API requests.

OpenRouter also exposes `openai/gpt-5.5` and `openai/gpt-5.5-pro`, so the existing fallback path is preserved.

## How to test

- `pnpm lint`
- `pnpm build`
- `npx tsx -e "import { getModelByKey } from './lib/ai/modelCatalog'; import { MODEL_SLUG } from './scripts/uploadsCatalog'; import { openAiReasoningEffortAttempts, openRouterReasoningEffortAttempts } from './lib/ai/reasoningProfiles'; const keys=['openai_gpt_5_5','openai_gpt_5_5_pro'] as const; for (const key of keys) console.log(key, getModelByKey(key).modelId, MODEL_SLUG[key]); console.log(openAiReasoningEffortAttempts('gpt-5.5-2026-04-23')?.join(',')); console.log(openAiReasoningEffortAttempts('gpt-5.5-pro-2026-04-23')?.join(',')); console.log(openRouterReasoningEffortAttempts('openai/gpt-5.5')?.join(',')); console.log(openRouterReasoningEffortAttempts('openai/gpt-5.5-pro')?.join(','));"`

`pnpm build` completed successfully. It emitted the repo's expected sitemap fallback warning because `DATABASE_URL` is not set in the clean worktree.

## Checklist

- [x] Catalog entries added
- [x] Upload slugs added
- [x] Reasoning-effort defaults use max supported thinking first
- [x] GPT 5.5 Pro stays on the Responses/background path
- [x] Lint and build pass

_(PR Body Written by Codex)_