### PR TITLE
(fix) improve gif export compression

### DIFF
--- a/components/sandbox/SandboxGifExportButton.tsx
+++ b/components/sandbox/SandboxGifExportButton.tsx
@@ -37,7 +37,40 @@ const LOSSLESS_OPT_LARGE_INPUT_BYTES = 10 * 1024 * 1024;
 const LOSSLESS_OPT_ALWAYS_KEEP_BYTES = 15 * 1024 * 1024;
 const LOSSLESS_OPT_MIN_ABS_SAVINGS_BYTES = 256 * 1024;
 const LOSSLESS_OPT_MIN_RELATIVE_SAVINGS = 0.03;
-const LOSSLESS_OPT_TARGET_MAX_BYTES = 15 * 1024 * 1024;
+const GIF_OPT_TARGET_MAX_BYTES = 15 * 1024 * 1024;
+// try cheaper loss first then resize only when size still blows past target
+const LOSSY_OPT_LEVELS = [20, 35, 50, 70, 90, 120] as const;
+const FINAL_LOSSY_OPT_LEVELS = [160, 200] as const;
+const RESIZE_OPT_STEPS: Record<
+  GifExportFormat,
+  ReadonlyArray<{ dimensions: string; lossy: number }>
+> = {
+  wide: [
+    { dimensions: "1600x900", lossy: 50 },
+    { dimensions: "1440x810", lossy: 70 },
+    { dimensions: "1280x720", lossy: 90 },
+    { dimensions: "960x540", lossy: 120 },
+  ],
+  vertical: [
+    { dimensions: "900x1600", lossy: 50 },
+    { dimensions: "810x1440", lossy: 70 },
+    { dimensions: "720x1280", lossy: 90 },
+    { dimensions: "540x960", lossy: 120 },
+  ],
+};
+const FINAL_RESIZE_OPT_STEPS: Record<
+  GifExportFormat,
+  ReadonlyArray<{ dimensions: string; lossy: number }>
+> = {
+  wide: [
+    { dimensions: "854x480", lossy: 160 },
+    { dimensions: "720x405", lossy: 200 },
+  ],
+  vertical: [
+    { dimensions: "480x854", lossy: 160 },
+    { dimensions: "405x720", lossy: 200 },
+  ],
+};
 
 const EXPORT_MARGIN_X = 22;
 const EXPORT_MARGIN_BOTTOM = 22;
@@ -231,7 +264,7 @@ function buildPaletteSampleFrames(frameCount: number, sampleCount: number): numb
   return Array.from(frames).sort((a, b) => a - b);
 }
 
