### PR TITLE
(fix) improve viewer spin and mobile controls

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -135,16 +135,6 @@
     color: hsl(var(--fg));
   }
 
-  @keyframes mb-swipe-nudge-right {
-    0%, 100% { transform: translateX(0); opacity: 0.5; }
-    50% { transform: translateX(3px); opacity: 0.9; }
-  }
-
-  @keyframes mb-swipe-nudge-left {
-    0%, 100% { transform: translateX(0); opacity: 0.5; }
-    50% { transform: translateX(-3px); opacity: 0.9; }
-  }
-
   @keyframes mb-fade-in-up {
     0% {
       opacity: 0;
@@ -1097,21 +1087,6 @@
 
   .mb-fade-in {
     animation: mb-fade-in-up 220ms ease-out both;
-  }
-
-  .mb-swipe-arrow-right {
-    animation: mb-swipe-nudge-right 2s ease-in-out infinite;
-  }
-
-  .mb-swipe-arrow-left {
-    animation: mb-swipe-nudge-left 2s ease-in-out infinite;
-  }
-
-  @media (prefers-reduced-motion: reduce) {
-    .mb-swipe-arrow-right,
-    .mb-swipe-arrow-left {
-      animation: none;
-    }
   }
 
   .mb-caret {

--- a/components/arena/Arena.tsx
+++ b/components/arena/Arena.tsx
@@ -1107,6 +1107,7 @@ export function Arena() {
   const submittingRef = useRef(false);
   const transitioningStateRef = useRef(false);
   const cardsScrollRef = useRef<HTMLDivElement | null>(null);
+  const programmaticMobileScrollRef = useRef<{ side: "a" | "b"; until: number } | null>(null);
   const revealRef = useRef<RevealState>({ kind: "none" });
   const transitionRef = useRef(false);
   const hydrateInFlightRef = useRef(new Set<string>());
@@ -1380,6 +1381,12 @@ export function Arena() {
     if (!el) return;
 
     const sync = () => {
+      const programmaticScroll = programmaticMobileScrollRef.current;
+      if (programmaticScroll && performance.now() < programmaticScroll.until) {
+        setMobileBuildView(programmaticScroll.side);
+        return;
+      }
+      programmaticMobileScrollRef.current = null;
       const max = Math.max(0, el.scrollWidth - el.clientWidth);
       if (max <= 0) {
         setMobileBuildView("a");
@@ -1406,6 +1413,8 @@ export function Arena() {
     if (!el) return;
     const max = Math.max(0, el.scrollWidth - el.clientWidth);
     const left = side === "a" ? 0 : max;
+    programmaticMobileScrollRef.current =
+      behavior === "smooth" ? { side, until: performance.now() + 420 } : null;
     setMobileBuildView(side);
     el.scrollTo({ left, behavior });
   }, []);
@@ -2584,13 +2593,6 @@ export function Arena() {
             <div
               className={`relative mb-card-enter min-w-full shrink-0 snap-center [scroll-snap-stop:always] rounded-2xl transition-all duration-200 ease-out motion-reduce:transition-none sm:rounded-3xl md:min-w-0 md:shrink md:snap-none ${mobileBuildView === "a" ? "ring-1 ring-accent/30 md:ring-border/60 md:shadow-none" : "ring-1 ring-border/60"} ${revealModels && revealAction === "A" ? "mb-reveal-highlight-a" : ""} ${revealModels && revealAction === "B" ? "mb-reveal-dim" : ""}`}
             >
-              {/* swipe hint – only on mobile, points toward Build B */}
-              <div className="pointer-events-none absolute right-2.5 top-2.5 z-10 flex items-center gap-1 md:hidden" aria-hidden="true">
-                <span className="text-[9px] uppercase tracking-widest text-muted2/40">swipe</span>
-                <span className="mb-swipe-arrow-right inline-block text-muted2/50">
-                  <svg width="12" height="12" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"><path d="M6 4l4 4-4 4"/></svg>
-                </span>
-              </div>
               <VoxelViewerCard
                 key={matchup ? `${matchup.id}:a` : "arena-build-a"}
                 title="Build A"
@@ -2641,13 +2643,6 @@ export function Arena() {
             <div
               className={`relative mb-card-enter mb-card-enter-delay min-w-full shrink-0 snap-center [scroll-snap-stop:always] rounded-2xl transition-all duration-200 ease-out motion-reduce:transition-none sm:rounded-3xl md:min-w-0 md:shrink md:snap-none ${mobileBuildView === "b" ? "ring-1 ring-accent2/30 md:ring-border/60 md:shadow-none" : "ring-1 ring-border/60"} ${revealModels && revealAction === "B" ? "mb-reveal-highlight-b" : ""} ${revealModels && revealAction === "A" ? "mb-reveal-dim" : ""}`}
             >
-              {/* swipe hint – only on mobile, points back toward Build A */}
-              <div className="pointer-events-none absolute right-2.5 top-2.5 z-10 flex items-center gap-1 md:hidden" aria-hidden="true">
-                <span className="mb-swipe-arrow-left inline-block text-muted2/50">
-                  <svg width="12" height="12" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"><path d="M10 4l-4 4 4 4"/></svg>
-                </span>
-                <span className="text-[9px] uppercase tracking-widest text-muted2/40">swipe</span>
-              </div>
               <VoxelViewerCard
                 key={matchup ? `${matchup.id}:b` : "arena-build-b"}
                 title="Build B"
@@ -2698,34 +2693,40 @@ export function Arena() {
           </div>
 
           {/* segmented build switcher – mobile only */}
-	          <div className="md:hidden">
-	            <div className="relative flex rounded-xl bg-bg/40 p-0.5 ring-1 ring-border/50">
-              {/* sliding indicator */}
-              <span
-                aria-hidden="true"
-                className="pointer-events-none absolute inset-y-0.5 left-0.5 w-[calc(50%-2px)] rounded-[10px] bg-card/70 ring-1 ring-border/40 transition-transform duration-200 ease-out"
-                style={{ transform: mobileBuildView === "b" ? "translateX(calc(100% + 4px))" : "translateX(0)" }}
-              />
+          <div className="md:hidden">
+            <div className="flex rounded-xl border border-border/55 bg-bg/45 p-0.5 shadow-[inset_0_1px_0_hsl(var(--fg)_/_0.04)] backdrop-blur-sm">
               <button
                 type="button"
                 aria-pressed={mobileBuildView === "a"}
-                className={`relative z-10 flex-1 rounded-[10px] py-2 text-center font-mono text-[12px] font-medium uppercase tracking-[0.12em] transition-colors ${mobileBuildView === "a" ? "text-fg" : "text-muted2 hover:text-fg"}`}
+                aria-current={mobileBuildView === "a" ? "true" : undefined}
+                aria-label="Show Build A"
+                className={`flex h-10 flex-1 items-center justify-center rounded-[10px] text-center font-mono text-[11px] font-semibold uppercase tracking-[0.13em] transition-colors ${
+                  mobileBuildView === "a"
+                    ? "bg-card/80 text-fg ring-1 ring-border/65 shadow-[inset_0_1px_0_hsl(var(--fg)_/_0.08)]"
+                    : "text-muted/60 hover:bg-bg/45 hover:text-fg"
+                }`}
                 disabled={buildSwitchDisabled}
                 onClick={() => scrollToMobileBuild("a")}
               >
-                Build A
+                <span>Build A</span>
               </button>
               <button
                 type="button"
                 aria-pressed={mobileBuildView === "b"}
-                className={`relative z-10 flex-1 rounded-[10px] py-2 text-center font-mono text-[12px] font-medium uppercase tracking-[0.12em] transition-colors ${mobileBuildView === "b" ? "text-fg" : "text-muted2 hover:text-fg"}`}
+                aria-current={mobileBuildView === "b" ? "true" : undefined}
+                aria-label="Show Build B"
+                className={`flex h-10 flex-1 items-center justify-center rounded-[10px] text-center font-mono text-[11px] font-semibold uppercase tracking-[0.13em] transition-colors ${
+                  mobileBuildView === "b"
+                    ? "bg-card/80 text-fg ring-1 ring-border/65 shadow-[inset_0_1px_0_hsl(var(--fg)_/_0.08)]"
+                    : "text-muted/60 hover:bg-bg/45 hover:text-fg"
+                }`}
                 disabled={buildSwitchDisabled}
                 onClick={() => scrollToMobileBuild("b")}
               >
-                Build B
-	              </button>
-	            </div>
-	          </div>
+                <span>Build B</span>
+              </button>
+            </div>
+          </div>
 
 	          {buildLoadError ? (
 	            <div className="mb-subpanel flex items-center justify-between gap-3 px-3 py-2 text-sm text-muted sm:px-4">

--- a/components/arena/Arena.tsx
+++ b/components/arena/Arena.tsx
@@ -1300,10 +1300,11 @@ export function Arena() {
   }, [clearAutoFullHydrationRetryTimer, matchup?.id]);
 
   useEffect(() => {
+    // New matchup should always start at Build A on mobile.
+    programmaticMobileScrollRef.current = null;
+    setMobileBuildView("a");
     const el = cardsScrollRef.current;
     if (!el) return;
-    // New matchup should always start at Build A on mobile.
-    setMobileBuildView("a");
     el.scrollTo({ left: 0, behavior: "auto" });
   }, [matchup?.id]);
 

--- a/components/voxel/VoxelViewer.tsx
+++ b/components/voxel/VoxelViewer.tsx
@@ -34,6 +34,11 @@ export type VoxelViewerHandle = {
 
 let atlasPromise: Promise<THREE.Texture> | null = null;
 const EXPORT_RENDER_OVERSCAN = 1;
+let viewerSpinPreference = true;
+const viewerSpinPreferenceListeners = new Set<(enabled: boolean) => void>();
+const MOBILE_DOUBLE_TAP_MS = 330;
+const MOBILE_TAP_MAX_TRAVEL_PX = 14;
+const MOBILE_DOUBLE_TAP_MAX_DISTANCE_PX = 34;
 
 type ViewerTheme = "light" | "dark";
 const REVEAL_ANIMATION_MIN_BLOCKS = Number.parseInt(
@@ -61,6 +66,51 @@ function getViewerPixelRatio(): number {
   // 1.5x on mobile cuts fragment work ~30% vs 2x retina with no perceptible loss
   const cap = isMobileViewerEnv() ? 1.5 : 2;
   return Math.min(dpr, cap);
+}
+
+function hasPanModifier(event: { ctrlKey?: boolean; metaKey?: boolean; shiftKey?: boolean }): boolean {
+  return Boolean(event.ctrlKey || event.metaKey || event.shiftKey);
+}
+
+function isPanModifierKey(event: { key?: string; code?: string }): boolean {
+  return (
+    event.key === "Control" ||
+    event.key === "Meta" ||
+    event.key === "Shift" ||
+    event.code === "ControlLeft" ||
+    event.code === "ControlRight" ||
+    event.code === "MetaLeft" ||
+    event.code === "MetaRight" ||
+    event.code === "ShiftLeft" ||
+    event.code === "ShiftRight"
+  );
+}
+
+function isTouchLikePointer(event: PointerEvent): boolean {
+  return event.pointerType !== "mouse" || isMobileViewerEnv();
+}
+
+function setViewerSpinPreference(enabled: boolean) {
+  if (viewerSpinPreference === enabled) return;
+  viewerSpinPreference = enabled;
+  viewerSpinPreferenceListeners.forEach((listener) => listener(enabled));
+}
+
+function toggleViewerSpinPreference() {
+  setViewerSpinPreference(!viewerSpinPreference);
+}
+
+export function useVoxelViewerSpinPreference() {
+  const [enabled, setEnabled] = useState(viewerSpinPreference);
+
+  useEffect(() => {
+    viewerSpinPreferenceListeners.add(setEnabled);
+    return () => {
+      viewerSpinPreferenceListeners.delete(setEnabled);
+    };
+  }, []);
+
+  return enabled;
 }
 
 function applyGridTheme(grid: THREE.GridHelper, theme: ViewerTheme) {
@@ -175,17 +225,26 @@ function computeBuildYieldAfterMs(blockCount: number): number {
   return 8;
 }
 
-function frameBounds(camera: THREE.PerspectiveCamera, controls: OrbitControls, bounds: BuildBounds) {
+function frameBounds(
+  camera: THREE.PerspectiveCamera,
+  controls: OrbitControls,
+  bounds: BuildBounds,
+  opts?: { reserveMobileBottomChrome?: boolean },
+) {
   const center = bounds.center;
   const radius = Math.max(0.001, bounds.radius);
-
-  controls.target.copy(center);
 
   const size = bounds.box.getSize(new THREE.Vector3());
   const horiz = Math.max(0.001, Math.max(size.x, size.z));
   const tallness = size.y / horiz;
   // slightly more top-down by default (about +10%)
   const yBias = THREE.MathUtils.clamp((0.38 + tallness * 0.22) * 1.1, 0.38, 0.95);
+  const reserveMobileBottomChrome = Boolean(opts?.reserveMobileBottomChrome && isMobileViewerEnv());
+  const target = center.clone();
+  if (reserveMobileBottomChrome) {
+    target.y -= THREE.MathUtils.clamp(size.y * 0.08, radius * 0.04, radius * 0.16);
+  }
+  controls.target.copy(target);
 
   const vFov = THREE.MathUtils.degToRad(camera.fov);
   const hFov = 2 * Math.atan(Math.tan(vFov / 2) * camera.aspect);
@@ -195,17 +254,61 @@ function frameBounds(camera: THREE.PerspectiveCamera, controls: OrbitControls, b
 
   const dir = new THREE.Vector3(1, yBias, 1).normalize();
   // slightly closer default framing
-  camera.position.copy(center).addScaledVector(dir, distance * 1.1);
+  camera.position.copy(target).addScaledVector(dir, distance * (reserveMobileBottomChrome ? 1.22 : 1.1));
   camera.near = Math.max(0.05, distance / 250);
   camera.far = Math.max(200, distance * 60);
   camera.updateProjectionMatrix();
-  camera.lookAt(center);
+  camera.lookAt(target);
 
   controls.minDistance = Math.max(0.5, distance * 0.12);
   controls.maxDistance = Math.max(40, distance * 14);
 
   controls.update();
   controls.saveState();
+}
+
+function ViewerControlHint({ isPanMode, spinEnabled }: { isPanMode: boolean; spinEnabled: boolean }) {
+  const itemClass = "inline-flex items-center gap-1.5 whitespace-nowrap";
+  const desktopItemClass = "hidden items-center gap-1.5 whitespace-nowrap sm:inline-flex";
+  const inputLabelClass = "text-fg/65";
+  const dividerClass = "h-1 w-1 rounded-full bg-muted/[0.18]";
+  const keyClass =
+    "inline-flex h-4 min-w-4 items-center justify-center rounded border border-border/40 bg-bg/40 px-1 font-mono text-[9px] font-semibold leading-none text-muted/70";
+  const spinKeyClass = `${keyClass} ${
+    spinEnabled ? "border-accent/20 bg-accent/[0.07] text-accent/75" : "text-muted/55"
+  }`;
+
+  return (
+    <div className="pointer-events-none absolute bottom-[4.15rem] left-2.5 right-2.5 z-10 flex sm:bottom-3 sm:left-3 sm:right-auto">
+      <div className="inline-flex max-w-full flex-wrap items-center gap-x-2 gap-y-1 rounded-full border border-border/40 bg-bg/[0.50] px-2.5 py-1 text-[10px] font-medium leading-none text-muted/70 backdrop-blur-sm sm:px-3">
+        <span className={itemClass}>
+          <span className={inputLabelClass}>Drag</span>
+          <span>{isPanMode ? "Pan" : "Rotate"}</span>
+        </span>
+        <span className={dividerClass} aria-hidden="true" />
+        <span className={desktopItemClass}>
+          <span className={keyClass}>Ctrl</span>
+          <span>Pan</span>
+        </span>
+        <span className={`${dividerClass} hidden sm:inline-flex`} aria-hidden="true" />
+        <span className={itemClass}>
+          <span className={`${inputLabelClass} sm:hidden`}>Pinch</span>
+          <span className={`${inputLabelClass} hidden sm:inline`}>Scroll</span>
+          <span>Zoom</span>
+        </span>
+        <span className={`${dividerClass} sm:hidden`} aria-hidden="true" />
+        <span className={`${itemClass} sm:hidden`}>
+          <span className={inputLabelClass}>Double tap</span>
+          <span>Spin</span>
+        </span>
+        <span className="hidden h-1 w-1 rounded-full bg-muted/[0.18] sm:inline-flex" aria-hidden="true" />
+        <span className={desktopItemClass}>
+          <span className={spinKeyClass}>S</span>
+          <span>{spinEnabled ? "Spin on" : "Spin off"}</span>
+        </span>
+      </div>
+    </div>
+  );
 }
 
 function collectRevealGeometries(group: THREE.Group): RevealGeometry[] {
@@ -261,6 +364,8 @@ export const VoxelViewer = forwardRef<VoxelViewerHandle, ViewerProps>(function V
   const exportRendererRef = useRef<THREE.WebGLRenderer | null>(null);
   const exportCanvasRef = useRef<HTMLCanvasElement | null>(null);
   const captureCanvasRef = useRef<HTMLCanvasElement | null>(null);
+  const tapStartRef = useRef<{ x: number; y: number; at: number } | null>(null);
+  const lastTapRef = useRef<{ x: number; y: number; at: number } | null>(null);
   const threeRef = useRef<{
     scene: THREE.Scene;
     camera: THREE.PerspectiveCamera;
@@ -272,7 +377,9 @@ export const VoxelViewer = forwardRef<VoxelViewerHandle, ViewerProps>(function V
   const [dragMode, setDragMode] = useState<DragMode>("orbit");
   const [isFullscreen, setIsFullscreen] = useState(false);
   const [supportsFullscreen, setSupportsFullscreen] = useState(false);
-  const [ctrlHeld, setCtrlHeld] = useState(false);
+  const [panModifierHeld, setPanModifierHeld] = useState(false);
+  const effectivePanMode = dragMode === "pan" || (dragMode === "orbit" && panModifierHeld);
+  const spinPreferenceEnabled = useVoxelViewerSpinPreference();
 
   const paletteDefs: BlockDefinition[] = useMemo(() => getPalette(palette), [palette]);
   const latestRef = useRef<{
@@ -361,12 +468,12 @@ export const VoxelViewer = forwardRef<VoxelViewerHandle, ViewerProps>(function V
     const vg = voxelGroupRef.current;
     const bounds = boundsRef.current;
     if (!three || !vg || !bounds) return;
-    frameBounds(three.camera, three.controls, bounds);
+    frameBounds(three.camera, three.controls, bounds, { reserveMobileBottomChrome: showControls });
     if (gridRef.current) {
       gridRef.current.position.y = bounds.box.min.y - 0.5;
     }
     requestRenderRef.current?.();
-  }, []);
+  }, [showControls]);
 
   const clearVoxelGroup = useCallback((three: NonNullable<typeof threeRef.current>) => {
     if (revealRafRef.current) {
@@ -848,6 +955,7 @@ export const VoxelViewer = forwardRef<VoxelViewerHandle, ViewerProps>(function V
     };
     const onEnd = () => {
       userInteractingRef.current = false;
+      if (autoRotateRef.current) requestRenderRef.current?.();
     };
     controls.addEventListener("start", onStart);
     controls.addEventListener("end", onEnd);
@@ -899,8 +1007,10 @@ export const VoxelViewer = forwardRef<VoxelViewerHandle, ViewerProps>(function V
         const controlsChanged = (controls.update() as boolean | void) === true;
 
         const vg = voxelGroupRef.current;
-        const shouldAutoRotate = Boolean(vg && autoRotateRef.current && !userInteractingRef.current);
-        if (vg && autoRotateRef.current && !userInteractingRef.current) {
+        const shouldAutoRotate = Boolean(
+          vg && autoRotateRef.current && !userInteractingRef.current,
+        );
+        if (vg && shouldAutoRotate) {
           vg.group.rotation.y += dt * 0.25;
         }
         renderer.render(scene, camera);
@@ -928,8 +1038,48 @@ export const VoxelViewer = forwardRef<VoxelViewerHandle, ViewerProps>(function V
     const ro = new ResizeObserver(onResize);
     ro.observe(mount);
 
-    const onDblClick = () => fitView();
+    const onPointerDownForTap = (e: PointerEvent) => {
+      if (!isTouchLikePointer(e) || e.isPrimary === false) return;
+      tapStartRef.current = { x: e.clientX, y: e.clientY, at: performance.now() };
+    };
+    const onPointerUpForTap = (e: PointerEvent) => {
+      if (!isTouchLikePointer(e) || e.isPrimary === false) return;
+      const now = performance.now();
+      const start = tapStartRef.current;
+      tapStartRef.current = null;
+      if (!start) return;
+
+      const travel = Math.hypot(e.clientX - start.x, e.clientY - start.y);
+      if (travel > MOBILE_TAP_MAX_TRAVEL_PX || now - start.at > MOBILE_DOUBLE_TAP_MS) {
+        lastTapRef.current = null;
+        return;
+      }
+
+      const previousTap = lastTapRef.current;
+      const distanceFromPrevious = previousTap
+        ? Math.hypot(e.clientX - previousTap.x, e.clientY - previousTap.y)
+        : Number.POSITIVE_INFINITY;
+      const isDoubleTap =
+        previousTap != null &&
+        now - previousTap.at <= MOBILE_DOUBLE_TAP_MS &&
+        distanceFromPrevious <= MOBILE_DOUBLE_TAP_MAX_DISTANCE_PX;
+      if (!isDoubleTap) {
+        lastTapRef.current = { x: e.clientX, y: e.clientY, at: now };
+        return;
+      }
+
+      e.preventDefault();
+      lastTapRef.current = null;
+      toggleViewerSpinPreference();
+      requestRender();
+    };
+    const onDblClick = () => {
+      if (isMobileViewerEnv()) return;
+      fitView();
+    };
     const onContextMenu = (e: Event) => e.preventDefault();
+    renderer.domElement.addEventListener("pointerdown", onPointerDownForTap);
+    renderer.domElement.addEventListener("pointerup", onPointerUpForTap);
     renderer.domElement.addEventListener("dblclick", onDblClick);
     renderer.domElement.addEventListener("contextmenu", onContextMenu);
     controls.addEventListener("change", requestRender);
@@ -979,6 +1129,10 @@ export const VoxelViewer = forwardRef<VoxelViewerHandle, ViewerProps>(function V
       }
       exportCanvasRef.current = null;
       captureCanvasRef.current = null;
+      tapStartRef.current = null;
+      lastTapRef.current = null;
+      renderer.domElement.removeEventListener("pointerdown", onPointerDownForTap);
+      renderer.domElement.removeEventListener("pointerup", onPointerUpForTap);
       renderer.domElement.removeEventListener("dblclick", onDblClick);
       renderer.domElement.removeEventListener("contextmenu", onContextMenu);
       renderer.domElement.remove();
@@ -1011,27 +1165,47 @@ export const VoxelViewer = forwardRef<VoxelViewerHandle, ViewerProps>(function V
   useEffect(() => {
     const three = threeRef.current;
     if (!three) return;
-    autoRotateRef.current = Boolean(autoRotate);
+    autoRotateRef.current = Boolean(autoRotate && spinPreferenceEnabled);
     three.controls.autoRotate = false;
     if (autoRotate) requestRenderRef.current?.();
-  }, [autoRotate]);
+  }, [autoRotate, spinPreferenceEnabled]);
+
+  const controlButtonClass =
+    "mb-btn h-11 flex-1 gap-1.5 rounded-lg px-3 text-[12px] leading-none sm:h-8 sm:flex-none sm:px-2.5 sm:text-[11px]";
+  const controlGhostClass = `${controlButtonClass} ring-1 ring-border/60 bg-bg/[0.46] text-fg/85 hover:bg-bg/[0.64] hover:ring-border/80`;
+  const controlActiveClass = `${controlButtonClass} ring-1 ring-border/75 bg-card/65 text-fg hover:bg-card/80 hover:ring-border`;
+  const controlKeyClass =
+    "hidden h-5 min-w-5 items-center justify-center rounded-md border border-border/55 bg-bg/45 px-1.5 font-mono text-[10px] font-semibold leading-none text-muted/75 sm:inline-flex";
+  const activeControlKeyClass = `${controlKeyClass} border-border/60 bg-bg/55 text-fg/80`;
 
   return (
     <div
       ref={containerRef}
       data-mb-voxel-viewer="true"
-      className={`relative h-full w-full outline-none focus-visible:ring-2 focus-visible:ring-accent/40 focus-visible:ring-offset-2 focus-visible:ring-offset-bg ${dragMode === "pan" || (dragMode === "orbit" && ctrlHeld) ? "cursor-move" : "cursor-grab active:cursor-grabbing"}`}
+      className={`relative h-full w-full outline-none focus-visible:ring-2 focus-visible:ring-accent/40 focus-visible:ring-offset-2 focus-visible:ring-offset-bg ${effectivePanMode ? "cursor-move" : "cursor-grab active:cursor-grabbing"}`}
       tabIndex={0}
+      onPointerEnter={(e) => {
+        setPanModifierHeld(hasPanModifier(e));
+      }}
       onPointerDown={(e) => {
+        setPanModifierHeld(hasPanModifier(e));
         containerRef.current?.focus();
       }}
+      onPointerMove={(e) => {
+        setPanModifierHeld(hasPanModifier(e));
+      }}
+      onPointerLeave={() => {
+        setPanModifierHeld(false);
+      }}
       onBlur={() => {
-        setCtrlHeld(false);
+        setPanModifierHeld(false);
       }}
       onKeyDown={(e) => {
-        // OrbitControls already maps Ctrl+left-drag to pan when LEFT is ROTATE.
+        // OrbitControls already maps modifier+left-drag to pan when LEFT is ROTATE.
         // Flipping dragMode here inverts back to rotate due its modifier behavior.
-        if ((e.key === "Control" || e.code === "ControlLeft" || e.code === "ControlRight") && !e.repeat) setCtrlHeld(true);
+        if (isPanModifierKey(e)) {
+          setPanModifierHeld(hasPanModifier(e));
+        }
         if ((e.key === "r" || e.key === "R") && !e.repeat) {
           e.preventDefault();
           fitView();
@@ -1040,42 +1214,51 @@ export const VoxelViewer = forwardRef<VoxelViewerHandle, ViewerProps>(function V
           e.preventDefault();
           void toggleFullscreen();
         }
+        if ((e.key === "s" || e.key === "S") && !e.repeat && !e.metaKey && !e.ctrlKey && !e.altKey) {
+          e.preventDefault();
+          toggleViewerSpinPreference();
+          requestRenderRef.current?.();
+        }
       }}
       onKeyUp={(e) => {
-        if (e.key === "Control" || e.code === "ControlLeft" || e.code === "ControlRight") setCtrlHeld(false);
+        if (isPanModifierKey(e)) setPanModifierHeld(hasPanModifier(e));
       }}
     >
       <div ref={mountRef} className="h-full w-full" />
 
       {showControls ? (
-        <div className="absolute inset-x-2.5 bottom-2.5 flex items-center gap-1 rounded-xl border border-border/60 bg-bg/70 p-1 backdrop-blur-md sm:inset-x-auto sm:bottom-auto sm:right-3 sm:top-3 sm:gap-2 sm:rounded-2xl sm:border-transparent sm:bg-transparent sm:p-0 sm:shadow-none sm:backdrop-blur-0">
-          <button
-            aria-pressed={dragMode === "pan" || (dragMode === "orbit" && ctrlHeld)}
-            aria-label={dragMode === "pan" || (dragMode === "orbit" && ctrlHeld) ? "Switch to rotate mode" : "Switch to move mode"}
-            className={`mb-btn h-9 flex-1 px-3 text-[12px] sm:h-9 sm:flex-none sm:px-3 sm:text-xs ${dragMode === "pan" || (dragMode === "orbit" && ctrlHeld) ? "mb-btn-primary" : "mb-btn-ghost"}`}
-            onClick={() => setDragMode((m) => (m === "pan" ? "orbit" : "pan"))}
-          >
-            <span>Move</span>
-            <span className="hidden sm:inline"><span className="mb-kbd">Ctrl</span></span>
-          </button>
-          <button
-            aria-label="Reset camera framing"
-            className="mb-btn mb-btn-ghost h-9 flex-1 px-3 text-[12px] sm:h-9 sm:flex-none sm:px-3 sm:text-xs"
-            onClick={fitView}
-          >
-            Reset <span className="hidden sm:inline"><span className="mb-kbd">R</span></span>
-          </button>
-          {supportsFullscreen || isFullscreen ? (
+        <>
+          <ViewerControlHint isPanMode={effectivePanMode} spinEnabled={Boolean(autoRotate && spinPreferenceEnabled)} />
+          <div className="absolute inset-x-2.5 bottom-2 flex items-center gap-1 rounded-xl border border-border/60 bg-bg/65 p-1 backdrop-blur-md sm:inset-x-auto sm:bottom-auto sm:right-3 sm:top-3 sm:gap-1.5 sm:rounded-full sm:border-transparent sm:bg-transparent sm:p-0 sm:shadow-none sm:backdrop-blur-0">
             <button
-              aria-label={isFullscreen ? "Exit fullscreen" : "Open fullscreen"}
-              className="mb-btn mb-btn-ghost h-9 flex-1 px-3 text-[12px] sm:h-9 sm:flex-none sm:px-3 sm:text-xs"
-              onClick={() => void toggleFullscreen()}
+              aria-pressed={effectivePanMode}
+              aria-label={effectivePanMode ? "Switch to rotate mode" : "Switch to pan mode"}
+              className={effectivePanMode ? controlActiveClass : controlGhostClass}
+              onClick={() => setDragMode((m) => (m === "pan" ? "orbit" : "pan"))}
             >
-              {isFullscreen ? "Exit" : "Expand"}{" "}
-              <span className="hidden sm:inline"><span className="mb-kbd">F</span></span>
+              <span>Pan</span>
+              <span className={effectivePanMode ? activeControlKeyClass : controlKeyClass}>Ctrl</span>
             </button>
-          ) : null}
-        </div>
+            <button
+              aria-label="Reset camera framing"
+              className={controlGhostClass}
+              onClick={fitView}
+            >
+              <span>Reset</span>
+              <span className={controlKeyClass}>R</span>
+            </button>
+            {supportsFullscreen || isFullscreen ? (
+              <button
+                aria-label={isFullscreen ? "Exit fullscreen" : "Open fullscreen"}
+                className={controlGhostClass}
+                onClick={() => void toggleFullscreen()}
+              >
+                <span>{isFullscreen ? "Exit" : "Expand"}</span>
+                <span className={controlKeyClass}>F</span>
+              </button>
+            ) : null}
+          </div>
+        </>
       ) : null}
     </div>
   );

--- a/components/voxel/VoxelViewerCard.tsx
+++ b/components/voxel/VoxelViewerCard.tsx
@@ -356,17 +356,6 @@ export function VoxelViewerCard({
             </div>
           ) : null}
 
-          {showBuildView && build ? (
-            <div className="pointer-events-none absolute bottom-[3.5rem] left-2.5 flex gap-2 sm:bottom-3 sm:left-3">
-              <span className="mb-badge px-2 py-0.5 text-[10px] sm:px-3 sm:py-1.5 sm:text-xs">
-                <span className="sm:hidden">Drag to spin • Pinch to zoom</span>
-                <span className="hidden sm:inline">
-                  Drag to rotate • <span className="mb-kbd">Ctrl</span>+drag to pan • Scroll to zoom
-                </span>
-              </span>
-            </div>
-          ) : null}
-
           {showLoadingHud ? (
             <VoxelLoadingHud
               label={hudLabel}


### PR DESCRIPTION
## What does this PR do?

Closes #37 (`[Feature] turn off the default spinning thing`).

- Adds a session-scoped viewer spin preference that can be toggled with `S` on desktop and double-tap on touch devices.
- Keeps spin resumable after rotate/pan interactions while making explicit spin off/on state visible in the viewer hint row.
- Makes Shift/Ctrl/Meta pan modifiers update the cursor and active pan state consistently.
- Reworks viewer controls into a denser, quieter toolbar with `Pan`, `Reset`, and `Expand` actions.
- Moves the build interaction hint into `VoxelViewer` so it can reflect the current rotate/pan mode.
- Stabilizes the mobile Build A/B selector and removes the old animated swipe hint that could compete with the selected state.

## Why?

The opened issue called out frustration with the default spinning behavior when users want to manually turn a build. The viewer now has a clean, reversible spin model: `S` toggles spin on desktop, double-tap toggles spin on touch devices, and regular rotate/pan interaction only pauses motion while the user is actively manipulating the build.

The same pass keeps the controls compact, fixes modifier-based pan affordances, quiets the mobile hint row, and keeps the mobile selector readable without relying on moving accent-color indicators.

## How to test

- `git diff --check`
- `pnpm lint`
- `pnpm exec tsc --noEmit`
- `npx impeccable --json components/arena/Arena.tsx components/voxel/VoxelViewer.tsx components/voxel/VoxelViewerCard.tsx`
- `pnpm build`
- `graphify update .`
- Local dev smoke check:
  - `GET /` -> `200`
  - `GET /api/arena/matchup?payload=adaptive` -> `200`

## Checklist

- [x] `pnpm lint` passes
- [x] Tested locally
- [x] Updated README or docs if needed
- [x] Desktop spin can be toggled with `S`
- [x] Mobile spin can be toggled by double-tapping the build canvas
- [x] Pan modifier state and cursor feedback stay aligned
- [x] Mobile Build A/B selector avoids accent-color jitter and clearly marks the selected build

_(PR Body Written by Codex)_
