### PR TITLE
(feat) add claude fable 5 support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,6 +36,8 @@ OPENROUTER_API_KEY=
 GOOGLE_SITE_VERIFICATION=
 
 # Optional overrides (defaults are used if unset)
+# Claude Fable 5 adaptive thinking effort: low | medium | high | xhigh | max
+ANTHROPIC_FABLE_5_EFFORT=max
 # Claude Opus 4.8 adaptive thinking effort: low | medium | high | xhigh | max
 ANTHROPIC_OPUS_4_8_EFFORT=max
 # Claude Opus 4.7 adaptive thinking effort: low | medium | high | xhigh | max

--- a/components/sandbox/SandboxLive.tsx
+++ b/components/sandbox/SandboxLive.tsx
@@ -1088,7 +1088,7 @@ export function SandboxLive({ initialPrompt }: { initialPrompt?: string }) {
                           value={customModel.modelId}
                           onChange={(e) => updateCustomModel({ modelId: e.target.value })}
                           disabled={running}
-                          placeholder="aws/anthropic/bedrock-claude-opus-4-8"
+                          placeholder="aws/anthropic/bedrock-claude-fable-5"
                         />
                       </label>
                       <label className="flex flex-col gap-1">

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -99,6 +99,7 @@ Copy `.env.example` to `.env` and set what you need.
 ### Optional Provider and Runtime Tuning
 
 - `MINEBENCH_ALLOW_SERVER_KEYS=1` (production opt-in for server env keys in `/api/generate`)
+- `ANTHROPIC_FABLE_5_EFFORT=low|medium|high|xhigh|max`
 - `ANTHROPIC_OPUS_4_8_EFFORT=low|medium|high|xhigh|max`
 - `ANTHROPIC_OPUS_4_7_EFFORT=low|medium|high|xhigh|max`
 - `ANTHROPIC_OPUS_4_6_EFFORT=low|medium|high|max`
@@ -109,6 +110,7 @@ Copy `.env.example` to `.env` and set what you need.
 - `OPENAI_BACKGROUND_POLL_MS=2000` (poll interval for background mode)
 - `ANTHROPIC_ENABLE_1M_CONTEXT_BETA=1`
 - `ANTHROPIC_THINKING_BUDGET` (legacy/manual thinking models)
+- Claude Fable 5 uses the native Anthropic model ID `claude-fable-5`, supports always-on adaptive thinking with effort `low|medium|high|xhigh|max`, and MineBench defaults it to `max` with a 128000-token output cap.
 - Claude 4.8 Opus uses the native Anthropic model ID `claude-opus-4-8`, supports adaptive effort `low|medium|high|xhigh|max`, and MineBench defaults it to `max` with a 128000-token output cap.
 - Gemini 3.5 Flash uses the native Google AI model ID `gemini-3.5-flash`, supports `thinking_level=high|medium|low|minimal`, and MineBench defaults it to `high` with a 65536-token output cap.
 - Grok 4.3 uses the native xAI API, reasons automatically, rejects `reasoning_effort`, and uses a `max_tokens` request of up to 1000000 unless `MINEBENCH_MAX_OUTPUT_TOKENS` lowers it; MineBench does not send a thinking override for this model.

--- a/lib/ai/generateVoxelBuild.ts
+++ b/lib/ai/generateVoxelBuild.ts
@@ -142,6 +142,16 @@ function formatOptionalInteger(value: number | undefined): string {
   return String(Math.floor(value));
 }
 
+function usesDefaultSamplingForModel(modelId: string): boolean {
+  const normalized = modelId.toLowerCase();
+  return (
+    normalized === "claude-fable-5" ||
+    normalized === "anthropic/claude-fable-5" ||
+    /^claude-opus-4-(?:7|8)(?:-|$)/.test(normalized) ||
+    /^anthropic\/claude-opus-4[.-](?:7|8)(?:$|[-:])/.test(normalized)
+  );
+}
+
 function describeRequestedThinkingMode(opts: {
   route: "direct" | "openrouter";
   provider: DirectProvider | "openrouter";
@@ -244,6 +254,8 @@ function providerRequestTraceLine(opts: {
           : 1.0
         : 0.6
       : opts.route === "direct" && opts.provider === "gemini" && opts.modelId.startsWith("gemini-3")
+      ? "default"
+      : usesDefaultSamplingForModel(opts.modelId)
       ? "default"
       : DEFAULT_TEMPERATURE;
   return `Request config: max_output_tokens=${Math.floor(opts.maxOutputTokens)}, reasoning_max_tokens=${formatOptionalInteger(opts.reasoningMaxTokens)}, thinking_mode=${thinkingMode}, temperature=${temperature}.`;

--- a/lib/ai/generateVoxelBuild.ts
+++ b/lib/ai/generateVoxelBuild.ts
@@ -84,6 +84,8 @@ function maxOutputTokenCapForModel(modelId: string): number | undefined {
   if (modelId === "deepseek/deepseek-v3.2") return 65_536;
   if (modelId === "glm-5.1" || modelId === "glm-5") return 131_072;
   if (
+    modelId === "claude-fable-5" ||
+    modelId === "anthropic/claude-fable-5" ||
     modelId.startsWith("claude-opus-4-8") ||
     modelId === "anthropic/claude-opus-4.8" ||
     modelId.startsWith("claude-opus-4-7") ||

--- a/lib/ai/modelCatalog.ts
+++ b/lib/ai/modelCatalog.ts
@@ -26,6 +26,7 @@ export type ModelKey =
   | "openai_gpt_4_1"
   | "openai_gpt_4o"
   | "openai_gpt_oss_120b"
+  | "anthropic_claude_fable_5"
   | "anthropic_claude_4_5_sonnet"
   | "anthropic_claude_4_6_sonnet"
   | "anthropic_claude_4_5_opus"
@@ -188,6 +189,14 @@ export const MODEL_CATALOG: ModelCatalogEntry[] = [
     displayName: "GPT OSS 120B",
     enabled: true,
     openRouterModelId: "openai/gpt-oss-120b",
+  },
+  {
+    key: "anthropic_claude_fable_5",
+    provider: "anthropic",
+    modelId: "claude-fable-5",
+    displayName: "Claude Fable 5",
+    enabled: true,
+    openRouterModelId: "anthropic/claude-fable-5",
   },
   {
     key: "anthropic_claude_4_5_sonnet",

--- a/lib/ai/providers/anthropic.ts
+++ b/lib/ai/providers/anthropic.ts
@@ -194,6 +194,13 @@ function anthropicClaudeVersion(modelId: string): { family: "opus" | "sonnet"; m
   return { family: match[1] as "opus" | "sonnet", major, minor };
 }
 
+function omitsSamplingParameters(modelId: string): boolean {
+  if (isFableOrMythos5(modelId)) return true;
+  const version = anthropicClaudeVersion(modelId);
+  if (!version) return false;
+  return version.family === "opus" && (version.major > 4 || (version.major === 4 && version.minor >= 7));
+}
+
 function isAdaptiveThinkingModel(modelId: string): boolean {
   if (isFableOrMythos5(modelId)) return true;
   const version = anthropicClaudeVersion(modelId);
@@ -329,6 +336,7 @@ export async function anthropicGenerateText(params: {
               ? { type: "enabled" as const, budget_tokens: budget }
               : undefined;
         const temperature = thinking ? 1 : (params.temperature ?? 0.2);
+        const sampling = omitsSamplingParameters(params.modelId) ? {} : { temperature };
         const efforts = usesAdaptiveThinking ? adaptiveEffortAttempts : [null];
         effortLoop: for (let effortIdx = 0; effortIdx < efforts.length; effortIdx += 1) {
           const effort = efforts[effortIdx];
@@ -359,7 +367,7 @@ export async function anthropicGenerateText(params: {
             body: JSON.stringify({
               model: params.modelId,
               max_tokens: tok,
-              temperature,
+              ...sampling,
               system: params.system,
               messages: [{ role: "user", content: params.user }],
               stream: streamResponses,

--- a/lib/ai/providers/anthropic.ts
+++ b/lib/ai/providers/anthropic.ts
@@ -181,6 +181,10 @@ function isLegacyManualThinkingModel(modelId: string): boolean {
   return modelId.startsWith("claude-sonnet-4-5") || modelId.startsWith("claude-opus-4-5");
 }
 
+function isFableOrMythos5(modelId: string): boolean {
+  return /^claude-(?:fable|mythos)-5(?:-|$)/.test(modelId);
+}
+
 function anthropicClaudeVersion(modelId: string): { family: "opus" | "sonnet"; major: number; minor: number } | null {
   const match = /^claude-(opus|sonnet)-(\d+)-(\d+)(?:-|$)/.exec(modelId);
   if (!match) return null;
@@ -191,18 +195,23 @@ function anthropicClaudeVersion(modelId: string): { family: "opus" | "sonnet"; m
 }
 
 function isAdaptiveThinkingModel(modelId: string): boolean {
+  if (isFableOrMythos5(modelId)) return true;
   const version = anthropicClaudeVersion(modelId);
   if (!version) return false;
   return version.major > 4 || (version.major === 4 && version.minor >= 6);
 }
 
 function supportsXhighEffort(modelId: string): boolean {
+  if (isFableOrMythos5(modelId)) return true;
   const version = anthropicClaudeVersion(modelId);
   if (!version) return false;
   return version.major > 4 || (version.major === 4 && version.minor >= 7);
 }
 
 function effortEnvVarForModel(modelId: string): string | null {
+  if (modelId.startsWith("claude-fable-5")) {
+    return "ANTHROPIC_FABLE_5_EFFORT";
+  }
   const version = anthropicClaudeVersion(modelId);
   if (!version) return null;
   if (version.family === "opus" && version.major === 4 && version.minor === 8) {

--- a/lib/ai/providers/openrouter.ts
+++ b/lib/ai/providers/openrouter.ts
@@ -128,9 +128,9 @@ function defaultTextVerbosity(modelId: string): TextVerbosity | undefined {
 
 function openRouterTemperaturePayload(modelId: string, temperature?: number): { temperature?: number } {
   const normalized = modelId.toLowerCase();
-  const usesDefaultSampling = /^anthropic\/claude-(?:opus-4[.-]8|4[.-]8-opus)(?:$|[-:])/.test(
-    normalized,
-  );
+  const usesDefaultSampling =
+    normalized === "anthropic/claude-fable-5" ||
+    /^anthropic\/claude-(?:opus-4[.-]8|4[.-]8-opus)(?:$|[-:])/.test(normalized);
   if (usesDefaultSampling) return {};
   return { temperature: temperature ?? 0.2 };
 }

--- a/lib/ai/reasoningProfiles.ts
+++ b/lib/ai/reasoningProfiles.ts
@@ -24,6 +24,10 @@ function isGemini3FlashFamily(modelId: string): boolean {
   return /(?:^|\/)gemini-3(?:[.-]\d+)?-flash/.test(modelId);
 }
 
+function isAnthropicFableOrMythos5(modelId: string): boolean {
+  return /(?:^|\/)claude-(?:fable|mythos)-5(?:[.-]|$)/.test(modelId);
+}
+
 function anthropicClaudeVersion(modelId: string): { major: number; minor: number } | null {
   const match = /(?:^|\/)claude-(?:opus|sonnet)-(\d+)[.-](\d+)(?:[.-]|$)/.exec(modelId);
   if (!match) return null;
@@ -34,12 +38,14 @@ function anthropicClaudeVersion(modelId: string): { major: number; minor: number
 }
 
 function isAnthropicAdaptiveModel(modelId: string): boolean {
+  if (isAnthropicFableOrMythos5(modelId)) return true;
   const version = anthropicClaudeVersion(modelId);
   if (!version) return false;
   return version.major > 4 || (version.major === 4 && version.minor >= 6);
 }
 
 function supportsAnthropicXhighEffort(modelId: string): boolean {
+  if (isAnthropicFableOrMythos5(modelId)) return true;
   const version = anthropicClaudeVersion(modelId);
   if (!version) return false;
   return version.major > 4 || (version.major === 4 && version.minor >= 7);

--- a/scripts/uploadsCatalog.ts
+++ b/scripts/uploadsCatalog.ts
@@ -48,6 +48,7 @@ export const MODEL_SLUG: Record<ModelKey, string> = {
   openai_gpt_4_1: "gpt-4-1",
   openai_gpt_4o: "gpt-4o",
   openai_gpt_oss_120b: "gpt-oss-120b",
+  anthropic_claude_fable_5: "claude-fable-5",
   anthropic_claude_4_5_sonnet: "sonnet",
   anthropic_claude_4_6_sonnet: "sonnet-4-6",
   anthropic_claude_4_5_opus: "opus",

--- a/tests/unit/providers/claude-fable-config.test.ts
+++ b/tests/unit/providers/claude-fable-config.test.ts
@@ -1,0 +1,179 @@
+import assert from "node:assert/strict";
+import { generateVoxelBuild } from "../../../lib/ai/generateVoxelBuild";
+import { getModelByKey } from "../../../lib/ai/modelCatalog";
+import {
+  anthropicAdaptiveEffortAttempts,
+  openRouterReasoningEffortAttempts,
+} from "../../../lib/ai/reasoningProfiles";
+import { MODEL_SLUG } from "../../../scripts/uploadsCatalog";
+
+type CapturedRequest = {
+  url: string;
+  body: Record<string, unknown>;
+};
+
+const capturedRequests: CapturedRequest[] = [];
+const originalFetch = globalThis.fetch;
+const originalEnv = {
+  anthropicStreamResponses: process.env.ANTHROPIC_STREAM_RESPONSES,
+  maxOutputTokens: process.env.MINEBENCH_MAX_OUTPUT_TOKENS,
+};
+
+function validBuildJson(): string {
+  return JSON.stringify({
+    version: "1.0",
+    boxes: [],
+    lines: [],
+    blocks: [{ x: 0, y: 0, z: 0, type: "stone" }],
+  });
+}
+
+globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+  assert.ok(init?.body, "provider request should include a JSON body");
+  assert.equal(typeof init.body, "string", "provider request body should be serialized JSON");
+
+  const url = String(input);
+  const body = JSON.parse(init.body as string) as Record<string, unknown>;
+  capturedRequests.push({ url, body });
+
+  if (url.includes("api.anthropic.com")) {
+    return new Response(
+      JSON.stringify({
+        content: [{ type: "text", text: validBuildJson() }],
+      }),
+      {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      },
+    );
+  }
+
+  return new Response(
+    JSON.stringify({
+      choices: [
+        {
+          message: {
+            content: validBuildJson(),
+          },
+        },
+      ],
+    }),
+    {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    },
+  );
+}) as typeof fetch;
+
+async function main() {
+  process.env.ANTHROPIC_STREAM_RESPONSES = "0";
+  process.env.MINEBENCH_MAX_OUTPUT_TOKENS = "999999";
+  process.env.OPENROUTER_BASE_URL = "https://openrouter.test/api";
+
+  const model = getModelByKey("anthropic_claude_fable_5");
+
+  assert.equal(model.provider, "anthropic");
+  assert.equal(model.modelId, "claude-fable-5");
+  assert.equal(model.displayName, "Claude Fable 5");
+  assert.equal(model.openRouterModelId, "anthropic/claude-fable-5");
+  assert.equal(MODEL_SLUG.anthropic_claude_fable_5, "claude-fable-5");
+  assert.deepEqual(anthropicAdaptiveEffortAttempts(model.modelId), [
+    "max",
+    "xhigh",
+    "high",
+    "medium",
+    "low",
+  ]);
+  assert.deepEqual(anthropicAdaptiveEffortAttempts(model.modelId, "xhigh"), [
+    "xhigh",
+    "high",
+    "medium",
+    "low",
+  ]);
+  assert.deepEqual(openRouterReasoningEffortAttempts(model.openRouterModelId), [
+    "max",
+    "xhigh",
+    "high",
+    "medium",
+    "low",
+  ]);
+
+  const directTraces: string[] = [];
+  await generateVoxelBuild({
+    modelKey: "anthropic_claude_fable_5",
+    prompt: "small tower",
+    gridSize: 64,
+    palette: "simple",
+    enableTools: false,
+    providerKeys: { anthropic: "test-anthropic-key" },
+    allowServerKeys: false,
+    onProviderTrace: (message) => directTraces.push(message),
+  });
+
+  const directRequest = capturedRequests.find((request) =>
+    request.url.includes("api.anthropic.com"),
+  )?.body;
+  assert.ok(directRequest, "direct Anthropic request should be captured");
+  assert.equal(directRequest.model, "claude-fable-5");
+  assert.equal(directRequest.max_tokens, 128000);
+  assert.equal(directRequest.temperature, 1);
+  assert.deepEqual(directRequest.thinking, { type: "adaptive" });
+  assert.deepEqual((directRequest.output_config as { effort?: unknown })?.effort, "max");
+  assert.ok(
+    directTraces.some((trace) =>
+      trace.includes("max_output_tokens=128000") &&
+      trace.includes("adaptive_effort=max->xhigh->high->medium->low"),
+    ),
+    "direct trace should report the 128000-token cap and max adaptive effort fallback",
+  );
+
+  const openRouterTraces: string[] = [];
+  await generateVoxelBuild({
+    modelKey: "anthropic_claude_fable_5",
+    prompt: "small tower",
+    gridSize: 64,
+    palette: "simple",
+    enableTools: false,
+    preferOpenRouter: true,
+    providerKeys: { openrouter: "test-openrouter-key" },
+    allowServerKeys: false,
+    onProviderTrace: (message) => openRouterTraces.push(message),
+  });
+
+  const openRouterRequest = capturedRequests.find((request) =>
+    request.url.includes("openrouter.test"),
+  )?.body;
+  assert.ok(openRouterRequest, "OpenRouter request should be captured");
+  assert.equal(openRouterRequest.model, "anthropic/claude-fable-5");
+  assert.equal(openRouterRequest.max_tokens, 128000);
+  assert.equal(Object.hasOwn(openRouterRequest, "temperature"), false);
+  assert.deepEqual(openRouterRequest.reasoning, { effort: "max" });
+  assert.ok(
+    openRouterTraces.some((trace) =>
+      trace.includes("max_output_tokens=128000") &&
+      trace.includes("effort_fallback=max->xhigh->high->medium->low->disabled"),
+    ),
+    "OpenRouter trace should report the 128000-token cap and max reasoning fallback",
+  );
+
+  console.log("claude fable config checks passed");
+}
+
+main()
+  .finally(() => {
+    globalThis.fetch = originalFetch;
+    if (originalEnv.anthropicStreamResponses === undefined) {
+      delete process.env.ANTHROPIC_STREAM_RESPONSES;
+    } else {
+      process.env.ANTHROPIC_STREAM_RESPONSES = originalEnv.anthropicStreamResponses;
+    }
+    if (originalEnv.maxOutputTokens === undefined) {
+      delete process.env.MINEBENCH_MAX_OUTPUT_TOKENS;
+    } else {
+      process.env.MINEBENCH_MAX_OUTPUT_TOKENS = originalEnv.maxOutputTokens;
+    }
+  })
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });

--- a/tests/unit/providers/claude-fable-config.test.ts
+++ b/tests/unit/providers/claude-fable-config.test.ts
@@ -116,15 +116,16 @@ async function main() {
   assert.ok(directRequest, "direct Anthropic request should be captured");
   assert.equal(directRequest.model, "claude-fable-5");
   assert.equal(directRequest.max_tokens, 128000);
-  assert.equal(directRequest.temperature, 1);
+  assert.equal(Object.hasOwn(directRequest, "temperature"), false);
   assert.deepEqual(directRequest.thinking, { type: "adaptive" });
   assert.deepEqual((directRequest.output_config as { effort?: unknown })?.effort, "max");
   assert.ok(
     directTraces.some((trace) =>
       trace.includes("max_output_tokens=128000") &&
-      trace.includes("adaptive_effort=max->xhigh->high->medium->low"),
+      trace.includes("adaptive_effort=max->xhigh->high->medium->low") &&
+      trace.includes("temperature=default"),
     ),
-    "direct trace should report the 128000-token cap and max adaptive effort fallback",
+    "direct trace should report the 128000-token cap, max adaptive effort fallback, and default sampling",
   );
 
   const openRouterTraces: string[] = [];
@@ -151,9 +152,10 @@ async function main() {
   assert.ok(
     openRouterTraces.some((trace) =>
       trace.includes("max_output_tokens=128000") &&
-      trace.includes("effort_fallback=max->xhigh->high->medium->low->disabled"),
+      trace.includes("effort_fallback=max->xhigh->high->medium->low->disabled") &&
+      trace.includes("temperature=default"),
     ),
-    "OpenRouter trace should report the 128000-token cap and max reasoning fallback",
+    "OpenRouter trace should report the 128000-token cap, max reasoning fallback, and default sampling",
   );
 
   console.log("claude fable config checks passed");


### PR DESCRIPTION
## What does this PR do?

- Adds Claude Fable 5 as a first-class MineBench model.
- Wires the canonical Anthropic model ID `claude-fable-5`.
- Preserves OpenRouter fallback support via `anthropic/claude-fable-5`.
- Adds the batch/import slug `claude-fable-5`.
- Caps synchronous generation requests at the documented 128000-token output limit.
- Enables the direct Anthropic adaptive effort ladder `max -> xhigh -> high -> medium -> low`, with `ANTHROPIC_FABLE_5_EFFORT` for operator overrides.
- Preserves the same OpenRouter effort fallback ladder before dropping to disabled reasoning as the final recovery path.
- Omits non-default sampling on the OpenRouter route for Claude Fable 5.
- Updates local env/docs surfaces and the custom-model placeholder for the new Fable line.
- Adds a focused regression test covering catalog, slug, direct Anthropic request shape, OpenRouter request shape, output cap, and max-effort traces.

## Why?

Anthropic's current Claude docs list Claude Fable 5 with API model ID `claude-fable-5`, a 1M-token context window, 128k max output, always-on adaptive thinking, and `low`, `medium`, `high`, `xhigh`, and `max` effort levels. The docs also state that manual `budget_tokens` are not supported, `max_tokens` is the hard limit for thinking plus response text, and non-default sampling is restricted for Fable-class requests.

MineBench's recent model-add PRs wire catalog entries, upload slugs, output caps, direct-provider reasoning behavior, OpenRouter fallback behavior, and operator docs together. This follows that pattern and keeps benchmark generation on the highest supported effort by default.

Server-side refusal fallback to Opus 4.8 is intentionally not enabled in the benchmark path because it can make a run served by another model while still being attributed to Fable. MineBench should keep model rows attributable unless a separate fallback experiment is explicitly designed.

References reviewed:

- Anthropic models overview: https://platform.claude.com/docs/en/about-claude/models/overview
- Introducing Claude Fable 5 and Claude Mythos 5: https://platform.claude.com/docs/en/about-claude/models/introducing-claude-fable-5-and-claude-mythos-5
- Anthropic adaptive thinking guide: https://platform.claude.com/docs/en/build-with-claude/adaptive-thinking
- Anthropic effort guide: https://platform.claude.com/docs/en/build-with-claude/effort
- Anthropic migration guide: https://platform.claude.com/docs/en/about-claude/models/migration-guide
- AWS Claude Fable 5 model card: https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-anthropic-claude-fable-5.html
- OpenRouter Claude Fable 5 page: https://openrouter.ai/anthropic/claude-fable-5

## How to test

- `pnpm test tests/unit/providers/claude-fable-config.test.ts`
- `pnpm test`
- `pnpm lint`
- `pnpm build`
- `pnpm batch:generate --model claude-fable-5`
- `graphify update .`
- `git diff --check`

## Checklist

- [x] Added catalog entry and upload slug
- [x] Confirmed direct Anthropic routing uses `claude-fable-5`
- [x] Confirmed OpenRouter fallback uses `anthropic/claude-fable-5`
- [x] Confirmed direct and OpenRouter effort ladders include `max`, `xhigh`, `high`, `medium`, and `low`
- [x] Applied the documented 128000-token synchronous output cap
- [x] Kept refusal fallback out of the default benchmark path to preserve attribution
- [x] Ran focused tests, full tests, lint, build, batch status, graphify update, and diff checks

_(PR written by Codex)_