### PR TITLE
(feat) add claude opus 4.8 support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,11 +36,13 @@ OPENROUTER_API_KEY=
 GOOGLE_SITE_VERIFICATION=
 
 # Optional overrides (defaults are used if unset)
-# Claude Opus 4.7 adaptive thinking effort: low | medium | high | max
+# Claude Opus 4.8 adaptive thinking effort: low | medium | high | xhigh | max
+ANTHROPIC_OPUS_4_8_EFFORT=max
+# Claude Opus 4.7 adaptive thinking effort: low | medium | high | xhigh | max
 ANTHROPIC_OPUS_4_7_EFFORT=max
-# Claude Opus 4.6 adaptive thinking effort: low | medium | high | max
+# Claude Opus 4.6 adaptive thinking effort: low | medium | high | xhigh | max
 ANTHROPIC_OPUS_4_6_EFFORT=max
-# Claude Sonnet 4.6 adaptive thinking effort: low | medium | high (max is unsupported)
+# Claude Sonnet 4.6 adaptive thinking effort: low | medium | high | xhigh | max
 ANTHROPIC_SONNET_4_6_EFFORT=high
 # Stream Anthropic responses (recommended for long-thinking runs)
 ANTHROPIC_STREAM_RESPONSES=1

--- a/.env.example
+++ b/.env.example
@@ -40,9 +40,9 @@ GOOGLE_SITE_VERIFICATION=
 ANTHROPIC_OPUS_4_8_EFFORT=max
 # Claude Opus 4.7 adaptive thinking effort: low | medium | high | xhigh | max
 ANTHROPIC_OPUS_4_7_EFFORT=max
-# Claude Opus 4.6 adaptive thinking effort: low | medium | high | xhigh | max
+# Claude Opus 4.6 adaptive thinking effort: low | medium | high | max
 ANTHROPIC_OPUS_4_6_EFFORT=max
-# Claude Sonnet 4.6 adaptive thinking effort: low | medium | high | xhigh | max
+# Claude Sonnet 4.6 adaptive thinking effort: low | medium | high | max
 ANTHROPIC_SONNET_4_6_EFFORT=high
 # Stream Anthropic responses (recommended for long-thinking runs)
 ANTHROPIC_STREAM_RESPONSES=1

