### PR TITLE
(fix) optimize sandbox build switching

### DIFF
--- a/components/leaderboard/ModelDetail.tsx
+++ b/components/leaderboard/ModelDetail.tsx
@@ -60,6 +60,22 @@ const STREAM_HARD_TIMEOUT_MS = Number.parseInt(
   process.env.NEXT_PUBLIC_ARENA_STREAM_HARD_TIMEOUT_MS ?? "35000",
   10,
 );
+const BUILD_LOAD_DEBOUNCE_MS = Number.parseInt(
+  process.env.NEXT_PUBLIC_MODEL_DETAIL_BUILD_LOAD_DEBOUNCE_MS ?? "250",
+  10,
+);
+const LARGE_BUILD_PREVIEW_BLOCKS = Number.parseInt(
+  process.env.NEXT_PUBLIC_MODEL_DETAIL_PREVIEW_BLOCKS ?? "100000",
+  10,
+);
+const FULL_BUILD_IDLE_MS = Number.parseInt(
+  process.env.NEXT_PUBLIC_MODEL_DETAIL_FULL_BUILD_IDLE_MS ?? "1200",
+  10,
+);
+const BUILD_CACHE_MAX_ENTRIES = Number.parseInt(
+  process.env.NEXT_PUBLIC_MODEL_DETAIL_BUILD_CACHE_MAX_ENTRIES ?? "8",
+  10,
+);
 
 type TimeoutSignal = {
   signal: AbortSignal;
@@ -133,6 +149,7 @@ async function readWithTimeout<T>(
 type CurvePoint = { x: number; y: number; value: number };
 type LoadedPromptBuild = {
   buildId: string;
+  variant: ArenaBuildVariant;
   voxelBuild: VoxelBuild;
   gridSize: number;
   palette: "simple" | "advanced";
@@ -178,6 +195,29 @@ function parseArenaBuildStreamLine(line: string): ArenaBuildStreamEvent | null {
   } catch {
     return null;
   }
+}
+
+function buildCacheKey(buildId: string, variant: ArenaBuildVariant) {
+  return `${buildId}:${variant}`;
+}
+
+function rememberLoadedBuild(
+  current: Record<string, LoadedPromptBuild>,
+  loadedBuild: LoadedPromptBuild,
+) {
+  const key = buildCacheKey(loadedBuild.buildId, loadedBuild.variant);
+  if (current[key]) return current;
+  const next = { ...current, [key]: loadedBuild };
+  const maxEntries =
+    Number.isFinite(BUILD_CACHE_MAX_ENTRIES) && BUILD_CACHE_MAX_ENTRIES > 0
+      ? Math.floor(BUILD_CACHE_MAX_ENTRIES)
+      : 8;
+  const keys = Object.keys(next);
+  while (keys.length > maxEntries) {
+    const oldest = keys.shift();
+    if (oldest) delete next[oldest];
+  }
+  return next;
 }
 
 async function fetchBuildVariantSnapshot(
@@ -1027,7 +1067,13 @@ export function ModelDetail({ data }: { data: ModelDetailStats }) {
   const hoveredPrompt = hoveredCurveIndex != null ? promptCurveSource[hoveredCurveIndex] : null;
   const activeBuildId = activePrompt?.build?.buildId ?? null;
   const activeBuildMeta = activePrompt?.build ?? null;
-  const activeCachedBuild = activeBuildId ? buildCache[activeBuildId] ?? null : null;
+  const activeFullCachedBuild = activeBuildId
+    ? buildCache[buildCacheKey(activeBuildId, "full")] ?? null
+    : null;
+  const activePreviewCachedBuild = activeBuildId
+    ? buildCache[buildCacheKey(activeBuildId, "preview")] ?? null
+    : null;
+  const activeCachedBuild = activeFullCachedBuild ?? activePreviewCachedBuild;
   const activeLoadedBuild =
     activeStreamingBuild && activeStreamingBuild.buildId === activeBuildId
       ? activeStreamingBuild
@@ -1035,7 +1081,7 @@ export function ModelDetail({ data }: { data: ModelDetailStats }) {
   const isActiveBuildLoading = Boolean(
     activePrompt?.build &&
       activeBuildId &&
-      !activeCachedBuild &&
+      !activeLoadedBuild &&
       activeBuildError == null,
   );
   const activeBuildLoadingLabel = useMemo(
@@ -1125,81 +1171,128 @@ export function ModelDetail({ data }: { data: ModelDetailStats }) {
       return;
     }
 
-    if (buildCacheRef.current[activeBuildId]) {
+    const getCachedBuild = (variant: ArenaBuildVariant) =>
+      buildCacheRef.current[buildCacheKey(activeBuildId, variant)] ?? null;
+    const cachedFullBuild = getCachedBuild("full");
+    const cachedPreviewBuild = getCachedBuild("preview");
+    if (cachedFullBuild || cachedPreviewBuild) {
       setActiveBuildError(null);
       setActiveBuildProgress({
-        receivedBlocks: activeBuildMeta.blockCount,
+        receivedBlocks: (cachedFullBuild ?? cachedPreviewBuild)?.blockCount ?? activeBuildMeta.blockCount,
         totalBlocks: activeBuildMeta.blockCount,
       });
       setActiveStreamingBuild(null);
-      return;
+      if (cachedFullBuild) return;
     }
 
     const controller = new AbortController();
-    setActiveBuildError(null);
-    setActiveBuildProgress({
-      receivedBlocks: 0,
-      totalBlocks: activeBuildMeta.blockCount || null,
-    });
-    setActiveStreamingBuild(null);
+    let fullTimer: ReturnType<typeof setTimeout> | null = null;
+    const largeBuild = activeBuildMeta.blockCount >= LARGE_BUILD_PREVIEW_BLOCKS;
 
-    void fetchBuildVariantStream(
-      {
+    const storePayload = (payload: BuildVariantResponse) => {
+      const loadedBuild: LoadedPromptBuild = {
         buildId: activeBuildId,
-        variant: "full",
-        checksum: activeBuildMeta.checksum,
-      },
-      {
-        signal: controller.signal,
-        allowLiveFallback: activeBuildMeta.blockCount < 100_000,
-        onProgress: (progressiveBuild, progress) => {
-          if (activeRequestRef.current !== requestId) return;
-          setActiveBuildProgress({
-            receivedBlocks: progress.receivedBlocks,
-            totalBlocks: progress.totalBlocks,
-          });
+        variant: payload.variant,
+        voxelBuild: payload.voxelBuild,
+        gridSize: activeBuildMeta.gridSize,
+        palette: activeBuildMeta.palette,
+        mode: activeBuildMeta.mode,
+        blockCount:
+          payload.variant === "full"
+            ? Math.max(activeBuildMeta.blockCount, payload.voxelBuild.blocks.length)
+            : payload.voxelBuild.blocks.length,
+      };
 
-          if (progress.receivedBlocks <= 0) return;
-          setActiveStreamingBuild({
-            buildId: activeBuildId,
-            voxelBuild: progressiveBuild,
-            gridSize: activeBuildMeta.gridSize,
-            palette: activeBuildMeta.palette,
-            mode: activeBuildMeta.mode,
-            blockCount: progress.receivedBlocks,
-          });
-        },
-      },
-    )
-      .then((payload) => {
-        if (activeRequestRef.current !== requestId) return;
-        const loadedBuild: LoadedPromptBuild = {
+      setBuildCache((current) => rememberLoadedBuild(current, loadedBuild));
+      return loadedBuild;
+    };
+
+    const loadVariant = async (variant: ArenaBuildVariant) => {
+      if (getCachedBuild(variant)) return null;
+      const payload = await fetchBuildVariantStream(
+        {
           buildId: activeBuildId,
-          voxelBuild: payload.voxelBuild,
-          gridSize: activeBuildMeta.gridSize,
-          palette: activeBuildMeta.palette,
-          mode: activeBuildMeta.mode,
-          blockCount: Math.max(activeBuildMeta.blockCount, payload.voxelBuild.blocks.length),
-        };
+          variant,
+          checksum: activeBuildMeta.checksum,
+        },
+        {
+          signal: controller.signal,
+          allowLiveFallback: !largeBuild && variant === "full",
+          onProgress: (progressiveBuild, progress) => {
+            if (activeRequestRef.current !== requestId) return;
+            setActiveBuildProgress({
+              receivedBlocks: progress.receivedBlocks,
+              totalBlocks: progress.totalBlocks,
+            });
 
-        setBuildCache((current) => {
-          if (current[loadedBuild.buildId]) return current;
-          return { ...current, [loadedBuild.buildId]: loadedBuild };
-        });
+            if (progress.receivedBlocks <= 0) return;
+            setActiveStreamingBuild({
+              buildId: activeBuildId,
+              variant,
+              voxelBuild: progressiveBuild,
+              gridSize: activeBuildMeta.gridSize,
+              palette: activeBuildMeta.palette,
+              mode: activeBuildMeta.mode,
+              blockCount: progress.receivedBlocks,
+            });
+          },
+        },
+      );
+      if (activeRequestRef.current !== requestId) return null;
+      return storePayload(payload);
+    };
+
+    const startTimer = setTimeout(() => {
+      if (activeRequestRef.current !== requestId || controller.signal.aborted) return;
+      setActiveBuildError(null);
+      setActiveBuildProgress({
+        receivedBlocks: cachedPreviewBuild?.blockCount ?? 0,
+        totalBlocks: activeBuildMeta.blockCount || null,
+      });
+      setActiveStreamingBuild(null);
+
+      void (async () => {
+        const initialVariant: ArenaBuildVariant = largeBuild ? "preview" : "full";
+        let latestLoaded: LoadedPromptBuild | null = getCachedBuild(initialVariant);
+        if (!latestLoaded) {
+          latestLoaded = await loadVariant(initialVariant);
+        }
+        if (activeRequestRef.current !== requestId) return;
         setActiveStreamingBuild(null);
-        setActiveBuildProgress({
-          receivedBlocks: loadedBuild.blockCount,
-          totalBlocks: loadedBuild.blockCount,
-        });
-      })
-      .catch((error: unknown) => {
+        if (latestLoaded) {
+          setActiveBuildProgress({
+            receivedBlocks: latestLoaded.blockCount,
+            totalBlocks: latestLoaded.variant === "full" ? latestLoaded.blockCount : activeBuildMeta.blockCount,
+          });
+        }
+
+        if (!largeBuild || getCachedBuild("full")) return;
+        fullTimer = setTimeout(() => {
+          if (activeRequestRef.current !== requestId || controller.signal.aborted) return;
+          void loadVariant("full")
+            .then((loadedFull) => {
+              if (activeRequestRef.current !== requestId || !loadedFull) return;
+              setActiveStreamingBuild(null);
+              setActiveBuildProgress({
+                receivedBlocks: loadedFull.blockCount,
+                totalBlocks: loadedFull.blockCount,
+              });
+            })
+            .catch(() => {
+              // Keep the preview visible if the full artifact is still warming.
+            });
+        }, FULL_BUILD_IDLE_MS);
+      })().catch((error: unknown) => {
         if (error instanceof Error && error.name === "AbortError") return;
         if (activeRequestRef.current !== requestId) return;
         setActiveBuildError(error instanceof Error ? error.message : "Failed to load build");
         setActiveStreamingBuild(null);
       });
+    }, BUILD_LOAD_DEBOUNCE_MS);
 
     return () => {
+      clearTimeout(startTimer);
+      if (fullTimer) clearTimeout(fullTimer);
       controller.abort();
     };
   }, [activeBuildId, activeBuildMeta]);
@@ -1913,6 +2006,7 @@ export function ModelDetail({ data }: { data: ModelDetailStats }) {
                       <SandboxGifExportButton
                         targets={modalExportTargets}
                         promptText={activePrompt.promptText}
+                        cancelKey={`${activePrompt.promptId}:${activeBuildId ?? "none"}:${activeLoadedBuild?.variant ?? "none"}`}
                         iconOnly
                         label="Export GIF"
                       />

--- a/components/sandbox/SandboxBenchmark.tsx
+++ b/components/sandbox/SandboxBenchmark.tsx
@@ -991,7 +991,7 @@ export function SandboxBenchmark() {
           : undefined;
 
         const laneError =
-          laneState.phase === "error"
+          laneState.phase === "error" && !selectionReloading
             ? laneState.error ?? "Failed to load build"
             : !build && !selectionReloading
               ? "No seeded build found for this model/prompt pair."

--- a/components/sandbox/SandboxBenchmark.tsx
+++ b/components/sandbox/SandboxBenchmark.tsx
@@ -546,6 +546,7 @@ export function SandboxBenchmark() {
   const [data, setData] = useState<BenchmarkResponse | null>(null);
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
+  const [selectionReloading, setSelectionReloading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [slotState, setSlotState] = useState<Record<Slot, SlotHydrationState>>({
     a: createEmptySlotState(),
@@ -612,6 +613,7 @@ export function SandboxBenchmark() {
         const nextData = await fetchBenchmarkResponse({ ...args, signal: loadAbort.signal });
         if (requestId !== requestIdRef.current) return;
 
+        setSelectionReloading(false);
         setData(nextData);
         setPromptId(nextData.selectedPrompt?.id ?? "");
         setModelPair({
@@ -621,7 +623,14 @@ export function SandboxBenchmark() {
       } catch (err) {
         if (err instanceof Error && err.name === "AbortError") return;
         if (requestId !== requestIdRef.current) return;
-        setError(err instanceof Error ? err.message : "Failed to load benchmark comparison data");
+        const message =
+          err instanceof Error ? err.message : "Failed to load benchmark comparison data";
+        setSelectionReloading(false);
+        setError(message);
+        setSlotState({
+          a: { ...createEmptySlotState(), phase: "error", error: message },
+          b: { ...createEmptySlotState(), phase: "error", error: message },
+        });
       } finally {
         if (requestId !== requestIdRef.current) return;
         if (loadAbortRef.current === loadAbort) {
@@ -873,6 +882,7 @@ export function SandboxBenchmark() {
 
   function handlePromptChange(nextPromptId: string) {
     setPromptId(nextPromptId);
+    setSelectionReloading(true);
     clearVisibleBuilds();
     setData((prev) => {
       if (!prev) return prev;
@@ -899,6 +909,7 @@ export function SandboxBenchmark() {
     if (modelKey === other) return;
     const nextPair = slot === "a" ? { a: modelKey, b: other } : { a: other, b: modelKey };
     setModelPair(nextPair);
+    setSelectionReloading(true);
     clearVisibleBuilds();
     setData((prev) =>
       prev
@@ -974,7 +985,7 @@ export function SandboxBenchmark() {
         const title = model ? model.displayName : slot === "a" ? "Model A" : "Model B";
 
         const hasRenderableBuild = Boolean(laneState.build);
-        const isHydrating = laneState.phase === "loading";
+        const isHydrating = laneState.phase === "loading" || (!build && selectionReloading);
         const loadingMessage = isHydrating
           ? formatBuildLoadingMessage(laneState.progress)
           : undefined;
@@ -982,7 +993,7 @@ export function SandboxBenchmark() {
         const laneError =
           laneState.phase === "error"
             ? laneState.error ?? "Failed to load build"
-            : !build
+            : !build && !selectionReloading
               ? "No seeded build found for this model/prompt pair."
               : undefined;
 
@@ -1068,6 +1079,7 @@ export function SandboxBenchmark() {
               type="button"
               className="mb-btn mb-btn-ghost h-8 rounded-full px-2.5 text-[11px] sm:h-9 sm:px-3 sm:text-xs"
               onClick={() => {
+                setSelectionReloading(true);
                 clearVisibleBuilds();
                 void runLoad(
                   {

--- a/components/sandbox/SandboxBenchmark.tsx
+++ b/components/sandbox/SandboxBenchmark.tsx
@@ -90,6 +90,7 @@ type BuildStreamProgress = {
 
 type FetchBuildVariantStreamOptions = {
   signal?: AbortSignal;
+  allowLiveFallback?: boolean;
   onProgress?: (
     build: VoxelBuild,
     progress: BuildStreamProgress,
@@ -277,6 +278,7 @@ async function fetchBenchmarkResponse(args: {
   promptId?: string;
   modelA?: string;
   modelB?: string;
+  signal?: AbortSignal;
 }): Promise<BenchmarkResponse> {
   const params = new URLSearchParams();
   if (args.promptId) params.set("promptId", args.promptId);
@@ -285,7 +287,7 @@ async function fetchBenchmarkResponse(args: {
 
   const query = params.toString();
   const url = query ? `/api/sandbox/benchmark?${query}` : "/api/sandbox/benchmark";
-  const res = await fetch(url, { method: "GET", cache: "no-store" });
+  const res = await fetch(url, { method: "GET", cache: "no-store", signal: args.signal });
   if (!res.ok) {
     const text = await res.text().catch(() => "");
     let message = text || "Failed to load benchmark comparison data";
@@ -426,7 +428,9 @@ async function fetchBuildVariantStreamOnce(
       if (event.type === "chunk") {
         sawFirstEvent = true;
         if (Array.isArray(event.blocks) && event.blocks.length > 0) {
-          streamedBlocks.push(...event.blocks);
+          for (const block of event.blocks) {
+            streamedBlocks.push(block);
+          }
         }
         totalBlocks = event.totalBlocks || totalBlocks;
         emitProgress({
@@ -502,7 +506,9 @@ async function fetchBuildVariantStream(
   const attempts: Array<() => Promise<BuildVariantResponse>> = [
     () => fetchBuildVariantStreamOnce(ref, true, opts),
     () => fetchBuildVariantSnapshot(ref, opts?.signal),
-    () => fetchBuildVariantStreamOnce(ref, false, opts),
+    ...(opts?.allowLiveFallback
+      ? [() => fetchBuildVariantStreamOnce(ref, false, opts)]
+      : []),
     () => fetchBuildVariantSnapshot(ref, opts?.signal, SNAPSHOT_FETCH_TIMEOUT_MS * 2),
   ];
 
@@ -548,6 +554,7 @@ export function SandboxBenchmark() {
 
   const requestIdRef = useRef(0);
   const hydrationRunIdRef = useRef(0);
+  const loadAbortRef = useRef<AbortController | null>(null);
   const slotAbortRef = useRef<Record<Slot, AbortController | null>>({ a: null, b: null });
   const buildCacheRef = useRef<Map<string, CachedBuild>>(new Map());
 
@@ -570,6 +577,18 @@ export function SandboxBenchmark() {
     return buildCacheRef.current.get(getBuildCacheKey(ref)) ?? null;
   }, []);
 
+  const clearVisibleBuilds = useCallback(() => {
+    for (const slot of ["a", "b"] as const) {
+      slotAbortRef.current[slot]?.abort();
+      slotAbortRef.current[slot] = null;
+    }
+    hydrationRunIdRef.current += 1;
+    setSlotState({
+      a: createEmptySlotState(),
+      b: createEmptySlotState(),
+    });
+  }, []);
+
   const runLoad = useCallback(
     async (
       args: {
@@ -577,16 +596,20 @@ export function SandboxBenchmark() {
         modelA?: string;
         modelB?: string;
       },
-      opts?: { initial?: boolean },
+      opts?: { initial?: boolean; bypassCache?: boolean },
     ) => {
       const requestId = ++requestIdRef.current;
+      loadAbortRef.current?.abort();
+      const loadAbort = new AbortController();
+      loadAbortRef.current = loadAbort;
       const isInitial = Boolean(opts?.initial);
+      if (opts?.bypassCache) buildCacheRef.current.clear();
       if (isInitial) setLoading(true);
       else setRefreshing(true);
       setError(null);
 
       try {
-        const nextData = await fetchBenchmarkResponse(args);
+        const nextData = await fetchBenchmarkResponse({ ...args, signal: loadAbort.signal });
         if (requestId !== requestIdRef.current) return;
 
         setData(nextData);
@@ -596,10 +619,14 @@ export function SandboxBenchmark() {
           b: nextData.selectedModels.b ?? "",
         });
       } catch (err) {
+        if (err instanceof Error && err.name === "AbortError") return;
         if (requestId !== requestIdRef.current) return;
         setError(err instanceof Error ? err.message : "Failed to load benchmark comparison data");
       } finally {
         if (requestId !== requestIdRef.current) return;
+        if (loadAbortRef.current === loadAbort) {
+          loadAbortRef.current = null;
+        }
         if (isInitial) setLoading(false);
         else setRefreshing(false);
       }
@@ -730,9 +757,11 @@ export function SandboxBenchmark() {
 
       void (async () => {
         try {
+          const initialDeliveryClass = getInitialDeliveryClass(lane.buildLoadHints);
           const streamFetch = () =>
             fetchBuildVariantStream(lane.buildRef, {
               signal: controller.signal,
+              allowLiveFallback: initialDeliveryClass !== "stream-artifact",
               onProgress: (progressiveBuild, progress, meta) => {
                 if (hydrationRunIdRef.current !== runId) return;
                 setSlotState((prev) => {
@@ -768,7 +797,6 @@ export function SandboxBenchmark() {
                 });
               },
             });
-          const initialDeliveryClass = getInitialDeliveryClass(lane.buildLoadHints);
           const payload =
             initialDeliveryClass === "snapshot" || initialDeliveryClass === "inline"
               ? await fetchBuildVariantSnapshot(lane.buildRef, controller.signal).catch(streamFetch)
@@ -845,6 +873,16 @@ export function SandboxBenchmark() {
 
   function handlePromptChange(nextPromptId: string) {
     setPromptId(nextPromptId);
+    clearVisibleBuilds();
+    setData((prev) => {
+      if (!prev) return prev;
+      const selectedPrompt = prev.prompts.find((p) => p.id === nextPromptId);
+      return {
+        ...prev,
+        selectedPrompt: selectedPrompt ? { id: selectedPrompt.id, text: selectedPrompt.text } : prev.selectedPrompt,
+        builds: { a: null, b: null },
+      };
+    });
     void runLoad(
       {
         promptId: nextPromptId,
@@ -861,6 +899,16 @@ export function SandboxBenchmark() {
     if (modelKey === other) return;
     const nextPair = slot === "a" ? { a: modelKey, b: other } : { a: other, b: modelKey };
     setModelPair(nextPair);
+    clearVisibleBuilds();
+    setData((prev) =>
+      prev
+        ? {
+            ...prev,
+            selectedModels: nextPair,
+            builds: { a: null, b: null },
+          }
+        : prev,
+    );
     void runLoad(
       {
         promptId,
@@ -890,7 +938,8 @@ export function SandboxBenchmark() {
     handlePromptChange(next.id);
   }
 
-  const selectedPromptText = data?.selectedPrompt?.text ?? "";
+  const selectedPromptText =
+    data?.prompts.find((p) => p.id === promptId)?.text ?? data?.selectedPrompt?.text ?? "";
   const selectedPromptIndex = data?.prompts.findIndex((p) => p.id === promptId) ?? -1;
   const totalPrompts = data?.prompts.length ?? 0;
   const canNavigatePrompts = totalPrompts > 1;
@@ -972,6 +1021,7 @@ export function SandboxBenchmark() {
                     },
                   ]}
                   promptText={selectedPromptText}
+                  cancelKey={`${promptId}:${slot}:${build.buildId}:${model.key}`}
                   iconOnly
                   label="Export GIF"
                 />
@@ -1009,6 +1059,7 @@ export function SandboxBenchmark() {
             <SandboxGifExportButton
               targets={compareTargets}
               promptText={selectedPromptText}
+              cancelKey={`${promptId}:${modelPair.a}:${modelPair.b}:${data?.builds.a?.buildId ?? "none"}:${data?.builds.b?.buildId ?? "none"}`}
               label="Export GIF"
               className="h-8 px-2.5 text-[11px] sm:h-9 sm:px-3 sm:text-xs"
             />
@@ -1016,16 +1067,17 @@ export function SandboxBenchmark() {
             <button
               type="button"
               className="mb-btn mb-btn-ghost h-8 rounded-full px-2.5 text-[11px] sm:h-9 sm:px-3 sm:text-xs"
-              onClick={() =>
+              onClick={() => {
+                clearVisibleBuilds();
                 void runLoad(
                   {
                     promptId,
                     modelA: modelPair.a,
                     modelB: modelPair.b,
                   },
-                  { initial: false },
-                )
-              }
+                  { initial: false, bypassCache: true },
+                );
+              }}
               disabled={loading || refreshing}
               title="Refresh builds"
             >

--- a/components/sandbox/SandboxGifExportButton.tsx
+++ b/components/sandbox/SandboxGifExportButton.tsx
@@ -366,6 +366,7 @@ async function optimizeGifBlobForSize(input: Blob, signal?: AbortSignal): Promis
       relativeSavings >= LOSSLESS_OPT_MIN_RELATIVE_SAVINGS;
     return meaningful ? best : input;
   } catch (err) {
+    if (err instanceof Error && err.name === "AbortError") throw err;
     console.warn("[gif-export] optimize skipped", err);
     if (input.size > GIF_OPT_TARGET_MAX_BYTES) {
       throw err instanceof Error

--- a/components/sandbox/SandboxGifExportButton.tsx
+++ b/components/sandbox/SandboxGifExportButton.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type { RefObject } from "react";
-import { useId, useState } from "react";
+import { useEffect, useId, useRef, useState } from "react";
 import type { VoxelViewerHandle } from "@/components/voxel/VoxelViewer";
 
 export type SandboxGifExportTarget = {
@@ -17,6 +17,7 @@ type Props = {
   label?: string;
   iconOnly?: boolean;
   className?: string;
+  cancelKey?: string;
 };
 
 type GifExportFormat = "wide" | "vertical";
@@ -117,6 +118,14 @@ function waitForNextPaint() {
   return new Promise<void>((resolve) => {
     window.requestAnimationFrame(() => resolve());
   });
+}
+
+function createAbortError() {
+  return new DOMException("Aborted", "AbortError");
+}
+
+function throwIfAborted(signal?: AbortSignal) {
+  if (signal?.aborted) throw createAbortError();
 }
 
 function wrapTextLines(ctx: CanvasRenderingContext2D, text: string, maxWidth: number): string[] {
@@ -287,7 +296,8 @@ function getPaletteSampleSize(profile: GifRenderProfile) {
   };
 }
 
-async function optimizeGifBlobForSize(input: Blob): Promise<Blob> {
+async function optimizeGifBlobForSize(input: Blob, signal?: AbortSignal): Promise<Blob> {
+  throwIfAborted(signal);
   if (input.size < LOSSLESS_OPT_MIN_INPUT_BYTES) return input;
 
   try {
@@ -295,13 +305,16 @@ async function optimizeGifBlobForSize(input: Blob): Promise<Blob> {
       import("gifsicle-wasm-browser"),
       input.arrayBuffer(),
     ]);
+    throwIfAborted(signal);
 
     const runOptimize = async (command: string) => {
+      throwIfAborted(signal);
       const outputs = await gifsicle.run({
         input: [{ file: inputBytes.slice(0), name: "in.gif" }],
         command: [`${command} in.gif -o /out/out.gif`],
         isStrict: true,
       });
+      throwIfAborted(signal);
       return outputs.find((file) => file.name.toLowerCase().endsWith(".gif")) ?? null;
     };
 
@@ -516,7 +529,9 @@ async function buildPaletteSamples(
   targets: SandboxGifExportTarget[],
   format: GifExportFormat,
   profile: GifRenderProfile,
+  signal?: AbortSignal,
 ) {
+  throwIfAborted(signal);
   const sampleSize = getPaletteSampleSize(profile);
   const sampleCanvas = document.createElement("canvas");
   sampleCanvas.width = sampleSize.width;
@@ -539,12 +554,16 @@ async function buildPaletteSamples(
   const sampleFrames = buildPaletteSampleFrames(FRAME_COUNT, PALETTE_SAMPLE_COUNT);
 
   for (let idx = 0; idx < sampleFrames.length; idx += 1) {
+    throwIfAborted(signal);
     const frame = sampleFrames[idx];
     const t = FRAME_COUNT > 1 ? frame / (FRAME_COUNT - 1) : 0;
     renderCompositeFrame(sampleCtx, layout, targets, t * Math.PI * 2);
     const pixels = sampleCtx.getImageData(0, 0, sampleCanvas.width, sampleCanvas.height).data;
     samples.push(pixels.buffer);
-    if (idx > 0 && idx % 4 === 0) await waitForNextPaint();
+    if (idx > 0 && idx % 4 === 0) {
+      await waitForNextPaint();
+      throwIfAborted(signal);
+    }
   }
 
   return samples;
@@ -556,7 +575,9 @@ async function buildGifBlob(
   format: GifExportFormat,
   profile: GifRenderProfile,
   onProgress?: (done: number, total: number) => void,
+  signal?: AbortSignal,
 ) {
+  throwIfAborted(signal);
   const { width, height } = profile;
 
   const frameCanvas = document.createElement("canvas");
@@ -630,8 +651,10 @@ async function buildGifBlob(
 
   worker.postMessage({ type: "start" });
   await readyPromise;
+  throwIfAborted(signal);
 
-  const paletteSamples = await buildPaletteSamples(targets, format, profile);
+  const paletteSamples = await buildPaletteSamples(targets, format, profile, signal);
+  throwIfAborted(signal);
   if (paletteSamples.length > 0) {
     worker.postMessage({ type: "palette", samples: paletteSamples }, paletteSamples);
   }
@@ -643,6 +666,7 @@ async function buildGifBlob(
     let completed = 0;
 
     for (let frame = 0; frame < FRAME_COUNT; frame += 1) {
+      throwIfAborted(signal);
       const t = FRAME_COUNT > 1 ? frame / (FRAME_COUNT - 1) : 0;
       renderCompositeFrame(frameCtx, layout, targets, t * Math.PI * 2);
 
@@ -671,17 +695,21 @@ async function buildGifBlob(
       if (inFlight.length >= MAX_IN_FLIGHT_FRAMES) {
         await inFlight[0];
         inFlight.shift();
+        throwIfAborted(signal);
       }
 
       if (frame > 0 && frame % YIELD_EVERY_FRAMES === 0) {
         await waitForNextPaint();
+        throwIfAborted(signal);
       }
     }
 
     if (inFlight.length) await Promise.all(inFlight);
+    throwIfAborted(signal);
 
     worker.postMessage({ type: "finish" });
     const bytes = await resultPromise;
+    throwIfAborted(signal);
     return new Blob([bytes], { type: "image/gif" });
   } finally {
     worker.terminate();
@@ -784,15 +812,20 @@ function GifFormatSelector({
   );
 }
 
-export function SandboxGifExportButton({ targets, promptText, label, iconOnly, className }: Props) {
+export function SandboxGifExportButton({ targets, promptText, label, iconOnly, className, cancelKey }: Props) {
   const tooltipId = useId();
   const [exporting, setExporting] = useState(false);
   const [optimizing, setOptimizing] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [progress, setProgress] = useState<{ done: number; total: number } | null>(null);
   const [format, setFormat] = useState<GifExportFormat>("wide");
+  const exportAbortRef = useRef<AbortController | null>(null);
 
   const hasTargets = targets.length > 0;
+
+  useEffect(() => {
+    exportAbortRef.current?.abort();
+  }, [cancelKey]);
 
   async function handleExport() {
     if (!hasTargets || exporting) return;
@@ -805,6 +838,8 @@ export function SandboxGifExportButton({ targets, promptText, label, iconOnly, c
     setOptimizing(false);
     setError(null);
     setProgress({ done: 0, total: FRAME_COUNT });
+    const abortController = new AbortController();
+    exportAbortRef.current = abortController;
     await waitForNextPaint();
     try {
       const profiles = EXPORT_RENDER_PROFILES[format];
@@ -824,17 +859,20 @@ export function SandboxGifExportButton({ targets, promptText, label, iconOnly, c
           (done, total) => {
             if (done === total || done % 2 === 0) setProgress({ done, total });
           },
+          abortController.signal,
         );
 
         setOptimizing(true);
         setProgress(null);
         try {
-          finalBlob = await optimizeGifBlobForSize(blob);
+          finalBlob = await optimizeGifBlobForSize(blob, abortController.signal);
           break;
         } catch (err) {
+          if (err instanceof Error && err.name === "AbortError") throw err;
           lastError = err;
           if (idx === profiles.length - 1) throw err;
           await waitForNextPaint();
+          throwIfAborted(abortController.signal);
         }
       }
 
@@ -848,12 +886,17 @@ export function SandboxGifExportButton({ targets, promptText, label, iconOnly, c
       const typeToken = targets.length === 2 ? "compare" : "build";
       const formatToken = format === "vertical" ? "vertical" : "wide";
       const fileName = `minebench-${typeToken}-${formatToken}-${modelToken}-${promptToken}-${stamp}.gif`;
+      throwIfAborted(abortController.signal);
       triggerDownload(finalBlob, fileName);
     } catch (err) {
+      if (err instanceof Error && err.name === "AbortError") return;
       const message = err instanceof Error ? err.message : "GIF export failed";
       setError(message);
       console.error("[gif-export]", err);
     } finally {
+      if (exportAbortRef.current === abortController) {
+        exportAbortRef.current = null;
+      }
       setOptimizing(false);
       setExporting(false);
       setProgress(null);

--- a/components/sandbox/SandboxLive.tsx
+++ b/components/sandbox/SandboxLive.tsx
@@ -442,6 +442,23 @@ export function SandboxLive({ initialPrompt }: { initialPrompt?: string }) {
     }
     return picked;
   }, [compareEnabled, customModel, modelPair.a, modelPair.b]);
+  const inputSignature = useMemo(
+    () =>
+      [
+        prompt,
+        gridSize,
+        palette,
+        selectedModels
+          .map((model) =>
+            model.kind === "catalog"
+              ? model.modelKey
+              : `${model.displayName}:${model.modelId}:${model.baseUrl}`,
+          )
+          .join("|"),
+      ].join("\0"),
+    [gridSize, palette, prompt, selectedModels],
+  );
+  const lastGenerateInputRef = useRef<string | null>(null);
 
   useEffect(() => {
     if (!running) return;
@@ -452,6 +469,22 @@ export function SandboxLive({ initialPrompt }: { initialPrompt?: string }) {
   useEffect(() => {
     saveProviderKeysToStorage(providerKeys);
   }, [providerKeys]);
+
+  useEffect(() => {
+    if (lastGenerateInputRef.current === inputSignature) return;
+    generateAbortRef.current?.abort();
+    generateAbortRef.current = null;
+    previewCacheRef.current.clear();
+    setRunning(false);
+    setRequestError(null);
+    setResults((prev) => {
+      const next = new Map(prev);
+      for (const model of selectedModels) {
+        next.set(model.id, { modelKey: model.id, status: "idle", voxelBuild: null });
+      }
+      return next;
+    });
+  }, [inputSignature, selectedModels]);
 
   useEffect(() => {
     if (!compareEnabled) return;
@@ -551,6 +584,7 @@ export function SandboxLive({ initialPrompt }: { initialPrompt?: string }) {
     }
 
     setRunning(true);
+    lastGenerateInputRef.current = inputSignature;
     setRequestError(null);
     forceRender((c) => c + 1);
     setResults((prev) => {
@@ -570,9 +604,9 @@ export function SandboxLive({ initialPrompt }: { initialPrompt?: string }) {
       return next;
     });
 
+    const abortController = new AbortController();
+    generateAbortRef.current = abortController;
     try {
-      const abortController = new AbortController();
-      generateAbortRef.current = abortController;
       const sanitizedKeys: ProviderApiKeys = {};
       const setKey = (k: keyof ProviderApiKeys, v: unknown) => {
         if (typeof v !== "string") return;
@@ -757,8 +791,10 @@ export function SandboxLive({ initialPrompt }: { initialPrompt?: string }) {
       }
       setRequestError(err instanceof Error ? err.message : "Request failed");
     } finally {
-      generateAbortRef.current = null;
-      setRunning(false);
+      if (generateAbortRef.current === abortController) {
+        generateAbortRef.current = null;
+        setRunning(false);
+      }
     }
   }
 
@@ -863,6 +899,7 @@ export function SandboxLive({ initialPrompt }: { initialPrompt?: string }) {
             <SandboxGifExportButton
               targets={gifTargets}
               promptText={prompt}
+              cancelKey={`${inputSignature}:${model.id}:${r?.status ?? "idle"}:${r?.metrics?.blockCount ?? 0}`}
               iconOnly
               label="Export GIF"
             />
@@ -1235,6 +1272,9 @@ export function SandboxLive({ initialPrompt }: { initialPrompt?: string }) {
             <SandboxGifExportButton
               targets={compareTargets}
               promptText={prompt}
+              cancelKey={`${inputSignature}:${compareTargets
+                .map((target) => `${target.modelName}:${target.blockCount}`)
+                .join("|")}`}
               label={selectedModels.length > 1 ? "Export comparison GIF" : "Export GIF"}
             />
             <div className="flex items-center gap-2">


### PR DESCRIPTION
## What does this PR do?

- Debounces model-detail prompt build loading and aborts stale requests when users hold left/right through builds.
- Loads large model-detail builds as previews first, then waits for the user to settle before attempting the full artifact.
- Bounds the model-detail build cache by variant so rapid navigation does not keep unbounded full payloads alive.
- Makes sandbox benchmark prompt/model changes clear the visible stale builds immediately and abort the previous benchmark/build hydration work.
- Makes the sandbox benchmark refresh button bypass the client build cache so it actually re-fetches the selected builds.
- Avoids full live stream fallback for stream-artifact benchmark lanes unless the lane was not expected to have a stream artifact.
- Cancels GIF export/optimization when the selected prompt, model, or build changes.
- Clears and aborts stale live sandbox generation results when prompt/model/grid/palette inputs change.

## Why?

Production Vercel logs on the current `master` deployment (`dpl_CZsCZf5N9MPHREUHTeiKozdCpZKF`) still showed the inconsistent behavior this targets:

- `/api/sandbox/benchmark` was repeatedly requested during sandbox browsing, with slow Prisma rows such as `4420ms`, `1745ms`, and `1101ms` attached to those requests.
- Full build stream bursts were clustered around rapid browsing, including repeated `/api/arena/builds/.../stream?variant=full` requests within the same few seconds.
- The same route family still had `Vercel Runtime Error` rows, including `/api/sandbox/benchmark` 500s and build-stream 500s.

The fix reduces abandoned client work and server pressure. Rapid switching now cancels the old request path instead of letting every intermediate prompt/model/build continue hydrating in the background, and heavy full-build loads are deferred until the user stops moving.

## How to test

- Vercel MCP runtime-log check against production before patch:
  - `/api/sandbox/benchmark`
  - `[arena] /stream`
  - `prisma slow query`
  - `Vercel Runtime Error`
- `pnpm lint`
- `pnpm build`

`pnpm build` completed successfully. It emitted the repo's expected sitemap fallback warning because the local database at `localhost:54327` was not running.

## Checklist

- [x] Production Vercel logs checked before patch
- [x] Prompt/model changes abort stale sandbox benchmark loads
- [x] Sandbox refresh bypasses the client build cache
- [x] Model-detail build switching is debounced and abortable
- [x] Large model-detail builds prefer preview before full artifact load
- [x] GIF export cancels when prompt/model/build context changes
- [x] `pnpm lint` passes
- [x] `pnpm build` passes

_(PR Body written by Codex)_