-async function optimizeGifBlobLossless(input: Blob): Promise<Blob> {
+async function optimizeGifBlobForSize(input: Blob, format: GifExportFormat): Promise<Blob> {
   if (input.size < LOSSLESS_OPT_MIN_INPUT_BYTES) return input;
 
   try {
@@ -240,41 +273,77 @@ async function optimizeGifBlobLossless(input: Blob): Promise<Blob> {
       input.arrayBuffer(),
     ]);
 
-    const runOptimize = async (level: "-O2" | "-O3") => {
+    const runOptimize = async (command: string) => {
       const outputs = await gifsicle.run({
         input: [{ file: inputBytes.slice(0), name: "in.gif" }],
-        command: [`${level} in.gif -o /out/out.gif`],
+        command: [`${command} in.gif -o /out/out.gif`],
         isStrict: true,
       });
       return outputs.find((file) => file.name.toLowerCase().endsWith(".gif")) ?? null;
     };
 
     const primaryLevel = input.size >= LOSSLESS_OPT_LARGE_INPUT_BYTES ? "-O2" : "-O3";
+    const lossyOptimizeLevel = input.size >= LOSSLESS_OPT_LARGE_INPUT_BYTES ? "-O2" : "-O3";
     let optimized = await runOptimize(primaryLevel);
+    let best = optimized && optimized.size < input.size ? optimized : input;
 
     if (
       primaryLevel === "-O2" &&
       optimized &&
-      optimized.size > LOSSLESS_OPT_TARGET_MAX_BYTES &&
+      optimized.size > GIF_OPT_TARGET_MAX_BYTES &&
       optimized.size < input.size
     ) {
       const tighter = await runOptimize("-O3");
       if (tighter && tighter.size < optimized.size) optimized = tighter;
+      if (tighter && tighter.size < best.size) best = tighter;
     }
 
-    if (!optimized) return input;
+    if (!optimized && best === input) return input;
+    if (best.size > GIF_OPT_TARGET_MAX_BYTES) {
+      for (const lossyLevel of LOSSY_OPT_LEVELS) {
+        // use the least lossy setting that gets under the target
+        const lossy = await runOptimize(`${lossyOptimizeLevel} --lossy=${lossyLevel}`);
+        if (lossy && lossy.size < best.size) best = lossy;
+        if (lossy && lossy.size <= GIF_OPT_TARGET_MAX_BYTES) return lossy;
+      }
+
+      for (const step of RESIZE_OPT_STEPS[format]) {
+        const resized = await runOptimize(
+          `${lossyOptimizeLevel} --lossy=${step.lossy} --resize-fit ${step.dimensions}`,
+        );
+        if (resized && resized.size < best.size) best = resized;
+        if (resized && resized.size <= GIF_OPT_TARGET_MAX_BYTES) return resized;
+      }
+
+      for (const lossyLevel of FINAL_LOSSY_OPT_LEVELS) {
+        const lossy = await runOptimize(`${lossyOptimizeLevel} --lossy=${lossyLevel}`);
+        if (lossy && lossy.size < best.size) best = lossy;
+        if (lossy && lossy.size <= GIF_OPT_TARGET_MAX_BYTES) return lossy;
+      }
+
+      for (const step of FINAL_RESIZE_OPT_STEPS[format]) {
+        const resized = await runOptimize(
+          `${lossyOptimizeLevel} --lossy=${step.lossy} --resize-fit ${step.dimensions}`,
+        );
+        if (resized && resized.size < best.size) best = resized;
+        if (resized && resized.size <= GIF_OPT_TARGET_MAX_BYTES) return resized;
+      }
+
+      return best;
+    }
+
     if (input.size >= LOSSLESS_OPT_ALWAYS_KEEP_BYTES) {
-      return optimized.size < input.size ? optimized : input;
+      return best.size < input.size ? best : input;
     }
 
-    const savings = input.size - optimized.size;
+    const savings = input.size - best.size;
     const relativeSavings = savings / Math.max(1, input.size);
     const meaningful =
       savings >= LOSSLESS_OPT_MIN_ABS_SAVINGS_BYTES &&
       relativeSavings >= LOSSLESS_OPT_MIN_RELATIVE_SAVINGS;
-    return meaningful ? optimized : input;
+    return meaningful ? best : input;
   } catch (err) {
-    console.warn("[gif-export] lossless optimize skipped", err);
+    console.warn("[gif-export] optimize skipped", err);
     return input;
   }
 }
@@ -648,19 +717,25 @@ function GifFormatSelector({
   format,
   disabled,
   compact,
+  embedded,
   onChange,
 }: {
   format: GifExportFormat;
   disabled: boolean;
   compact?: boolean;
+  embedded?: boolean;
   onChange: (format: GifExportFormat) => void;
 }) {
   return (
     <div
       role="group"
       aria-label="GIF format"
-      className={`inline-flex shrink-0 items-center rounded-full border border-border/70 bg-bg/45 p-0.5 text-muted shadow-[0_12px_30px_-24px_rgba(4,11,31,0.9)] backdrop-blur-sm ${
-        compact ? "h-8" : "h-9"
+      className={`inline-flex shrink-0 items-center rounded-full text-muted ${
+        embedded
+          ? "p-0"
+          : "border border-border/70 bg-bg/45 p-0.5 shadow-[0_12px_30px_-24px_rgba(4,11,31,0.9)] backdrop-blur-sm"
+      } ${
+        compact ? "h-7" : "h-8"
       }`}
     >
       {GIF_FORMATS.map((value) => {
@@ -675,12 +750,12 @@ function GifFormatSelector({
             aria-pressed={active}
             title={label}
             onClick={() => onChange(value)}
-            className={`grid place-items-center rounded-full transition disabled:cursor-not-allowed disabled:opacity-45 ${
+            className={`grid place-items-center rounded-full transition-colors duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/55 disabled:cursor-not-allowed disabled:opacity-45 ${
               compact ? "h-7 w-7" : "h-8 w-8"
             } ${
               active
-                ? "bg-fg/14 text-fg shadow-[inset_0_0_0_1px_rgba(255,255,255,0.08)]"
-                : "hover:bg-fg/7 hover:text-fg"
+                ? "bg-accent/15 text-accent ring-1 ring-accent/40 shadow-[0_8px_20px_-16px_hsl(var(--accent)_/_0.7)]"
+                : "text-muted/75 hover:bg-fg/7 hover:text-fg"
             }`}
           >
             <FormatIcon format={value} />
@@ -719,7 +794,7 @@ export function SandboxGifExportButton({ targets, promptText, label, iconOnly, c
       });
       setOptimizing(true);
       setProgress(null);
-      const finalBlob = await optimizeGifBlobLossless(blob);
+      const finalBlob = await optimizeGifBlobForSize(blob, format);
       const modelToken = targets.map((t) => sanitizeFilePart(t.modelName) || "model").join("-vs-");
       const promptToken = sanitizeFilePart(promptText ?? "sandbox");
       const stamp = new Date().toISOString().replace(/[:.]/g, "-");
@@ -750,7 +825,13 @@ export function SandboxGifExportButton({ targets, promptText, label, iconOnly, c
   const isUnavailable = !hasTargets;
   const shouldKeepTooltipVisible = Boolean(iconOnly && (busy || error));
   const formatSelector = (
-    <GifFormatSelector format={format} disabled={busy} compact={iconOnly} onChange={setFormat} />
+    <GifFormatSelector
+      format={format}
+      disabled={busy}
+      compact={iconOnly}
+      embedded
+      onChange={setFormat}
+    />
   );
 
   const button = (
@@ -763,7 +844,11 @@ export function SandboxGifExportButton({ targets, promptText, label, iconOnly, c
       title={iconOnly ? undefined : buttonTitle}
       onClick={() => void handleExport()}
       disabled={isUnavailable}
-      className={`${iconOnly ? "mb-btn mb-btn-ghost h-8 w-8 rounded-full border border-border/70 bg-bg/55 p-0 text-muted hover:text-fg" : "mb-btn mb-btn-ghost h-9 rounded-full border border-border/70 bg-bg/55 px-3 text-xs tracking-[0.01em] backdrop-blur-sm sm:text-sm"} ${busy ? "cursor-progress opacity-75" : ""} disabled:cursor-not-allowed disabled:opacity-40 ${className ?? ""}`}
+      className={`inline-flex select-none items-center justify-center rounded-full font-semibold text-fg transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/35 ${
+        iconOnly
+          ? "h-7 w-7 p-0 text-muted hover:bg-fg/7 hover:text-fg"
+          : `h-8 gap-1.5 px-3 text-xs tracking-[0.01em] hover:bg-fg/7 sm:px-3.5 sm:text-sm ${className ?? ""}`
+      } ${busy ? "cursor-progress opacity-75" : ""} disabled:cursor-not-allowed disabled:opacity-40`}
     >
       <span className={`inline-flex items-center ${iconOnly ? "justify-center" : "gap-1.5"}`}>
         <svg
@@ -786,15 +871,16 @@ export function SandboxGifExportButton({ targets, promptText, label, iconOnly, c
 
   if (!iconOnly) {
     return (
-      <div className="inline-flex items-center gap-1.5">
+      <div className="inline-flex h-9 items-center rounded-full border border-border/70 bg-bg/55 p-0.5 shadow-[0_18px_44px_-28px_rgba(4,11,31,0.95)] backdrop-blur-sm">
         {formatSelector}
+        <span className="mx-1 h-4 w-px bg-border/45" aria-hidden="true" />
         {button}
       </div>
     );
   }
 
   return (
-    <div className="group/gif-export relative inline-flex items-center gap-1">
+    <div className="group/gif-export relative inline-flex h-8 items-center rounded-full border border-border/70 bg-bg/55 p-0.5 shadow-[0_18px_44px_-28px_rgba(4,11,31,0.95)] backdrop-blur-sm">
       <div
         id={tooltipId}
         role="status"
@@ -804,6 +890,7 @@ export function SandboxGifExportButton({ targets, promptText, label, iconOnly, c
         <span className="block truncate">{buttonTitle}</span>
       </div>
       {formatSelector}
+      <span className="mx-1 h-3.5 w-px bg-border/45" aria-hidden="true" />
       {button}
     </div>
   );

--- a/components/sandbox/SandboxGifExportButton.tsx
+++ b/components/sandbox/SandboxGifExportButton.tsx
@@ -28,8 +28,8 @@ const GIF_DELAY_TICK_MS = 10;
 const ROTATION_SLOWDOWN_FACTOR = 1.25;
 const MAX_IN_FLIGHT_FRAMES = 6;
 const YIELD_EVERY_FRAMES = 50;
-const PALETTE_SAMPLE_COUNT = 12;
-const PALETTE_SAMPLE_SIZE = { width: 640, height: 360 };
+const PALETTE_SAMPLE_COUNT = 18;
+const PALETTE_SAMPLE_LONG_EDGE = 720;
 const EXPORT_SIZE_WIDE = { width: 1920, height: 1080 };
 const EXPORT_SIZE_VERTICAL = { width: 1080, height: 1920 };
 const LOSSLESS_OPT_MIN_INPUT_BYTES = 6 * 1024 * 1024;
@@ -38,41 +38,26 @@ const LOSSLESS_OPT_ALWAYS_KEEP_BYTES = 15 * 1024 * 1024;
 const LOSSLESS_OPT_MIN_ABS_SAVINGS_BYTES = 256 * 1024;
 const LOSSLESS_OPT_MIN_RELATIVE_SAVINGS = 0.03;
 const GIF_OPT_TARGET_MAX_BYTES = 15 * 1024 * 1024;
-// try cheaper loss first then resize only when size still blows past target
-const LOSSY_OPT_LEVELS = [20, 35, 50, 70, 90, 120] as const;
-const FINAL_LOSSY_OPT_LEVELS = [160, 200] as const;
-const RESIZE_OPT_STEPS: Record<
+// keep post-processing light so color and motion stay stable
+const LOSSY_OPT_LEVELS = [12, 20, 28, 35] as const;
+const EXPORT_RENDER_PROFILES: Record<
   GifExportFormat,
-  ReadonlyArray<{ dimensions: string; lossy: number }>
+  ReadonlyArray<{ width: number; height: number }>
 > = {
   wide: [
-    { dimensions: "1600x900", lossy: 50 },
-    { dimensions: "1440x810", lossy: 70 },
-    { dimensions: "1280x720", lossy: 90 },
-    { dimensions: "960x540", lossy: 120 },
+    EXPORT_SIZE_WIDE,
+    { width: 1600, height: 900 },
+    { width: 1440, height: 810 },
+    { width: 1280, height: 720 },
+    { width: 960, height: 540 },
   ],
   vertical: [
-    { dimensions: "900x1600", lossy: 50 },
-    { dimensions: "810x1440", lossy: 70 },
-    { dimensions: "720x1280", lossy: 90 },
-    { dimensions: "540x960", lossy: 120 },
-  ],
-};
-const HARD_CAP_RESIZE_OPT_STEPS: Record<
-  GifExportFormat,
-  ReadonlyArray<{ dimensions: string; lossy: number; colors?: number }>
-> = {
-  wide: [
-    { dimensions: "854x480", lossy: 160 },
-    { dimensions: "720x405", lossy: 200, colors: 192 },
-    { dimensions: "640x360", lossy: 240, colors: 160 },
-    { dimensions: "480x270", lossy: 280, colors: 128 },
-  ],
-  vertical: [
-    { dimensions: "480x854", lossy: 160 },
-    { dimensions: "405x720", lossy: 200, colors: 192 },
-    { dimensions: "360x640", lossy: 240, colors: 160 },
-    { dimensions: "270x480", lossy: 280, colors: 128 },
+    EXPORT_SIZE_VERTICAL,
+    { width: 900, height: 1600 },
+    { width: 810, height: 1440 },
+    { width: 720, height: 1280 },
+    { width: 640, height: 1138 },
+    { width: 540, height: 960 },
   ],
 };
 
@@ -97,6 +82,8 @@ type ExportLayout = {
     urlText: string;
   };
 };
+
+type GifRenderProfile = (typeof EXPORT_RENDER_PROFILES)[GifExportFormat][number];
 
 function buildFrameDelaySchedule(frameCount: number, slowdownFactor: number): number[] {
   const baseDelayTicks = Math.max(1, Math.round(FRAME_DELAY_MS / GIF_DELAY_TICK_MS));
@@ -255,7 +242,15 @@ function buildPaletteSampleFrames(frameCount: number, sampleCount: number): numb
   return Array.from(frames).sort((a, b) => a - b);
 }
 
-async function optimizeGifBlobForSize(input: Blob, format: GifExportFormat): Promise<Blob> {
+function getPaletteSampleSize(profile: GifRenderProfile) {
+  const scale = PALETTE_SAMPLE_LONG_EDGE / Math.max(profile.width, profile.height);
+  return {
+    width: Math.max(1, Math.round(profile.width * scale)),
+    height: Math.max(1, Math.round(profile.height * scale)),
+  };
+}
+
+async function optimizeGifBlobForSize(input: Blob): Promise<Blob> {
   if (input.size < LOSSLESS_OPT_MIN_INPUT_BYTES) return input;
 
   try {
@@ -289,36 +284,20 @@ async function optimizeGifBlobForSize(input: Blob, format: GifExportFormat): Pro
       if (tighter && tighter.size < best.size) best = tighter;
     }
 
-    if (!optimized && best === input) return input;
+    if (!optimized && best === input) {
+      if (input.size > GIF_OPT_TARGET_MAX_BYTES) {
+        throw new Error(
+          `GIF stayed above 15 MB after optimization (${(input.size / 1024 / 1024).toFixed(1)} MB)`,
+        );
+      }
+      return input;
+    }
     if (best.size > GIF_OPT_TARGET_MAX_BYTES) {
       for (const lossyLevel of LOSSY_OPT_LEVELS) {
         // use the least lossy setting that gets under the target
         const lossy = await runOptimize(`${lossyOptimizeLevel} --lossy=${lossyLevel}`);
         if (lossy && lossy.size < best.size) best = lossy;
         if (lossy && lossy.size <= GIF_OPT_TARGET_MAX_BYTES) return lossy;
-      }
-
-      for (const step of RESIZE_OPT_STEPS[format]) {
-        const resized = await runOptimize(
-          `${lossyOptimizeLevel} --lossy=${step.lossy} --resize-fit ${step.dimensions}`,
-        );
-        if (resized && resized.size < best.size) best = resized;
-        if (resized && resized.size <= GIF_OPT_TARGET_MAX_BYTES) return resized;
-      }
-
-      for (const lossyLevel of FINAL_LOSSY_OPT_LEVELS) {
-        const lossy = await runOptimize(`${lossyOptimizeLevel} --lossy=${lossyLevel}`);
-        if (lossy && lossy.size < best.size) best = lossy;
-        if (lossy && lossy.size <= GIF_OPT_TARGET_MAX_BYTES) return lossy;
-      }
-
-      for (const step of HARD_CAP_RESIZE_OPT_STEPS[format]) {
-        const colorsArg = step.colors ? ` --colors ${step.colors}` : "";
-        const resized = await runOptimize(
-          `${lossyOptimizeLevel} --lossy=${step.lossy}${colorsArg} --resize-fit ${step.dimensions}`,
-        );
-        if (resized && resized.size < best.size) best = resized;
-        if (resized && resized.size <= GIF_OPT_TARGET_MAX_BYTES) return resized;
       }
 
       throw new Error(
@@ -498,23 +477,25 @@ function renderCompositeFrame(
 
 async function buildPaletteSamples(
   targets: SandboxGifExportTarget[],
-  promptText: string,
   format: GifExportFormat,
+  profile: GifRenderProfile,
 ) {
+  const sampleSize = getPaletteSampleSize(profile);
   const sampleCanvas = document.createElement("canvas");
-  sampleCanvas.width = PALETTE_SAMPLE_SIZE.width;
-  sampleCanvas.height = PALETTE_SAMPLE_SIZE.height;
+  sampleCanvas.width = sampleSize.width;
+  sampleCanvas.height = sampleSize.height;
   const sampleCtx = sampleCanvas.getContext("2d", { willReadFrequently: true });
   if (!sampleCtx) throw new Error("Unable to initialize palette sampler");
   sampleCtx.imageSmoothingEnabled = true;
   sampleCtx.imageSmoothingQuality = "high";
 
+  // palette pass uses short prompt so model colors stay dominant
   const layout = buildExportLayout(
     sampleCtx,
     targets.length,
     sampleCanvas.width,
     sampleCanvas.height,
-    promptText,
+    "",
     format,
   );
   const samples: ArrayBuffer[] = [];
@@ -536,9 +517,10 @@ async function buildGifBlob(
   targets: SandboxGifExportTarget[],
   promptText: string,
   format: GifExportFormat,
+  profile: GifRenderProfile,
   onProgress?: (done: number, total: number) => void,
 ) {
-  const { width, height } = format === "vertical" ? EXPORT_SIZE_VERTICAL : EXPORT_SIZE_WIDE;
+  const { width, height } = profile;
 
   const frameCanvas = document.createElement("canvas");
   frameCanvas.width = width;
@@ -612,7 +594,7 @@ async function buildGifBlob(
   worker.postMessage({ type: "start" });
   await readyPromise;
 
-  const paletteSamples = await buildPaletteSamples(targets, promptText, format);
+  const paletteSamples = await buildPaletteSamples(targets, format, profile);
   if (paletteSamples.length > 0) {
     worker.postMessage({ type: "palette", samples: paletteSamples }, paletteSamples);
   }
@@ -771,6 +753,9 @@ export function SandboxGifExportButton({ targets, promptText, label, iconOnly, c
   const [optimizing, setOptimizing] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [progress, setProgress] = useState<{ done: number; total: number } | null>(null);
+  const [profileAttempt, setProfileAttempt] = useState<{ index: number; total: number } | null>(
+    null,
+  );
   const [format, setFormat] = useState<GifExportFormat>("wide");
 
   const hasTargets = targets.length > 0;
@@ -786,14 +771,45 @@ export function SandboxGifExportButton({ targets, promptText, label, iconOnly, c
     setOptimizing(false);
     setError(null);
     setProgress({ done: 0, total: FRAME_COUNT });
+    setProfileAttempt(null);
     await waitForNextPaint();
     try {
-      const blob = await buildGifBlob(targets, promptText ?? "", format, (done, total) => {
-        if (done === total || done % 2 === 0) setProgress({ done, total });
-      });
-      setOptimizing(true);
-      setProgress(null);
-      const finalBlob = await optimizeGifBlobForSize(blob, format);
+      const profiles = EXPORT_RENDER_PROFILES[format];
+      let finalBlob: Blob | null = null;
+      let lastError: unknown = null;
+
+      for (let idx = 0; idx < profiles.length; idx += 1) {
+        const profile = profiles[idx] ?? profiles[profiles.length - 1];
+        setProfileAttempt({ index: idx + 1, total: profiles.length });
+        setOptimizing(false);
+        setProgress({ done: 0, total: FRAME_COUNT });
+
+        const blob = await buildGifBlob(
+          targets,
+          promptText ?? "",
+          format,
+          profile,
+          (done, total) => {
+            if (done === total || done % 2 === 0) setProgress({ done, total });
+          },
+        );
+
+        setOptimizing(true);
+        setProgress(null);
+        try {
+          finalBlob = await optimizeGifBlobForSize(blob);
+          break;
+        } catch (err) {
+          lastError = err;
+          if (idx === profiles.length - 1) throw err;
+          await waitForNextPaint();
+        }
+      }
+
+      if (!finalBlob) {
+        throw lastError instanceof Error ? lastError : new Error("GIF export failed");
+      }
+
       const modelToken = targets.map((t) => sanitizeFilePart(t.modelName) || "model").join("-vs-");
       const promptToken = sanitizeFilePart(promptText ?? "sandbox");
       const stamp = new Date().toISOString().replace(/[:.]/g, "-");
@@ -809,14 +825,19 @@ export function SandboxGifExportButton({ targets, promptText, label, iconOnly, c
       setOptimizing(false);
       setExporting(false);
       setProgress(null);
+      setProfileAttempt(null);
     }
   }
 
+  const passLabel =
+    profileAttempt && profileAttempt.total > 1
+      ? ` pass ${profileAttempt.index}/${profileAttempt.total}`
+      : "";
   const displayLabel = exporting
     ? optimizing
-      ? "Optimizing..."
+      ? `Optimizing${passLabel}...`
       : progress
-        ? `Rendering ${Math.max(0, progress.done)}/${progress.total}`
+        ? `Rendering ${Math.max(0, progress.done)}/${progress.total}${passLabel}`
         : "Rendering..."
     : (label ?? (targets.length === 2 ? "Export comparison GIF" : "Export GIF"));
   const buttonTitle = error ?? displayLabel;

--- a/components/sandbox/SandboxGifExportButton.tsx
+++ b/components/sandbox/SandboxGifExportButton.tsx
@@ -753,9 +753,6 @@ export function SandboxGifExportButton({ targets, promptText, label, iconOnly, c
   const [optimizing, setOptimizing] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [progress, setProgress] = useState<{ done: number; total: number } | null>(null);
-  const [profileAttempt, setProfileAttempt] = useState<{ index: number; total: number } | null>(
-    null,
-  );
   const [format, setFormat] = useState<GifExportFormat>("wide");
 
   const hasTargets = targets.length > 0;
@@ -771,7 +768,6 @@ export function SandboxGifExportButton({ targets, promptText, label, iconOnly, c
     setOptimizing(false);
     setError(null);
     setProgress({ done: 0, total: FRAME_COUNT });
-    setProfileAttempt(null);
     await waitForNextPaint();
     try {
       const profiles = EXPORT_RENDER_PROFILES[format];
@@ -780,7 +776,6 @@ export function SandboxGifExportButton({ targets, promptText, label, iconOnly, c
 
       for (let idx = 0; idx < profiles.length; idx += 1) {
         const profile = profiles[idx] ?? profiles[profiles.length - 1];
-        setProfileAttempt({ index: idx + 1, total: profiles.length });
         setOptimizing(false);
         setProgress({ done: 0, total: FRAME_COUNT });
 
@@ -825,19 +820,14 @@ export function SandboxGifExportButton({ targets, promptText, label, iconOnly, c
       setOptimizing(false);
       setExporting(false);
       setProgress(null);
-      setProfileAttempt(null);
     }
   }
 
-  const passLabel =
-    profileAttempt && profileAttempt.total > 1
-      ? ` pass ${profileAttempt.index}/${profileAttempt.total}`
-      : "";
   const displayLabel = exporting
     ? optimizing
-      ? `Optimizing${passLabel}...`
+      ? "Optimizing..."
       : progress
-        ? `Rendering ${Math.max(0, progress.done)}/${progress.total}${passLabel}`
+        ? `Rendering ${Math.max(0, progress.done)}/${progress.total}`
         : "Rendering..."
     : (label ?? (targets.length === 2 ? "Export comparison GIF" : "Export GIF"));
   const buttonTitle = error ?? displayLabel;

--- a/components/sandbox/SandboxGifExportButton.tsx
+++ b/components/sandbox/SandboxGifExportButton.tsx
@@ -68,6 +68,7 @@ const PANEL_PAD = 12;
 const PANEL_META_HEIGHT = 62;
 const PANEL_RADIUS = 18;
 const CAPTURE_RADIUS = 14;
+const MIN_EXPORT_PANEL_HEIGHT = 220;
 const HEADER_PROMPT_FONT = '600 18px "IBM Plex Sans", "Segoe UI", sans-serif';
 const HEADER_PROMPT_LINE_HEIGHT = 23;
 const GIF_FORMATS: GifExportFormat[] = ["wide", "vertical"];
@@ -160,6 +161,38 @@ function wrapTextLines(ctx: CanvasRenderingContext2D, text: string, maxWidth: nu
   return lines;
 }
 
+function fitTextWithEllipsis(ctx: CanvasRenderingContext2D, text: string, maxWidth: number) {
+  const clean = text.replace(/\s+/g, " ").trim();
+  if (!clean || ctx.measureText(clean).width <= maxWidth) return clean;
+
+  const suffix = "...";
+  let lo = 0;
+  let hi = clean.length;
+  while (lo < hi) {
+    const mid = Math.ceil((lo + hi) / 2);
+    const candidate = `${clean.slice(0, mid).replace(/\s+$/g, "")}${suffix}`;
+    if (ctx.measureText(candidate).width <= maxWidth) lo = mid;
+    else hi = mid - 1;
+  }
+
+  return `${clean.slice(0, lo).replace(/\s+$/g, "")}${suffix}`;
+}
+
+function capPromptLines(
+  ctx: CanvasRenderingContext2D,
+  lines: string[],
+  maxLines: number,
+  maxWidth: number,
+) {
+  const lineLimit = Math.max(1, maxLines);
+  if (lines.length <= lineLimit) return lines;
+
+  const visible = lines.slice(0, lineLimit);
+  const overflowText = lines.slice(lineLimit - 1).join(" ");
+  visible[lineLimit - 1] = fitTextWithEllipsis(ctx, overflowText, maxWidth);
+  return visible;
+}
+
 function roundedRectPath(
   ctx: CanvasRenderingContext2D,
   x: number,
@@ -189,11 +222,15 @@ function buildExportLayout(
   const panelGap = count === 1 ? 0 : PANEL_GAP;
   ctx.font = HEADER_PROMPT_FONT;
   const normalizedPrompt = promptText.replace(/\s+/g, " ").trim();
-  const promptLines = wrapTextLines(
-    ctx,
-    `Prompt: ${normalizedPrompt || "sandbox prompt"}`,
-    width - 56,
-  );
+  const promptMaxWidth = width - 56;
+  const allPromptLines = wrapTextLines(ctx, `Prompt: ${normalizedPrompt || "sandbox prompt"}`, promptMaxWidth);
+  const maxPanelTop =
+    format === "vertical"
+      ? height - EXPORT_MARGIN_BOTTOM - panelGap * (count - 1) - MIN_EXPORT_PANEL_HEIGHT * count
+      : height - EXPORT_MARGIN_BOTTOM - MIN_EXPORT_PANEL_HEIGHT;
+  // free-form prompts still need room for viewers
+  const maxPromptLines = Math.floor((maxPanelTop - 84) / HEADER_PROMPT_LINE_HEIGHT);
+  const promptLines = capPromptLines(ctx, allPromptLines, maxPromptLines, promptMaxWidth);
   const panelTop = Math.max(104, 60 + promptLines.length * HEADER_PROMPT_LINE_HEIGHT + 24);
   const panelRects =
     format === "vertical"
@@ -857,8 +894,8 @@ export function SandboxGifExportButton({ targets, promptText, label, iconOnly, c
       className={`inline-flex select-none items-center justify-center rounded-full font-semibold text-fg transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/35 ${
         iconOnly
           ? "h-7 w-7 p-0 text-muted hover:bg-fg/7 hover:text-fg"
-          : `h-8 gap-1.5 px-3 text-xs tracking-[0.01em] hover:bg-fg/7 sm:px-3.5 sm:text-sm ${className ?? ""}`
-      } ${busy ? "cursor-progress opacity-75" : ""} disabled:cursor-not-allowed disabled:opacity-40`}
+          : "h-8 gap-1.5 px-3 text-xs tracking-[0.01em] hover:bg-fg/7 sm:px-3.5 sm:text-sm"
+      } ${busy ? "cursor-progress opacity-75" : ""} disabled:cursor-not-allowed disabled:opacity-40 ${className ?? ""}`}
     >
       <span className={`inline-flex items-center ${iconOnly ? "justify-center" : "gap-1.5"}`}>
         <svg

--- a/components/sandbox/SandboxGifExportButton.tsx
+++ b/components/sandbox/SandboxGifExportButton.tsx
@@ -26,8 +26,8 @@ const GIF_DELAY_TICK_MS = 10;
 const ROTATION_SLOWDOWN_FACTOR = 1.25;
 const MAX_IN_FLIGHT_FRAMES = 6;
 const YIELD_EVERY_FRAMES = 50;
-const PALETTE_SAMPLE_COUNT = 8;
-const PALETTE_SAMPLE_SIZE = { width: 480, height: 270 };
+const PALETTE_SAMPLE_COUNT = 12;
+const PALETTE_SAMPLE_SIZE = { width: 640, height: 360 };
 const EXPORT_SIZE_SINGLE = { width: 1920, height: 1080 };
 const EXPORT_SIZE_COMPARE = { width: 1920, height: 1080 };
 const LOSSLESS_OPT_MIN_INPUT_BYTES = 6 * 1024 * 1024;
@@ -44,6 +44,8 @@ const PANEL_PAD = 12;
 const PANEL_META_HEIGHT = 62;
 const PANEL_RADIUS = 18;
 const CAPTURE_RADIUS = 14;
+const HEADER_PROMPT_FONT = '600 18px "IBM Plex Sans", "Segoe UI", sans-serif';
+const HEADER_PROMPT_LINE_HEIGHT = 23;
 
 type ExportLayout = {
   width: number;
@@ -173,7 +175,7 @@ function buildExportLayout(
 ): ExportLayout {
   const panelGap = count === 1 ? 0 : PANEL_GAP;
   const panelWidth = (width - EXPORT_MARGIN_X * 2 - panelGap * (count - 1)) / count;
-  ctx.font = '500 13px "IBM Plex Sans", "Segoe UI", sans-serif';
+  ctx.font = HEADER_PROMPT_FONT;
   const normalizedPrompt = promptText.replace(/\s+/g, " ").trim();
   const promptLines = wrapTextLines(
     ctx,
@@ -181,7 +183,7 @@ function buildExportLayout(
     width - 56,
     2,
   );
-  const panelTop = Math.max(86, 54 + promptLines.length * 16 + 22);
+  const panelTop = Math.max(104, 60 + promptLines.length * HEADER_PROMPT_LINE_HEIGHT + 24);
   const panelHeight = height - panelTop - EXPORT_MARGIN_BOTTOM;
 
   return {
@@ -297,12 +299,11 @@ function drawBaseBackdrop(
   ctx.textBaseline = "top";
   ctx.fillText(opts.title, 28, 18);
 
-  ctx.fillStyle = "rgba(148, 163, 184, 0.95)";
-  ctx.font = '500 13px "IBM Plex Sans", "Segoe UI", sans-serif';
-  const promptY = 54;
-  const lineHeight = 16;
+  ctx.fillStyle = "rgba(203, 213, 225, 0.95)";
+  ctx.font = HEADER_PROMPT_FONT;
+  const promptY = 60;
   for (let i = 0; i < opts.promptLines.length; i += 1) {
-    ctx.fillText(opts.promptLines[i] ?? "", 28, promptY + i * lineHeight);
+    ctx.fillText(opts.promptLines[i] ?? "", 28, promptY + i * HEADER_PROMPT_LINE_HEIGHT);
   }
 
   ctx.fillStyle = "rgba(100, 116, 139, 0.85)";

--- a/components/sandbox/SandboxGifExportButton.tsx
+++ b/components/sandbox/SandboxGifExportButton.tsx
@@ -58,17 +58,21 @@ const RESIZE_OPT_STEPS: Record<
     { dimensions: "540x960", lossy: 120 },
   ],
 };
-const FINAL_RESIZE_OPT_STEPS: Record<
+const HARD_CAP_RESIZE_OPT_STEPS: Record<
   GifExportFormat,
-  ReadonlyArray<{ dimensions: string; lossy: number }>
+  ReadonlyArray<{ dimensions: string; lossy: number; colors?: number }>
 > = {
   wide: [
     { dimensions: "854x480", lossy: 160 },
-    { dimensions: "720x405", lossy: 200 },
+    { dimensions: "720x405", lossy: 200, colors: 192 },
+    { dimensions: "640x360", lossy: 240, colors: 160 },
+    { dimensions: "480x270", lossy: 280, colors: 128 },
   ],
   vertical: [
     { dimensions: "480x854", lossy: 160 },
-    { dimensions: "405x720", lossy: 200 },
+    { dimensions: "405x720", lossy: 200, colors: 192 },
+    { dimensions: "360x640", lossy: 240, colors: 160 },
+    { dimensions: "270x480", lossy: 280, colors: 128 },
   ],
 };
 
@@ -127,58 +131,46 @@ function waitForNextPaint() {
   });
 }
 
-function fitTextWithEllipsis(ctx: CanvasRenderingContext2D, text: string, maxWidth: number) {
-  const clean = text.replace(/\s+/g, " ").trim();
-  if (!clean) return "";
-  if (ctx.measureText(clean).width <= maxWidth) return clean;
-  const ellipsis = "...";
-  let lo = 0;
-  let hi = clean.length;
-  while (lo < hi) {
-    const mid = Math.ceil((lo + hi) / 2);
-    const candidate = `${clean.slice(0, mid).replace(/\s+$/g, "")}${ellipsis}`;
-    if (ctx.measureText(candidate).width <= maxWidth) lo = mid;
-    else hi = mid - 1;
-  }
-  return `${clean.slice(0, lo).replace(/\s+$/g, "")}${ellipsis}`;
-}
-
-function wrapTextLines(
-  ctx: CanvasRenderingContext2D,
-  text: string,
-  maxWidth: number,
-  maxLines: number,
-): string[] {
+function wrapTextLines(ctx: CanvasRenderingContext2D, text: string, maxWidth: number): string[] {
   const clean = text.replace(/\s+/g, " ").trim();
   if (!clean) return [];
   const words = clean.split(" ");
   const lines: string[] = [];
 
   let current = "";
-  let idx = 0;
-  while (idx < words.length) {
-    const next = current ? `${current} ${words[idx]}` : words[idx];
+  for (const word of words) {
+    if (ctx.measureText(word).width > maxWidth) {
+      if (current) {
+        lines.push(current);
+        current = "";
+      }
+
+      let chunk = "";
+      for (const char of word) {
+        const nextChunk = `${chunk}${char}`;
+        if (chunk && ctx.measureText(nextChunk).width > maxWidth) {
+          lines.push(chunk);
+          chunk = char;
+        } else {
+          chunk = nextChunk;
+        }
+      }
+      current = chunk;
+      continue;
+    }
+
+    const next = current ? `${current} ${word}` : word;
     if (ctx.measureText(next).width <= maxWidth || current === "") {
       current = next;
-      idx += 1;
       continue;
     }
 
     lines.push(current);
-    current = "";
-    if (lines.length >= Math.max(1, maxLines - 1)) break;
+    current = word;
   }
 
-  if (current && lines.length < maxLines) lines.push(current);
-
-  if (idx < words.length && lines.length > 0) {
-    const remainder = words.slice(idx).join(" ");
-    const last = lines.pop() ?? "";
-    const combined = last ? `${last} ${remainder}` : remainder;
-    lines.push(fitTextWithEllipsis(ctx, combined, maxWidth));
-  }
-
-  return lines.slice(0, maxLines);
+  if (current) lines.push(current);
+  return lines;
 }
 
 function roundedRectPath(
@@ -214,7 +206,6 @@ function buildExportLayout(
     ctx,
     `Prompt: ${normalizedPrompt || "sandbox prompt"}`,
     width - 56,
-    2,
   );
   const panelTop = Math.max(104, 60 + promptLines.length * HEADER_PROMPT_LINE_HEIGHT + 24);
   const panelRects =
@@ -321,15 +312,18 @@ async function optimizeGifBlobForSize(input: Blob, format: GifExportFormat): Pro
         if (lossy && lossy.size <= GIF_OPT_TARGET_MAX_BYTES) return lossy;
       }
 
-      for (const step of FINAL_RESIZE_OPT_STEPS[format]) {
+      for (const step of HARD_CAP_RESIZE_OPT_STEPS[format]) {
+        const colorsArg = step.colors ? ` --colors ${step.colors}` : "";
         const resized = await runOptimize(
-          `${lossyOptimizeLevel} --lossy=${step.lossy} --resize-fit ${step.dimensions}`,
+          `${lossyOptimizeLevel} --lossy=${step.lossy}${colorsArg} --resize-fit ${step.dimensions}`,
         );
         if (resized && resized.size < best.size) best = resized;
         if (resized && resized.size <= GIF_OPT_TARGET_MAX_BYTES) return resized;
       }
 
-      return best;
+      throw new Error(
+        `GIF stayed above 15 MB after optimization (${(best.size / 1024 / 1024).toFixed(1)} MB)`,
+      );
     }
 
     if (input.size >= LOSSLESS_OPT_ALWAYS_KEEP_BYTES) {
@@ -344,6 +338,11 @@ async function optimizeGifBlobForSize(input: Blob, format: GifExportFormat): Pro
     return meaningful ? best : input;
   } catch (err) {
     console.warn("[gif-export] optimize skipped", err);
+    if (input.size > GIF_OPT_TARGET_MAX_BYTES) {
+      throw err instanceof Error
+        ? err
+        : new Error("GIF optimization failed before it could fit under 15 MB");
+    }
     return input;
   }
 }
@@ -414,8 +413,8 @@ function drawPanel(
   const { x, y, width, height, target, capture } = opts;
   const captureX = x + PANEL_PAD;
   const captureY = y + PANEL_PAD + PANEL_META_HEIGHT;
-  const captureWidth = width - PANEL_PAD * 2;
-  const captureHeight = height - PANEL_PAD * 2 - PANEL_META_HEIGHT;
+  const captureWidth = Math.max(1, width - PANEL_PAD * 2);
+  const captureHeight = Math.max(1, height - PANEL_PAD * 2 - PANEL_META_HEIGHT);
 
   ctx.save();
   roundedRectPath(ctx, x, y, width, height, PANEL_RADIUS);

--- a/components/sandbox/SandboxGifExportButton.tsx
+++ b/components/sandbox/SandboxGifExportButton.tsx
@@ -48,6 +48,7 @@ const PANEL_RADIUS = 18;
 const CAPTURE_RADIUS = 14;
 const HEADER_PROMPT_FONT = '600 18px "IBM Plex Sans", "Segoe UI", sans-serif';
 const HEADER_PROMPT_LINE_HEIGHT = 23;
+const GIF_FORMATS: GifExportFormat[] = ["wide", "vertical"];
 
 type ExportLayout = {
   width: number;
@@ -615,6 +616,81 @@ function triggerDownload(blob: Blob, fileName: string) {
   }, 60_000);
 }
 
+function FormatIcon({ format }: { format: GifExportFormat }) {
+  const rect =
+    format === "wide"
+      ? { x: 3.5, y: 7, width: 17, height: 10, rx: 2.2 }
+      : { x: 7, y: 3.5, width: 10, height: 17, rx: 2.2 };
+  return (
+    <svg aria-hidden="true" viewBox="0 0 24 24" className="h-4 w-4">
+      <rect
+        x={rect.x}
+        y={rect.y}
+        width={rect.width}
+        height={rect.height}
+        rx={rect.rx}
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.7"
+      />
+      <path
+        d={format === "wide" ? "M7 10h10M7 14h6" : "M10 7h4M10 11h4M10 15h3"}
+        fill="none"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeWidth="1.45"
+      />
+    </svg>
+  );
+}
+
+function GifFormatSelector({
+  format,
+  disabled,
+  compact,
+  onChange,
+}: {
+  format: GifExportFormat;
+  disabled: boolean;
+  compact?: boolean;
+  onChange: (format: GifExportFormat) => void;
+}) {
+  return (
+    <div
+      role="group"
+      aria-label="GIF format"
+      className={`inline-flex shrink-0 items-center rounded-full border border-border/70 bg-bg/45 p-0.5 text-muted shadow-[0_12px_30px_-24px_rgba(4,11,31,0.9)] backdrop-blur-sm ${
+        compact ? "h-8" : "h-9"
+      }`}
+    >
+      {GIF_FORMATS.map((value) => {
+        const active = format === value;
+        const label = value === "wide" ? "Wide GIF" : "Vertical GIF";
+        return (
+          <button
+            key={value}
+            type="button"
+            disabled={disabled}
+            aria-label={label}
+            aria-pressed={active}
+            title={label}
+            onClick={() => onChange(value)}
+            className={`grid place-items-center rounded-full transition disabled:cursor-not-allowed disabled:opacity-45 ${
+              compact ? "h-7 w-7" : "h-8 w-8"
+            } ${
+              active
+                ? "bg-fg/14 text-fg shadow-[inset_0_0_0_1px_rgba(255,255,255,0.08)]"
+                : "hover:bg-fg/7 hover:text-fg"
+            }`}
+          >
+            <FormatIcon format={value} />
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
 export function SandboxGifExportButton({ targets, promptText, label, iconOnly, className }: Props) {
   const tooltipId = useId();
   const [exporting, setExporting] = useState(false);
@@ -673,69 +749,8 @@ export function SandboxGifExportButton({ targets, promptText, label, iconOnly, c
   const busy = exporting || optimizing;
   const isUnavailable = !hasTargets;
   const shouldKeepTooltipVisible = Boolean(iconOnly && (busy || error));
-  const nextFormat = format === "wide" ? "vertical" : "wide";
-  const formatTitle =
-    format === "wide" ? "Wide GIF selected. Switch to vertical." : "Vertical GIF selected. Switch to wide.";
-
-  const formatToggle = (
-    <button
-      type="button"
-      aria-label={formatTitle}
-      title={formatTitle}
-      disabled={busy}
-      onClick={() => setFormat(nextFormat)}
-      className="mb-btn mb-btn-ghost h-8 w-8 rounded-full border border-border/70 bg-bg/55 p-0 text-muted hover:text-fg disabled:cursor-not-allowed disabled:opacity-45"
-    >
-      <span className="sr-only">{formatTitle}</span>
-      <svg aria-hidden="true" viewBox="0 0 24 24" className="h-4 w-4">
-        {format === "wide" ? (
-          <rect
-            x="3.5"
-            y="7"
-            width="17"
-            height="10"
-            rx="2.2"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="1.7"
-          />
-        ) : (
-          <rect
-            x="7"
-            y="3.5"
-            width="10"
-            height="17"
-            rx="2.2"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="1.7"
-          />
-        )}
-      </svg>
-    </button>
-  );
-
-  const formatSegment = (
-    <div
-      role="group"
-      aria-label="GIF format"
-      className="inline-flex h-9 overflow-hidden rounded-full border border-border/70 bg-bg/55 p-0.5 text-[11px] text-muted backdrop-blur-sm"
-    >
-      {(["wide", "vertical"] as const).map((value) => (
-        <button
-          key={value}
-          type="button"
-          disabled={busy}
-          aria-pressed={format === value}
-          onClick={() => setFormat(value)}
-          className={`rounded-full px-2.5 transition disabled:cursor-not-allowed disabled:opacity-45 ${
-            format === value ? "bg-fg/12 text-fg" : "hover:text-fg"
-          }`}
-        >
-          {value === "wide" ? "16:9" : "9:16"}
-        </button>
-      ))}
-    </div>
+  const formatSelector = (
+    <GifFormatSelector format={format} disabled={busy} compact={iconOnly} onChange={setFormat} />
   );
 
   const button = (
@@ -772,7 +787,7 @@ export function SandboxGifExportButton({ targets, promptText, label, iconOnly, c
   if (!iconOnly) {
     return (
       <div className="inline-flex items-center gap-1.5">
-        {formatSegment}
+        {formatSelector}
         {button}
       </div>
     );
@@ -788,7 +803,7 @@ export function SandboxGifExportButton({ targets, promptText, label, iconOnly, c
       >
         <span className="block truncate">{buttonTitle}</span>
       </div>
-      {formatToggle}
+      {formatSelector}
       {button}
     </div>
   );

--- a/components/sandbox/SandboxGifExportButton.tsx
+++ b/components/sandbox/SandboxGifExportButton.tsx
@@ -19,6 +19,8 @@ type Props = {
   className?: string;
 };
 
+type GifExportFormat = "wide" | "vertical";
+
 const TARGET_FPS = 60;
 const FRAME_DELAY_MS = Math.round(1000 / TARGET_FPS);
 const FRAME_COUNT = 160;
@@ -28,14 +30,14 @@ const MAX_IN_FLIGHT_FRAMES = 6;
 const YIELD_EVERY_FRAMES = 50;
 const PALETTE_SAMPLE_COUNT = 12;
 const PALETTE_SAMPLE_SIZE = { width: 640, height: 360 };
-const EXPORT_SIZE_SINGLE = { width: 1920, height: 1080 };
-const EXPORT_SIZE_COMPARE = { width: 1920, height: 1080 };
+const EXPORT_SIZE_WIDE = { width: 1920, height: 1080 };
+const EXPORT_SIZE_VERTICAL = { width: 1080, height: 1920 };
 const LOSSLESS_OPT_MIN_INPUT_BYTES = 6 * 1024 * 1024;
 const LOSSLESS_OPT_LARGE_INPUT_BYTES = 10 * 1024 * 1024;
 const LOSSLESS_OPT_ALWAYS_KEEP_BYTES = 15 * 1024 * 1024;
 const LOSSLESS_OPT_MIN_ABS_SAVINGS_BYTES = 256 * 1024;
 const LOSSLESS_OPT_MIN_RELATIVE_SAVINGS = 0.03;
-const LOSSLESS_OPT_TARGET_MAX_BYTES = 30 * 1024 * 1024;
+const LOSSLESS_OPT_TARGET_MAX_BYTES = 15 * 1024 * 1024;
 
 const EXPORT_MARGIN_X = 22;
 const EXPORT_MARGIN_BOTTOM = 22;
@@ -50,10 +52,7 @@ const HEADER_PROMPT_LINE_HEIGHT = 23;
 type ExportLayout = {
   width: number;
   height: number;
-  panelWidth: number;
-  panelHeight: number;
-  panelGap: number;
-  panelTop: number;
+  panelRects: Array<{ x: number; y: number; width: number; height: number }>;
   header: {
     title: string;
     promptLines: string[];
@@ -172,9 +171,9 @@ function buildExportLayout(
   width: number,
   height: number,
   promptText: string,
+  format: GifExportFormat,
 ): ExportLayout {
   const panelGap = count === 1 ? 0 : PANEL_GAP;
-  const panelWidth = (width - EXPORT_MARGIN_X * 2 - panelGap * (count - 1)) / count;
   ctx.font = HEADER_PROMPT_FONT;
   const normalizedPrompt = promptText.replace(/\s+/g, " ").trim();
   const promptLines = wrapTextLines(
@@ -184,15 +183,34 @@ function buildExportLayout(
     2,
   );
   const panelTop = Math.max(104, 60 + promptLines.length * HEADER_PROMPT_LINE_HEIGHT + 24);
-  const panelHeight = height - panelTop - EXPORT_MARGIN_BOTTOM;
+  const panelRects =
+    format === "vertical"
+      ? Array.from({ length: count }, (_, idx) => {
+          const panelWidth = width - EXPORT_MARGIN_X * 2;
+          const panelHeight =
+            (height - panelTop - EXPORT_MARGIN_BOTTOM - panelGap * (count - 1)) / count;
+          return {
+            x: EXPORT_MARGIN_X,
+            y: panelTop + idx * (panelHeight + panelGap),
+            width: panelWidth,
+            height: panelHeight,
+          };
+        })
+      : Array.from({ length: count }, (_, idx) => {
+          const panelWidth = (width - EXPORT_MARGIN_X * 2 - panelGap * (count - 1)) / count;
+          const panelHeight = height - panelTop - EXPORT_MARGIN_BOTTOM;
+          return {
+            x: EXPORT_MARGIN_X + idx * (panelWidth + panelGap),
+            y: panelTop,
+            width: panelWidth,
+            height: panelHeight,
+          };
+        });
 
   return {
     width,
     height,
-    panelWidth,
-    panelHeight,
-    panelGap,
-    panelTop,
+    panelRects,
     header: {
       title: count === 2 ? "MineBench Comparison" : "MineBench Build",
       promptLines,
@@ -385,10 +403,10 @@ function renderCompositeFrame(
 
   for (let idx = 0; idx < targets.length; idx += 1) {
     const target = targets[idx];
-    const panelX = EXPORT_MARGIN_X + idx * (layout.panelWidth + layout.panelGap);
-    const panelY = layout.panelTop;
-    const captureWidth = Math.max(1, Math.round(layout.panelWidth - PANEL_PAD * 2));
-    const captureHeight = Math.max(1, Math.round(layout.panelHeight - PANEL_PAD * 2 - PANEL_META_HEIGHT));
+    const panel = layout.panelRects[idx];
+    if (!panel) continue;
+    const captureWidth = Math.max(1, Math.round(panel.width - PANEL_PAD * 2));
+    const captureHeight = Math.max(1, Math.round(panel.height - PANEL_PAD * 2 - PANEL_META_HEIGHT));
     const capture = target.viewerRef.current?.captureFrame({
       rotationY: angle,
       width: captureWidth,
@@ -399,17 +417,21 @@ function renderCompositeFrame(
     }
 
     drawPanel(ctx, {
-      x: panelX,
-      y: panelY,
-      width: layout.panelWidth,
-      height: layout.panelHeight,
+      x: panel.x,
+      y: panel.y,
+      width: panel.width,
+      height: panel.height,
       target,
       capture,
     });
   }
 }
 
-async function buildPaletteSamples(targets: SandboxGifExportTarget[], promptText: string) {
+async function buildPaletteSamples(
+  targets: SandboxGifExportTarget[],
+  promptText: string,
+  format: GifExportFormat,
+) {
   const sampleCanvas = document.createElement("canvas");
   sampleCanvas.width = PALETTE_SAMPLE_SIZE.width;
   sampleCanvas.height = PALETTE_SAMPLE_SIZE.height;
@@ -424,6 +446,7 @@ async function buildPaletteSamples(targets: SandboxGifExportTarget[], promptText
     sampleCanvas.width,
     sampleCanvas.height,
     promptText,
+    format,
   );
   const samples: ArrayBuffer[] = [];
   const sampleFrames = buildPaletteSampleFrames(FRAME_COUNT, PALETTE_SAMPLE_COUNT);
@@ -443,11 +466,10 @@ async function buildPaletteSamples(targets: SandboxGifExportTarget[], promptText
 async function buildGifBlob(
   targets: SandboxGifExportTarget[],
   promptText: string,
+  format: GifExportFormat,
   onProgress?: (done: number, total: number) => void,
 ) {
-  const count = targets.length;
-  const width = count === 1 ? EXPORT_SIZE_SINGLE.width : EXPORT_SIZE_COMPARE.width;
-  const height = count === 1 ? EXPORT_SIZE_SINGLE.height : EXPORT_SIZE_COMPARE.height;
+  const { width, height } = format === "vertical" ? EXPORT_SIZE_VERTICAL : EXPORT_SIZE_WIDE;
 
   const frameCanvas = document.createElement("canvas");
   frameCanvas.width = width;
@@ -521,12 +543,12 @@ async function buildGifBlob(
   worker.postMessage({ type: "start" });
   await readyPromise;
 
-  const paletteSamples = await buildPaletteSamples(targets, promptText);
+  const paletteSamples = await buildPaletteSamples(targets, promptText, format);
   if (paletteSamples.length > 0) {
     worker.postMessage({ type: "palette", samples: paletteSamples }, paletteSamples);
   }
 
-  const layout = buildExportLayout(frameCtx, count, width, height, promptText);
+  const layout = buildExportLayout(frameCtx, targets.length, width, height, promptText, format);
 
   try {
     const inFlight: Promise<void>[] = [];
@@ -583,10 +605,14 @@ function triggerDownload(blob: Blob, fileName: string) {
   const a = document.createElement("a");
   a.href = url;
   a.download = fileName;
+  a.rel = "noopener";
+  a.style.display = "none";
   document.body.appendChild(a);
   a.click();
-  a.remove();
-  URL.revokeObjectURL(url);
+  window.setTimeout(() => {
+    a.remove();
+    URL.revokeObjectURL(url);
+  }, 60_000);
 }
 
 export function SandboxGifExportButton({ targets, promptText, label, iconOnly, className }: Props) {
@@ -595,6 +621,7 @@ export function SandboxGifExportButton({ targets, promptText, label, iconOnly, c
   const [optimizing, setOptimizing] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [progress, setProgress] = useState<{ done: number; total: number } | null>(null);
+  const [format, setFormat] = useState<GifExportFormat>("wide");
 
   const hasTargets = targets.length > 0;
 
@@ -611,7 +638,7 @@ export function SandboxGifExportButton({ targets, promptText, label, iconOnly, c
     setProgress({ done: 0, total: FRAME_COUNT });
     await waitForNextPaint();
     try {
-      const blob = await buildGifBlob(targets, promptText ?? "", (done, total) => {
+      const blob = await buildGifBlob(targets, promptText ?? "", format, (done, total) => {
         if (done === total || done % 2 === 0) setProgress({ done, total });
       });
       setOptimizing(true);
@@ -621,7 +648,8 @@ export function SandboxGifExportButton({ targets, promptText, label, iconOnly, c
       const promptToken = sanitizeFilePart(promptText ?? "sandbox");
       const stamp = new Date().toISOString().replace(/[:.]/g, "-");
       const typeToken = targets.length === 2 ? "compare" : "build";
-      const fileName = `minebench-${typeToken}-${modelToken}-${promptToken}-${stamp}.gif`;
+      const formatToken = format === "vertical" ? "vertical" : "wide";
+      const fileName = `minebench-${typeToken}-${formatToken}-${modelToken}-${promptToken}-${stamp}.gif`;
       triggerDownload(finalBlob, fileName);
     } catch (err) {
       const message = err instanceof Error ? err.message : "GIF export failed";
@@ -645,6 +673,70 @@ export function SandboxGifExportButton({ targets, promptText, label, iconOnly, c
   const busy = exporting || optimizing;
   const isUnavailable = !hasTargets;
   const shouldKeepTooltipVisible = Boolean(iconOnly && (busy || error));
+  const nextFormat = format === "wide" ? "vertical" : "wide";
+  const formatTitle =
+    format === "wide" ? "Wide GIF selected. Switch to vertical." : "Vertical GIF selected. Switch to wide.";
+
+  const formatToggle = (
+    <button
+      type="button"
+      aria-label={formatTitle}
+      title={formatTitle}
+      disabled={busy}
+      onClick={() => setFormat(nextFormat)}
+      className="mb-btn mb-btn-ghost h-8 w-8 rounded-full border border-border/70 bg-bg/55 p-0 text-muted hover:text-fg disabled:cursor-not-allowed disabled:opacity-45"
+    >
+      <span className="sr-only">{formatTitle}</span>
+      <svg aria-hidden="true" viewBox="0 0 24 24" className="h-4 w-4">
+        {format === "wide" ? (
+          <rect
+            x="3.5"
+            y="7"
+            width="17"
+            height="10"
+            rx="2.2"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="1.7"
+          />
+        ) : (
+          <rect
+            x="7"
+            y="3.5"
+            width="10"
+            height="17"
+            rx="2.2"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="1.7"
+          />
+        )}
+      </svg>
+    </button>
+  );
+
+  const formatSegment = (
+    <div
+      role="group"
+      aria-label="GIF format"
+      className="inline-flex h-9 overflow-hidden rounded-full border border-border/70 bg-bg/55 p-0.5 text-[11px] text-muted backdrop-blur-sm"
+    >
+      {(["wide", "vertical"] as const).map((value) => (
+        <button
+          key={value}
+          type="button"
+          disabled={busy}
+          aria-pressed={format === value}
+          onClick={() => setFormat(value)}
+          className={`rounded-full px-2.5 transition disabled:cursor-not-allowed disabled:opacity-45 ${
+            format === value ? "bg-fg/12 text-fg" : "hover:text-fg"
+          }`}
+        >
+          {value === "wide" ? "16:9" : "9:16"}
+        </button>
+      ))}
+    </div>
+  );
 
   const button = (
     <button
@@ -677,10 +769,17 @@ export function SandboxGifExportButton({ targets, promptText, label, iconOnly, c
     </button>
   );
 
-  if (!iconOnly) return button;
+  if (!iconOnly) {
+    return (
+      <div className="inline-flex items-center gap-1.5">
+        {formatSegment}
+        {button}
+      </div>
+    );
+  }
 
   return (
-    <div className="group/gif-export relative inline-flex items-center">
+    <div className="group/gif-export relative inline-flex items-center gap-1">
       <div
         id={tooltipId}
         role="status"
@@ -689,6 +788,7 @@ export function SandboxGifExportButton({ targets, promptText, label, iconOnly, c
       >
         <span className="block truncate">{buttonTitle}</span>
       </div>
+      {formatToggle}
       {button}
     </div>
   );

--- a/components/sandbox/gifenc.worker.ts
+++ b/components/sandbox/gifenc.worker.ts
@@ -25,74 +25,24 @@ type OutMessage = OutReady | OutAck | OutResult | OutError;
 type Encoder = ReturnType<typeof createOffsetGifEncoder>;
 type Palette = number[][];
 
+const RESERVED_TRANSPARENT_COLOR: [number, number, number] = [11, 18, 32];
+
 let encoder: Encoder | null = null;
 let globalPalette: Palette | null = null;
+let opaquePalette: Palette | null = null;
 let expectedWidth = 0;
 let expectedHeight = 0;
 let transparentIndex = -1;
-let previousPixels: Uint8ClampedArray | null = null;
+let previousIndex: Uint8Array | null = null;
 
 function reset() {
   encoder = null;
   globalPalette = null;
+  opaquePalette = null;
   expectedWidth = 0;
   expectedHeight = 0;
   transparentIndex = -1;
-  previousPixels = null;
-}
-
-function pickLeastUsedPaletteIndex(indexed: Uint8Array, paletteSize: number): number {
-  if (paletteSize < 2) return -1;
-  const counts = new Uint32Array(paletteSize);
-  for (let i = 0; i < indexed.length; i += 1) {
-    counts[indexed[i] ?? 0] += 1;
-  }
-
-  let best = 0;
-  let bestCount = counts[0] ?? 0;
-  for (let i = 1; i < counts.length; i += 1) {
-    const n = counts[i] ?? 0;
-    if (n < bestCount) {
-      best = i;
-      bestCount = n;
-    }
-  }
-  return best;
-}
-
-function nearestOpaqueIndex(
-  palette: Palette,
-  excluded: number,
-  r: number,
-  g: number,
-  b: number,
-  cache: Map<number, number>,
-): number {
-  const key = (r << 16) | (g << 8) | b;
-  const cached = cache.get(key);
-  if (typeof cached === "number") return cached;
-
-  let best = excluded === 0 ? 1 : 0;
-  if (best >= palette.length) best = 0;
-  let bestDist = Number.POSITIVE_INFINITY;
-
-  for (let i = 0; i < palette.length; i += 1) {
-    if (i === excluded) continue;
-    const color = palette[i];
-    if (!color) continue;
-    const dr = (color[0] ?? 0) - r;
-    const dg = (color[1] ?? 0) - g;
-    const db = (color[2] ?? 0) - b;
-    const dist = dr * dr + dg * dg + db * db;
-    if (dist < bestDist) {
-      bestDist = dist;
-      best = i;
-      if (dist === 0) break;
-    }
-  }
-
-  cache.set(key, best);
-  return best;
+  previousIndex = null;
 }
 
 function post(msg: OutMessage, transfer?: Transferable[]) {
@@ -118,12 +68,20 @@ function buildPaletteFromSamples(samples: ArrayBuffer[]) {
     offset += view.length;
   }
 
-  return quantize(merged, 256) as Palette;
+  return quantize(merged, 255) as Palette;
+}
+
+function installPalette(palette: Palette | null) {
+  const opaque = palette && palette.length > 0 ? palette.slice(0, 255) : [[0, 0, 0]];
+  // reserve one transparent slot so real pixels never get remapped into trails
+  globalPalette = [...opaque, RESERVED_TRANSPARENT_COLOR];
+  opaquePalette = opaque;
+  transparentIndex = opaque.length;
 }
 
 function findDirtyRect(
-  pixels: Uint8ClampedArray,
-  previous: Uint8ClampedArray,
+  indexed: Uint8Array,
+  previous: Uint8Array,
   width: number,
   height: number,
 ) {
@@ -133,13 +91,8 @@ function findDirtyRect(
   let maxY = -1;
 
   for (let y = 0, px = 0; y < height; y += 1) {
-    for (let x = 0; x < width; x += 1, px += 4) {
-      const changed =
-        pixels[px] !== previous[px] ||
-        pixels[px + 1] !== previous[px + 1] ||
-        pixels[px + 2] !== previous[px + 2] ||
-        pixels[px + 3] !== previous[px + 3];
-      if (!changed) continue;
+    for (let x = 0; x < width; x += 1, px += 1) {
+      if (indexed[px] === previous[px]) continue;
       if (x < minX) minX = x;
       if (y < minY) minY = y;
       if (x > maxX) maxX = x;
@@ -157,18 +110,18 @@ function findDirtyRect(
   };
 }
 
-function extractSubPixels(
-  pixels: Uint8ClampedArray,
+function extractSubIndex(
+  indexed: Uint8Array,
   frameWidth: number,
   rect: { x: number; y: number; width: number; height: number },
 ) {
-  const subPixels = new Uint8ClampedArray(rect.width * rect.height * 4);
+  const subIndex = new Uint8Array(rect.width * rect.height);
   for (let y = 0; y < rect.height; y += 1) {
-    const srcStart = ((rect.y + y) * frameWidth + rect.x) * 4;
-    const srcEnd = srcStart + rect.width * 4;
-    subPixels.set(pixels.subarray(srcStart, srcEnd), y * rect.width * 4);
+    const srcStart = (rect.y + y) * frameWidth + rect.x;
+    const srcEnd = srcStart + rect.width;
+    subIndex.set(indexed.subarray(srcStart, srcEnd), y * rect.width);
   }
-  return subPixels;
+  return subIndex;
 }
 
 self.onmessage = (event: MessageEvent<InMessage>) => {
@@ -188,7 +141,7 @@ self.onmessage = (event: MessageEvent<InMessage>) => {
     }
 
     if (msg.type === "palette") {
-      globalPalette = buildPaletteFromSamples(msg.samples);
+      installPalette(buildPaletteFromSamples(msg.samples));
       return;
     }
 
@@ -201,26 +154,27 @@ self.onmessage = (event: MessageEvent<InMessage>) => {
       }
 
       const pixels = new Uint8ClampedArray(msg.pixels);
-      if (!globalPalette) {
-        globalPalette = quantize(pixels, 256) as Palette;
+      if (!globalPalette || !opaquePalette) {
+        installPalette(quantize(pixels, 255) as Palette);
       }
+      const palette = globalPalette;
+      const colorPalette = opaquePalette;
+      if (!palette || !colorPalette) throw new Error("Palette not initialized");
 
-      if (msg.frameIndex === 0 || !previousPixels || previousPixels.length !== pixels.length) {
-        const firstIndex = applyPalette(pixels, globalPalette);
-        if (transparentIndex < 0) {
-          transparentIndex = pickLeastUsedPaletteIndex(firstIndex, globalPalette.length);
-        }
-        encoder.writeFrame(firstIndex, msg.width, msg.height, {
-          palette: globalPalette,
+      const indexed = applyPalette(pixels, colorPalette);
+
+      if (msg.frameIndex === 0 || !previousIndex || previousIndex.length !== indexed.length) {
+        encoder.writeFrame(indexed, msg.width, msg.height, {
+          palette,
           delay: msg.delay,
           repeat: msg.frameIndex === 0 ? 0 : undefined,
         });
-        previousPixels = pixels.slice();
+        previousIndex = indexed.slice();
         post({ type: "ack", frameIndex: msg.frameIndex });
         return;
       }
 
-      const dirtyRect = findDirtyRect(pixels, previousPixels, expectedWidth, expectedHeight);
+      const dirtyRect = findDirtyRect(indexed, previousIndex, expectedWidth, expectedHeight);
       if (!dirtyRect) {
         const idleIndex = new Uint8Array([Math.max(0, transparentIndex)]);
         encoder.writeFrame(idleIndex, 1, 1, {
@@ -231,43 +185,22 @@ self.onmessage = (event: MessageEvent<InMessage>) => {
           transparentIndex: transparentIndex >= 0 ? transparentIndex : undefined,
           dispose: transparentIndex >= 0 ? 1 : undefined,
         });
-        previousPixels = pixels.slice();
+        previousIndex = indexed.slice();
         post({ type: "ack", frameIndex: msg.frameIndex });
         return;
       }
 
-      const subPixels = extractSubPixels(pixels, expectedWidth, dirtyRect);
-      const index = applyPalette(subPixels, globalPalette);
+      const index = extractSubIndex(indexed, expectedWidth, dirtyRect);
       let hasTransparentPixels = false;
 
-      if (transparentIndex >= 0 && globalPalette.length > 1) {
-        const remapCache = new Map<number, number>();
+      if (transparentIndex >= 0) {
         for (let y = 0, idx = 0; y < dirtyRect.height; y += 1) {
-          const subRowStart = y * dirtyRect.width * 4;
-          const prevRowStart = ((dirtyRect.y + y) * expectedWidth + dirtyRect.x) * 4;
+          const prevRowStart = (dirtyRect.y + y) * expectedWidth + dirtyRect.x;
           for (let x = 0; x < dirtyRect.width; x += 1, idx += 1) {
-            const subOffset = subRowStart + x * 4;
-            const prevOffset = prevRowStart + x * 4;
-            const unchanged =
-              subPixels[subOffset] === previousPixels[prevOffset] &&
-              subPixels[subOffset + 1] === previousPixels[prevOffset + 1] &&
-              subPixels[subOffset + 2] === previousPixels[prevOffset + 2] &&
-              subPixels[subOffset + 3] === previousPixels[prevOffset + 3];
-            if (unchanged) {
+            const prevOffset = prevRowStart + x;
+            if (indexed[prevOffset] === previousIndex[prevOffset]) {
               index[idx] = transparentIndex;
               hasTransparentPixels = true;
-              continue;
-            }
-
-            if (index[idx] === transparentIndex) {
-              index[idx] = nearestOpaqueIndex(
-                globalPalette,
-                transparentIndex,
-                subPixels[subOffset] ?? 0,
-                subPixels[subOffset + 1] ?? 0,
-                subPixels[subOffset + 2] ?? 0,
-                remapCache,
-              );
             }
           }
         }
@@ -281,7 +214,7 @@ self.onmessage = (event: MessageEvent<InMessage>) => {
         transparentIndex: hasTransparentPixels ? transparentIndex : undefined,
         dispose: hasTransparentPixels ? 1 : undefined,
       });
-      previousPixels = pixels.slice();
+      previousIndex = indexed.slice();
       post({ type: "ack", frameIndex: msg.frameIndex });
       return;
     }


### PR DESCRIPTION
## What does this PR do?

- Keeps GIF exports at the existing 60 FPS and 1920x1080 wide canvas size by default.
- Adds a vertical 1080x1920 GIF export mode for short-form content.
  - (for the content creators :)
- Attaches the wide/vertical layout selector to the GIF export button, with the selected format using the global translucent accent treatment.
- Fixes single-build downloads by keeping the generated object URL alive after the synthetic download click instead of revoking it immediately.
- Improves encoder compression by comparing palette-indexed frames before building dirty rectangles, so unchanged visual pixels are skipped even if raw canvas RGB values differ.
- Reserves a dedicated transparent palette slot for delta frames so real scene/background colors cannot be remapped into transparent trails.
- Samples more/larger palette frames and makes the prompt text in the exported GIF header more readable.
- Adds an adaptive 15 MB optimizer ladder: lossless first, then low-to-moderate lossy compression, then orientation-aware resize fallbacks only when needed.
  -  (also for the content creators :)

## Why?

GIF exports could still land in the 15-50 MB range, and recent delta-frame optimization could leave subtle dark blue trails as builds rotate. The old transparent-index path reused a real palette color, so newly uncovered background pixels could be forced to a neighboring blue instead of their intended color.

The export control also needed clearer hierarchy: format is a preflight choice, while Export GIF is the primary action. The selector now stays attached to the action without competing with it.

## How to test

- `npx impeccable --json components/sandbox/SandboxGifExportButton.tsx`
- `pnpm lint`
- `pnpm build`

## Checklist

- [x] `pnpm lint` passes
- [x] `pnpm build` passes
- [x] Kept 60 FPS and 1920x1080 wide export dimensions
- [x] Added 1080x1920 vertical export mode
- [x] Attached and polished the format selector
- [x] Added adaptive 15 MB optimization fallbacks
- [x] Left local prompt experiment unstaged

_(PR Body written by Codex)_