### PR TITLE
(feat) add GLM 5.2 benchmark support

### DIFF
--- a/lib/ai/generateVoxelBuild.ts
+++ b/lib/ai/generateVoxelBuild.ts
@@ -82,7 +82,9 @@ function maxOutputTokenCapForModel(modelId: string): number | undefined {
     return 384_000;
   }
   if (modelId === "deepseek/deepseek-v3.2") return 65_536;
-  if (modelId === "glm-5.1" || modelId === "glm-5") return 131_072;
+  if (modelId === "glm-5.2" || modelId === "glm-5.1" || modelId === "glm-5") {
+    return 131_072;
+  }
   if (
     modelId === "claude-fable-5" ||
     modelId === "anthropic/claude-fable-5" ||

--- a/lib/ai/modelCatalog.ts
+++ b/lib/ai/modelCatalog.ts
@@ -48,6 +48,7 @@ export type ModelKey =
   | "xai_grok_4_3"
   | "xai_grok_4_1"
   | "xai_grok_4_20"
+  | "zai_glm_5_2"
   | "zai_glm_5_1"
   | "zai_glm_5"
   | "zai_glm_4_7"
@@ -366,6 +367,15 @@ export const MODEL_CATALOG: ModelCatalogEntry[] = [
     displayName: "Grok 4.20",
     enabled: true,
     openRouterModelId: "x-ai/grok-4.20",
+  },
+  {
+    key: "zai_glm_5_2",
+    provider: "zai",
+    modelId: "glm-5.2",
+    displayName: "Z.AI GLM 5.2",
+    enabled: true,
+    openRouterModelId: "z-ai/glm-5.2",
+    forceOpenRouter: true,
   },
   {
     key: "zai_glm_5_1",

--- a/lib/ai/reasoningProfiles.ts
+++ b/lib/ai/reasoningProfiles.ts
@@ -306,6 +306,16 @@ export function openRouterReasoningEffortAttempts(
       override,
     );
   }
+  if (modelId === "z-ai/glm-5.2") {
+    const normalized = normalizeReasoningOverride(override);
+    if (!normalized || normalized === "max" || normalized === "xhigh") {
+      return ["xhigh", "high"];
+    }
+    if (normalized === "high") return ["high"];
+    throw new Error(
+      `${label} does not support reasoning '${override}'. Supported values: max, xhigh, high.`,
+    );
+  }
   if (
     modelId === "z-ai/glm-5.1" ||
     modelId === "z-ai/glm-5"

--- a/scripts/uploadsCatalog.ts
+++ b/scripts/uploadsCatalog.ts
@@ -70,6 +70,7 @@ export const MODEL_SLUG: Record<ModelKey, string> = {
   xai_grok_4_3: "grok-4-3",
   xai_grok_4_1: "grok-4-1",
   xai_grok_4_20: "grok-4-20",
+  zai_glm_5_2: "glm-5-2",
   zai_glm_5_1: "glm-5-1",
   zai_glm_5: "glm-5",
   zai_glm_4_7: "glm-4-7",

--- a/tests/unit/providers/glm-5-2-config.test.ts
+++ b/tests/unit/providers/glm-5-2-config.test.ts
@@ -1,0 +1,120 @@
+import assert from "node:assert/strict";
+import { generateVoxelBuild } from "../../../lib/ai/generateVoxelBuild";
+import { getModelByKey } from "../../../lib/ai/modelCatalog";
+import { openRouterReasoningEffortAttempts } from "../../../lib/ai/reasoningProfiles";
+import { MODEL_SLUG } from "../../../scripts/uploadsCatalog";
+
+type CapturedRequest = {
+  url: string;
+  body: Record<string, unknown>;
+};
+
+const capturedRequests: CapturedRequest[] = [];
+const originalFetch = globalThis.fetch;
+const originalEnv = {
+  maxOutputTokens: process.env.MINEBENCH_MAX_OUTPUT_TOKENS,
+};
+
+function validBuildJson(): string {
+  return JSON.stringify({
+    version: "1.0",
+    boxes: [],
+    lines: [],
+    blocks: [{ x: 0, y: 0, z: 0, type: "stone" }],
+  });
+}
+
+globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+  assert.ok(init?.body, "OpenRouter request should include a JSON body");
+  assert.equal(typeof init.body, "string", "OpenRouter request body should be serialized JSON");
+
+  capturedRequests.push({
+    url: String(input),
+    body: JSON.parse(init.body as string) as Record<string, unknown>,
+  });
+
+  return new Response(
+    JSON.stringify({
+      choices: [
+        {
+          message: {
+            content: validBuildJson(),
+          },
+        },
+      ],
+    }),
+    {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    },
+  );
+}) as typeof fetch;
+
+async function main() {
+  process.env.MINEBENCH_MAX_OUTPUT_TOKENS = "999999";
+  process.env.OPENROUTER_BASE_URL = "https://openrouter.test/api";
+
+  const model = getModelByKey("zai_glm_5_2");
+
+  assert.equal(model.provider, "zai");
+  assert.equal(model.modelId, "glm-5.2");
+  assert.equal(model.displayName, "Z.AI GLM 5.2");
+  assert.equal(model.openRouterModelId, "z-ai/glm-5.2");
+  assert.equal(model.forceOpenRouter, true);
+  assert.equal(MODEL_SLUG.zai_glm_5_2, "glm-5-2");
+  assert.deepEqual(openRouterReasoningEffortAttempts(model.openRouterModelId), [
+    "xhigh",
+    "high",
+  ]);
+  assert.deepEqual(openRouterReasoningEffortAttempts(model.openRouterModelId, "max"), [
+    "xhigh",
+    "high",
+  ]);
+  assert.deepEqual(openRouterReasoningEffortAttempts(model.openRouterModelId, "high"), [
+    "high",
+  ]);
+
+  const traces: string[] = [];
+  await generateVoxelBuild({
+    modelKey: "zai_glm_5_2",
+    prompt: "small tower",
+    gridSize: 64,
+    palette: "simple",
+    enableTools: false,
+    providerKeys: { openrouter: "test-openrouter-key" },
+    allowServerKeys: false,
+    onProviderTrace: (message) => traces.push(message),
+  });
+
+  const openRouterRequest = capturedRequests.find((request) =>
+    request.url.includes("openrouter.test"),
+  )?.body;
+  assert.ok(openRouterRequest, "OpenRouter request should be captured");
+  assert.equal(openRouterRequest.model, "z-ai/glm-5.2");
+  assert.equal(openRouterRequest.max_tokens, 131072);
+  assert.deepEqual(openRouterRequest.reasoning, { effort: "xhigh" });
+  assert.ok(
+    traces.some((trace) =>
+      trace.includes("max_output_tokens=131072") &&
+      trace.includes("effort_fallback=xhigh->high->disabled") &&
+      trace.includes("temperature=1"),
+    ),
+    "OpenRouter trace should report the 131072-token cap, GLM 5.2 max effort fallback, and default sampling",
+  );
+
+  console.log("glm 5.2 config checks passed");
+}
+
+main()
+  .finally(() => {
+    globalThis.fetch = originalFetch;
+    if (originalEnv.maxOutputTokens === undefined) {
+      delete process.env.MINEBENCH_MAX_OUTPUT_TOKENS;
+    } else {
+      process.env.MINEBENCH_MAX_OUTPUT_TOKENS = originalEnv.maxOutputTokens;
+    }
+  })
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });


### PR DESCRIPTION
## Summary

- Add `Z.AI GLM 5.2` to the MineBench model catalog as OpenRouter-only via `z-ai/glm-5.2`.
- Add the benchmark upload slug `glm-5-2`.
- Cap GLM 5.2 generation at 131,072 output tokens and route default reasoning through OpenRouter `xhigh -> high`, with `max` mapped to `xhigh`.
- Add a provider regression test that verifies catalog metadata, slug mapping, OpenRouter request shape, token cap, reasoning payload, and trace output.

## Research Notes

- Z.AI documents GLM-5.2 with text input/output, 1M context, 128K maximum output tokens, and `reasoning_effort` support.
- OpenRouter exposes the model as `z-ai/glm-5.2`, with `xhigh` and `high` reasoning efforts; `xhigh` maps to Z.AI max reasoning.

## Verification

- `pnpm test tests/unit/providers/glm-5-2-config.test.ts`
- `pnpm test tests/unit/providers`
- `pnpm lint`
- `pnpm build`
- `graphify update .`
- `git diff --check HEAD~1..HEAD`

*(PR written by Codex)*
