### PR TITLE
(feat) add Claude Sonnet 5 benchmark support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -38,6 +38,8 @@ GOOGLE_SITE_VERIFICATION=
 # Optional overrides (defaults are used if unset)
 # Claude Fable 5 adaptive thinking effort: low | medium | high | xhigh | max
 ANTHROPIC_FABLE_5_EFFORT=max
+# Claude Sonnet 5 adaptive thinking effort: low | medium | high | xhigh | max
+ANTHROPIC_SONNET_5_EFFORT=max
 # Claude Opus 4.8 adaptive thinking effort: low | medium | high | xhigh | max
 ANTHROPIC_OPUS_4_8_EFFORT=max
 # Claude Opus 4.7 adaptive thinking effort: low | medium | high | xhigh | max

--- a/app/api/admin/seed/route.ts
+++ b/app/api/admin/seed/route.ts
@@ -6,6 +6,7 @@ import { generateVoxelBuild } from "@/lib/ai/generateVoxelBuild";
 import { createHash } from "node:crypto";
 import { maybePrecomputeArenaArtifactsForBuild } from "@/lib/arena/artifactMaintenance";
 import { invalidateArenaCoverageCache } from "@/lib/arena/coverage";
+import { modelCatalogSeedUpsertArgs } from "@/lib/admin/seedModelCatalog";
 
 export const runtime = "nodejs";
 
