### PR TITLE
(feat) add GPT 5.6 Sol benchmark support

### DIFF
--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -111,7 +111,7 @@ Copy `.env.example` to `.env` and set what you need.
 - `OPENAI_BACKGROUND_POLL_MS=2000` (poll interval for background mode)
 - `ANTHROPIC_ENABLE_1M_CONTEXT_BETA=1`
 - `ANTHROPIC_THINKING_BUDGET` (legacy/manual thinking models)
-- GPT 5.6 Sol uses the native OpenAI model ID `gpt-5.6-sol` through the Responses API with `reasoning.mode=pro`, defaults to `reasoning.effort=max`, and uses the model's 128000-token combined reasoning and output cap.
+- GPT 5.6 Sol uses the native OpenAI model ID `gpt-5.6-sol` through the Responses API with `reasoning.mode=pro`, defaults to `reasoning.effort=max`, and uses the model's 128000-token combined reasoning and output cap. Its OpenRouter fallback uses `openai/gpt-5.6-sol-pro` with max effort and strict structured output.
 - Claude Fable 5 uses the native Anthropic model ID `claude-fable-5`, supports always-on adaptive thinking with effort `low|medium|high|xhigh|max`, and MineBench defaults it to `max` with a 128000-token output cap.
 - Claude Sonnet 5 uses the native Anthropic model ID `claude-sonnet-5`, supports adaptive thinking with effort `low|medium|high|xhigh|max`, and MineBench defaults it to `max` with a 128000-token output cap.
 - Claude 4.8 Opus uses the native Anthropic model ID `claude-opus-4-8`, supports adaptive effort `low|medium|high|xhigh|max`, and MineBench defaults it to `max` with a 128000-token output cap.

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -111,6 +111,7 @@ Copy `.env.example` to `.env` and set what you need.
 - `OPENAI_BACKGROUND_POLL_MS=2000` (poll interval for background mode)
 - `ANTHROPIC_ENABLE_1M_CONTEXT_BETA=1`
 - `ANTHROPIC_THINKING_BUDGET` (legacy/manual thinking models)
+- GPT 5.6 Sol uses the native OpenAI model ID `gpt-5.6-sol` through the Responses API with `reasoning.mode=pro`, defaults to `reasoning.effort=max`, and uses the model's 128000-token combined reasoning and output cap.
 - Claude Fable 5 uses the native Anthropic model ID `claude-fable-5`, supports always-on adaptive thinking with effort `low|medium|high|xhigh|max`, and MineBench defaults it to `max` with a 128000-token output cap.
 - Claude Sonnet 5 uses the native Anthropic model ID `claude-sonnet-5`, supports adaptive thinking with effort `low|medium|high|xhigh|max`, and MineBench defaults it to `max` with a 128000-token output cap.
 - Claude 4.8 Opus uses the native Anthropic model ID `claude-opus-4-8`, supports adaptive effort `low|medium|high|xhigh|max`, and MineBench defaults it to `max` with a 128000-token output cap.

