### PR TITLE
(fix) keep sandbox stream artifacts on stream path

### DIFF
--- a/components/sandbox/SandboxBenchmark.tsx
+++ b/components/sandbox/SandboxBenchmark.tsx
@@ -90,6 +90,7 @@ type BuildStreamProgress = {
 
 type FetchBuildVariantStreamOptions = {
   signal?: AbortSignal;
+  allowSnapshotFallback?: boolean;
   allowLiveFallback?: boolean;
   onProgress?: (
     build: VoxelBuild,
@@ -500,6 +501,9 @@ async function fetchBuildVariantStreamOnce(
       hasComplete && (announcedTotal == null || streamedBlocks.length >= announcedTotal);
 
     if (!streamLooksComplete) {
+      if (opts?.allowSnapshotFallback === false) {
+        throw new Error("Build stream ended before all blocks loaded");
+      }
       return fetchBuildVariantSnapshot(ref, opts?.signal);
     }
 
@@ -527,11 +531,15 @@ async function fetchBuildVariantStream(
   let lastError: unknown = null;
   const attempts: Array<() => Promise<BuildVariantResponse>> = [
     () => fetchBuildVariantStreamOnce(ref, true, opts),
-    () => fetchBuildVariantSnapshot(ref, opts?.signal),
+    ...(opts?.allowSnapshotFallback === false
+      ? []
+      : [
+          () => fetchBuildVariantSnapshot(ref, opts?.signal),
+          () => fetchBuildVariantSnapshot(ref, opts?.signal, SNAPSHOT_FETCH_TIMEOUT_MS * 2),
+        ]),
     ...(opts?.allowLiveFallback
       ? [() => fetchBuildVariantStreamOnce(ref, false, opts)]
       : []),
-    () => fetchBuildVariantSnapshot(ref, opts?.signal, SNAPSHOT_FETCH_TIMEOUT_MS * 2),
   ];
 
   for (const attempt of attempts) {
@@ -796,9 +804,11 @@ export function SandboxBenchmark() {
       void (async () => {
         try {
           const deliveryClass = getHydrationDeliveryClass(lane.buildLoadHints, lane.buildRef.variant);
+          const allowSnapshotFallback = deliveryClass !== "stream-artifact";
           const streamFetch = () =>
             fetchBuildVariantStream(lane.buildRef, {
               signal: controller.signal,
+              allowSnapshotFallback,
               allowLiveFallback: deliveryClass !== "stream-artifact",
               onProgress: (progressiveBuild, progress, meta) => {
                 if (hydrationRunIdRef.current !== runId) return;


### PR DESCRIPTION
## Summary
- keep sandbox stream-artifact builds on the stream endpoint instead of falling back to snapshot hydration
- pass snapshot fallback policy into sandbox stream hydration, matching the Arena behavior for large artifact-backed builds

## Root cause
Very large sandbox builds can require the stream artifact endpoint. The sandbox hydration path still attempted snapshot fallback after an incomplete stream attempt, which surfaced the expected API error: "Build must be loaded through the stream artifact endpoint."

## Validation
- git diff --check
- pnpm lint