@@ -124,27 +125,7 @@ export async function POST(req: Request) {
     });
 
     for (const m of MODEL_CATALOG) {
-      await tx.model.upsert({
-        where: { key: m.key },
-        create: {
-          key: m.key,
-          provider: m.provider,
-          modelId: m.modelId,
-          displayName: m.displayName,
-          enabled: m.enabled,
-          isBaseline: false,
-          eloRating: 1500,
-          glickoRd: 350,
-          glickoVolatility: 0.06,
-          conservativeRating: 800,
-        },
-        update: {
-          provider: m.provider,
-          modelId: m.modelId,
-          displayName: m.displayName,
-          enabled: m.enabled,
-        },
-      });
+      await tx.model.upsert(modelCatalogSeedUpsertArgs(m));
     }
 
     for (const text of CURATED_PROMPTS) {

--- a/app/api/admin/seed/route.ts
+++ b/app/api/admin/seed/route.ts
@@ -6,7 +6,10 @@ import { generateVoxelBuild } from "@/lib/ai/generateVoxelBuild";
 import { createHash } from "node:crypto";
 import { maybePrecomputeArenaArtifactsForBuild } from "@/lib/arena/artifactMaintenance";
 import { invalidateArenaCoverageCache } from "@/lib/arena/coverage";
-import { modelCatalogSeedUpsertArgs } from "@/lib/admin/seedModelCatalog";
+import {
+  isCatalogModelGeneratableForSeed,
+  modelCatalogSeedUpsertArgs,
+} from "@/lib/admin/seedModelCatalog";
 
 export const runtime = "nodejs";
 
@@ -68,17 +71,18 @@ function providerKeyStatus() {
 function isModelGeneratable(args: { modelKey: string; provider: string }) {
   const status = providerKeyStatus();
   const catalog = MODEL_CATALOG.find((m) => m.key === args.modelKey);
-  const canUseOpenRouter = Boolean(status.openrouter && catalog?.openRouterModelId);
+  if (catalog) {
+    return isCatalogModelGeneratableForSeed({ model: catalog, providerKeys: status });
+  }
 
-  if (catalog?.forceOpenRouter) return canUseOpenRouter;
-  if (args.provider === "xai") return status.xai || canUseOpenRouter;
+  if (args.provider === "xai") return status.xai;
 
-  if (args.provider === "openai") return status.openai || canUseOpenRouter;
-  if (args.provider === "anthropic") return status.anthropic || canUseOpenRouter;
-  if (args.provider === "gemini") return status.gemini || canUseOpenRouter;
-  if (args.provider === "moonshot") return status.moonshot || canUseOpenRouter;
-  if (args.provider === "deepseek") return status.deepseek || canUseOpenRouter;
-  if (args.provider === "minimax") return status.minimax || canUseOpenRouter;
+  if (args.provider === "openai") return status.openai;
+  if (args.provider === "anthropic") return status.anthropic;
+  if (args.provider === "gemini") return status.gemini;
+  if (args.provider === "moonshot") return status.moonshot;
+  if (args.provider === "deepseek") return status.deepseek;
+  if (args.provider === "minimax") return status.minimax;
 
   // Unknown provider: assume it's callable (or OpenRouter-gated via catalog entries).
   return true;

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -100,6 +100,7 @@ Copy `.env.example` to `.env` and set what you need.
 
 - `MINEBENCH_ALLOW_SERVER_KEYS=1` (production opt-in for server env keys in `/api/generate`)
 - `ANTHROPIC_FABLE_5_EFFORT=low|medium|high|xhigh|max`
+- `ANTHROPIC_SONNET_5_EFFORT=low|medium|high|xhigh|max`
 - `ANTHROPIC_OPUS_4_8_EFFORT=low|medium|high|xhigh|max`
 - `ANTHROPIC_OPUS_4_7_EFFORT=low|medium|high|xhigh|max`
 - `ANTHROPIC_OPUS_4_6_EFFORT=low|medium|high|max`
@@ -111,6 +112,7 @@ Copy `.env.example` to `.env` and set what you need.
 - `ANTHROPIC_ENABLE_1M_CONTEXT_BETA=1`
 - `ANTHROPIC_THINKING_BUDGET` (legacy/manual thinking models)
 - Claude Fable 5 uses the native Anthropic model ID `claude-fable-5`, supports always-on adaptive thinking with effort `low|medium|high|xhigh|max`, and MineBench defaults it to `max` with a 128000-token output cap.
+- Claude Sonnet 5 uses the native Anthropic model ID `claude-sonnet-5`, supports adaptive thinking with effort `low|medium|high|xhigh|max`, and MineBench defaults it to `max` with a 128000-token output cap.
 - Claude 4.8 Opus uses the native Anthropic model ID `claude-opus-4-8`, supports adaptive effort `low|medium|high|xhigh|max`, and MineBench defaults it to `max` with a 128000-token output cap.
 - Gemini 3.5 Flash uses the native Google AI model ID `gemini-3.5-flash`, supports `thinking_level=high|medium|low|minimal`, and MineBench defaults it to `high` with a 65536-token output cap.
 - Grok 4.3 uses the native xAI API, reasons automatically, rejects `reasoning_effort`, and uses a `max_tokens` request of up to 1000000 unless `MINEBENCH_MAX_OUTPUT_TOKENS` lowers it; MineBench does not send a thinking override for this model.

--- a/lib/admin/seedModelCatalog.ts
+++ b/lib/admin/seedModelCatalog.ts
@@ -1,0 +1,29 @@
+import type { ModelCatalogEntry } from "@/lib/ai/modelCatalog";
+
+const INITIAL_RATING_FIELDS = {
+  eloRating: 1500,
+  glickoRd: 350,
+  glickoVolatility: 0.06,
+  conservativeRating: 800,
+};
+
+export function modelCatalogSeedUpsertArgs(m: ModelCatalogEntry) {
+  return {
+    where: { key: m.key },
+    create: {
+      key: m.key,
+      provider: m.provider,
+      modelId: m.modelId,
+      displayName: m.displayName,
+      enabled: m.enabled,
+      isBaseline: false,
+      ...INITIAL_RATING_FIELDS,
+    },
+    update: {
+      provider: m.provider,
+      modelId: m.modelId,
+      displayName: m.displayName,
+      ...(m.importOnly ? {} : { enabled: m.enabled }),
+    },
+  };
+}

--- a/lib/admin/seedModelCatalog.ts
+++ b/lib/admin/seedModelCatalog.ts
@@ -1,5 +1,16 @@
 import type { ModelCatalogEntry } from "@/lib/ai/modelCatalog";
 
+export type SeedProviderKeyStatus = {
+  openai: boolean;
+  anthropic: boolean;
+  gemini: boolean;
+  moonshot: boolean;
+  deepseek: boolean;
+  minimax: boolean;
+  xai: boolean;
+  openrouter: boolean;
+};
+
 const INITIAL_RATING_FIELDS = {
   eloRating: 1500,
   glickoRd: 350,
@@ -26,4 +37,25 @@ export function modelCatalogSeedUpsertArgs(m: ModelCatalogEntry) {
       ...(m.importOnly ? {} : { enabled: m.enabled }),
     },
   };
+}
+
+export function isCatalogModelGeneratableForSeed(args: {
+  model: ModelCatalogEntry;
+  providerKeys: SeedProviderKeyStatus;
+}): boolean {
+  const { model, providerKeys } = args;
+  if (model.importOnly) return false;
+
+  const canUseOpenRouter = Boolean(providerKeys.openrouter && model.openRouterModelId);
+  if (model.forceOpenRouter) return canUseOpenRouter;
+  if (model.provider === "xai") return providerKeys.xai || canUseOpenRouter;
+
+  if (model.provider === "openai") return providerKeys.openai || canUseOpenRouter;
+  if (model.provider === "anthropic") return providerKeys.anthropic || canUseOpenRouter;
+  if (model.provider === "gemini") return providerKeys.gemini || canUseOpenRouter;
+  if (model.provider === "moonshot") return providerKeys.moonshot || canUseOpenRouter;
+  if (model.provider === "deepseek") return providerKeys.deepseek || canUseOpenRouter;
+  if (model.provider === "minimax") return providerKeys.minimax || canUseOpenRouter;
+
+  return true;
 }

--- a/lib/ai/generateVoxelBuild.ts
+++ b/lib/ai/generateVoxelBuild.ts
@@ -86,6 +86,8 @@ function maxOutputTokenCapForModel(modelId: string): number | undefined {
   if (
     modelId === "claude-fable-5" ||
     modelId === "anthropic/claude-fable-5" ||
+    modelId === "claude-sonnet-5" ||
+    modelId === "anthropic/claude-sonnet-5" ||
     modelId.startsWith("claude-opus-4-8") ||
     modelId === "anthropic/claude-opus-4.8" ||
     modelId.startsWith("claude-opus-4-7") ||
@@ -147,6 +149,8 @@ function usesDefaultSamplingForModel(modelId: string): boolean {
   return (
     normalized === "claude-fable-5" ||
     normalized === "anthropic/claude-fable-5" ||
+    normalized === "claude-sonnet-5" ||
+    normalized === "anthropic/claude-sonnet-5" ||
     /^claude-opus-4-(?:7|8)(?:-|$)/.test(normalized) ||
     /^anthropic\/claude-opus-4[.-](?:7|8)(?:$|[-:])/.test(normalized)
   );

--- a/lib/ai/generateVoxelBuild.ts
+++ b/lib/ai/generateVoxelBuild.ts
@@ -274,6 +274,7 @@ type ResolvedModel = {
   displayName: string;
   openRouterModelId?: string;
   forceOpenRouter?: boolean;
+  importOnly?: boolean;
   baseUrl?: string;
 };
 
@@ -431,6 +432,7 @@ export type GenerateVoxelBuildParams = {
     displayName: string;
     openRouterModelId?: string;
     forceOpenRouter?: boolean;
+    importOnly?: boolean;
     baseUrl?: string;
   };
   prompt: string;
@@ -889,8 +891,18 @@ export async function generateVoxelBuild(
         displayName: catalogModel.displayName,
         openRouterModelId: catalogModel.openRouterModelId,
         forceOpenRouter: catalogModel.forceOpenRouter,
+        importOnly: catalogModel.importOnly,
       };
     })();
+  if (model.importOnly) {
+    return {
+      ok: false,
+      error:
+        `${model.displayName} is import-only in MineBench. Add web harness JSON files such as ` +
+        `uploads/castle/castle-gpt-4-5-web-harness.json and upload/import them.`,
+      generationTimeMs: 0,
+    };
+  }
   const paletteDefs = getPalette(params.palette);
   const enableTools = params.enableTools ?? true;
   const maxAttempts = params.maxAttempts ?? (enableTools ? 8 : 3);

--- a/lib/ai/modelCatalog.ts
+++ b/lib/ai/modelCatalog.ts
@@ -24,6 +24,7 @@ export type ModelKey =
   | "openai_gpt_5_mini"
   | "openai_gpt_5_nano"
   | "openai_gpt_4_1"
+  | "openai_gpt_4_5_web_harness"
   | "openai_gpt_4o"
   | "openai_gpt_oss_120b"
   | "anthropic_claude_fable_5"
@@ -68,6 +69,8 @@ export type ModelCatalogEntry = {
   openRouterModelId?: string;
   // optional: force routing via OpenRouter even if a direct provider key exists
   forceOpenRouter?: boolean;
+  // optional: model is available only through imported benchmark artifacts
+  importOnly?: boolean;
 };
 
 export const MODEL_CATALOG: ModelCatalogEntry[] = [
@@ -174,6 +177,14 @@ export const MODEL_CATALOG: ModelCatalogEntry[] = [
     displayName: "GPT 4.1",
     enabled: true,
     openRouterModelId: "openai/gpt-4.1",
+  },
+  {
+    key: "openai_gpt_4_5_web_harness",
+    provider: "openai",
+    modelId: "gpt-4.5-preview",
+    displayName: "GPT 4.5 (web harness)",
+    enabled: false,
+    importOnly: true,
   },
   {
     key: "openai_gpt_4o",

--- a/lib/ai/modelCatalog.ts
+++ b/lib/ai/modelCatalog.ts
@@ -27,6 +27,7 @@ export type ModelKey =
   | "openai_gpt_4o"
   | "openai_gpt_oss_120b"
   | "anthropic_claude_fable_5"
+  | "anthropic_claude_sonnet_5"
   | "anthropic_claude_4_5_sonnet"
   | "anthropic_claude_4_6_sonnet"
   | "anthropic_claude_4_5_opus"
@@ -197,6 +198,14 @@ export const MODEL_CATALOG: ModelCatalogEntry[] = [
     displayName: "Claude Fable 5",
     enabled: true,
     openRouterModelId: "anthropic/claude-fable-5",
+  },
+  {
+    key: "anthropic_claude_sonnet_5",
+    provider: "anthropic",
+    modelId: "claude-sonnet-5",
+    displayName: "Claude Sonnet 5",
+    enabled: true,
+    openRouterModelId: "anthropic/claude-sonnet-5",
   },
   {
     key: "anthropic_claude_4_5_sonnet",

--- a/lib/ai/providers/anthropic.ts
+++ b/lib/ai/providers/anthropic.ts
@@ -185,6 +185,10 @@ function isFableOrMythos5(modelId: string): boolean {
   return /^claude-(?:fable|mythos)-5(?:-|$)/.test(modelId);
 }
 
+function isSonnet5(modelId: string): boolean {
+  return /^claude-sonnet-5(?:-|$)/.test(modelId);
+}
+
 function anthropicClaudeVersion(modelId: string): { family: "opus" | "sonnet"; major: number; minor: number } | null {
   const match = /^claude-(opus|sonnet)-(\d+)-(\d+)(?:-|$)/.exec(modelId);
   if (!match) return null;
@@ -195,6 +199,7 @@ function anthropicClaudeVersion(modelId: string): { family: "opus" | "sonnet"; m
 }
 
 function omitsSamplingParameters(modelId: string): boolean {
+  if (isSonnet5(modelId)) return true;
   if (isFableOrMythos5(modelId)) return true;
   const version = anthropicClaudeVersion(modelId);
   if (!version) return false;
@@ -202,6 +207,7 @@ function omitsSamplingParameters(modelId: string): boolean {
 }
 
 function isAdaptiveThinkingModel(modelId: string): boolean {
+  if (isSonnet5(modelId)) return true;
   if (isFableOrMythos5(modelId)) return true;
   const version = anthropicClaudeVersion(modelId);
   if (!version) return false;
@@ -209,6 +215,7 @@ function isAdaptiveThinkingModel(modelId: string): boolean {
 }
 
 function supportsXhighEffort(modelId: string): boolean {
+  if (isSonnet5(modelId)) return true;
   if (isFableOrMythos5(modelId)) return true;
   const version = anthropicClaudeVersion(modelId);
   if (!version) return false;
@@ -218,6 +225,9 @@ function supportsXhighEffort(modelId: string): boolean {
 function effortEnvVarForModel(modelId: string): string | null {
   if (modelId.startsWith("claude-fable-5")) {
     return "ANTHROPIC_FABLE_5_EFFORT";
+  }
+  if (modelId.startsWith("claude-sonnet-5")) {
+    return "ANTHROPIC_SONNET_5_EFFORT";
   }
   const version = anthropicClaudeVersion(modelId);
   if (!version) return null;

--- a/lib/ai/providers/anthropic.ts
+++ b/lib/ai/providers/anthropic.ts
@@ -13,7 +13,7 @@ type AnthropicMessageResponse = {
 
 type AnthropicStreamEvent = {
   type?: unknown;
-  delta?: { type?: unknown; text?: unknown } | unknown;
+  delta?: { type?: unknown; text?: unknown; partial_json?: unknown } | unknown;
 };
 
 type AnthropicEffort = "low" | "medium" | "high" | "xhigh" | "max";
@@ -473,8 +473,13 @@ export async function anthropicGenerateText(params: {
       }
       // message streaming sends incremental deltas on content_block_delta
       if (parsed?.type === "content_block_delta") {
-        const deltaObj = parsed.delta as { text?: unknown } | undefined;
-        const chunk = deltaObj && typeof deltaObj.text === "string" ? deltaObj.text : "";
+        const deltaObj = parsed.delta as { text?: unknown; partial_json?: unknown } | undefined;
+        const chunk =
+          deltaObj && typeof deltaObj.text === "string"
+            ? deltaObj.text
+            : deltaObj && typeof deltaObj.partial_json === "string"
+              ? deltaObj.partial_json
+              : "";
         if (chunk) {
           text += chunk;
           params.onDelta?.(chunk);

--- a/lib/ai/providers/openrouter.ts
+++ b/lib/ai/providers/openrouter.ts
@@ -130,6 +130,7 @@ function openRouterTemperaturePayload(modelId: string, temperature?: number): { 
   const normalized = modelId.toLowerCase();
   const usesDefaultSampling =
     normalized === "anthropic/claude-fable-5" ||
+    normalized === "anthropic/claude-sonnet-5" ||
     /^anthropic\/claude-(?:opus-4[.-]8|4[.-]8-opus)(?:$|[-:])/.test(normalized);
   if (usesDefaultSampling) return {};
   return { temperature: temperature ?? 0.2 };

--- a/lib/ai/reasoningProfiles.ts
+++ b/lib/ai/reasoningProfiles.ts
@@ -57,6 +57,43 @@ function supportsAnthropicXhighEffort(modelId: string): boolean {
   return version.major > 4 || (version.major === 4 && version.minor >= 7);
 }
 
+function anthropicAdaptiveEffortEnvVar(modelId: string): string | null {
+  if (isAnthropicFableOrMythos5(modelId)) return "ANTHROPIC_FABLE_5_EFFORT";
+  if (isAnthropicSonnet5(modelId)) return "ANTHROPIC_SONNET_5_EFFORT";
+  const version = anthropicClaudeVersion(modelId);
+  if (!version) return null;
+  if (modelId.includes("claude-opus-4") && version.major === 4 && version.minor === 8) {
+    return "ANTHROPIC_OPUS_4_8_EFFORT";
+  }
+  if (modelId.includes("claude-opus-4") && version.major === 4 && version.minor === 7) {
+    return "ANTHROPIC_OPUS_4_7_EFFORT";
+  }
+  if (modelId.includes("claude-opus-4") && version.major === 4 && version.minor === 6) {
+    return "ANTHROPIC_OPUS_4_6_EFFORT";
+  }
+  if (modelId.includes("claude-sonnet-4") && version.major === 4 && version.minor === 6) {
+    return "ANTHROPIC_SONNET_4_6_EFFORT";
+  }
+  return null;
+}
+
+function anthropicAdaptiveEffortOverride(modelId: string, override?: string): string | undefined {
+  const normalizedOverride = normalizeReasoningOverride(override);
+  if (normalizedOverride) return normalizedOverride;
+
+  const envVar = anthropicAdaptiveEffortEnvVar(modelId);
+  const normalizedEnv = envVar ? normalizeReasoningOverride(process.env[envVar]) : undefined;
+  if (!normalizedEnv) return undefined;
+  if (normalizedEnv === "low" || normalizedEnv === "medium" || normalizedEnv === "high") {
+    return normalizedEnv;
+  }
+  if (normalizedEnv === "xhigh") {
+    return supportsAnthropicXhighEffort(modelId) ? "xhigh" : "high";
+  }
+  if (normalizedEnv === "max") return "max";
+  return undefined;
+}
+
 function descendingAttempts<T extends string>(
   label: string,
   allowed: readonly T[],
@@ -123,7 +160,7 @@ export function anthropicAdaptiveEffortAttempts(
     supportsAnthropicXhighEffort(modelId)
       ? ["max", "xhigh", "high", "medium", "low"]
       : ["max", "high", "medium", "low"],
-    override,
+    anthropicAdaptiveEffortOverride(modelId, override),
   );
 }
 

--- a/lib/ai/reasoningProfiles.ts
+++ b/lib/ai/reasoningProfiles.ts
@@ -346,7 +346,7 @@ export function openRouterReasoningEffortAttempts(
       supportsAnthropicXhighEffort(modelId)
         ? ["max", "xhigh", "high", "medium", "low"]
         : ["max", "high", "medium", "low"],
-      override,
+      anthropicAdaptiveEffortOverride(modelId, override),
     );
   }
   if (

--- a/lib/ai/reasoningProfiles.ts
+++ b/lib/ai/reasoningProfiles.ts
@@ -28,6 +28,10 @@ function isAnthropicFableOrMythos5(modelId: string): boolean {
   return /(?:^|\/)claude-(?:fable|mythos)-5(?:[.-]|$)/.test(modelId);
 }
 
+function isAnthropicSonnet5(modelId: string): boolean {
+  return /(?:^|\/)claude-sonnet-5(?:[.-]|$)/.test(modelId);
+}
+
 function anthropicClaudeVersion(modelId: string): { major: number; minor: number } | null {
   const match = /(?:^|\/)claude-(?:opus|sonnet)-(\d+)[.-](\d+)(?:[.-]|$)/.exec(modelId);
   if (!match) return null;
@@ -38,6 +42,7 @@ function anthropicClaudeVersion(modelId: string): { major: number; minor: number
 }
 
 function isAnthropicAdaptiveModel(modelId: string): boolean {
+  if (isAnthropicSonnet5(modelId)) return true;
   if (isAnthropicFableOrMythos5(modelId)) return true;
   const version = anthropicClaudeVersion(modelId);
   if (!version) return false;
@@ -45,6 +50,7 @@ function isAnthropicAdaptiveModel(modelId: string): boolean {
 }
 
 function supportsAnthropicXhighEffort(modelId: string): boolean {
+  if (isAnthropicSonnet5(modelId)) return true;
   if (isAnthropicFableOrMythos5(modelId)) return true;
   const version = anthropicClaudeVersion(modelId);
   if (!version) return false;

--- a/scripts/batch-generate.ts
+++ b/scripts/batch-generate.ts
@@ -26,7 +26,7 @@
 import * as fs from "fs";
 import * as path from "path";
 import { createHash } from "node:crypto";
-import { pathToFileURL } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { gzipSync } from "node:zlib";
 import { generateVoxelBuild } from "../lib/ai/generateVoxelBuild";
 import { maxBlocksForGrid } from "../lib/ai/limits";
@@ -358,6 +358,13 @@ function isEmptyPlaceholder(filePath: string): boolean {
 
 function getMissingJobs(jobs: Job[]): Job[] {
   return jobs.filter((j) => isEmptyPlaceholder(j.filePath));
+}
+
+export function getImportOnlyModelsForGenerationJobs(
+  jobsToGenerate: Array<Pick<Job, "modelKey">>,
+) {
+  const modelKeys = new Set(jobsToGenerate.map((job) => job.modelKey));
+  return MODEL_CATALOG.filter((model) => modelKeys.has(model.key) && model.importOnly);
 }
 
 async function generateAndSave(
@@ -827,22 +834,6 @@ Upload notes:
 
   printStatus(allJobs);
 
-  if (opts.generate) {
-    const importOnlyModels = selectedModelKeys
-      .flatMap((modelKey) => {
-        const model = MODEL_CATALOG.find((m) => m.key === modelKey);
-        return model?.importOnly ? [model] : [];
-      });
-    if (importOnlyModels.length > 0) {
-      console.error(
-        "\nError: these models are import-only and cannot be generated through provider APIs:\n" +
-          importOnlyModels.map((m) => `  - ${MODEL_SLUG[m.key]} (${m.displayName})`).join("\n") +
-          "\n\nDrop JSON files into existing upload prompt folders, for example uploads/castle/castle-gpt-4-5-web-harness.json, then run upload/status without --generate.\n",
-      );
-      process.exit(1);
-    }
-  }
-
   const missing = getMissingJobs(allJobs);
   const existing = allJobs.filter((j) => !isEmptyPlaceholder(j.filePath));
   console.log(`\n🔍 Missing builds: ${missing.length}`);
@@ -863,6 +854,17 @@ Upload notes:
 
   // generate missing builds only if --generate flag is set
   const jobsToGenerate = opts.generate ? (opts.overwrite ? allJobs : missing) : [];
+  if (opts.generate) {
+    const importOnlyModels = getImportOnlyModelsForGenerationJobs(jobsToGenerate);
+    if (importOnlyModels.length > 0) {
+      console.error(
+        "\nError: these models are import-only and cannot be generated through provider APIs:\n" +
+          importOnlyModels.map((m) => `  - ${MODEL_SLUG[m.key]} (${m.displayName})`).join("\n") +
+          "\n\nDrop JSON files into existing upload prompt folders, for example uploads/castle/castle-gpt-4-5-web-harness.json, then run upload/status without --generate.\n",
+      );
+      process.exit(1);
+    }
+  }
   if (opts.generate && jobsToGenerate.length > 0 && opts.concurrency > jobsToGenerate.length) {
     console.error(
       `\nError: --concurrency ${opts.concurrency} exceeds the number of selected build jobs (${jobsToGenerate.length}).\n` +
@@ -957,7 +959,13 @@ Upload notes:
   }
 }
 
-main().catch((err) => {
-  console.error("Fatal error:", err);
-  process.exit(1);
-});
+const isDirectRun = process.argv[1]
+  ? path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)
+  : false;
+
+if (isDirectRun) {
+  main().catch((err) => {
+    console.error("Fatal error:", err);
+    process.exit(1);
+  });
+}

--- a/scripts/batch-generate.ts
+++ b/scripts/batch-generate.ts
@@ -827,6 +827,22 @@ Upload notes:
 
   printStatus(allJobs);
 
+  if (opts.generate) {
+    const importOnlyModels = selectedModelKeys
+      .flatMap((modelKey) => {
+        const model = MODEL_CATALOG.find((m) => m.key === modelKey);
+        return model?.importOnly ? [model] : [];
+      });
+    if (importOnlyModels.length > 0) {
+      console.error(
+        "\nError: these models are import-only and cannot be generated through provider APIs:\n" +
+          importOnlyModels.map((m) => `  - ${MODEL_SLUG[m.key]} (${m.displayName})`).join("\n") +
+          "\n\nDrop JSON files into existing upload prompt folders, for example uploads/castle/castle-gpt-4-5-web-harness.json, then run upload/status without --generate.\n",
+      );
+      process.exit(1);
+    }
+  }
+
   const missing = getMissingJobs(allJobs);
   const existing = allJobs.filter((j) => !isEmptyPlaceholder(j.filePath));
   console.log(`\n🔍 Missing builds: ${missing.length}`);

--- a/scripts/batch-generate.ts
+++ b/scripts/batch-generate.ts
@@ -287,6 +287,47 @@ export function getCandidateModels(modelFilters: string[]): ModelKey[] {
   return getDefaultCandidateModels();
 }
 
+function getModel(modelKey: ModelKey) {
+  return MODEL_CATALOG.find((model) => model.key === modelKey);
+}
+
+function exactImportOnlyModelKeys(modelFilters: string[]): Set<ModelKey> {
+  const normalizedFilters = modelFilters.map((filter) => filter.trim().toLowerCase()).filter(Boolean);
+  return new Set(
+    MODEL_CATALOG
+      .filter((model) => model.importOnly)
+      .flatMap((model) => {
+        const slug = MODEL_SLUG[model.key].toLowerCase();
+        const key = model.key.toLowerCase();
+        return normalizedFilters.includes(slug) || normalizedFilters.includes(key) ? [model.key] : [];
+      }),
+  );
+}
+
+export function getJobsToGenerate<T extends Pick<Job, "modelKey">>(opts: {
+  generate: boolean;
+  overwrite: boolean;
+  modelFilters: string[];
+  allJobs: T[];
+  missingJobs: T[];
+}): T[] {
+  if (!opts.generate) return [];
+  const candidates = opts.overwrite ? opts.allJobs : opts.missingJobs;
+  const explicitImportOnlyModels = exactImportOnlyModelKeys(opts.modelFilters);
+  return candidates.filter((job) => {
+    const model = getModel(job.modelKey);
+    if (!model?.importOnly) return true;
+    return explicitImportOnlyModels.has(job.modelKey);
+  });
+}
+
+function getModelsMissingOpenRouterForGenerationJobs(jobsToGenerate: Array<Pick<Job, "modelKey">>): string[] {
+  const modelKeys = new Set(jobsToGenerate.map((job) => job.modelKey));
+  return MODEL_CATALOG
+    .filter((model) => modelKeys.has(model.key) && !model.openRouterModelId)
+    .map((model) => `${model.key} (${model.displayName})`);
+}
+
 function getAllPromptSlugs(): string[] {
   const slugs = new Set<string>(Object.keys(PROMPT_MAP));
   for (const slug of listUploadPromptSlugs()) slugs.add(slug);
@@ -805,23 +846,6 @@ Upload notes:
       console.error("\nError: --openrouter requires OPENROUTER_API_KEY.\n");
       process.exit(1);
     }
-
-    const missingOpenRouter: string[] = [];
-    for (const modelKey of selectedModelKeys) {
-      const entry = MODEL_CATALOG.find((m) => m.key === modelKey);
-      if (entry && !entry.openRouterModelId) {
-        missingOpenRouter.push(`${entry.key} (${entry.displayName})`);
-      }
-    }
-
-    if (missingOpenRouter.length > 0) {
-      console.error(
-        "\nError: --openrouter was requested, but these models are not integrated via OpenRouter:\n" +
-          missingOpenRouter.map((m) => `  - ${m}`).join("\n") +
-          "\n\nAdd openRouterModelId in lib/ai/modelCatalog.ts or remove these models from the selection.\n"
-      );
-      process.exit(1);
-    }
   }
 
   const modelCountForSummary = selectedModelKeys.length;
@@ -853,7 +877,13 @@ Upload notes:
   }
 
   // generate missing builds only if --generate flag is set
-  const jobsToGenerate = opts.generate ? (opts.overwrite ? allJobs : missing) : [];
+  const jobsToGenerate = getJobsToGenerate({
+    generate: opts.generate,
+    overwrite: opts.overwrite,
+    modelFilters: opts.modelFilters,
+    allJobs,
+    missingJobs: missing,
+  });
   if (opts.generate) {
     const importOnlyModels = getImportOnlyModelsForGenerationJobs(jobsToGenerate);
     if (importOnlyModels.length > 0) {
@@ -861,6 +891,17 @@ Upload notes:
         "\nError: these models are import-only and cannot be generated through provider APIs:\n" +
           importOnlyModels.map((m) => `  - ${MODEL_SLUG[m.key]} (${m.displayName})`).join("\n") +
           "\n\nDrop JSON files into existing upload prompt folders, for example uploads/castle/castle-gpt-4-5-web-harness.json, then run upload/status without --generate.\n",
+      );
+      process.exit(1);
+    }
+  }
+  if (opts.openrouter && opts.generate && jobsToGenerate.length > 0) {
+    const missingOpenRouter = getModelsMissingOpenRouterForGenerationJobs(jobsToGenerate);
+    if (missingOpenRouter.length > 0) {
+      console.error(
+        "\nError: --openrouter was requested, but these models are not integrated via OpenRouter:\n" +
+          missingOpenRouter.map((m) => `  - ${m}`).join("\n") +
+          "\n\nAdd openRouterModelId in lib/ai/modelCatalog.ts or remove these models from the selection.\n"
       );
       process.exit(1);
     }

--- a/scripts/batch-generate.ts
+++ b/scripts/batch-generate.ts
@@ -275,16 +275,16 @@ function ensureDir(dir: string) {
   }
 }
 
-function getEnabledModels(): ModelKey[] {
-  return MODEL_CATALOG.filter((m) => m.enabled).map((m) => m.key);
+function getDefaultCandidateModels(): ModelKey[] {
+  return MODEL_CATALOG.filter((m) => m.enabled || m.importOnly).map((m) => m.key);
 }
 
-function getCandidateModels(modelFilters: string[]): ModelKey[] {
+export function getCandidateModels(modelFilters: string[]): ModelKey[] {
   // If the user is explicitly filtering by model, include disabled models too so
   // existing builds (e.g. benchmark-only models) can be uploaded/status-checked.
   // Generation will still be gated elsewhere unless the user explicitly requests it.
   if (modelFilters.length > 0) return MODEL_CATALOG.map((m) => m.key);
-  return getEnabledModels();
+  return getDefaultCandidateModels();
 }
 
 function getAllPromptSlugs(): string[] {

--- a/scripts/uploadsCatalog.ts
+++ b/scripts/uploadsCatalog.ts
@@ -49,6 +49,7 @@ export const MODEL_SLUG: Record<ModelKey, string> = {
   openai_gpt_4o: "gpt-4o",
   openai_gpt_oss_120b: "gpt-oss-120b",
   anthropic_claude_fable_5: "claude-fable-5",
+  anthropic_claude_sonnet_5: "sonnet-5",
   anthropic_claude_4_5_sonnet: "sonnet",
   anthropic_claude_4_6_sonnet: "sonnet-4-6",
   anthropic_claude_4_5_opus: "opus",

--- a/scripts/uploadsCatalog.ts
+++ b/scripts/uploadsCatalog.ts
@@ -46,6 +46,7 @@ export const MODEL_SLUG: Record<ModelKey, string> = {
   openai_gpt_5_mini: "gpt-5-mini",
   openai_gpt_5_nano: "gpt-5-nano",
   openai_gpt_4_1: "gpt-4-1",
+  openai_gpt_4_5_web_harness: "gpt-4-5-web-harness",
   openai_gpt_4o: "gpt-4o",
   openai_gpt_oss_120b: "gpt-oss-120b",
   anthropic_claude_fable_5: "claude-fable-5",

--- a/tests/unit/admin/seed-model-catalog.test.ts
+++ b/tests/unit/admin/seed-model-catalog.test.ts
@@ -1,6 +1,9 @@
 import assert from "node:assert/strict";
 import { getModelByKey } from "../../../lib/ai/modelCatalog";
-import { modelCatalogSeedUpsertArgs } from "../../../lib/admin/seedModelCatalog";
+import {
+  isCatalogModelGeneratableForSeed,
+  modelCatalogSeedUpsertArgs,
+} from "../../../lib/admin/seedModelCatalog";
 
 const importedWebHarnessModel = getModelByKey("openai_gpt_4_5_web_harness");
 const importedWebHarnessUpsert = modelCatalogSeedUpsertArgs(importedWebHarnessModel);
@@ -17,5 +20,21 @@ const regularModelUpsert = modelCatalogSeedUpsertArgs(regularModel);
 
 assert.equal(regularModelUpsert.create.enabled, true);
 assert.equal(regularModelUpsert.update.enabled, true);
+
+assert.equal(
+  isCatalogModelGeneratableForSeed({
+    model: importedWebHarnessModel,
+    providerKeys: { openai: true, openrouter: true },
+  }),
+  false,
+  "seed generation should skip import-only models even when provider keys are present",
+);
+assert.equal(
+  isCatalogModelGeneratableForSeed({
+    model: regularModel,
+    providerKeys: { anthropic: true, openrouter: false },
+  }),
+  true,
+);
 
 console.log("seed model catalog checks passed");

--- a/tests/unit/admin/seed-model-catalog.test.ts
+++ b/tests/unit/admin/seed-model-catalog.test.ts
@@ -1,0 +1,21 @@
+import assert from "node:assert/strict";
+import { getModelByKey } from "../../../lib/ai/modelCatalog";
+import { modelCatalogSeedUpsertArgs } from "../../../lib/admin/seedModelCatalog";
+
+const importedWebHarnessModel = getModelByKey("openai_gpt_4_5_web_harness");
+const importedWebHarnessUpsert = modelCatalogSeedUpsertArgs(importedWebHarnessModel);
+
+assert.equal(importedWebHarnessUpsert.create.enabled, false);
+assert.equal(
+  Object.hasOwn(importedWebHarnessUpsert.update, "enabled"),
+  false,
+  "seed updates should not disable an already-imported import-only model",
+);
+
+const regularModel = getModelByKey("anthropic_claude_sonnet_5");
+const regularModelUpsert = modelCatalogSeedUpsertArgs(regularModel);
+
+assert.equal(regularModelUpsert.create.enabled, true);
+assert.equal(regularModelUpsert.update.enabled, true);
+
+console.log("seed model catalog checks passed");

--- a/tests/unit/admin/seed-model-catalog.test.ts
+++ b/tests/unit/admin/seed-model-catalog.test.ts
@@ -3,7 +3,22 @@ import { getModelByKey } from "../../../lib/ai/modelCatalog";
 import {
   isCatalogModelGeneratableForSeed,
   modelCatalogSeedUpsertArgs,
+  type SeedProviderKeyStatus,
 } from "../../../lib/admin/seedModelCatalog";
+
+function providerKeyStatus(overrides: Partial<SeedProviderKeyStatus>): SeedProviderKeyStatus {
+  return {
+    openai: false,
+    anthropic: false,
+    gemini: false,
+    moonshot: false,
+    deepseek: false,
+    minimax: false,
+    xai: false,
+    openrouter: false,
+    ...overrides,
+  };
+}
 
 const importedWebHarnessModel = getModelByKey("openai_gpt_4_5_web_harness");
 const importedWebHarnessUpsert = modelCatalogSeedUpsertArgs(importedWebHarnessModel);
@@ -24,7 +39,7 @@ assert.equal(regularModelUpsert.update.enabled, true);
 assert.equal(
   isCatalogModelGeneratableForSeed({
     model: importedWebHarnessModel,
-    providerKeys: { openai: true, openrouter: true },
+    providerKeys: providerKeyStatus({ openai: true, openrouter: true }),
   }),
   false,
   "seed generation should skip import-only models even when provider keys are present",
@@ -32,7 +47,7 @@ assert.equal(
 assert.equal(
   isCatalogModelGeneratableForSeed({
     model: regularModel,
-    providerKeys: { anthropic: true, openrouter: false },
+    providerKeys: providerKeyStatus({ anthropic: true }),
   }),
   true,
 );

--- a/tests/unit/providers/claude-sonnet-5-config.test.ts
+++ b/tests/unit/providers/claude-sonnet-5-config.test.ts
@@ -207,6 +207,33 @@ async function main() {
     "OpenRouter trace should report the 128000-token cap, max reasoning fallback, and default sampling",
   );
 
+  capturedRequests.length = 0;
+  process.env.ANTHROPIC_SONNET_5_EFFORT = "low";
+  const lowEffortTraces: string[] = [];
+  await generateVoxelBuild({
+    modelKey: "anthropic_claude_sonnet_5",
+    prompt: "small tower",
+    gridSize: 64,
+    palette: "simple",
+    enableTools: false,
+    providerKeys: { anthropic: "test-anthropic-key" },
+    allowServerKeys: false,
+    onProviderTrace: (message) => lowEffortTraces.push(message),
+  });
+
+  const lowEffortDirectRequest = capturedRequests.find((request) =>
+    request.url.includes("api.anthropic.com"),
+  );
+  assert.ok(lowEffortDirectRequest, "low-effort direct Anthropic request should be captured");
+  assert.deepEqual((lowEffortDirectRequest.body.output_config as { effort?: unknown })?.effort, "low");
+  assert.ok(
+    lowEffortTraces.some((trace) =>
+      trace.includes("adaptive_effort=low") &&
+      trace.includes("temperature=default"),
+    ),
+    "direct trace should report the Sonnet 5 env effort override",
+  );
+
   process.env.ANTHROPIC_STREAM_RESPONSES = "1";
   const streamingResult = await generateVoxelBuild({
     modelKey: "anthropic_claude_sonnet_5",

--- a/tests/unit/providers/claude-sonnet-5-config.test.ts
+++ b/tests/unit/providers/claude-sonnet-5-config.test.ts
@@ -30,6 +30,36 @@ function validBuildJson(): string {
   });
 }
 
+function validToolCallJson(): string {
+  return JSON.stringify({
+    tool: "voxel.exec",
+    input: {
+      code: 'box(0, 0, 0, 11, 7, 11, "stone");',
+      gridSize: 64,
+      palette: "simple",
+      seed: 123,
+    },
+  });
+}
+
+function streamingStructuredAnthropicResponse(text: string): Response {
+  const mid = Math.floor(text.length / 2);
+  const chunks = [text.slice(0, mid), text.slice(mid)];
+  const events = chunks.map((partialJson) => (
+    `event: content_block_delta\n` +
+    `data: ${JSON.stringify({
+      type: "content_block_delta",
+      index: 0,
+      delta: { type: "input_json_delta", partial_json: partialJson },
+    })}\n\n`
+  ));
+
+  return new Response(events.join(""), {
+    status: 200,
+    headers: { "Content-Type": "text/event-stream" },
+  });
+}
+
 function normalizeHeaders(headers: HeadersInit | undefined): Record<string, string> {
   if (!headers) return {};
   if (headers instanceof Headers) return Object.fromEntries(headers.entries());
@@ -50,6 +80,10 @@ globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit): Promis
   });
 
   if (url.includes("api.anthropic.com")) {
+    if (body.stream) {
+      return streamingStructuredAnthropicResponse(validToolCallJson());
+    }
+
     return new Response(
       JSON.stringify({
         content: [{ type: "text", text: validBuildJson() }],
@@ -172,6 +206,21 @@ async function main() {
     ),
     "OpenRouter trace should report the 128000-token cap, max reasoning fallback, and default sampling",
   );
+
+  process.env.ANTHROPIC_STREAM_RESPONSES = "1";
+  const streamingResult = await generateVoxelBuild({
+    modelKey: "anthropic_claude_sonnet_5",
+    prompt: "small tower",
+    gridSize: 64,
+    palette: "simple",
+    enableTools: true,
+    providerKeys: { anthropic: "test-anthropic-key" },
+    allowServerKeys: false,
+  });
+  assert.equal(streamingResult.ok, true, "streamed Anthropic structured output should parse");
+  if (streamingResult.ok) {
+    assert.equal(streamingResult.blockCount, 1152);
+  }
 
   console.log("claude sonnet 5 config checks passed");
 }

--- a/tests/unit/providers/claude-sonnet-5-config.test.ts
+++ b/tests/unit/providers/claude-sonnet-5-config.test.ts
@@ -234,6 +234,33 @@ async function main() {
     "direct trace should report the Sonnet 5 env effort override",
   );
 
+  capturedRequests.length = 0;
+  const lowOpenRouterEffortTraces: string[] = [];
+  await generateVoxelBuild({
+    modelKey: "anthropic_claude_sonnet_5",
+    prompt: "small tower",
+    gridSize: 64,
+    palette: "simple",
+    enableTools: false,
+    preferOpenRouter: true,
+    providerKeys: { openrouter: "test-openrouter-key" },
+    allowServerKeys: false,
+    onProviderTrace: (message) => lowOpenRouterEffortTraces.push(message),
+  });
+
+  const lowOpenRouterEffortRequest = capturedRequests.find((request) =>
+    request.url.includes("openrouter.test"),
+  )?.body;
+  assert.ok(lowOpenRouterEffortRequest, "low-effort OpenRouter request should be captured");
+  assert.deepEqual(lowOpenRouterEffortRequest.reasoning, { effort: "low" });
+  assert.ok(
+    lowOpenRouterEffortTraces.some((trace) =>
+      trace.includes("effort_fallback=low->disabled") &&
+      trace.includes("temperature=default"),
+    ),
+    "OpenRouter trace should report the Sonnet 5 env effort override",
+  );
+
   process.env.ANTHROPIC_STREAM_RESPONSES = "1";
   const streamingResult = await generateVoxelBuild({
     modelKey: "anthropic_claude_sonnet_5",

--- a/tests/unit/providers/claude-sonnet-5-config.test.ts
+++ b/tests/unit/providers/claude-sonnet-5-config.test.ts
@@ -1,0 +1,201 @@
+import assert from "node:assert/strict";
+import { generateVoxelBuild } from "../../../lib/ai/generateVoxelBuild";
+import { getModelByKey } from "../../../lib/ai/modelCatalog";
+import {
+  anthropicAdaptiveEffortAttempts,
+  openRouterReasoningEffortAttempts,
+} from "../../../lib/ai/reasoningProfiles";
+import { MODEL_SLUG } from "../../../scripts/uploadsCatalog";
+
+type CapturedRequest = {
+  url: string;
+  headers: Record<string, string>;
+  body: Record<string, unknown>;
+};
+
+const capturedRequests: CapturedRequest[] = [];
+const originalFetch = globalThis.fetch;
+const originalEnv = {
+  anthropicStreamResponses: process.env.ANTHROPIC_STREAM_RESPONSES,
+  maxOutputTokens: process.env.MINEBENCH_MAX_OUTPUT_TOKENS,
+  sonnet5Effort: process.env.ANTHROPIC_SONNET_5_EFFORT,
+};
+
+function validBuildJson(): string {
+  return JSON.stringify({
+    version: "1.0",
+    boxes: [],
+    lines: [],
+    blocks: [{ x: 0, y: 0, z: 0, type: "stone" }],
+  });
+}
+
+function normalizeHeaders(headers: HeadersInit | undefined): Record<string, string> {
+  if (!headers) return {};
+  if (headers instanceof Headers) return Object.fromEntries(headers.entries());
+  if (Array.isArray(headers)) return Object.fromEntries(headers);
+  return headers;
+}
+
+globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+  assert.ok(init?.body, "provider request should include a JSON body");
+  assert.equal(typeof init.body, "string", "provider request body should be serialized JSON");
+
+  const url = String(input);
+  const body = JSON.parse(init.body as string) as Record<string, unknown>;
+  capturedRequests.push({
+    url,
+    headers: normalizeHeaders(init.headers),
+    body,
+  });
+
+  if (url.includes("api.anthropic.com")) {
+    return new Response(
+      JSON.stringify({
+        content: [{ type: "text", text: validBuildJson() }],
+      }),
+      {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      },
+    );
+  }
+
+  return new Response(
+    JSON.stringify({
+      choices: [
+        {
+          message: {
+            content: validBuildJson(),
+          },
+        },
+      ],
+    }),
+    {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    },
+  );
+}) as typeof fetch;
+
+async function main() {
+  process.env.ANTHROPIC_STREAM_RESPONSES = "0";
+  process.env.MINEBENCH_MAX_OUTPUT_TOKENS = "999999";
+  process.env.ANTHROPIC_SONNET_5_EFFORT = "max";
+  process.env.OPENROUTER_BASE_URL = "https://openrouter.test/api";
+
+  const model = getModelByKey("anthropic_claude_sonnet_5");
+
+  assert.equal(model.provider, "anthropic");
+  assert.equal(model.modelId, "claude-sonnet-5");
+  assert.equal(model.displayName, "Claude Sonnet 5");
+  assert.equal(model.openRouterModelId, "anthropic/claude-sonnet-5");
+  assert.equal(MODEL_SLUG.anthropic_claude_sonnet_5, "sonnet-5");
+  assert.deepEqual(anthropicAdaptiveEffortAttempts(model.modelId), [
+    "max",
+    "xhigh",
+    "high",
+    "medium",
+    "low",
+  ]);
+  assert.deepEqual(anthropicAdaptiveEffortAttempts(model.modelId, "xhigh"), [
+    "xhigh",
+    "high",
+    "medium",
+    "low",
+  ]);
+  assert.deepEqual(openRouterReasoningEffortAttempts(model.openRouterModelId), [
+    "max",
+    "xhigh",
+    "high",
+    "medium",
+    "low",
+  ]);
+
+  const directTraces: string[] = [];
+  await generateVoxelBuild({
+    modelKey: "anthropic_claude_sonnet_5",
+    prompt: "small tower",
+    gridSize: 64,
+    palette: "simple",
+    enableTools: false,
+    providerKeys: { anthropic: "test-anthropic-key" },
+    allowServerKeys: false,
+    onProviderTrace: (message) => directTraces.push(message),
+  });
+
+  const directRequest = capturedRequests.find((request) =>
+    request.url.includes("api.anthropic.com"),
+  );
+  assert.ok(directRequest, "direct Anthropic request should be captured");
+  assert.equal(directRequest.body.model, "claude-sonnet-5");
+  assert.equal(directRequest.body.max_tokens, 128000);
+  assert.equal(Object.hasOwn(directRequest.body, "temperature"), false);
+  assert.equal(Object.hasOwn(directRequest.headers, "anthropic-beta"), false);
+  assert.deepEqual(directRequest.body.thinking, { type: "adaptive" });
+  assert.deepEqual((directRequest.body.output_config as { effort?: unknown })?.effort, "max");
+  assert.ok(
+    directTraces.some((trace) =>
+      trace.includes("max_output_tokens=128000") &&
+      trace.includes("adaptive_effort=max->xhigh->high->medium->low") &&
+      trace.includes("temperature=default"),
+    ),
+    "direct trace should report the 128000-token cap, max adaptive effort fallback, and default sampling",
+  );
+
+  const openRouterTraces: string[] = [];
+  await generateVoxelBuild({
+    modelKey: "anthropic_claude_sonnet_5",
+    prompt: "small tower",
+    gridSize: 64,
+    palette: "simple",
+    enableTools: false,
+    preferOpenRouter: true,
+    providerKeys: { openrouter: "test-openrouter-key" },
+    allowServerKeys: false,
+    onProviderTrace: (message) => openRouterTraces.push(message),
+  });
+
+  const openRouterRequest = capturedRequests.find((request) =>
+    request.url.includes("openrouter.test"),
+  )?.body;
+  assert.ok(openRouterRequest, "OpenRouter request should be captured");
+  assert.equal(openRouterRequest.model, "anthropic/claude-sonnet-5");
+  assert.equal(openRouterRequest.max_tokens, 128000);
+  assert.equal(Object.hasOwn(openRouterRequest, "temperature"), false);
+  assert.deepEqual(openRouterRequest.reasoning, { effort: "max" });
+  assert.ok(
+    openRouterTraces.some((trace) =>
+      trace.includes("max_output_tokens=128000") &&
+      trace.includes("effort_fallback=max->xhigh->high->medium->low->disabled") &&
+      trace.includes("temperature=default"),
+    ),
+    "OpenRouter trace should report the 128000-token cap, max reasoning fallback, and default sampling",
+  );
+
+  console.log("claude sonnet 5 config checks passed");
+}
+
+main()
+  .finally(() => {
+    globalThis.fetch = originalFetch;
+    if (originalEnv.anthropicStreamResponses === undefined) {
+      delete process.env.ANTHROPIC_STREAM_RESPONSES;
+    } else {
+      process.env.ANTHROPIC_STREAM_RESPONSES = originalEnv.anthropicStreamResponses;
+    }
+    if (originalEnv.maxOutputTokens === undefined) {
+      delete process.env.MINEBENCH_MAX_OUTPUT_TOKENS;
+    } else {
+      process.env.MINEBENCH_MAX_OUTPUT_TOKENS = originalEnv.maxOutputTokens;
+    }
+    if (originalEnv.sonnet5Effort === undefined) {
+      delete process.env.ANTHROPIC_SONNET_5_EFFORT;
+    } else {
+      process.env.ANTHROPIC_SONNET_5_EFFORT = originalEnv.sonnet5Effort;
+    }
+  })
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });

--- a/tests/unit/providers/gpt-4-5-web-harness-config.test.ts
+++ b/tests/unit/providers/gpt-4-5-web-harness-config.test.ts
@@ -1,0 +1,49 @@
+import assert from "node:assert/strict";
+import { generateVoxelBuild } from "../../../lib/ai/generateVoxelBuild";
+import { getModelByKey } from "../../../lib/ai/modelCatalog";
+import { MODEL_SLUG } from "../../../scripts/uploadsCatalog";
+
+async function main() {
+  const model = getModelByKey("openai_gpt_4_5_web_harness");
+
+  assert.equal(model.provider, "openai");
+  assert.equal(model.modelId, "gpt-4.5-preview");
+  assert.equal(model.displayName, "GPT 4.5 (web harness)");
+  assert.equal(model.enabled, false);
+  assert.equal(model.importOnly, true);
+  assert.equal(model.openRouterModelId, undefined);
+  assert.equal(MODEL_SLUG.openai_gpt_4_5_web_harness, "gpt-4-5-web-harness");
+
+  const originalFetch = globalThis.fetch;
+  let fetchCalled = false;
+  globalThis.fetch = (async (): Promise<Response> => {
+    fetchCalled = true;
+    return new Response("unexpected", { status: 500 });
+  }) as typeof fetch;
+
+  try {
+    const result = await generateVoxelBuild({
+      modelKey: "openai_gpt_4_5_web_harness",
+      prompt: "small tower",
+      gridSize: 64,
+      palette: "simple",
+      enableTools: false,
+      providerKeys: { openai: "test-openai-key" },
+      allowServerKeys: false,
+    });
+
+    assert.equal(result.ok, false);
+    assert.match(result.error, /import-only/i);
+    assert.match(result.error, /web harness JSON/i);
+    assert.equal(fetchCalled, false);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+
+  console.log("gpt 4.5 web harness config checks passed");
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/tests/unit/scripts/batch-generate-import-only.test.ts
+++ b/tests/unit/scripts/batch-generate-import-only.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import {
   getCandidateModels,
   getImportOnlyModelsForGenerationJobs,
+  getJobsToGenerate,
 } from "../../../scripts/batch-generate";
 import type { ModelKey } from "../../../lib/ai/modelCatalog";
 
@@ -13,6 +14,51 @@ async function main() {
   assert.ok(
     getCandidateModels([]).includes("openai_gpt_4_5_web_harness"),
     "default batch candidates should include import-only models for status/upload",
+  );
+
+  assert.deepEqual(
+    getJobsToGenerate({
+      generate: true,
+      overwrite: false,
+      modelFilters: [],
+      allJobs: [
+        job("openai_gpt_5_2"),
+        job("openai_gpt_4_5_web_harness"),
+      ],
+      missingJobs: [
+        job("openai_gpt_5_2"),
+        job("openai_gpt_4_5_web_harness"),
+      ],
+    }).map((candidate) => candidate.modelKey),
+    ["openai_gpt_5_2"],
+  );
+
+  assert.deepEqual(
+    getJobsToGenerate({
+      generate: true,
+      overwrite: false,
+      modelFilters: ["gpt"],
+      allJobs: [
+        job("openai_gpt_5_2"),
+        job("openai_gpt_4_5_web_harness"),
+      ],
+      missingJobs: [
+        job("openai_gpt_5_2"),
+        job("openai_gpt_4_5_web_harness"),
+      ],
+    }).map((candidate) => candidate.modelKey),
+    ["openai_gpt_5_2"],
+  );
+
+  assert.deepEqual(
+    getJobsToGenerate({
+      generate: true,
+      overwrite: false,
+      modelFilters: ["gpt-4-5-web-harness"],
+      allJobs: [job("openai_gpt_4_5_web_harness")],
+      missingJobs: [job("openai_gpt_4_5_web_harness")],
+    }).map((candidate) => candidate.modelKey),
+    ["openai_gpt_4_5_web_harness"],
   );
 
   assert.deepEqual(

--- a/tests/unit/scripts/batch-generate-import-only.test.ts
+++ b/tests/unit/scripts/batch-generate-import-only.test.ts
@@ -1,5 +1,8 @@
 import assert from "node:assert/strict";
-import { getImportOnlyModelsForGenerationJobs } from "../../../scripts/batch-generate";
+import {
+  getCandidateModels,
+  getImportOnlyModelsForGenerationJobs,
+} from "../../../scripts/batch-generate";
 import type { ModelKey } from "../../../lib/ai/modelCatalog";
 
 function job(modelKey: ModelKey) {
@@ -7,6 +10,11 @@ function job(modelKey: ModelKey) {
 }
 
 async function main() {
+  assert.ok(
+    getCandidateModels([]).includes("openai_gpt_4_5_web_harness"),
+    "default batch candidates should include import-only models for status/upload",
+  );
+
   assert.deepEqual(
     getImportOnlyModelsForGenerationJobs([
       job("openai_gpt_5_2"),

--- a/tests/unit/scripts/batch-generate-import-only.test.ts
+++ b/tests/unit/scripts/batch-generate-import-only.test.ts
@@ -1,0 +1,33 @@
+import assert from "node:assert/strict";
+import { getImportOnlyModelsForGenerationJobs } from "../../../scripts/batch-generate";
+import type { ModelKey } from "../../../lib/ai/modelCatalog";
+
+function job(modelKey: ModelKey) {
+  return { modelKey };
+}
+
+async function main() {
+  assert.deepEqual(
+    getImportOnlyModelsForGenerationJobs([
+      job("openai_gpt_5_2"),
+      job("anthropic_claude_sonnet_5"),
+    ]),
+    [],
+  );
+
+  const importOnlyModels = getImportOnlyModelsForGenerationJobs([
+    job("openai_gpt_5_2"),
+    job("openai_gpt_4_5_web_harness"),
+  ]);
+
+  assert.equal(importOnlyModels.length, 1);
+  assert.equal(importOnlyModels[0].key, "openai_gpt_4_5_web_harness");
+  assert.equal(importOnlyModels[0].importOnly, true);
+
+  console.log("batch generate import-only job filtering checks passed");
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

- Add Claude Sonnet 5 to the MineBench model catalog with direct Anthropic routing and OpenRouter fallback.
- Add the benchmark upload slug `sonnet-5`.
- Cap Sonnet 5 generation at 128,000 output tokens and route default reasoning through the max-to-low adaptive effort ladder.
- Add provider regression coverage for catalog metadata, slug mapping, direct Anthropic request shape, OpenRouter request shape, token cap, reasoning payload, and trace output.
- GPT 4.5 was also added, though through the web-harness as the API was deprecated
  - Thanks to [@Raphi-2Code](https://x.com/R2Cdev_) for providing the model's builds!

## Research Notes

- Anthropic documents Claude Sonnet 5 as `claude-sonnet-5` with a 1M-token context window, 128k maximum output, adaptive thinking, and effort levels up to `max`.
- OpenRouter exposes the model as `anthropic/claude-sonnet-5`.

## Verification

- `pnpm test tests/unit/providers/claude-sonnet-5-config.test.ts`
- `pnpm test tests/unit/providers`
- `pnpm lint`
- `pnpm test`
- `pnpm build`
- `graphify update .`
- `git diff --cached --check`

*(PR written by Codex)*