### PR TITLE
(fix) decode model detail build artifacts

### DIFF
--- a/components/leaderboard/ModelDetail.tsx
+++ b/components/leaderboard/ModelDetail.tsx
@@ -15,6 +15,11 @@ import type {
   ArenaBuildVariant,
 } from "@/lib/arena/types";
 import {
+  isGzipChunk,
+  readBuildVariantJson,
+  streamFromFirstChunk,
+} from "@/lib/arena/clientBuildResponse";
+import {
   VoxelLoadingHud,
   formatVoxelLoadingMessage,
   type VoxelLoadingProgress,
@@ -77,6 +82,7 @@ const BUILD_CACHE_MAX_ENTRIES = Number.parseInt(
   process.env.NEXT_PUBLIC_MODEL_DETAIL_BUILD_CACHE_MAX_ENTRIES ?? "8",
   10,
 );
+let snapshotStorageRedirectBlocked = false;
 
 type TimeoutSignal = {
   signal: AbortSignal;
@@ -115,12 +121,14 @@ async function readWithTimeout<T>(
   read: () => Promise<T>,
   timeoutMs: number,
   signal?: AbortSignal,
+  onTimeout?: () => void,
 ): Promise<T> {
   if (signal?.aborted) throw new DOMException("Aborted", "AbortError");
   return await new Promise<T>((resolve, reject) => {
     const timer =
       Number.isFinite(timeoutMs) && timeoutMs > 0
         ? window.setTimeout(() => {
+            onTimeout?.();
             cleanup();
             reject(new Error("Build stream stalled"));
           }, timeoutMs)
@@ -202,6 +210,36 @@ function buildCacheKey(buildId: string, variant: ArenaBuildVariant) {
   return `${buildId}:${variant}`;
 }
 
+function isAbortError(err: unknown): boolean {
+  return err instanceof Error && err.name === "AbortError";
+}
+
+function shouldRetrySnapshotWithoutRedirect(status: number): boolean {
+  return [400, 403, 404, 500, 502, 504].includes(status);
+}
+
+async function readErrorResponse(res: Response, fallback: string): Promise<string> {
+  let detail: string | null = null;
+  try {
+    const body = await res.clone().json();
+    if (body && typeof body === "object") {
+      const candidate = (body as Record<string, unknown>).error ?? (body as Record<string, unknown>).message;
+      if (typeof candidate === "string" && candidate.trim()) detail = candidate.trim();
+    }
+  } catch {
+    // fall through to text
+  }
+  if (!detail) {
+    try {
+      const text = (await res.text()).trim();
+      if (text && !text.startsWith("<") && text.length <= 500) detail = text;
+    } catch {
+      // ignore
+    }
+  }
+  return detail ?? fallback;
+}
+
 function rememberLoadedBuild(
   current: Record<string, LoadedPromptBuild>,
   loadedBuild: LoadedPromptBuild,
@@ -225,15 +263,45 @@ async function fetchBuildVariantSnapshot(
   ref: ArenaBuildRef,
   signal?: AbortSignal,
   timeoutMs = SNAPSHOT_FETCH_TIMEOUT_MS,
+  opts?: { redirect?: boolean },
 ): Promise<BuildVariantResponse> {
   const url = new URL(`/api/arena/builds/${encodeURIComponent(ref.buildId)}`, window.location.origin);
   url.searchParams.set("variant", ref.variant);
   if (ref.checksum) url.searchParams.set("checksum", ref.checksum);
+  const allowRedirect = opts?.redirect !== false && !snapshotStorageRedirectBlocked;
+  if (!allowRedirect) url.searchParams.set("redirect", "0");
   const timed = makeTimeoutSignal(signal, timeoutMs);
   try {
-    const res = await fetch(url, { method: "GET", signal: timed.signal });
-    if (!res.ok) throw new Error(await res.text());
-    return (await res.json()) as BuildVariantResponse;
+    let res: Response;
+    try {
+      res = await fetch(url, {
+        method: "GET",
+        credentials: "same-origin",
+        signal: timed.signal,
+        redirect: "follow",
+      });
+    } catch (err: unknown) {
+      if (allowRedirect && !isAbortError(err)) {
+        snapshotStorageRedirectBlocked = true;
+        return fetchBuildVariantSnapshot(ref, signal, timeoutMs, { redirect: false });
+      }
+      throw err;
+    }
+    if (!res.ok) {
+      if (allowRedirect && shouldRetrySnapshotWithoutRedirect(res.status)) {
+        return fetchBuildVariantSnapshot(ref, signal, timeoutMs, { redirect: false });
+      }
+      throw new Error(await readErrorResponse(res, "Failed to load build"));
+    }
+    try {
+      return await readBuildVariantJson<BuildVariantResponse>(res);
+    } catch (err: unknown) {
+      if (allowRedirect && !isAbortError(err)) {
+        snapshotStorageRedirectBlocked = true;
+        return fetchBuildVariantSnapshot(ref, signal, timeoutMs, { redirect: false });
+      }
+      throw err;
+    }
   } finally {
     timed.cleanup();
   }
@@ -257,20 +325,45 @@ async function fetchBuildVariantStreamOnce(
   try {
     res = await fetch(url, {
       method: "GET",
+      credentials: "same-origin",
       signal: requestTimed.signal,
     });
   } finally {
     requestTimed.cleanup();
   }
-  if (!res.ok) throw new Error(await res.text());
+  if (!res.ok) throw new Error(await readErrorResponse(res, "Failed to load build"));
 
   const contentType = res.headers.get("content-type") ?? "";
   if (!res.body || !contentType.includes("application/x-ndjson")) {
-    return (await res.json()) as BuildVariantResponse;
+    return await readBuildVariantJson<BuildVariantResponse>(res);
   }
 
+  let reader: ReadableStreamDefaultReader<Uint8Array> | null = null;
+  let cancelled = false;
+  const cancelReader = () => {
+    if (cancelled) return;
+    cancelled = true;
+    void reader?.cancel().catch(() => undefined);
+  };
+
   try {
-    const reader = res.body.getReader();
+    reader = res.body.getReader();
+    const firstRead = await readWithTimeout(
+      () => reader!.read(),
+      STREAM_FIRST_EVENT_TIMEOUT_MS,
+      opts?.signal,
+      cancelReader,
+    );
+    if (firstRead.done || !firstRead.value) {
+      throw new Error("Build stream ended before any data loaded");
+    }
+    const firstChunk = firstRead.value;
+    const stream = streamFromFirstChunk(firstChunk, reader);
+    reader = isGzipChunk(firstChunk)
+      ? stream
+          .pipeThrough(new DecompressionStream("gzip") as unknown as TransformStream<Uint8Array, Uint8Array>)
+          .getReader()
+      : stream.getReader();
     const decoder = new TextDecoder();
     let buffer = "";
     const startedAt = performance.now();
@@ -349,13 +442,15 @@ async function fetchBuildVariantStreamOnce(
 
     while (true) {
       if (performance.now() - startedAt > STREAM_HARD_TIMEOUT_MS) {
+        cancelReader();
         throw new Error("Build stream hard timeout");
       }
 
       const { done, value } = await readWithTimeout(
-        () => reader.read(),
+        () => reader!.read(),
         sawFirstEvent ? STREAM_STALL_TIMEOUT_MS : STREAM_FIRST_EVENT_TIMEOUT_MS,
         opts?.signal,
+        cancelReader,
       );
       if (done) break;
       buffer += decoder.decode(value, { stream: true });
@@ -378,6 +473,7 @@ async function fetchBuildVariantStreamOnce(
       hasComplete && (announcedTotal == null || streamedBlocks.length >= announcedTotal);
 
     if (!streamLooksComplete) {
+      cancelReader();
       return fetchBuildVariantSnapshot(ref, opts?.signal);
     }
 
@@ -393,7 +489,8 @@ async function fetchBuildVariantStreamOnce(
       },
     };
   } catch (err: unknown) {
-    if (err instanceof Error && err.name === "AbortError") throw err;
+    cancelReader();
+    if (isAbortError(err)) throw err;
     throw err;
   }
 }

--- a/components/leaderboard/ModelDetail.tsx
+++ b/components/leaderboard/ModelDetail.tsx
@@ -15,9 +15,9 @@ import type {
   ArenaBuildVariant,
 } from "@/lib/arena/types";
 import {
-  isGzipChunk,
+  isGzipStreamPrefix,
   readBuildVariantJson,
-  streamFromFirstChunk,
+  streamFromInitialChunks,
 } from "@/lib/arena/clientBuildResponse";
 import {
   VoxelLoadingHud,
@@ -348,18 +348,26 @@ async function fetchBuildVariantStreamOnce(
 
   try {
     reader = res.body.getReader();
-    const firstRead = await readWithTimeout(
-      () => reader!.read(),
-      STREAM_FIRST_EVENT_TIMEOUT_MS,
-      opts?.signal,
-      cancelReader,
-    );
-    if (firstRead.done || !firstRead.value) {
+    const initialChunks: Uint8Array[] = [];
+    let initialByteCount = 0;
+    while (initialByteCount < 2) {
+      const initialRead = await readWithTimeout(
+        () => reader!.read(),
+        STREAM_FIRST_EVENT_TIMEOUT_MS,
+        opts?.signal,
+        cancelReader,
+      );
+      if (initialRead.done) break;
+      if (initialRead.value && initialRead.value.length > 0) {
+        initialChunks.push(initialRead.value);
+        initialByteCount += initialRead.value.length;
+      }
+    }
+    if (initialChunks.length === 0) {
       throw new Error("Build stream ended before any data loaded");
     }
-    const firstChunk = firstRead.value;
-    const stream = streamFromFirstChunk(firstChunk, reader);
-    reader = isGzipChunk(firstChunk)
+    const stream = streamFromInitialChunks(initialChunks, reader);
+    reader = isGzipStreamPrefix(initialChunks)
       ? stream
           .pipeThrough(new DecompressionStream("gzip") as unknown as TransformStream<Uint8Array, Uint8Array>)
           .getReader()

--- a/lib/arena/clientBuildResponse.ts
+++ b/lib/arena/clientBuildResponse.ts
@@ -1,0 +1,46 @@
+const GZIP_MAGIC_0 = 0x1f;
+const GZIP_MAGIC_1 = 0x8b;
+
+export function isGzipChunk(chunk: Uint8Array): boolean {
+  return chunk.length >= 2 && chunk[0] === GZIP_MAGIC_0 && chunk[1] === GZIP_MAGIC_1;
+}
+
+export async function gunzipBytes(bytes: Uint8Array): Promise<Uint8Array> {
+  if (typeof DecompressionStream !== "function") {
+    throw new Error("Compressed build artifact is not supported by this browser.");
+  }
+  const body = bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength) as ArrayBuffer;
+  const decompressor = new DecompressionStream("gzip") as unknown as TransformStream<Uint8Array, Uint8Array>;
+  const stream = new Blob([body]).stream().pipeThrough(decompressor);
+  return new Uint8Array(await new Response(stream).arrayBuffer());
+}
+
+export async function readBuildVariantJson<T>(res: Response): Promise<T> {
+  const bytes = new Uint8Array(await res.arrayBuffer());
+  const body = isGzipChunk(bytes) ? await gunzipBytes(bytes) : bytes;
+  return JSON.parse(new TextDecoder().decode(body)) as T;
+}
+
+export function streamFromFirstChunk(
+  firstChunk: Uint8Array,
+  reader: ReadableStreamDefaultReader<Uint8Array>,
+): ReadableStream<Uint8Array> {
+  return new ReadableStream<Uint8Array>({
+    async start(controller) {
+      controller.enqueue(firstChunk);
+      try {
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          if (value) controller.enqueue(value);
+        }
+        controller.close();
+      } catch (err) {
+        controller.error(err);
+      }
+    },
+    cancel(reason) {
+      return reader.cancel(reason);
+    },
+  });
+}

--- a/lib/arena/clientBuildResponse.ts
+++ b/lib/arena/clientBuildResponse.ts
@@ -5,6 +5,19 @@ export function isGzipChunk(chunk: Uint8Array): boolean {
   return chunk.length >= 2 && chunk[0] === GZIP_MAGIC_0 && chunk[1] === GZIP_MAGIC_1;
 }
 
+function byteAt(chunks: readonly Uint8Array[], targetIndex: number): number | null {
+  let offset = targetIndex;
+  for (const chunk of chunks) {
+    if (offset < chunk.length) return chunk[offset];
+    offset -= chunk.length;
+  }
+  return null;
+}
+
+export function isGzipStreamPrefix(chunks: readonly Uint8Array[]): boolean {
+  return byteAt(chunks, 0) === GZIP_MAGIC_0 && byteAt(chunks, 1) === GZIP_MAGIC_1;
+}
+
 export async function gunzipBytes(bytes: Uint8Array): Promise<Uint8Array> {
   if (typeof DecompressionStream !== "function") {
     throw new Error("Compressed build artifact is not supported by this browser.");
@@ -21,26 +34,49 @@ export async function readBuildVariantJson<T>(res: Response): Promise<T> {
   return JSON.parse(new TextDecoder().decode(body)) as T;
 }
 
+export function streamFromInitialChunks(
+  initialChunks: readonly Uint8Array[],
+  reader: ReadableStreamDefaultReader<Uint8Array>,
+): ReadableStream<Uint8Array> {
+  let replayIndex = 0;
+  return new ReadableStream<Uint8Array>(
+    {
+      async pull(controller) {
+        if (replayIndex < initialChunks.length) {
+          controller.enqueue(initialChunks[replayIndex]);
+          replayIndex += 1;
+          return;
+        }
+        try {
+          const { done, value } = await reader.read();
+          if (done) {
+            controller.close();
+            return;
+          }
+          if (value) {
+            controller.enqueue(value);
+          }
+        } catch (err) {
+          controller.error(err);
+        }
+      },
+      async cancel(reason) {
+        try {
+          await reader.cancel(reason);
+        } catch {
+          // already canceled
+        } finally {
+          reader.releaseLock();
+        }
+      },
+    },
+    { highWaterMark: 0 },
+  );
+}
+
 export function streamFromFirstChunk(
   firstChunk: Uint8Array,
   reader: ReadableStreamDefaultReader<Uint8Array>,
 ): ReadableStream<Uint8Array> {
-  return new ReadableStream<Uint8Array>({
-    async start(controller) {
-      controller.enqueue(firstChunk);
-      try {
-        while (true) {
-          const { done, value } = await reader.read();
-          if (done) break;
-          if (value) controller.enqueue(value);
-        }
-        controller.close();
-      } catch (err) {
-        controller.error(err);
-      }
-    },
-    cancel(reason) {
-      return reader.cancel(reason);
-    },
-  });
+  return streamFromInitialChunks([firstChunk], reader);
 }

--- a/scripts/test-client-build-response.ts
+++ b/scripts/test-client-build-response.ts
@@ -1,0 +1,58 @@
+import assert from "node:assert/strict";
+import { gzipSync } from "node:zlib";
+import {
+  isGzipChunk,
+  readBuildVariantJson,
+  streamFromFirstChunk,
+} from "../lib/arena/clientBuildResponse";
+
+async function main() {
+  const payload = {
+    buildId: "test-build",
+    variant: "preview",
+    checksum: "test-checksum",
+    serverValidated: true,
+    voxelBuild: {
+      version: "1.0",
+      blocks: [{ x: 0, y: 0, z: 0, type: "stone" }],
+    },
+  };
+
+  const gzipped = gzipSync(Buffer.from(JSON.stringify(payload)));
+  const response = new Response(gzipped, {
+    headers: { "Content-Type": "application/json; charset=utf-8" },
+  });
+
+  const decoded = await readBuildVariantJson<typeof payload>(response);
+
+  assert.deepEqual(decoded, payload);
+
+  const ndjsonPayload = [
+    JSON.stringify({ type: "hello", buildId: "test-build", variant: "preview" }),
+    JSON.stringify({ type: "complete", totalBlocks: 0 }),
+    "",
+  ].join("\n");
+  const gzippedStream = new Uint8Array(gzipSync(Buffer.from(ndjsonPayload)));
+  assert.equal(isGzipChunk(gzippedStream), true);
+
+  const firstChunk = gzippedStream.slice(0, 8);
+  const rest = gzippedStream.slice(8);
+  const source = new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(rest);
+      controller.close();
+    },
+  });
+  const reader = source.getReader();
+  const reconstructed = streamFromFirstChunk(firstChunk, reader).pipeThrough(
+    new DecompressionStream("gzip") as unknown as TransformStream<Uint8Array, Uint8Array>,
+  );
+  const decodedStream = await new Response(reconstructed).text();
+
+  assert.equal(decodedStream, ndjsonPayload);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/scripts/test-client-build-response.ts
+++ b/scripts/test-client-build-response.ts
@@ -2,8 +2,9 @@ import assert from "node:assert/strict";
 import { gzipSync } from "node:zlib";
 import {
   isGzipChunk,
+  isGzipStreamPrefix,
   readBuildVariantJson,
-  streamFromFirstChunk,
+  streamFromInitialChunks,
 } from "../lib/arena/clientBuildResponse";
 
 async function main() {
@@ -35,8 +36,10 @@ async function main() {
   const gzippedStream = new Uint8Array(gzipSync(Buffer.from(ndjsonPayload)));
   assert.equal(isGzipChunk(gzippedStream), true);
 
-  const firstChunk = gzippedStream.slice(0, 8);
-  const rest = gzippedStream.slice(8);
+  const initialChunks = [gzippedStream.slice(0, 1), gzippedStream.slice(1, 2)];
+  assert.equal(isGzipStreamPrefix(initialChunks), true);
+
+  const rest = gzippedStream.slice(2);
   const source = new ReadableStream<Uint8Array>({
     start(controller) {
       controller.enqueue(rest);
@@ -44,12 +47,39 @@ async function main() {
     },
   });
   const reader = source.getReader();
-  const reconstructed = streamFromFirstChunk(firstChunk, reader).pipeThrough(
+  const reconstructed = streamFromInitialChunks(initialChunks, reader).pipeThrough(
     new DecompressionStream("gzip") as unknown as TransformStream<Uint8Array, Uint8Array>,
   );
   const decodedStream = await new Response(reconstructed).text();
 
   assert.equal(decodedStream, ndjsonPayload);
+
+  const encoder = new TextEncoder();
+  let sourceReadCount = 0;
+  const sourceChunks = ["b", "c", "d"];
+  const backpressureSource = {
+    async read() {
+      sourceReadCount += 1;
+      const next = sourceChunks.shift();
+      return next == null
+        ? { done: true as const, value: undefined }
+        : { done: false as const, value: encoder.encode(next) };
+    },
+    async cancel() {},
+    releaseLock() {},
+  } as ReadableStreamDefaultReader<Uint8Array>;
+  const backpressureReader = streamFromInitialChunks(
+    [encoder.encode("a")],
+    backpressureSource,
+  ).getReader();
+
+  const firstReplay = await backpressureReader.read();
+  assert.equal(new TextDecoder().decode(firstReplay.value), "a");
+  assert.ok(sourceReadCount < 3);
+
+  const secondReplay = await backpressureReader.read();
+  assert.equal(new TextDecoder().decode(secondReplay.value), "b");
+  assert.ok(sourceReadCount < 3);
 }
 
 main().catch((error) => {


### PR DESCRIPTION
## Summary

- Fix model detail prompt build hydration for gzipped signed snapshot and NDJSON artifact responses.
- Add shared client helpers for gzip detection, decompression, and first-chunk stream reconstruction.
- Add a focused regression script for gzipped build JSON and stream decoding.

## Root Cause

Supabase signed artifact responses can return gzip bytes without a `Content-Encoding` header. The model detail loader parsed those bytes as plain JSON or NDJSON, which caused the modal to fall from retrieval progress to “Build unavailable.”

## Test Plan

- `npx tsx scripts/test-client-build-response.ts`
- `pnpm lint`
- `npx tsc --noEmit`
- `pnpm build`

*(PR written by Codex)*