### PR TITLE
(fix) tune gif export speed and quality

### DIFF
--- a/components/sandbox/SandboxGifExportButton.tsx
+++ b/components/sandbox/SandboxGifExportButton.tsx
@@ -28,11 +28,11 @@ const MAX_IN_FLIGHT_FRAMES = 4;
 const YIELD_EVERY_FRAMES = 24;
 const COMPARISON_FRAME_COUNT = 96;
 const SINGLE_FRAME_COUNT = 144;
-const COMPARISON_FRAME_DELAY_MS = 30;
-const SINGLE_FRAME_DELAY_MS = 20;
-const COMPARISON_PALETTE_SAMPLE_COUNT = 10;
+const COMPARISON_FRAME_DELAY_MS = 40;
+const SINGLE_FRAME_DELAY_MS = 30;
+const COMPARISON_PALETTE_SAMPLE_COUNT = 12;
 const SINGLE_PALETTE_SAMPLE_COUNT = 16;
-const COMPARISON_PALETTE_SAMPLE_LONG_EDGE = 540;
+const COMPARISON_PALETTE_SAMPLE_LONG_EDGE = 640;
 const SINGLE_PALETTE_SAMPLE_LONG_EDGE = 720;
 const BYTES_PER_MB = 1024 * 1024;
 const LOSSLESS_OPT_MIN_INPUT_BYTES = 6 * BYTES_PER_MB;
@@ -51,11 +51,13 @@ const EXPORT_RENDER_PROFILES: Record<
     { width: 840, height: 945 },
   ],
   wide: [
+    { width: 1440, height: 810 },
     { width: 1280, height: 720 },
     { width: 960, height: 540 },
     { width: 720, height: 405 },
   ],
   vertical: [
+    { width: 810, height: 1440 },
     { width: 720, height: 1280 },
     { width: 640, height: 1138 },
     { width: 540, height: 960 },

--- a/scripts/verify-gif-export-config.ts
+++ b/scripts/verify-gif-export-config.ts
@@ -1,0 +1,110 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import ts from "typescript";
+
+const SOURCE_PATH = "components/sandbox/SandboxGifExportButton.tsx";
+const sourceText = readFileSync(SOURCE_PATH, "utf8");
+const sourceFile = ts.createSourceFile(SOURCE_PATH, sourceText, ts.ScriptTarget.Latest, true, ts.ScriptKind.TSX);
+
+function readNumericConst(name: string): number {
+  let value: number | null = null;
+
+  const visit = (node: ts.Node) => {
+    if (
+      ts.isVariableDeclaration(node) &&
+      ts.isIdentifier(node.name) &&
+      node.name.text === name &&
+      node.initializer
+    ) {
+      if (ts.isNumericLiteral(node.initializer)) {
+        value = Number(node.initializer.text);
+      } else if (
+        ts.isPrefixUnaryExpression(node.initializer) &&
+        node.initializer.operator === ts.SyntaxKind.MinusToken &&
+        ts.isNumericLiteral(node.initializer.operand)
+      ) {
+        value = -Number(node.initializer.operand.text);
+      }
+    }
+    ts.forEachChild(node, visit);
+  };
+
+  visit(sourceFile);
+  if (value === null) {
+    throw new Error(`${name} should be a numeric const`);
+  }
+  return value;
+}
+
+function readRenderProfiles(): Record<string, Array<{ width: number; height: number }>> {
+  let profiles: Record<string, Array<{ width: number; height: number }>> | null = null;
+
+  const visit = (node: ts.Node) => {
+    if (
+      ts.isVariableDeclaration(node) &&
+      ts.isIdentifier(node.name) &&
+      node.name.text === "EXPORT_RENDER_PROFILES" &&
+      node.initializer &&
+      ts.isObjectLiteralExpression(node.initializer)
+    ) {
+      const parsed: Record<string, Array<{ width: number; height: number }>> = {};
+      for (const property of node.initializer.properties) {
+        if (!ts.isPropertyAssignment(property) || !ts.isIdentifier(property.name)) continue;
+        if (!ts.isArrayLiteralExpression(property.initializer)) continue;
+        parsed[property.name.text] = property.initializer.elements.map((element) => {
+          assert.ok(ts.isObjectLiteralExpression(element), "render profile entries should be objects");
+          const widthProperty = element.properties.find(
+            (entry): entry is ts.PropertyAssignment =>
+              ts.isPropertyAssignment(entry) &&
+              ts.isIdentifier(entry.name) &&
+              entry.name.text === "width",
+          );
+          const heightProperty = element.properties.find(
+            (entry): entry is ts.PropertyAssignment =>
+              ts.isPropertyAssignment(entry) &&
+              ts.isIdentifier(entry.name) &&
+              entry.name.text === "height",
+          );
+          assert.ok(widthProperty, "render profile width should be present");
+          assert.ok(heightProperty, "render profile height should be present");
+          assert.ok(ts.isNumericLiteral(widthProperty.initializer), "render profile width should be numeric");
+          assert.ok(ts.isNumericLiteral(heightProperty.initializer), "render profile height should be numeric");
+          return {
+            width: Number(widthProperty.initializer.text),
+            height: Number(heightProperty.initializer.text),
+          };
+        });
+      }
+      profiles = parsed;
+    }
+    ts.forEachChild(node, visit);
+  };
+
+  visit(sourceFile);
+  assert.ok(profiles, "EXPORT_RENDER_PROFILES should be defined");
+  return profiles;
+}
+
+const comparisonFrameCount = readNumericConst("COMPARISON_FRAME_COUNT");
+const singleFrameCount = readNumericConst("SINGLE_FRAME_COUNT");
+const comparisonFrameDelayMs = readNumericConst("COMPARISON_FRAME_DELAY_MS");
+const singleFrameDelayMs = readNumericConst("SINGLE_FRAME_DELAY_MS");
+
+assert.equal(comparisonFrameCount, 96);
+assert.equal(singleFrameCount, 144);
+assert.equal(comparisonFrameDelayMs, 40);
+assert.equal(singleFrameDelayMs, 30);
+assert.equal(comparisonFrameCount * comparisonFrameDelayMs, 3840);
+assert.equal(singleFrameCount * singleFrameDelayMs, 4320);
+assert.equal(readNumericConst("COMPARISON_PALETTE_SAMPLE_COUNT"), 12);
+assert.equal(readNumericConst("COMPARISON_PALETTE_SAMPLE_LONG_EDGE"), 640);
+
+const profiles = readRenderProfiles();
+assert.deepEqual(profiles.wide?.[0], { width: 1440, height: 810 });
+assert.deepEqual(profiles.vertical?.[0], { width: 810, height: 1440 });
+assert.ok(
+  sourceText.includes("frame / runtime.frameCount"),
+  "GIF frame sampling should omit the duplicate endpoint for a seamless loop",
+);
+
+console.log("gif export config checks passed");


### PR DESCRIPTION
## Summary
- Slow GIF rotation while preserving the same duplicate-endpoint-free loop sampling.
- Raise comparison GIF source quality with a higher first render profile and stronger palette sampling.
- Add a verifier that locks the GIF export frame cadence, source profiles, palette sampling, and seamless-loop guardrail.

## Validation
- npx tsx scripts/verify-gif-export-config.ts
- pnpm lint
- npx tsc --noEmit
- git diff --check

*(PR written by Codex)*