### PR TITLE
(feat) add Grok 4.5 benchmark support

### DIFF
--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -116,6 +116,7 @@ Copy `.env.example` to `.env` and set what you need.
 - Claude 4.8 Opus uses the native Anthropic model ID `claude-opus-4-8`, supports adaptive effort `low|medium|high|xhigh|max`, and MineBench defaults it to `max` with a 128000-token output cap.
 - Gemini 3.5 Flash uses the native Google AI model ID `gemini-3.5-flash`, supports `thinking_level=high|medium|low|minimal`, and MineBench defaults it to `high` with a 65536-token output cap.
 - Grok 4.3 uses the native xAI API, reasons automatically, rejects `reasoning_effort`, and uses a `max_tokens` request of up to 1000000 unless `MINEBENCH_MAX_OUTPUT_TOKENS` lowers it; MineBench does not send a thinking override for this model.
+- Grok 4.5 uses the native xAI API with `reasoning_effort=high` and `max_completion_tokens=500000`. The token request is bounded by the model's 500000-token context window, so input and reasoning reduce the visible output available. OpenRouter fallback uses `x-ai/grok-4.5` with the same reasoning level and `max_tokens` request.
 - DeepSeek V4 Pro uses the native DeepSeek API with JSON Output mode, defaults to `thinking=max` and `max_tokens=384000`; use `pnpm batch:generate --reasoning high` only when intentionally lowering effort.
 - `OPENROUTER_BASE_URL`, `MOONSHOT_BASE_URL`, `DEEPSEEK_BASE_URL`, `MINIMAX_BASE_URL`, `XAI_BASE_URL`
 - `AI_DEBUG=1` (logs raw model output on failures)

--- a/lib/ai/generateVoxelBuild.ts
+++ b/lib/ai/generateVoxelBuild.ts
@@ -26,6 +26,7 @@ import {
   openRouterReasoningEnabledForModel,
   openRouterReasoningEffortAttempts as openRouterReasoningEffortAttemptsForModel,
   xaiAutomaticReasoningForModel,
+  xaiReasoningEffortAttempts,
 } from "@/lib/ai/reasoningProfiles";
 import { parseVoxelBuildSpec, validateVoxelBuild } from "@/lib/voxel/validate";
 import type { VoxelBuild } from "@/lib/voxel/types";