--- a/components/sandbox/SandboxLive.tsx
+++ b/components/sandbox/SandboxLive.tsx
@@ -1088,7 +1088,7 @@ export function SandboxLive({ initialPrompt }: { initialPrompt?: string }) {
                           value={customModel.modelId}
                           onChange={(e) => updateCustomModel({ modelId: e.target.value })}
                           disabled={running}
-                          placeholder="aws/anthropic/bedrock-claude-opus-4-7"
+                          placeholder="aws/anthropic/bedrock-claude-opus-4-8"
                         />
                       </label>
                       <label className="flex flex-col gap-1">

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -101,8 +101,8 @@ Copy `.env.example` to `.env` and set what you need.
 - `MINEBENCH_ALLOW_SERVER_KEYS=1` (production opt-in for server env keys in `/api/generate`)
 - `ANTHROPIC_OPUS_4_8_EFFORT=low|medium|high|xhigh|max`
 - `ANTHROPIC_OPUS_4_7_EFFORT=low|medium|high|xhigh|max`
-- `ANTHROPIC_OPUS_4_6_EFFORT=low|medium|high|xhigh|max`
-- `ANTHROPIC_SONNET_4_6_EFFORT=low|medium|high|xhigh|max` (runtime falls back automatically if provider rejects `max`)
+- `ANTHROPIC_OPUS_4_6_EFFORT=low|medium|high|max`
+- `ANTHROPIC_SONNET_4_6_EFFORT=low|medium|high|max` (runtime falls back automatically if provider rejects `max`)
 - `ANTHROPIC_STREAM_RESPONSES=1`
 - `OPENAI_STREAM_RESPONSES=1` (applies to live-delta callers; batch generation uses non-streamed Responses JSON)
 - `OPENAI_USE_BACKGROUND_MODE=1` (recommended for long-running Responses jobs; defaults on for `gpt-5*` when not streaming deltas)

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -99,15 +99,17 @@ Copy `.env.example` to `.env` and set what you need.
 ### Optional Provider and Runtime Tuning
 
 - `MINEBENCH_ALLOW_SERVER_KEYS=1` (production opt-in for server env keys in `/api/generate`)
-- `ANTHROPIC_OPUS_4_7_EFFORT=low|medium|high|max`
-- `ANTHROPIC_OPUS_4_6_EFFORT=low|medium|high|max`
-- `ANTHROPIC_SONNET_4_6_EFFORT=low|medium|high|max` (runtime falls back automatically if provider rejects `max`)
+- `ANTHROPIC_OPUS_4_8_EFFORT=low|medium|high|xhigh|max`
+- `ANTHROPIC_OPUS_4_7_EFFORT=low|medium|high|xhigh|max`
+- `ANTHROPIC_OPUS_4_6_EFFORT=low|medium|high|xhigh|max`
+- `ANTHROPIC_SONNET_4_6_EFFORT=low|medium|high|xhigh|max` (runtime falls back automatically if provider rejects `max`)
 - `ANTHROPIC_STREAM_RESPONSES=1`
 - `OPENAI_STREAM_RESPONSES=1` (applies to live-delta callers; batch generation uses non-streamed Responses JSON)
 - `OPENAI_USE_BACKGROUND_MODE=1` (recommended for long-running Responses jobs; defaults on for `gpt-5*` when not streaming deltas)
 - `OPENAI_BACKGROUND_POLL_MS=2000` (poll interval for background mode)
 - `ANTHROPIC_ENABLE_1M_CONTEXT_BETA=1`
 - `ANTHROPIC_THINKING_BUDGET` (legacy/manual thinking models)
+- Claude 4.8 Opus uses the native Anthropic model ID `claude-opus-4-8`, supports adaptive effort `low|medium|high|xhigh|max`, and MineBench defaults it to `max` with a 128000-token output cap.
 - Gemini 3.5 Flash uses the native Google AI model ID `gemini-3.5-flash`, supports `thinking_level=high|medium|low|minimal`, and MineBench defaults it to `high` with a 65536-token output cap.
 - Grok 4.3 uses the native xAI API, reasons automatically, rejects `reasoning_effort`, and uses a `max_tokens` request of up to 1000000 unless `MINEBENCH_MAX_OUTPUT_TOKENS` lowers it; MineBench does not send a thinking override for this model.
 - DeepSeek V4 Pro uses the native DeepSeek API with JSON Output mode, defaults to `thinking=max` and `max_tokens=384000`; use `pnpm batch:generate --reasoning high` only when intentionally lowering effort.

--- a/lib/ai/generateVoxelBuild.ts
+++ b/lib/ai/generateVoxelBuild.ts
@@ -84,6 +84,8 @@ function maxOutputTokenCapForModel(modelId: string): number | undefined {
   if (modelId === "deepseek/deepseek-v3.2") return 65_536;
   if (modelId === "glm-5.1" || modelId === "glm-5") return 131_072;
   if (
+    modelId.startsWith("claude-opus-4-8") ||
+    modelId === "anthropic/claude-opus-4.8" ||
     modelId.startsWith("claude-opus-4-7") ||
     modelId === "anthropic/claude-opus-4.7"
   ) {

--- a/lib/ai/modelCatalog.ts
+++ b/lib/ai/modelCatalog.ts
@@ -31,6 +31,7 @@ export type ModelKey =
   | "anthropic_claude_4_5_opus"
   | "anthropic_claude_4_6_opus"
   | "anthropic_claude_4_7_opus"
+  | "anthropic_claude_4_8_opus"
   | "gemini_3_5_flash"
   | "gemini_3_0_pro"
   | "gemini_3_1_pro"
@@ -227,6 +228,14 @@ export const MODEL_CATALOG: ModelCatalogEntry[] = [
     displayName: "Claude 4.7 Opus",
     enabled: true,
     openRouterModelId: "anthropic/claude-opus-4.7",
+  },
+  {
+    key: "anthropic_claude_4_8_opus",
+    provider: "anthropic",
+    modelId: "claude-opus-4-8",
+    displayName: "Claude 4.8 Opus",
+    enabled: true,
+    openRouterModelId: "anthropic/claude-opus-4.8",
   },
   {
     key: "gemini_3_5_flash",

--- a/lib/ai/providers/anthropic.ts
+++ b/lib/ai/providers/anthropic.ts
@@ -16,7 +16,7 @@ type AnthropicStreamEvent = {
   delta?: { type?: unknown; text?: unknown } | unknown;
 };
 
-type AnthropicEffort = "low" | "medium" | "high" | "max";
+type AnthropicEffort = "low" | "medium" | "high" | "xhigh" | "max";
 
 const CONTEXT_1M_BETA = "context-1m-2025-08-07";
 const STRUCTURED_OUTPUT_TOOL_NAME = "emit_structured_json";
@@ -144,15 +144,15 @@ function parseEffortEnv(
   opts: { defaultEffort: AnthropicEffort; allowMax: boolean },
 ): AnthropicEffort {
   const raw = (process.env[envVar] ?? "").trim().toLowerCase();
-  if (raw === "low" || raw === "medium" || raw === "high") return raw;
+  if (raw === "low" || raw === "medium" || raw === "high" || raw === "xhigh") return raw;
   if (raw === "max") return opts.allowMax ? "max" : "high";
   return opts.defaultEffort;
 }
 
 function effortFallbacks(initial: AnthropicEffort, opts: { allowMax: boolean }): AnthropicEffort[] {
   const ordered: AnthropicEffort[] = opts.allowMax
-    ? ["max", "high", "medium", "low"]
-    : ["high", "medium", "low"];
+    ? ["max", "xhigh", "high", "medium", "low"]
+    : ["xhigh", "high", "medium", "low"];
   const startIndex = Math.max(0, ordered.indexOf(initial));
   return ordered.slice(startIndex);
 }
@@ -180,6 +180,10 @@ function isOpus47(modelId: string): boolean {
   return modelId.startsWith("claude-opus-4-7");
 }
 
+function isOpus48(modelId: string): boolean {
+  return modelId.startsWith("claude-opus-4-8");
+}
+
 function isOpus46(modelId: string): boolean {
   return modelId.startsWith("claude-opus-4-6");
 }
@@ -189,10 +193,17 @@ function isSonnet46(modelId: string): boolean {
 }
 
 function isAdaptiveThinkingModel(modelId: string): boolean {
-  return isOpus47(modelId) || isOpus46(modelId) || isSonnet46(modelId);
+  return isOpus48(modelId) || isOpus47(modelId) || isOpus46(modelId) || isSonnet46(modelId);
 }
 
 function parseAdaptiveEfforts(modelId: string): AnthropicEffort[] {
+  if (isOpus48(modelId)) {
+    const preferred = parseEffortEnv("ANTHROPIC_OPUS_4_8_EFFORT", {
+      defaultEffort: "max",
+      allowMax: true,
+    });
+    return effortFallbacks(preferred, { allowMax: true });
+  }
   if (isOpus47(modelId)) {
     const preferred = parseEffortEnv("ANTHROPIC_OPUS_4_7_EFFORT", {
       defaultEffort: "max",

--- a/lib/ai/providers/anthropic.ts
+++ b/lib/ai/providers/anthropic.ts
@@ -141,18 +141,23 @@ function parseThinkingBudget(): number | null {
 
 function parseEffortEnv(
   envVar: string,
-  opts: { defaultEffort: AnthropicEffort; allowMax: boolean },
+  opts: { defaultEffort: AnthropicEffort; allowMax: boolean; allowXhigh: boolean },
 ): AnthropicEffort {
   const raw = (process.env[envVar] ?? "").trim().toLowerCase();
-  if (raw === "low" || raw === "medium" || raw === "high" || raw === "xhigh") return raw;
+  if (raw === "low" || raw === "medium" || raw === "high") return raw;
+  if (raw === "xhigh") return opts.allowXhigh ? "xhigh" : "high";
   if (raw === "max") return opts.allowMax ? "max" : "high";
   return opts.defaultEffort;
 }
 
-function effortFallbacks(initial: AnthropicEffort, opts: { allowMax: boolean }): AnthropicEffort[] {
+function effortFallbacks(initial: AnthropicEffort, opts: { allowMax: boolean; allowXhigh: boolean }): AnthropicEffort[] {
   const ordered: AnthropicEffort[] = opts.allowMax
-    ? ["max", "xhigh", "high", "medium", "low"]
-    : ["xhigh", "high", "medium", "low"];
+    ? opts.allowXhigh
+      ? ["max", "xhigh", "high", "medium", "low"]
+      : ["max", "high", "medium", "low"]
+    : opts.allowXhigh
+      ? ["xhigh", "high", "medium", "low"]
+      : ["high", "medium", "low"];
   const startIndex = Math.max(0, ordered.indexOf(initial));
   return ordered.slice(startIndex);
 }
@@ -176,56 +181,56 @@ function isLegacyManualThinkingModel(modelId: string): boolean {
   return modelId.startsWith("claude-sonnet-4-5") || modelId.startsWith("claude-opus-4-5");
 }
 
-function isOpus47(modelId: string): boolean {
-  return modelId.startsWith("claude-opus-4-7");
-}
-
-function isOpus48(modelId: string): boolean {
-  return modelId.startsWith("claude-opus-4-8");
-}
-
-function isOpus46(modelId: string): boolean {
-  return modelId.startsWith("claude-opus-4-6");
-}
-
-function isSonnet46(modelId: string): boolean {
-  return modelId.startsWith("claude-sonnet-4-6");
+function anthropicClaudeVersion(modelId: string): { family: "opus" | "sonnet"; major: number; minor: number } | null {
+  const match = /^claude-(opus|sonnet)-(\d+)-(\d+)(?:-|$)/.exec(modelId);
+  if (!match) return null;
+  const major = Number.parseInt(match[2] ?? "", 10);
+  const minor = Number.parseInt(match[3] ?? "", 10);
+  if (!Number.isFinite(major) || !Number.isFinite(minor)) return null;
+  return { family: match[1] as "opus" | "sonnet", major, minor };
 }
 
 function isAdaptiveThinkingModel(modelId: string): boolean {
-  return isOpus48(modelId) || isOpus47(modelId) || isOpus46(modelId) || isSonnet46(modelId);
+  const version = anthropicClaudeVersion(modelId);
+  if (!version) return false;
+  return version.major > 4 || (version.major === 4 && version.minor >= 6);
+}
+
+function supportsXhighEffort(modelId: string): boolean {
+  const version = anthropicClaudeVersion(modelId);
+  if (!version) return false;
+  return version.major > 4 || (version.major === 4 && version.minor >= 7);
+}
+
+function effortEnvVarForModel(modelId: string): string | null {
+  const version = anthropicClaudeVersion(modelId);
+  if (!version) return null;
+  if (version.family === "opus" && version.major === 4 && version.minor === 8) {
+    return "ANTHROPIC_OPUS_4_8_EFFORT";
+  }
+  if (version.family === "opus" && version.major === 4 && version.minor === 7) {
+    return "ANTHROPIC_OPUS_4_7_EFFORT";
+  }
+  if (version.family === "opus" && version.major === 4 && version.minor === 6) {
+    return "ANTHROPIC_OPUS_4_6_EFFORT";
+  }
+  if (version.family === "sonnet" && version.major === 4 && version.minor === 6) {
+    return "ANTHROPIC_SONNET_4_6_EFFORT";
+  }
+  return null;
 }
 
 function parseAdaptiveEfforts(modelId: string): AnthropicEffort[] {
-  if (isOpus48(modelId)) {
-    const preferred = parseEffortEnv("ANTHROPIC_OPUS_4_8_EFFORT", {
-      defaultEffort: "max",
-      allowMax: true,
-    });
-    return effortFallbacks(preferred, { allowMax: true });
-  }
-  if (isOpus47(modelId)) {
-    const preferred = parseEffortEnv("ANTHROPIC_OPUS_4_7_EFFORT", {
-      defaultEffort: "max",
-      allowMax: true,
-    });
-    return effortFallbacks(preferred, { allowMax: true });
-  }
-  if (isOpus46(modelId)) {
-    const preferred = parseEffortEnv("ANTHROPIC_OPUS_4_6_EFFORT", {
-      defaultEffort: "max",
-      allowMax: true,
-    });
-    return effortFallbacks(preferred, { allowMax: true });
-  }
-  if (isSonnet46(modelId)) {
-    const preferred = parseEffortEnv("ANTHROPIC_SONNET_4_6_EFFORT", {
-      defaultEffort: "max",
-      allowMax: true,
-    });
-    return effortFallbacks(preferred, { allowMax: true });
-  }
-  return ["high"];
+  const allowXhigh = supportsXhighEffort(modelId);
+  const envVar = effortEnvVarForModel(modelId);
+  const preferred = envVar
+    ? parseEffortEnv(envVar, {
+        defaultEffort: "max",
+        allowMax: true,
+        allowXhigh,
+      })
+    : "max";
+  return effortFallbacks(preferred, { allowMax: true, allowXhigh });
 }
 
 function supportsContext1mBeta(modelId: string): boolean {

--- a/lib/ai/reasoningProfiles.ts
+++ b/lib/ai/reasoningProfiles.ts
@@ -1,4 +1,4 @@
-export type AnthropicAdaptiveEffort = "low" | "medium" | "high" | "max";
+export type AnthropicAdaptiveEffort = "low" | "medium" | "high" | "xhigh" | "max";
 export type GeminiThinkingLevel = "minimal" | "low" | "medium" | "high";
 
 export type GeminiThinkingConfig = {
@@ -79,6 +79,7 @@ export function anthropicAdaptiveEffortAttempts(
 ): AnthropicAdaptiveEffort[] | undefined {
   const isAdaptiveModel =
     modelId.startsWith("claude-opus-4-7") ||
+    modelId.startsWith("claude-opus-4-8") ||
     modelId.startsWith("claude-opus-4-6") ||
     modelId.startsWith("claude-sonnet-4-6");
   if (!isAdaptiveModel) {
@@ -91,7 +92,7 @@ export function anthropicAdaptiveEffortAttempts(
 
   return descendingAttempts(
     `Anthropic model ${modelId}`,
-    ["max", "high", "medium", "low"],
+    ["max", "xhigh", "high", "medium", "low"],
     override,
   );
 }
@@ -274,6 +275,7 @@ export function openRouterReasoningEffortAttempts(
   }
   if (
     modelId === "anthropic/claude-opus-4.7" ||
+    modelId === "anthropic/claude-opus-4.8" ||
     modelId === "anthropic/claude-sonnet-4.6" ||
     modelId === "anthropic/claude-opus-4.6"
   ) {

--- a/lib/ai/reasoningProfiles.ts
+++ b/lib/ai/reasoningProfiles.ts
@@ -24,6 +24,27 @@ function isGemini3FlashFamily(modelId: string): boolean {
   return /(?:^|\/)gemini-3(?:[.-]\d+)?-flash/.test(modelId);
 }
 
+function anthropicClaudeVersion(modelId: string): { major: number; minor: number } | null {
+  const match = /(?:^|\/)claude-(?:opus|sonnet)-(\d+)[.-](\d+)(?:[.-]|$)/.exec(modelId);
+  if (!match) return null;
+  const major = Number.parseInt(match[1] ?? "", 10);
+  const minor = Number.parseInt(match[2] ?? "", 10);
+  if (!Number.isFinite(major) || !Number.isFinite(minor)) return null;
+  return { major, minor };
+}
+
+function isAnthropicAdaptiveModel(modelId: string): boolean {
+  const version = anthropicClaudeVersion(modelId);
+  if (!version) return false;
+  return version.major > 4 || (version.major === 4 && version.minor >= 6);
+}
+
+function supportsAnthropicXhighEffort(modelId: string): boolean {
+  const version = anthropicClaudeVersion(modelId);
+  if (!version) return false;
+  return version.major > 4 || (version.major === 4 && version.minor >= 7);
+}
+
 function descendingAttempts<T extends string>(
   label: string,
   allowed: readonly T[],
@@ -77,12 +98,7 @@ export function anthropicAdaptiveEffortAttempts(
   modelId: string,
   override?: string,
 ): AnthropicAdaptiveEffort[] | undefined {
-  const isAdaptiveModel =
-    modelId.startsWith("claude-opus-4-7") ||
-    modelId.startsWith("claude-opus-4-8") ||
-    modelId.startsWith("claude-opus-4-6") ||
-    modelId.startsWith("claude-sonnet-4-6");
-  if (!isAdaptiveModel) {
+  if (!isAnthropicAdaptiveModel(modelId)) {
     const normalized = normalizeReasoningOverride(override);
     if (normalized) {
       throw new Error(`Anthropic model ${modelId} does not expose an adaptive effort override.`);
@@ -92,7 +108,9 @@ export function anthropicAdaptiveEffortAttempts(
 
   return descendingAttempts(
     `Anthropic model ${modelId}`,
-    ["max", "xhigh", "high", "medium", "low"],
+    supportsAnthropicXhighEffort(modelId)
+      ? ["max", "xhigh", "high", "medium", "low"]
+      : ["max", "high", "medium", "low"],
     override,
   );
 }
@@ -273,15 +291,12 @@ export function openRouterReasoningEffortAttempts(
   if (modelId.startsWith("openai/gpt-5")) {
     return descendingAttempts(label, ["xhigh", "high"], override);
   }
-  if (
-    modelId === "anthropic/claude-opus-4.7" ||
-    modelId === "anthropic/claude-opus-4.8" ||
-    modelId === "anthropic/claude-sonnet-4.6" ||
-    modelId === "anthropic/claude-opus-4.6"
-  ) {
+  if (isAnthropicAdaptiveModel(modelId)) {
     return descendingAttempts(
       label,
-      ["max", "xhigh", "high", "medium", "low"],
+      supportsAnthropicXhighEffort(modelId)
+        ? ["max", "xhigh", "high", "medium", "low"]
+        : ["max", "high", "medium", "low"],
       override,
     );
   }

--- a/scripts/uploadsCatalog.ts
+++ b/scripts/uploadsCatalog.ts
@@ -53,6 +53,7 @@ export const MODEL_SLUG: Record<ModelKey, string> = {
   anthropic_claude_4_5_opus: "opus",
   anthropic_claude_4_6_opus: "opus-4-6",
   anthropic_claude_4_7_opus: "opus-4-7",
+  anthropic_claude_4_8_opus: "opus-4-8",
   gemini_3_5_flash: "gemini-3-5-flash",
   gemini_3_0_pro: "gemini-pro",
   gemini_3_1_pro: "gemini-3-1-pro",


### PR DESCRIPTION
## What does this PR do?

- Adds Claude 4.8 Opus as a first-class MineBench model.
- Wires the canonical Anthropic model ID `claude-opus-4-8`.
- Preserves OpenRouter fallback support via `anthropic/claude-opus-4.8`.
- Adds the batch/import slug `opus-4-8`.
- Caps synchronous generation requests at the documented 128000-token output limit.
- Enables the direct Anthropic adaptive effort ladder `max -> xhigh -> high -> medium -> low`, with `ANTHROPIC_OPUS_4_8_EFFORT` for operator overrides.
- Preserves the same OpenRouter effort fallback ladder before dropping to disabled reasoning as the final recovery path.
- Updates local env/docs surfaces and the custom-model placeholder for the new Opus line.

## Why?

Anthropic's current Claude docs list Claude Opus 4.8 with API model ID `claude-opus-4-8`, a 1M-token context window on the Claude API, 128k synchronous Messages API max output, adaptive thinking support, and `low`, `medium`, `high`, `xhigh`, and `max` effort levels. The docs also state that Opus 4.8 uses adaptive thinking instead of manual `budget_tokens`, and that `temperature`, `top_p`, and `top_k` non-defaults are not supported on the Messages API.

MineBench's recent model-add PRs consistently wire model catalog entries, upload slugs, output caps, direct-provider reasoning behavior, OpenRouter fallback behavior, and operator docs together. This follows that pattern and keeps benchmarking on the highest supported effort by default. Fast mode is intentionally not wired into the default path because it is a research-preview premium mode and would change benchmark cost/latency conditions.

References reviewed:

- Anthropic models overview: https://platform.claude.com/docs/en/about-claude/models/overview
- What's new in Claude Opus 4.8: https://platform.claude.com/docs/en/about-claude/models/whats-new-claude-4-8
- Anthropic effort guide: https://platform.claude.com/docs/en/build-with-claude/effort
- OpenRouter Claude Opus 4.8 API page: https://openrouter.ai/anthropic/claude-opus-4.8/api

## How to test

- `npx tsx -e "import assert from 'node:assert/strict'; import { getModelByKey } from './lib/ai/modelCatalog'; import { MODEL_SLUG } from './scripts/uploadsCatalog'; import { anthropicAdaptiveEffortAttempts, openRouterReasoningEffortAttempts } from './lib/ai/reasoningProfiles'; const key = 'anthropic_claude_4_8_opus' as const; const model = getModelByKey(key); assert.equal(model.modelId, 'claude-opus-4-8'); assert.equal(model.openRouterModelId, 'anthropic/claude-opus-4.8'); assert.equal(MODEL_SLUG[key], 'opus-4-8'); assert.deepEqual(anthropicAdaptiveEffortAttempts('claude-opus-4-8'), ['max','xhigh','high','medium','low']); assert.deepEqual(anthropicAdaptiveEffortAttempts('claude-opus-4-8', 'xhigh'), ['xhigh','high','medium','low']); assert.deepEqual(openRouterReasoningEffortAttempts('anthropic/claude-opus-4.8'), ['max','xhigh','high','medium','low']); console.log(JSON.stringify({ key, slug: MODEL_SLUG[key], model }, null, 2));"`
- Direct Anthropic trace probe with a fake key confirmed `max_output_tokens=128000` and `adaptive_effort=max->xhigh->high->medium->low`.
- OpenRouter trace probe with a fake key confirmed `max_output_tokens=128000` and `effort_fallback=max->xhigh->high->medium->low->disabled`.
- `pnpm batch:generate --model opus-4-8`
- `pnpm lint`
- `pnpm build`
- `graphify update .`

## Checklist

- [x] Added catalog entry and upload slug
- [x] Confirmed direct Anthropic routing uses `claude-opus-4-8`
- [x] Confirmed OpenRouter fallback uses `anthropic/claude-opus-4.8`
- [x] Confirmed direct and OpenRouter effort ladders include `max`, `xhigh`, `high`, `medium`, and `low`
- [x] Applied the documented 128000-token synchronous output cap
- [x] Kept fast mode out of the default benchmark path
- [x] Ran focused probes, batch status, lint, build, and graphify update

_(PR written by Codex)_