--- a/lib/ai/generateVoxelBuild.ts
+++ b/lib/ai/generateVoxelBuild.ts
@@ -149,6 +149,7 @@ function formatOptionalInteger(value: number | undefined): string {
 function usesDefaultSamplingForModel(modelId: string): boolean {
   const normalized = modelId.toLowerCase();
   return (
+    normalized.startsWith("openai/gpt-5.6") ||
     normalized === "claude-fable-5" ||
     normalized === "anthropic/claude-fable-5" ||
     normalized === "claude-sonnet-5" ||

--- a/lib/ai/generateVoxelBuild.ts
+++ b/lib/ai/generateVoxelBuild.ts
@@ -149,6 +149,7 @@ function formatOptionalInteger(value: number | undefined): string {
 function usesDefaultSamplingForModel(modelId: string): boolean {
   const normalized = modelId.toLowerCase();
   return (
+    normalized.startsWith("gpt-5.6") ||
     normalized.startsWith("openai/gpt-5.6") ||
     normalized === "claude-fable-5" ||
     normalized === "anthropic/claude-fable-5" ||

--- a/lib/ai/generateVoxelBuild.ts
+++ b/lib/ai/generateVoxelBuild.ts
@@ -63,7 +63,7 @@ function defaultOutputTokenRequestForModel(modelId: string): number | undefined 
 }
 
 function maxOutputTokenCapForModel(modelId: string): number | undefined {
-  // OpenAI's latest GPT-5 family models use max_output_tokens as a total
+  // OpenAI's GPT-5 family models use max_output_tokens as a total
   // generation budget that includes reasoning tokens. Most GPT-5 variants in
   // MineBench are currently capped at 128k output tokens, with the older
   // gpt-5-pro alias remaining at 272k.
@@ -205,13 +205,18 @@ function describeRequestedThinkingMode(opts: {
   if (opts.provider === "custom") return "default";
 
   if (opts.provider === "openai") {
+    const usesProReasoning = opts.modelId.startsWith("gpt-5.6");
+    const reasoningMode = usesProReasoning
+      ? "reasoning_mode=pro,"
+      : "";
+    const finalFallback = usesProReasoning ? "pro-default" : "disabled";
     if (opts.reasoningEffortAttempts && opts.reasoningEffortAttempts.length > 0) {
-      return `reasoning_effort_fallback=${opts.reasoningEffortAttempts.join("->")}->disabled`;
+      return `${reasoningMode}reasoning_effort_fallback=${opts.reasoningEffortAttempts.join("->")}->${finalFallback}`;
     }
     if (typeof opts.reasoningMaxTokens === "number") {
-      return `reasoning_max_tokens<=${Math.floor(opts.reasoningMaxTokens)}`;
+      return `${reasoningMode}reasoning_max_tokens<=${Math.floor(opts.reasoningMaxTokens)}`;
     }
-    return "default";
+    return reasoningMode ? "reasoning_mode=pro" : "default";
   }
 
   if (opts.provider === "anthropic") {

--- a/lib/ai/modelCatalog.ts
+++ b/lib/ai/modelCatalog.ts
@@ -11,6 +11,7 @@ export type Provider =
   | "meta";
 
 export type ModelKey =
+  | "openai_gpt_5_6_sol"
   | "openai_gpt_5_5"
   | "openai_gpt_5_5_pro"
   | "openai_gpt_5_4"
@@ -75,6 +76,13 @@ export type ModelCatalogEntry = {
 };
 
 export const MODEL_CATALOG: ModelCatalogEntry[] = [
+  {
+    key: "openai_gpt_5_6_sol",
+    provider: "openai",
+    modelId: "gpt-5.6-sol",
+    displayName: "GPT 5.6 Sol",
+    enabled: true,
+  },
   {
     key: "openai_gpt_5_5",
     provider: "openai",

--- a/lib/ai/modelCatalog.ts
+++ b/lib/ai/modelCatalog.ts
@@ -82,6 +82,7 @@ export const MODEL_CATALOG: ModelCatalogEntry[] = [
     modelId: "gpt-5.6-sol",
     displayName: "GPT 5.6 Sol",
     enabled: true,
+    openRouterModelId: "openai/gpt-5.6-sol-pro",
   },
   {
     key: "openai_gpt_5_5",

--- a/lib/ai/providers/openai.ts
+++ b/lib/ai/providers/openai.ts
@@ -445,10 +445,12 @@ export async function openaiGenerateText(params: {
 
   const isGpt5Family = params.modelId.startsWith("gpt-5");
   const isGptOssFamily = params.modelId.startsWith("gpt-oss-");
+  const isGpt56 = params.modelId.startsWith("gpt-5.6");
   // Some models are Responses-only (or otherwise not supported in chat/completions).
   // For these, don't fall back to chat/completions because it hides the real failure cause.
   const isGpt55Pro = params.modelId.startsWith("gpt-5.5-pro");
   const isResponsesOnlyModel =
+    isGpt56 ||
     params.modelId === "gpt-5.2-pro" ||
     isGpt55Pro ||
     params.modelId.startsWith("gpt-5.4-pro") ||
@@ -456,7 +458,9 @@ export async function openaiGenerateText(params: {
     params.modelId === "gpt-5.2-codex" ||
     params.modelId === "gpt-5.3-codex";
   const defaultReasoningEffortAttempts: string[] = isGpt5Family
-    ? isGpt55Pro
+    ? isGpt56
+      ? ["max", "xhigh", "high", "medium", "low", "none"]
+      : isGpt55Pro
       ? ["xhigh", "high", "medium"]
       : params.modelId.startsWith("gpt-5.5")
         ? ["xhigh", "high", "medium", "low", "none"]
@@ -509,11 +513,17 @@ export async function openaiGenerateText(params: {
       for (const [cfgIdx, cfg] of reasoningConfigAttempts.entries()) {
         const reasoning =
           cfg?.kind === "effort"
-            ? { effort: cfg.effort }
+            ? { effort: cfg.effort, ...(isGpt56 ? { mode: "pro" } : {}) }
             : cfg?.kind === "max_tokens"
-              ? { max_tokens: clampReasoningBudget(cfg.maxTokens, tok) }
-              : undefined;
-        const currentReasoningLabel = describeReasoningConfigAttempt(cfg, tok);
+              ? {
+                  max_tokens: clampReasoningBudget(cfg.maxTokens, tok),
+                  ...(isGpt56 ? { mode: "pro" } : {}),
+                }
+              : isGpt56
+                ? { mode: "pro" }
+                : undefined;
+        const currentReasoningLabel =
+          isGpt56 && !cfg ? "pro-default" : describeReasoningConfigAttempt(cfg, tok);
         while (true) {
           const textVerbosity = useDefaultVerbosity ? defaultTextVerbosity(params.modelId) : undefined;
           const payload: Record<string, unknown> = {

--- a/lib/ai/providers/openrouter.ts
+++ b/lib/ai/providers/openrouter.ts
@@ -123,12 +123,14 @@ function looksLikeVerbosityConfigError(body: string): boolean {
 }
 
 function defaultTextVerbosity(modelId: string): TextVerbosity | undefined {
+  if (modelId.startsWith("openai/gpt-5.6")) return undefined;
   return modelId.startsWith("openai/gpt-5") ? "high" : undefined;
 }
 
 function openRouterTemperaturePayload(modelId: string, temperature?: number): { temperature?: number } {
   const normalized = modelId.toLowerCase();
   const usesDefaultSampling =
+    normalized.startsWith("openai/gpt-5.6") ||
     normalized === "anthropic/claude-fable-5" ||
     normalized === "anthropic/claude-sonnet-5" ||
     /^anthropic\/claude-(?:opus-4[.-]8|4[.-]8-opus)(?:$|[-:])/.test(normalized);
@@ -325,40 +327,6 @@ export async function openrouterGenerateText(params: {
 
     if (!res.ok) {
       const body = lastBody || (await res.text().catch(() => ""));
-      if (res.status === 400 && params.jsonSchema) {
-        const retry = await fetchWithRetry(
-          `${baseUrl}/v1/chat/completions`,
-          {
-            method: "POST",
-            headers: {
-              Authorization: `Bearer ${apiKey}`,
-              "Content-Type": "application/json",
-              "HTTP-Referer": "https://minebench.dev",
-              "X-Title": "MineBench",
-            },
-            signal: controller.signal,
-            body: JSON.stringify({
-              model: params.modelId,
-              messages: [
-                { role: "system", content: params.system },
-                { role: "user", content: params.user },
-              ],
-              stream: false,
-              ...openRouterTemperaturePayload(params.modelId, params.temperature),
-              max_tokens: maxTokens,
-            }),
-          },
-          { tries: 3, minDelayMs: 400, maxDelayMs: 2000 },
-        );
-
-        if (!retry.ok) {
-          const retryBody = await retry.text().catch(() => "");
-          throw new Error(`OpenRouter error ${retry.status}: ${retryBody || body}`);
-        }
-
-        const retryData = (await retry.json()) as OpenRouterChatResponse;
-        return { text: extractTextFromChatCompletions(retryData) };
-      }
       throw new Error(`OpenRouter error ${res.status}: ${body}`);
     }
 

--- a/lib/ai/reasoningProfiles.ts
+++ b/lib/ai/reasoningProfiles.ts
@@ -117,6 +117,13 @@ export function openAiReasoningEffortAttempts(
   override?: string,
 ): string[] | undefined {
   const label = `OpenAI model ${modelId}`;
+  if (modelId.startsWith("gpt-5.6")) {
+    return descendingAttempts(
+      label,
+      ["max", "xhigh", "high", "medium", "low", "none"],
+      override,
+    );
+  }
   if (modelId.startsWith("gpt-5.5-pro")) {
     return descendingAttempts(label, ["xhigh", "high", "medium"], override);
   }

--- a/lib/ai/reasoningProfiles.ts
+++ b/lib/ai/reasoningProfiles.ts
@@ -332,6 +332,13 @@ export function openRouterReasoningEffortAttempts(
   override?: string,
 ): string[] | undefined {
   const label = `OpenRouter model ${modelId}`;
+  if (modelId.startsWith("openai/gpt-5.6")) {
+    return descendingAttempts(
+      label,
+      ["max", "xhigh", "high", "medium", "low", "none"],
+      override,
+    );
+  }
   if (modelId === "openai/gpt-5.5-pro") {
     return descendingAttempts(label, ["xhigh", "high", "medium"], override);
   }

--- a/scripts/uploadsCatalog.ts
+++ b/scripts/uploadsCatalog.ts
@@ -33,6 +33,7 @@ export const PROMPT_MAP: Record<string, string> = {
 
 // Model key to short filename slug.
 export const MODEL_SLUG: Record<ModelKey, string> = {
+  openai_gpt_5_6_sol: "gpt-5-6-sol",
   openai_gpt_5_5: "gpt-5-5",
   openai_gpt_5_5_pro: "gpt-5-5-pro",
   openai_gpt_5_4: "gpt-5-4",

--- a/tests/unit/providers/gpt-5-6-sol-config.test.ts
+++ b/tests/unit/providers/gpt-5-6-sol-config.test.ts
@@ -1,7 +1,10 @@
 import assert from "node:assert/strict";
 import { generateVoxelBuild } from "../../../lib/ai/generateVoxelBuild";
 import { getModelByKey } from "../../../lib/ai/modelCatalog";
-import { openAiReasoningEffortAttempts } from "../../../lib/ai/reasoningProfiles";
+import {
+  openAiReasoningEffortAttempts,
+  openRouterReasoningEffortAttempts,
+} from "../../../lib/ai/reasoningProfiles";
 import { MODEL_SLUG } from "../../../scripts/uploadsCatalog";
 
 type CapturedRequest = {
@@ -26,13 +29,26 @@ function validBuildJson(): string {
 }
 
 globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
-  assert.ok(init?.body, "OpenAI request should include a JSON body");
-  assert.equal(typeof init.body, "string", "OpenAI request body should be serialized JSON");
+  assert.ok(init?.body, "Provider request should include a JSON body");
+  assert.equal(typeof init.body, "string", "Provider request body should be serialized JSON");
 
+  const url = String(input);
   capturedRequests.push({
-    url: String(input),
+    url,
     body: JSON.parse(init.body as string) as Record<string, unknown>,
   });
+
+  if (url.includes("/chat/completions")) {
+    return new Response(
+      JSON.stringify({
+        choices: [{ message: { content: validBuildJson() } }],
+      }),
+      {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      },
+    );
+  }
 
   return new Response(
     JSON.stringify({
@@ -55,7 +71,7 @@ async function main() {
   assert.equal(model.provider, "openai");
   assert.equal(model.modelId, "gpt-5.6-sol");
   assert.equal(model.displayName, "GPT 5.6 Sol");
-  assert.equal(model.openRouterModelId, undefined);
+  assert.equal(model.openRouterModelId, "openai/gpt-5.6-sol-pro");
   assert.equal(MODEL_SLUG.openai_gpt_5_6_sol, "gpt-5-6-sol");
   assert.deepEqual(openAiReasoningEffortAttempts(model.modelId), [
     "max",
@@ -66,6 +82,14 @@ async function main() {
     "none",
   ]);
   assert.deepEqual(openAiReasoningEffortAttempts(model.modelId, "max"), [
+    "max",
+    "xhigh",
+    "high",
+    "medium",
+    "low",
+    "none",
+  ]);
+  assert.deepEqual(openRouterReasoningEffortAttempts(model.openRouterModelId), [
     "max",
     "xhigh",
     "high",
@@ -107,6 +131,49 @@ async function main() {
       trace.includes("temperature=1"),
     ),
     "direct trace should report the output cap, max reasoning fallback, and pro mode",
+  );
+
+  const openRouterTraces: string[] = [];
+  await generateVoxelBuild({
+    modelKey: "openai_gpt_5_6_sol",
+    prompt: "small tower",
+    gridSize: 64,
+    palette: "simple",
+    enableTools: false,
+    providerKeys: { openrouter: "test-openrouter-key" },
+    allowServerKeys: false,
+    onProviderTrace: (message) => openRouterTraces.push(message),
+  });
+
+  const openRouterRequest = capturedRequests.find((candidate) =>
+    candidate.url.includes("/chat/completions"),
+  )?.body;
+  assert.ok(openRouterRequest, "OpenRouter request should be captured");
+  assert.equal(openRouterRequest.model, "openai/gpt-5.6-sol-pro");
+  assert.equal(openRouterRequest.max_tokens, 128000);
+  assert.deepEqual(openRouterRequest.reasoning, { effort: "max" });
+  assert.equal(Object.hasOwn(openRouterRequest, "temperature"), false);
+  assert.equal(Object.hasOwn(openRouterRequest, "text"), false);
+  assert.deepEqual(openRouterRequest.provider, { require_parameters: true });
+  assert.equal(
+    (openRouterRequest.response_format as { type?: unknown })?.type,
+    "json_schema",
+  );
+  const openRouterJsonSchema = (
+    openRouterRequest.response_format as {
+      json_schema?: { strict?: unknown; schema?: unknown };
+    }
+  )?.json_schema;
+  assert.equal(openRouterJsonSchema?.strict, true);
+  assert.ok(openRouterJsonSchema?.schema, "OpenRouter request should include the voxel schema");
+  assert.ok(
+    openRouterTraces.some((trace) =>
+      trace.includes("Routing via OpenRouter (openai/gpt-5.6-sol-pro)") &&
+      trace.includes("max_output_tokens=128000") &&
+      trace.includes("effort_fallback=max->xhigh->high->medium->low->none->disabled") &&
+      trace.includes("temperature=default"),
+    ),
+    "OpenRouter trace should report the pro route, output cap, and max reasoning fallback",
   );
 
   console.log("gpt 5.6 sol config checks passed");

--- a/tests/unit/providers/gpt-5-6-sol-config.test.ts
+++ b/tests/unit/providers/gpt-5-6-sol-config.test.ts
@@ -128,9 +128,9 @@ async function main() {
       trace.includes("max_output_tokens=128000") &&
       trace.includes("reasoning_effort_fallback=max->xhigh->high->medium->low->none->pro-default") &&
       trace.includes("reasoning_mode=pro") &&
-      trace.includes("temperature=1"),
+      trace.includes("temperature=default"),
     ),
-    "direct trace should report the output cap, max reasoning fallback, and pro mode",
+    "direct trace should report the output cap, max reasoning fallback, pro mode, and default sampling",
   );
 
   const openRouterTraces: string[] = [];

--- a/tests/unit/providers/gpt-5-6-sol-config.test.ts
+++ b/tests/unit/providers/gpt-5-6-sol-config.test.ts
@@ -1,0 +1,132 @@
+import assert from "node:assert/strict";
+import { generateVoxelBuild } from "../../../lib/ai/generateVoxelBuild";
+import { getModelByKey } from "../../../lib/ai/modelCatalog";
+import { openAiReasoningEffortAttempts } from "../../../lib/ai/reasoningProfiles";
+import { MODEL_SLUG } from "../../../scripts/uploadsCatalog";
+
+type CapturedRequest = {
+  url: string;
+  body: Record<string, unknown>;
+};
+
+const capturedRequests: CapturedRequest[] = [];
+const originalFetch = globalThis.fetch;
+const originalEnv = {
+  maxOutputTokens: process.env.MINEBENCH_MAX_OUTPUT_TOKENS,
+  useBackgroundMode: process.env.OPENAI_USE_BACKGROUND_MODE,
+};
+
+function validBuildJson(): string {
+  return JSON.stringify({
+    version: "1.0",
+    boxes: [],
+    lines: [],
+    blocks: [{ x: 0, y: 0, z: 0, type: "stone" }],
+  });
+}
+
+globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+  assert.ok(init?.body, "OpenAI request should include a JSON body");
+  assert.equal(typeof init.body, "string", "OpenAI request body should be serialized JSON");
+
+  capturedRequests.push({
+    url: String(input),
+    body: JSON.parse(init.body as string) as Record<string, unknown>,
+  });
+
+  return new Response(
+    JSON.stringify({
+      output_text: validBuildJson(),
+      status: "completed",
+    }),
+    {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    },
+  );
+}) as typeof fetch;
+
+async function main() {
+  process.env.MINEBENCH_MAX_OUTPUT_TOKENS = "999999";
+  process.env.OPENAI_USE_BACKGROUND_MODE = "0";
+
+  const model = getModelByKey("openai_gpt_5_6_sol");
+
+  assert.equal(model.provider, "openai");
+  assert.equal(model.modelId, "gpt-5.6-sol");
+  assert.equal(model.displayName, "GPT 5.6 Sol");
+  assert.equal(model.openRouterModelId, undefined);
+  assert.equal(MODEL_SLUG.openai_gpt_5_6_sol, "gpt-5-6-sol");
+  assert.deepEqual(openAiReasoningEffortAttempts(model.modelId), [
+    "max",
+    "xhigh",
+    "high",
+    "medium",
+    "low",
+    "none",
+  ]);
+  assert.deepEqual(openAiReasoningEffortAttempts(model.modelId, "max"), [
+    "max",
+    "xhigh",
+    "high",
+    "medium",
+    "low",
+    "none",
+  ]);
+
+  const traces: string[] = [];
+  await generateVoxelBuild({
+    modelKey: "openai_gpt_5_6_sol",
+    prompt: "small tower",
+    gridSize: 64,
+    palette: "simple",
+    enableTools: false,
+    providerKeys: { openai: "test-openai-key" },
+    allowServerKeys: false,
+    onProviderTrace: (message) => traces.push(message),
+  });
+
+  const request = capturedRequests.find((candidate) =>
+    candidate.url.includes("api.openai.com/v1/responses"),
+  )?.body;
+  assert.ok(request, "OpenAI Responses request should be captured");
+  assert.equal(request.model, "gpt-5.6-sol");
+  assert.equal(request.max_output_tokens, 128000);
+  assert.equal(Object.hasOwn(request, "temperature"), false);
+  assert.deepEqual(request.reasoning, { effort: "max", mode: "pro" });
+  assert.deepEqual((request.text as { verbosity?: unknown })?.verbosity, "high");
+  assert.equal(
+    ((request.text as { format?: { type?: unknown } })?.format)?.type,
+    "json_schema",
+  );
+  assert.ok(
+    traces.some((trace) =>
+      trace.includes("max_output_tokens=128000") &&
+      trace.includes("reasoning_effort_fallback=max->xhigh->high->medium->low->none->pro-default") &&
+      trace.includes("reasoning_mode=pro") &&
+      trace.includes("temperature=1"),
+    ),
+    "direct trace should report the output cap, max reasoning fallback, and pro mode",
+  );
+
+  console.log("gpt 5.6 sol config checks passed");
+}
+
+main()
+  .finally(() => {
+    globalThis.fetch = originalFetch;
+    if (originalEnv.maxOutputTokens === undefined) {
+      delete process.env.MINEBENCH_MAX_OUTPUT_TOKENS;
+    } else {
+      process.env.MINEBENCH_MAX_OUTPUT_TOKENS = originalEnv.maxOutputTokens;
+    }
+    if (originalEnv.useBackgroundMode === undefined) {
+      delete process.env.OPENAI_USE_BACKGROUND_MODE;
+    } else {
+      process.env.OPENAI_USE_BACKGROUND_MODE = originalEnv.useBackgroundMode;
+    }
+  })
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });

--- a/tests/unit/providers/openrouter-opus-request.test.ts
+++ b/tests/unit/providers/openrouter-opus-request.test.ts
@@ -8,6 +8,7 @@ type CapturedRequest = {
 
 const capturedRequests: CapturedRequest[] = [];
 const originalFetch = globalThis.fetch;
+let failWithBadRequest = false;
 
 globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
   assert.ok(init?.body, "OpenRouter request should include a JSON body");
@@ -16,6 +17,13 @@ globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit): Promis
     url: String(input),
     body: JSON.parse(init.body as string) as Record<string, unknown>,
   });
+
+  if (failWithBadRequest) {
+    return new Response(JSON.stringify({ error: { message: "invalid request" } }), {
+      status: 400,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
 
   return new Response(
     JSON.stringify({
@@ -92,7 +100,54 @@ async function main() {
   assert.equal(ordinaryRequest.model, "openai/gpt-4.1");
   assert.equal(ordinaryRequest.temperature, 0.2);
 
-  console.log("openrouter opus request checks passed");
+  failWithBadRequest = true;
+  const failedRequestIndex = capturedRequests.length;
+  const originalConsoleError = console.error;
+  console.error = () => {};
+  try {
+    await assert.rejects(
+      openrouterGenerateText({
+        modelId: "openai/gpt-4.1",
+        apiKey: "test-openrouter-key",
+        system: "Return valid JSON.",
+        user: "Build a small test shape.",
+        maxOutputTokens: 512,
+        jsonSchema: {
+          type: "object",
+          additionalProperties: false,
+          properties: {
+            ok: { type: "boolean" },
+          },
+          required: ["ok"],
+        },
+      }),
+      /OpenRouter error 400/,
+    );
+  } finally {
+    console.error = originalConsoleError;
+  }
+  assert.equal(
+    capturedRequests.length,
+    failedRequestIndex + 1,
+    "A structured-output rejection must not retry without the schema",
+  );
+  const failedRequest = capturedRequests[failedRequestIndex]?.body;
+  assert.ok(failedRequest, "Failed structured-output request should be captured");
+  assert.deepEqual(failedRequest.provider, { require_parameters: true });
+  assert.equal(
+    (failedRequest.response_format as { type?: unknown })?.type,
+    "json_schema",
+  );
+  assert.equal(
+    (
+      failedRequest.response_format as {
+        json_schema?: { strict?: unknown };
+      }
+    )?.json_schema?.strict,
+    true,
+  );
+
+  console.log("openrouter request checks passed");
 }
 
 main()


### PR DESCRIPTION
## Summary

- Add GPT 5.6 Sol to the model and upload catalogs.
- Route `gpt-5.6-sol` through OpenAI Responses with pro mode, max reasoning effort, high verbosity, strict structured output, and the 128000-token combined reasoning/output cap.
- Add `openai/gpt-5.6-sol-pro` as the OpenRouter fallback with pro mode, max reasoning effort, the same output cap, and the shared strict schema contract.
- Keep direct OpenAI routing Responses-only because Chat Completions does not expose pro mode.
- Keep OpenRouter schema requests fail-closed instead of silently retrying without schema constraints.
- Report default sampling consistently for the direct and OpenRouter GPT 5.6 routes.
- Add focused direct, fallback, and schema-rejection regression coverage plus operator documentation.

## Research Notes

- OpenAI documents `gpt-5.6-sol` as the flagship GPT 5.6 tier; the `gpt-5.6` alias currently routes to Sol.
- The highest direct configuration is `reasoning: { mode: "pro", effort: "max" }`.
- OpenRouter publishes `openai/gpt-5.6-sol-pro` as the same Sol model served with pro mode. Its live metadata supports `max` reasoning effort, a 1050000-token context window, and a 128000-token maximum completion budget.
- OpenRouter lists `response_format` and structured outputs for this route. MineBench sends `response_format.type=json_schema`, `strict=true`, and `provider.require_parameters=true`, and now fails closed if that contract is rejected.
- Sources: [GPT 5.6 Sol model](https://developers.openai.com/api/docs/models/gpt-5.6-sol), [GPT 5.6 guidance](https://developers.openai.com/api/docs/guides/latest-model), [OpenRouter GPT 5.6 Sol Pro](https://openrouter.ai/openai/gpt-5.6-sol-pro), [OpenRouter structured outputs](https://openrouter.ai/docs/guides/features/structured-outputs).

## Review Follow-up

- Address the Codex finding that the direct `gpt-5.6-sol` request omitted `temperature` while its trace reported `temperature=1`.
- Recognize both direct and OpenRouter GPT 5.6 model IDs as default-sampled, with focused regression coverage for the direct trace.
- Repair the master merge resolution so the GPT 5.6 and Grok 4.5 OpenRouter reasoning branches are both syntactically complete and independently covered.

## Verification

- `pnpm exec tsx tests/unit/providers/gpt-5-6-sol-config.test.ts`
- `pnpm exec tsx tests/unit/providers/grok-4-5-config.test.ts`
- `pnpm exec tsx tests/unit/providers/openrouter-opus-request.test.ts`
- `pnpm exec tsx tests/run.ts tests/unit/providers`
- `pnpm lint`
- `pnpm test`
- `pnpm build`
- `graphify update .`
- `git diff --check`

*(PR written by Codex)*
