### PR TITLE
feat: upgrade MiniMax default model to M3

### DIFF
--- a/lib/ai/generateVoxelBuild.ts
+++ b/lib/ai/generateVoxelBuild.ts
@@ -91,10 +91,10 @@ function maxOutputTokenCapForModel(modelId: string): number | undefined {
   ) {
     return 128_000;
   }
-  // MiniMax M2.7's OpenAI-compatible route rejects the larger MineBench default
-  // output budgets. Keep a lower completion budget so the prompt plus output
-  // stays within the model's effective request limit.
-  if (modelId === "MiniMax-M2.7") return 131_072;
+  // MiniMax M3 and M2.7's OpenAI-compatible route rejects the larger MineBench
+  // default output budgets. Keep a lower completion budget so the prompt plus
+  // output stays within the model's effective request limit.
+  if (modelId === "MiniMax-M3" || modelId === "MiniMax-M2.7") return 131_072;
   if (
     modelId === "grok-4-1-fast" ||
     modelId === "grok-4-1-fast-reasoning" ||

--- a/lib/ai/modelCatalog.ts
+++ b/lib/ai/modelCatalog.ts
@@ -52,8 +52,8 @@ export type ModelKey =
   | "zai_glm_4_7"
   | "qwen_qwen3_max_thinking"
   | "qwen_qwen3_5_397b_a17b"
+  | "minimax_m3"
   | "minimax_m2_7"
-  | "minimax_m2_5"
   | "meta_llama_4_maverick";
 
 export type ModelCatalogEntry = {
@@ -404,20 +404,20 @@ export const MODEL_CATALOG: ModelCatalogEntry[] = [
     forceOpenRouter: true,
   },
   {
+    key: "minimax_m3",
+    provider: "minimax",
+    modelId: "MiniMax-M3",
+    displayName: "MiniMax M3",
+    enabled: true,
+    openRouterModelId: "minimax/minimax-m3",
+  },
+  {
     key: "minimax_m2_7",
     provider: "minimax",
     modelId: "MiniMax-M2.7",
     displayName: "MiniMax M2.7",
     enabled: true,
     openRouterModelId: "minimax/minimax-m2.7",
-  },
-  {
-    key: "minimax_m2_5",
-    provider: "minimax",
-    modelId: "MiniMax-M2.5",
-    displayName: "MiniMax M2.5",
-    enabled: true,
-    openRouterModelId: "minimax/minimax-m2.5",
   },
   {
     key: "meta_llama_4_maverick",

--- a/lib/ai/reasoningProfiles.ts
+++ b/lib/ai/reasoningProfiles.ts
@@ -328,8 +328,8 @@ export function openRouterReasoningEffortAttempts(
     return descendingAttempts(label, ["xhigh", "high", "medium", "low"], override);
   }
   if (
-    modelId === "minimax/minimax-m2.7" ||
-    modelId === "minimax/minimax-m2.5"
+    modelId === "minimax/minimax-m3" ||
+    modelId === "minimax/minimax-m2.7"
   ) {
     return descendingAttempts(
       label,

--- a/scripts/uploadsCatalog.ts
+++ b/scripts/uploadsCatalog.ts
@@ -74,8 +74,8 @@ export const MODEL_SLUG: Record<ModelKey, string> = {
   zai_glm_4_7: "glm-4-7",
   qwen_qwen3_max_thinking: "qwen3-max-thinking",
   qwen_qwen3_5_397b_a17b: "qwen3-5-397b-a17b",
+  minimax_m3: "minimax-m3",
   minimax_m2_7: "minimax-m2-7",
-  minimax_m2_5: "minimax-m2-5",
   meta_llama_4_maverick: "llama-4-maverick",
 };
 


### PR DESCRIPTION
## Summary
Upgrade MiniMax model configuration to use M3 as the default model in the MineBench benchmark catalog.

## Changes
- Add MiniMax-M3 to the model selection list and place it before the legacy M2.7 entry
- Keep MiniMax-M2.7 as an alternative
- Remove older MiniMax-M2.5 entry
- Update the matching upload slug, OpenRouter reasoning profile, and direct-provider output token cap so the new M3 ID flows through the existing provider routing

## Why
MiniMax-M3 is the latest model, with a 512K context window, up to 128K output, and image input support on both the OpenAI- and Anthropic-compatible routes. M2.5 is being retired; M2.7 is retained as the previous-generation fallback.

## Testing
- pnpm test — 9/9 test files passed
- pnpm lint — clean
- Verified model catalog, upload slug map, reasoning profile list, and direct-provider token cap all reference the new M3 ID