### PR TITLE
(feat) add gemini 3.5 flash support

### DIFF
--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -108,6 +108,7 @@ Copy `.env.example` to `.env` and set what you need.
 - `OPENAI_BACKGROUND_POLL_MS=2000` (poll interval for background mode)
 - `ANTHROPIC_ENABLE_1M_CONTEXT_BETA=1`
 - `ANTHROPIC_THINKING_BUDGET` (legacy/manual thinking models)
+- Gemini 3.5 Flash uses the native Google AI model ID `gemini-3.5-flash`, supports `thinking_level=high|medium|low|minimal`, and MineBench defaults it to `high` with a 65536-token output cap.
 - Grok 4.3 uses the native xAI API, reasons automatically, rejects `reasoning_effort`, and uses a `max_tokens` request of up to 1000000 unless `MINEBENCH_MAX_OUTPUT_TOKENS` lowers it; MineBench does not send a thinking override for this model.
 - DeepSeek V4 Pro uses the native DeepSeek API with JSON Output mode, defaults to `thinking=max` and `max_tokens=384000`; use `pnpm batch:generate --reasoning high` only when intentionally lowering effort.
 - `OPENROUTER_BASE_URL`, `MOONSHOT_BASE_URL`, `DEEPSEEK_BASE_URL`, `MINIMAX_BASE_URL`, `XAI_BASE_URL`