@@ -50,6 +51,7 @@ function parseOptionalIntEnvVar(name: string): number | undefined {
 }
 
 function defaultOutputTokenRequestForModel(modelId: string): number | undefined {
+  if (modelId === "grok-4.5" || modelId === "x-ai/grok-4.5") return 500_000;
   if (modelId === "grok-4.3" || modelId === "x-ai/grok-4.3") return 1_000_000;
   if (
     modelId === "deepseek-v4-pro" ||
@@ -73,6 +75,7 @@ function maxOutputTokenCapForModel(modelId: string): number | undefined {
     return 65_536;
   }
   if (modelId === "grok-4.3" || modelId === "x-ai/grok-4.3") return 1_000_000;
+  if (modelId === "grok-4.5" || modelId === "x-ai/grok-4.5") return 500_000;
   if (
     modelId === "deepseek-v4-pro" ||
     modelId === "deepseek-v4-flash" ||
@@ -195,7 +198,12 @@ function describeRequestedThinkingMode(opts: {
     if (opts.deepseekThinkingConfig.type === "disabled") return "thinking=disabled";
     return `thinking=${opts.deepseekThinkingConfig.reasoningEffort ?? "high"}`;
   }
-  if (opts.provider === "xai") return "automatic";
+  if (opts.provider === "xai") {
+    if (opts.reasoningEffortAttempts && opts.reasoningEffortAttempts.length > 0) {
+      return `reasoning_effort=${opts.reasoningEffortAttempts[0]}`;
+    }
+    return "automatic";
+  }
   if (opts.provider === "moonshot") {
     return opts.moonshotThinkingConfig
       ? `thinking=${opts.moonshotThinkingConfig.type}`
@@ -597,6 +605,7 @@ async function callDirectProvider(args: {
       system: args.system,
       user: args.user,
       maxOutputTokens: args.maxOutputTokens,
+      reasoningEffortAttempts: args.reasoningEffortAttempts,
       temperature: DEFAULT_TEMPERATURE,
       jsonSchema: args.jsonSchema,
       signal: args.signal,
@@ -711,6 +720,10 @@ async function providerGenerateText(args: {
       model.provider === "openai"
         ? openAiReasoningEffortAttempts(model.modelId, args.reasoning)
         : undefined;
+    const directXaiReasoningEffortAttempts =
+      model.provider === "xai"
+        ? xaiReasoningEffortAttempts(model.modelId, args.reasoning)
+        : undefined;
     const directAnthropicAdaptiveEffortAttempts =
       model.provider === "anthropic"
         ? anthropicAdaptiveEffortAttempts(model.modelId, args.reasoning)
@@ -727,7 +740,7 @@ async function providerGenerateText(args: {
       model.provider === "deepseek"
         ? deepseekThinkingConfigForModel(model.modelId, args.reasoning)
         : undefined;
-    if (model.provider === "xai") {
+    if (model.provider === "xai" && !directXaiReasoningEffortAttempts) {
       xaiAutomaticReasoningForModel(model.modelId, args.reasoning);
     }
     args.onProviderTrace?.(
@@ -738,7 +751,8 @@ async function providerGenerateText(args: {
           modelId: model.modelId,
           maxOutputTokens: args.maxOutputTokens,
           reasoningMaxTokens: args.reasoningMaxTokens,
-          reasoningEffortAttempts: directOpenAiReasoningEffortAttempts,
+          reasoningEffortAttempts:
+            directOpenAiReasoningEffortAttempts ?? directXaiReasoningEffortAttempts,
           adaptiveEffortAttempts: directAnthropicAdaptiveEffortAttempts,
           geminiThinkingConfig: directGeminiThinkingConfig,
           moonshotThinkingConfig: directMoonshotThinkingConfig,
@@ -756,7 +770,8 @@ async function providerGenerateText(args: {
         jsonSchema: args.jsonSchema,
         maxOutputTokens: args.maxOutputTokens,
         reasoningMaxTokens: args.reasoningMaxTokens,
-        reasoningEffortAttempts: directOpenAiReasoningEffortAttempts,
+        reasoningEffortAttempts:
+          directOpenAiReasoningEffortAttempts ?? directXaiReasoningEffortAttempts,
         adaptiveEffortAttempts: directAnthropicAdaptiveEffortAttempts,
         geminiThinkingConfig: directGeminiThinkingConfig,
         moonshotThinkingConfig: directMoonshotThinkingConfig,

--- a/lib/ai/modelCatalog.ts
+++ b/lib/ai/modelCatalog.ts
@@ -47,6 +47,7 @@ export type ModelKey =
   | "moonshot_kimi_k2_5"
   | "deepseek_v4_pro"
   | "deepseek_v3_2"
+  | "xai_grok_4_5"
   | "xai_grok_4_3"
   | "xai_grok_4_1"
   | "xai_grok_4_20"
@@ -363,6 +364,14 @@ export const MODEL_CATALOG: ModelCatalogEntry[] = [
     enabled: true,
     openRouterModelId: "deepseek/deepseek-v3.2",
     forceOpenRouter: true,
+  },
+  {
+    key: "xai_grok_4_5",
+    provider: "xai",
+    modelId: "grok-4.5",
+    displayName: "Grok 4.5",
+    enabled: true,
+    openRouterModelId: "x-ai/grok-4.5",
   },
   {
     key: "xai_grok_4_3",

--- a/lib/ai/providers/nvidia.ts
+++ b/lib/ai/providers/nvidia.ts
@@ -438,6 +438,7 @@ function looksLikeTokenLimitError(body: string): boolean {
   const b = body.toLowerCase();
   return (
     b.includes("max_tokens") ||
+    b.includes("max_completion_tokens") ||
     (b.includes("maximum") && b.includes("tokens")) ||
     b.includes("too many tokens") ||
     b.includes("token limit") ||
@@ -469,6 +470,8 @@ export async function openAiCompatibleGenerateText(params: {
   system: string;
   user: string;
   maxOutputTokens?: number;
+  maxTokensParameter?: "max_tokens" | "max_completion_tokens";
+  reasoningEffort?: string;
   temperature?: number;
   jsonSchema?: Record<string, unknown>;
   serviceLabel?: string;
@@ -508,7 +511,8 @@ export async function openAiCompatibleGenerateText(params: {
           ],
           stream: Boolean(params.onDelta),
           temperature: params.temperature ?? 0.2,
-          max_tokens: tok,
+          [params.maxTokensParameter ?? "max_tokens"]: tok,
+          ...(params.reasoningEffort ? { reasoning_effort: params.reasoningEffort } : {}),
           ...(useStructuredOutput && params.jsonSchema
             ? {
                 response_format: {

--- a/lib/ai/providers/xai.ts
+++ b/lib/ai/providers/xai.ts
@@ -1,11 +1,28 @@
 import { openAiCompatibleGenerateText } from "@/lib/ai/providers/nvidia";
 
+export function xaiRequestConfigForModel(
+  modelId: string,
+  reasoningEffort?: string,
+): {
+  maxTokensParameter: "max_tokens" | "max_completion_tokens";
+  reasoningEffort?: string;
+} {
+  if (modelId === "grok-4.5") {
+    return {
+      maxTokensParameter: "max_completion_tokens",
+      reasoningEffort: reasoningEffort ?? "high",
+    };
+  }
+  return { maxTokensParameter: "max_tokens" };
+}
+
 export async function xaiGenerateText(params: {
   modelId: string;
   apiKey?: string;
   system: string;
   user: string;
   maxOutputTokens?: number;
+  reasoningEffortAttempts?: string[];
   temperature?: number;
   jsonSchema?: Record<string, unknown>;
   signal?: AbortSignal;
@@ -16,6 +33,10 @@ export async function xaiGenerateText(params: {
   if (!apiKey) throw new Error("Missing XAI_API_KEY");
 
   const baseUrl = process.env.XAI_BASE_URL ?? "https://api.x.ai/v1";
+  const requestConfig = xaiRequestConfigForModel(
+    params.modelId,
+    params.reasoningEffortAttempts?.[0],
+  );
 
   return openAiCompatibleGenerateText({
     modelId: params.modelId,
@@ -24,6 +45,8 @@ export async function xaiGenerateText(params: {
     system: params.system,
     user: params.user,
     maxOutputTokens: params.maxOutputTokens,
+    maxTokensParameter: requestConfig.maxTokensParameter,
+    reasoningEffort: requestConfig.reasoningEffort,
     temperature: params.temperature,
     jsonSchema: params.jsonSchema,
     serviceLabel: "xAI",

--- a/lib/ai/reasoningProfiles.ts
+++ b/lib/ai/reasoningProfiles.ts
@@ -320,11 +320,39 @@ export function xaiAutomaticReasoningForModel(
   );
 }
 
+export function xaiReasoningEffortAttempts(
+  modelId: string,
+  override?: string,
+): string[] | undefined {
+  const normalized = normalizeReasoningOverride(override);
+  const isGrok45 = modelId === "grok-4.5" || modelId === "x-ai/grok-4.5";
+
+  if (!isGrok45) {
+    if (normalized) {
+      throw new Error(`xAI model ${modelId} does not expose a reasoning-effort override.`);
+    }
+    return undefined;
+  }
+
+  if (!normalized || normalized === "max" || normalized === "xhigh" || normalized === "high") {
+    return ["high", "medium", "low"];
+  }
+  if (normalized === "medium") return ["medium", "low"];
+  if (normalized === "low") return ["low"];
+
+  throw new Error(
+    `xAI model ${modelId} does not support reasoning '${override}'. Supported values: max, high, medium, low.`,
+  );
+}
+
 export function openRouterReasoningEffortAttempts(
   modelId: string,
   override?: string,
 ): string[] | undefined {
   const label = `OpenRouter model ${modelId}`;
+  if (modelId === "x-ai/grok-4.5") {
+    return xaiReasoningEffortAttempts(modelId, override);
+  }
   if (modelId === "openai/gpt-5.5-pro") {
     return descendingAttempts(label, ["xhigh", "high", "medium"], override);
   }

--- a/lib/ai/reasoningProfiles.ts
+++ b/lib/ai/reasoningProfiles.ts
@@ -327,12 +327,7 @@ export function xaiReasoningEffortAttempts(
   const normalized = normalizeReasoningOverride(override);
   const isGrok45 = modelId === "grok-4.5" || modelId === "x-ai/grok-4.5";
 
-  if (!isGrok45) {
-    if (normalized) {
-      throw new Error(`xAI model ${modelId} does not expose a reasoning-effort override.`);
-    }
-    return undefined;
-  }
+  if (!isGrok45) return undefined;
 
   if (!normalized || normalized === "max" || normalized === "xhigh" || normalized === "high") {
     return ["high", "medium", "low"];

--- a/scripts/uploadsCatalog.ts
+++ b/scripts/uploadsCatalog.ts
@@ -69,6 +69,7 @@ export const MODEL_SLUG: Record<ModelKey, string> = {
   moonshot_kimi_k2_5: "kimi-k2-5",
   deepseek_v4_pro: "deepseek-v4-pro",
   deepseek_v3_2: "deepseek-v3-2",
+  xai_grok_4_5: "grok-4-5",
   xai_grok_4_3: "grok-4-3",
   xai_grok_4_1: "grok-4-1",
   xai_grok_4_20: "grok-4-20",

--- a/tests/unit/providers/grok-4-5-config.test.ts
+++ b/tests/unit/providers/grok-4-5-config.test.ts
@@ -1,0 +1,143 @@
+import assert from "node:assert/strict";
+import { generateVoxelBuild } from "../../../lib/ai/generateVoxelBuild";
+import { getModelByKey } from "../../../lib/ai/modelCatalog";
+import {
+  openRouterReasoningEffortAttempts,
+  xaiReasoningEffortAttempts,
+} from "../../../lib/ai/reasoningProfiles";
+import { xaiRequestConfigForModel } from "../../../lib/ai/providers/xai";
+import { MODEL_SLUG } from "../../../scripts/uploadsCatalog";
+
+type CapturedRequest = {
+  url: string;
+  body: Record<string, unknown>;
+};
+
+const capturedRequests: CapturedRequest[] = [];
+const originalFetch = globalThis.fetch;
+const originalEnv = {
+  maxOutputTokens: process.env.MINEBENCH_MAX_OUTPUT_TOKENS,
+  openRouterBaseUrl: process.env.OPENROUTER_BASE_URL,
+};
+
+function validBuildJson(): string {
+  return JSON.stringify({
+    version: "1.0",
+    boxes: [],
+    lines: [],
+    blocks: [{ x: 0, y: 0, z: 0, type: "stone" }],
+  });
+}
+
+globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+  assert.ok(init?.body, "OpenRouter request should include a JSON body");
+  assert.equal(typeof init.body, "string", "OpenRouter request body should be serialized JSON");
+
+  capturedRequests.push({
+    url: String(input),
+    body: JSON.parse(init.body as string) as Record<string, unknown>,
+  });
+
+  return new Response(
+    JSON.stringify({
+      choices: [
+        {
+          message: {
+            content: validBuildJson(),
+          },
+        },
+      ],
+    }),
+    {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    },
+  );
+}) as typeof fetch;
+
+async function main() {
+  process.env.MINEBENCH_MAX_OUTPUT_TOKENS = "999999";
+  process.env.OPENROUTER_BASE_URL = "https://openrouter.test/api";
+
+  const model = getModelByKey("xai_grok_4_5");
+
+  assert.equal(model.provider, "xai");
+  assert.equal(model.modelId, "grok-4.5");
+  assert.equal(model.displayName, "Grok 4.5");
+  assert.equal(model.openRouterModelId, "x-ai/grok-4.5");
+  assert.equal(model.forceOpenRouter, undefined);
+  assert.equal(MODEL_SLUG.xai_grok_4_5, "grok-4-5");
+  assert.deepEqual(xaiReasoningEffortAttempts(model.modelId), ["high", "medium", "low"]);
+  assert.deepEqual(xaiReasoningEffortAttempts(model.modelId, "max"), [
+    "high",
+    "medium",
+    "low",
+  ]);
+  assert.deepEqual(xaiReasoningEffortAttempts(model.modelId, "medium"), [
+    "medium",
+    "low",
+  ]);
+  assert.deepEqual(openRouterReasoningEffortAttempts(model.openRouterModelId), [
+    "high",
+    "medium",
+    "low",
+  ]);
+  assert.deepEqual(xaiRequestConfigForModel(model.modelId), {
+    maxTokensParameter: "max_completion_tokens",
+    reasoningEffort: "high",
+  });
+
+  const traces: string[] = [];
+  await generateVoxelBuild({
+    modelKey: "xai_grok_4_5",
+    prompt: "small tower",
+    gridSize: 64,
+    palette: "simple",
+    enableTools: false,
+    preferOpenRouter: true,
+    providerKeys: { openrouter: "test-openrouter-key" },
+    allowServerKeys: false,
+    onProviderTrace: (message) => traces.push(message),
+  });
+
+  const request = capturedRequests.find((candidate) =>
+    candidate.url.includes("openrouter.test"),
+  )?.body;
+  assert.ok(request, "OpenRouter request should be captured");
+  assert.equal(request.model, "x-ai/grok-4.5");
+  assert.equal(request.max_tokens, 500000);
+  assert.deepEqual(request.reasoning, { effort: "high" });
+  assert.equal(
+    ((request.response_format as { json_schema?: { strict?: unknown } })?.json_schema)?.strict,
+    true,
+  );
+  assert.ok(
+    traces.some((trace) =>
+      trace.includes("max_output_tokens=500000") &&
+      trace.includes("effort_fallback=high->medium->low->disabled") &&
+      trace.includes("temperature=1"),
+    ),
+    "OpenRouter trace should report the context-bounded cap and highest reasoning effort",
+  );
+
+  console.log("grok 4.5 config checks passed");
+}
+
+main()
+  .finally(() => {
+    globalThis.fetch = originalFetch;
+    if (originalEnv.maxOutputTokens === undefined) {
+      delete process.env.MINEBENCH_MAX_OUTPUT_TOKENS;
+    } else {
+      process.env.MINEBENCH_MAX_OUTPUT_TOKENS = originalEnv.maxOutputTokens;
+    }
+    if (originalEnv.openRouterBaseUrl === undefined) {
+      delete process.env.OPENROUTER_BASE_URL;
+    } else {
+      process.env.OPENROUTER_BASE_URL = originalEnv.openRouterBaseUrl;
+    }
+  })
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });

--- a/tests/unit/providers/grok-4-5-config.test.ts
+++ b/tests/unit/providers/grok-4-5-config.test.ts
@@ -3,6 +3,7 @@ import { generateVoxelBuild } from "../../../lib/ai/generateVoxelBuild";
 import { getModelByKey } from "../../../lib/ai/modelCatalog";
 import {
   openRouterReasoningEffortAttempts,
+  xaiAutomaticReasoningForModel,
   xaiReasoningEffortAttempts,
 } from "../../../lib/ai/reasoningProfiles";
 import { xaiRequestConfigForModel } from "../../../lib/ai/providers/xai";
@@ -77,6 +78,16 @@ async function main() {
     "medium",
     "low",
   ]);
+  assert.equal(
+    xaiReasoningEffortAttempts("grok-4.3", "automatic"),
+    undefined,
+    "automatic xAI models should bypass the explicit effort helper",
+  );
+  assert.equal(
+    xaiAutomaticReasoningForModel("grok-4.3", "automatic"),
+    "automatic",
+    "Grok 4.3 should preserve its automatic reasoning override",
+  );
   assert.deepEqual(openRouterReasoningEffortAttempts(model.openRouterModelId), [
     "high",
     "medium",


### PR DESCRIPTION
## Summary

- Add Grok 4.5 to the model and upload catalogs with direct xAI and OpenRouter routing.
- Use the highest supported reasoning effort, `high`, for both routes.
- Request the 500000-token context-bounded ceiling with direct xAI `max_completion_tokens` and OpenRouter `max_tokens`.
- Preserve the existing automatic reasoning overrides for Grok 4.3, Grok 4.1, and Grok 4.20.
- Add focused request-configuration and regression coverage plus operator documentation.

## Research Notes

- xAI documents `grok-4.5` as its flagship model with a 500000-token context window and `low`, `medium`, and `high` reasoning; `high` is both the default and the highest value.
- xAI does not publish a separate numeric completion cap. The 500000 request is bounded by the context window, so input and reasoning reduce the visible output available.
- Direct Chat Completions uses `max_completion_tokens` and top-level `reasoning_effort`; OpenRouter uses `max_tokens` and `reasoning.effort`.
- Sources: [Grok 4.5 model](https://docs.x.ai/developers/grok-4-5), [xAI reasoning](https://docs.x.ai/developers/model-capabilities/text/reasoning), [xAI models](https://docs.x.ai/developers/models).

## Review Follow-up

- Addressed Codex's P2 finding by limiting the explicit-effort helper to Grok 4.5 semantics. Other xAI models now continue into the existing automatic-reasoning validator.
- Added regression assertions that Grok 4.3 bypasses the explicit-effort helper and preserves its `automatic` override.

## Verification

- `pnpm test tests/unit/providers/grok-4-5-config.test.ts`
- `pnpm test tests/unit/providers`
- `pnpm lint`
- `pnpm test`
- `pnpm build`
- `graphify update .`
- `git diff --check`

*(PR written by Codex)*