--- a/lib/ai/generateVoxelBuild.ts
+++ b/lib/ai/generateVoxelBuild.ts
@@ -69,6 +69,9 @@ function maxOutputTokenCapForModel(modelId: string): number | undefined {
   // gpt-5-pro alias remaining at 272k.
   if (modelId === "gpt-5-pro") return 272_000;
   if (modelId.startsWith("gpt-5")) return 128_000;
+  if (modelId === "gemini-3.5-flash" || modelId === "google/gemini-3.5-flash") {
+    return 65_536;
+  }
   if (modelId === "grok-4.3" || modelId === "x-ai/grok-4.3") return 1_000_000;
   if (
     modelId === "deepseek-v4-pro" ||
@@ -236,6 +239,8 @@ function providerRequestTraceLine(opts: {
           ? 0.6
           : 1.0
         : 0.6
+      : opts.route === "direct" && opts.provider === "gemini" && opts.modelId.startsWith("gemini-3")
+      ? "default"
       : DEFAULT_TEMPERATURE;
   return `Request config: max_output_tokens=${Math.floor(opts.maxOutputTokens)}, reasoning_max_tokens=${formatOptionalInteger(opts.reasoningMaxTokens)}, thinking_mode=${thinkingMode}, temperature=${temperature}.`;
 }

--- a/lib/ai/modelCatalog.ts
+++ b/lib/ai/modelCatalog.ts
@@ -31,6 +31,7 @@ export type ModelKey =
   | "anthropic_claude_4_5_opus"
   | "anthropic_claude_4_6_opus"
   | "anthropic_claude_4_7_opus"
+  | "gemini_3_5_flash"
   | "gemini_3_0_pro"
   | "gemini_3_1_pro"
   | "gemini_3_0_flash"
@@ -226,6 +227,14 @@ export const MODEL_CATALOG: ModelCatalogEntry[] = [
     displayName: "Claude 4.7 Opus",
     enabled: true,
     openRouterModelId: "anthropic/claude-opus-4.7",
+  },
+  {
+    key: "gemini_3_5_flash",
+    provider: "gemini",
+    modelId: "gemini-3.5-flash",
+    displayName: "Gemini 3.5 Flash",
+    enabled: true,
+    openRouterModelId: "google/gemini-3.5-flash",
   },
   {
     key: "gemini_3_0_pro",

--- a/lib/ai/providers/gemini.ts
+++ b/lib/ai/providers/gemini.ts
@@ -26,6 +26,10 @@ function bestThinkingConfigForModel(modelId: string): GeminiThinkingConfig | und
   return undefined;
 }
 
+function usesDefaultSampling(modelId: string): boolean {
+  return modelId.startsWith("gemini-3");
+}
+
 function withMaxOutputTokens(message: string, maxOutputTokens: number): string {
   const budget = Math.floor(maxOutputTokens);
   const trimmed = message.trim().replace(/[.!?]$/, "");
@@ -75,14 +79,15 @@ export async function geminiGenerateText(params: {
   try {
     const thinkingConfig = params.thinkingConfig ?? bestThinkingConfigForModel(params.modelId);
     const thinkingConfigLine = describeThinkingConfigLine(thinkingConfig);
+    const generationConfig = {
+      ...(usesDefaultSampling(params.modelId) ? {} : { temperature: params.temperature ?? 0.2 }),
+      maxOutputTokens: params.maxOutputTokens ?? 8192,
+      ...(thinkingConfig ? { thinkingConfig } : {}),
+    };
     const basePayload = {
       systemInstruction: { parts: [{ text: params.system }] },
       contents: [{ role: "user", parts: [{ text: params.user }] }],
-      generationConfig: {
-        temperature: params.temperature ?? 0.2,
-        maxOutputTokens: params.maxOutputTokens ?? 8192,
-        ...(thinkingConfig ? { thinkingConfig } : {}),
-      },
+      generationConfig,
     };
 
     const uniqTokens = tokenBudgetCandidates(basePayload.generationConfig.maxOutputTokens);

--- a/lib/ai/reasoningProfiles.ts
+++ b/lib/ai/reasoningProfiles.ts
@@ -20,6 +20,10 @@ function normalizeReasoningOverride(value?: string): string | undefined {
   return normalized ? normalized : undefined;
 }
 
+function isGemini3FlashFamily(modelId: string): boolean {
+  return /(?:^|\/)gemini-3(?:[.-]\d+)?-flash/.test(modelId);
+}
+
 function descendingAttempts<T extends string>(
   label: string,
   allowed: readonly T[],
@@ -99,18 +103,16 @@ export function geminiThinkingConfigForModel(
   const normalized = normalizeReasoningOverride(override);
 
   if (modelId.startsWith("gemini-3")) {
+    const allowed: readonly GeminiThinkingLevel[] = isGemini3FlashFamily(modelId)
+      ? ["high", "medium", "low", "minimal"]
+      : ["high", "low"];
     if (!normalized) return { thinkingLevel: "high" };
-    if (
-      normalized !== "high" &&
-      normalized !== "medium" &&
-      normalized !== "low" &&
-      normalized !== "minimal"
-    ) {
+    if (!allowed.includes(normalized as GeminiThinkingLevel)) {
       throw new Error(
-        `Gemini model ${modelId} does not support reasoning '${override}'. Supported values: high, medium, low, minimal.`,
+        `Gemini model ${modelId} does not support reasoning '${override}'. Supported values: ${allowed.join(", ")}.`,
       );
     }
-    return { thinkingLevel: normalized };
+    return { thinkingLevel: normalized as GeminiThinkingLevel };
   }
 
   if (modelId.startsWith("gemma-4")) {
@@ -288,7 +290,11 @@ export function openRouterReasoningEffortAttempts(
     return descendingAttempts(label, ["xhigh", "high", "medium", "low"], override);
   }
   if (modelId.startsWith("google/gemini-3")) {
-    return descendingAttempts(label, ["high", "medium", "low", "minimal"], override);
+    return descendingAttempts(
+      label,
+      isGemini3FlashFamily(modelId) ? ["high", "medium", "low", "minimal"] : ["high", "low"],
+      override,
+    );
   }
   if (modelId === "google/gemma-4-31b-it") {
     return descendingAttempts(label, ["high"], override);

--- a/lib/ai/reasoningProfiles.ts
+++ b/lib/ai/reasoningProfiles.ts
@@ -292,7 +292,9 @@ export function openRouterReasoningEffortAttempts(
   if (modelId.startsWith("google/gemini-3")) {
     return descendingAttempts(
       label,
-      isGemini3FlashFamily(modelId) ? ["high", "medium", "low", "minimal"] : ["high", "low"],
+      isGemini3FlashFamily(modelId)
+        ? ["high", "medium", "low", "minimal"]
+        : ["high", "medium", "low"],
       override,
     );
   }

--- a/lib/ai/reasoningProfiles.ts
+++ b/lib/ai/reasoningProfiles.ts
@@ -1,7 +1,8 @@
 export type AnthropicAdaptiveEffort = "low" | "medium" | "high" | "max";
+export type GeminiThinkingLevel = "minimal" | "low" | "medium" | "high";
 
 export type GeminiThinkingConfig = {
-  thinkingLevel?: "low" | "high";
+  thinkingLevel?: GeminiThinkingLevel;
   thinkingBudget?: number;
 };
 
@@ -99,9 +100,14 @@ export function geminiThinkingConfigForModel(
 
   if (modelId.startsWith("gemini-3")) {
     if (!normalized) return { thinkingLevel: "high" };
-    if (normalized !== "high" && normalized !== "low") {
+    if (
+      normalized !== "high" &&
+      normalized !== "medium" &&
+      normalized !== "low" &&
+      normalized !== "minimal"
+    ) {
       throw new Error(
-        `Gemini model ${modelId} does not support reasoning '${override}'. Supported values: high, low.`,
+        `Gemini model ${modelId} does not support reasoning '${override}'. Supported values: high, medium, low, minimal.`,
       );
     }
     return { thinkingLevel: normalized };

--- a/scripts/uploadsCatalog.ts
+++ b/scripts/uploadsCatalog.ts
@@ -53,6 +53,7 @@ export const MODEL_SLUG: Record<ModelKey, string> = {
   anthropic_claude_4_5_opus: "opus",
   anthropic_claude_4_6_opus: "opus-4-6",
   anthropic_claude_4_7_opus: "opus-4-7",
+  gemini_3_5_flash: "gemini-3-5-flash",
   gemini_3_0_pro: "gemini-pro",
   gemini_3_1_pro: "gemini-3-1-pro",
   gemini_3_0_flash: "gemini-flash",


### PR DESCRIPTION
## What does this PR do?

- Adds Gemini 3.5 Flash as a first-class MineBench model using the native Google AI model ID `gemini-3.5-flash`.
- Wires the batch/upload slug `gemini-3-5-flash` for generation and import workflows.
- Caps Gemini 3.5 Flash at the documented 65536-token output limit before MineBench builds the schema/request budget.
- Expands direct Gemini 3 thinking overrides to `high`, `medium`, `low`, and `minimal`, while defaulting MineBench runs to `high` for the strongest supported native reasoning mode.
- Preserves OpenRouter fallback via `google/gemini-3.5-flash`.
- Stops sending sampling overrides for direct Gemini 3.x requests so the Google route follows the Gemini 3.x parameter guidance.
- Documents the Gemini 3.5 Flash model ID, thinking levels, and output cap in local development notes.

## Why?

Google's current Gemini API docs list Gemini 3.5 Flash as GA/stable with model ID `gemini-3.5-flash`, a 1,048,576-token input window, a 65,536-token output limit, structured outputs, Batch API support, function calling, code execution, search grounding, URL context, caching, Flex inference, Priority inference, and thinking support.

The Gemini 3.5 migration guide also says Gemini 3.x should use `thinking_level` instead of `thinking_budget`, with available values `minimal`, `low`, `medium`, and `high`; `medium` is Google's default, but MineBench uses `high` by default to benchmark the highest supported native reasoning setting. The same guide recommends removing `temperature`, `top_p`, and `top_k` for Gemini 3.x requests, so the direct Gemini provider now leaves sampling at provider defaults for these models.

## How to test

- `npx tsx -e "import { getModelByKey } from './lib/ai/modelCatalog'; import { MODEL_SLUG, MODEL_KEY_BY_SLUG } from './scripts/uploadsCatalog'; import { geminiThinkingConfigForModel, openRouterReasoningEffortAttempts } from './lib/ai/reasoningProfiles'; const key = MODEL_KEY_BY_SLUG['gemini-3-5-flash']; const model = getModelByKey(key); console.log(JSON.stringify({ key, slug: MODEL_SLUG[key], provider: model.provider, modelId: model.modelId, displayName: model.displayName, openRouterModelId: model.openRouterModelId, directDefault: geminiThinkingConfigForModel(model.modelId), directMedium: geminiThinkingConfigForModel(model.modelId, 'medium'), directMinimal: geminiThinkingConfigForModel(model.modelId, 'minimal'), openRouter: openRouterReasoningEffortAttempts(model.openRouterModelId ?? '') }, null, 2));"`
- `npx tsx -e "import { generateVoxelBuild } from './lib/ai/generateVoxelBuild'; void (async () => { try { await generateVoxelBuild({ prompt: 'castle', gridSize: 64, palette: 'simple', modelKey: 'gemini_3_5_flash', providerKeys: { gemini: 'fake-key' }, allowServerKeys: false, maxAttempts: 1, onProviderTrace: (message) => console.log(message) }); } catch (error) { console.log(String(error instanceof Error ? error.message : error)); } })();"`
- `pnpm batch:generate --model gemini-3-5-flash`
- `npx tsx -e "import { geminiThinkingConfigForModel } from './lib/ai/reasoningProfiles'; for (const level of ['high','medium','low','minimal'] as const) console.log(level, JSON.stringify(geminiThinkingConfigForModel('gemini-3.5-flash', level))); try { geminiThinkingConfigForModel('gemini-3.5-flash', 'max'); } catch (error) { console.log(String(error instanceof Error ? error.message : error)); }"`
- `pnpm lint`
- `pnpm build`
- `graphify update .`

`pnpm build` passed after refreshing the local pnpm install. It emitted the existing sitemap fallback warning because the local Postgres server at `localhost:54327` was not running.

## Checklist

- [x] Added catalog entry and batch/upload slug
- [x] Confirmed direct Gemini routing uses `gemini-3.5-flash`
- [x] Confirmed direct Gemini thinking defaults to `high` and supports `medium`, `low`, and `minimal` overrides
- [x] Confirmed unsupported `max` override is rejected instead of silently inventing a Gemini effort level
- [x] Preserved OpenRouter fallback routing
- [x] Applied the documented 65536-token output cap
- [x] Removed direct Gemini 3.x sampling overrides
- [x] Ran lint, build, graphify update, and no-generation slug/routing checks

_(PR written by Codex)_