### PR TITLE
(feat) add Kimi K3 benchmark support

### DIFF
--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -112,6 +112,7 @@ Copy `.env.example` to `.env` and set what you need.
 - `ANTHROPIC_ENABLE_1M_CONTEXT_BETA=1`
 - `ANTHROPIC_THINKING_BUDGET` (legacy/manual thinking models)
 - GPT 5.6 Sol uses the native OpenAI model ID `gpt-5.6-sol` through the Responses API with `reasoning.mode=pro`, defaults to `reasoning.effort=max`, and uses the model's 128000-token combined reasoning and output cap. Its OpenRouter fallback uses `openai/gpt-5.6-sol-pro` with max effort and strict structured output.
+- Kimi K3 uses the native Moonshot model ID `kimi-k3`, always reasons with `reasoning_effort=max`, and omits its fixed sampling parameters. Its OpenRouter fallback uses `moonshotai/kimi-k3` with max effort.
 - Claude Fable 5 uses the native Anthropic model ID `claude-fable-5`, supports always-on adaptive thinking with effort `low|medium|high|xhigh|max`, and MineBench defaults it to `max` with a 128000-token output cap.
 - Claude Sonnet 5 uses the native Anthropic model ID `claude-sonnet-5`, supports adaptive thinking with effort `low|medium|high|xhigh|max`, and MineBench defaults it to `max` with a 128000-token output cap.
 - Claude 4.8 Opus uses the native Anthropic model ID `claude-opus-4-8`, supports adaptive effort `low|medium|high|xhigh|max`, and MineBench defaults it to `max` with a 128000-token output cap.

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -112,7 +112,7 @@ Copy `.env.example` to `.env` and set what you need.
 - `ANTHROPIC_ENABLE_1M_CONTEXT_BETA=1`
 - `ANTHROPIC_THINKING_BUDGET` (legacy/manual thinking models)
 - GPT 5.6 Sol uses the native OpenAI model ID `gpt-5.6-sol` through the Responses API with `reasoning.mode=pro`, defaults to `reasoning.effort=max`, and uses the model's 128000-token combined reasoning and output cap. Its OpenRouter fallback uses `openai/gpt-5.6-sol-pro` with max effort and strict structured output.
-- Kimi K3 uses the native Moonshot model ID `kimi-k3`, always reasons with `reasoning_effort=max`, and omits its fixed sampling parameters. Its OpenRouter fallback uses `moonshotai/kimi-k3` with max effort.
+- Kimi K3 uses the native Moonshot model ID `kimi-k3`, always reasons with `reasoning_effort=max`, uses its 1048576-token completion ceiling, and omits its fixed sampling parameters. Its OpenRouter fallback uses `moonshotai/kimi-k3` with max effort and fails closed if that effort is rejected.
 - Claude Fable 5 uses the native Anthropic model ID `claude-fable-5`, supports always-on adaptive thinking with effort `low|medium|high|xhigh|max`, and MineBench defaults it to `max` with a 128000-token output cap.
 - Claude Sonnet 5 uses the native Anthropic model ID `claude-sonnet-5`, supports adaptive thinking with effort `low|medium|high|xhigh|max`, and MineBench defaults it to `max` with a 128000-token output cap.
 - Claude 4.8 Opus uses the native Anthropic model ID `claude-opus-4-8`, supports adaptive effort `low|medium|high|xhigh|max`, and MineBench defaults it to `max` with a 128000-token output cap.

--- a/lib/ai/generateVoxelBuild.ts
+++ b/lib/ai/generateVoxelBuild.ts
@@ -51,6 +51,7 @@ function parseOptionalIntEnvVar(name: string): number | undefined {
 }
 
 function defaultOutputTokenRequestForModel(modelId: string): number | undefined {
+  if (modelId === "kimi-k3" || modelId === "moonshotai/kimi-k3") return 1_048_576;
   if (modelId === "grok-4.5" || modelId === "x-ai/grok-4.5") return 500_000;
   if (modelId === "grok-4.3" || modelId === "x-ai/grok-4.3") return 1_000_000;
   if (
@@ -71,6 +72,7 @@ function maxOutputTokenCapForModel(modelId: string): number | undefined {
   // gpt-5-pro alias remaining at 272k.
   if (modelId === "gpt-5-pro") return 272_000;
   if (modelId.startsWith("gpt-5")) return 128_000;
+  if (modelId === "kimi-k3" || modelId === "moonshotai/kimi-k3") return 1_048_576;
   if (modelId === "gemini-3.5-flash" || modelId === "google/gemini-3.5-flash") {
     return 65_536;
   }

--- a/lib/ai/generateVoxelBuild.ts
+++ b/lib/ai/generateVoxelBuild.ts
@@ -154,6 +154,8 @@ function usesDefaultSamplingForModel(modelId: string): boolean {
   return (
     normalized.startsWith("gpt-5.6") ||
     normalized.startsWith("openai/gpt-5.6") ||
+    normalized === "kimi-k3" ||
+    normalized === "moonshotai/kimi-k3" ||
     normalized === "claude-fable-5" ||
     normalized === "anthropic/claude-fable-5" ||
     normalized === "claude-sonnet-5" ||
@@ -207,7 +209,10 @@ function describeRequestedThinkingMode(opts: {
     return "automatic";
   }
   if (opts.provider === "moonshot") {
-    return opts.moonshotThinkingConfig
+    if (opts.moonshotThinkingConfig?.reasoningEffort) {
+      return `reasoning_effort=${opts.moonshotThinkingConfig.reasoningEffort}`;
+    }
+    return opts.moonshotThinkingConfig?.type
       ? `thinking=${opts.moonshotThinkingConfig.type}`
       : "default";
   }
@@ -269,7 +274,9 @@ function providerRequestTraceLine(opts: {
     opts.deepseekThinkingConfig?.type === "enabled"
       ? "n/a"
       : opts.route === "direct" && opts.provider === "moonshot"
-      ? opts.modelId === "kimi-k2.6" || opts.modelId === "kimi-k2.5"
+      ? opts.modelId === "kimi-k3"
+        ? "default"
+        : opts.modelId === "kimi-k2.6" || opts.modelId === "kimi-k2.5"
         ? opts.moonshotThinkingConfig?.type === "disabled"
           ? 0.6
           : 1.0

--- a/lib/ai/modelCatalog.ts
+++ b/lib/ai/modelCatalog.ts
@@ -43,6 +43,7 @@ export type ModelKey =
   | "gemini_3_1_flash_lite"
   | "gemini_2_5_pro"
   | "gemma_4_31b"
+  | "moonshot_kimi_k3"
   | "moonshot_kimi_k2"
   | "moonshot_kimi_k2_6"
   | "moonshot_kimi_k2_5"
@@ -332,6 +333,14 @@ export const MODEL_CATALOG: ModelCatalogEntry[] = [
     displayName: "Gemma 4 31B",
     enabled: true,
     openRouterModelId: "google/gemma-4-31b-it",
+  },
+  {
+    key: "moonshot_kimi_k3",
+    provider: "moonshot",
+    modelId: "kimi-k3",
+    displayName: "Kimi K3",
+    enabled: true,
+    openRouterModelId: "moonshotai/kimi-k3",
   },
   {
     key: "moonshot_kimi_k2",

--- a/lib/ai/providers/moonshot.ts
+++ b/lib/ai/providers/moonshot.ts
@@ -36,7 +36,8 @@ function looksLikeTokenLimitError(body: string): boolean {
 function defaultMoonshotTemperature(
   modelId: string,
   thinkingConfig?: MoonshotThinkingConfig,
-): number {
+): number | undefined {
+  if (modelId === "kimi-k3") return undefined;
   if (modelId === "kimi-k2.6" || modelId === "kimi-k2.5") {
     return thinkingConfig?.type === "disabled" ? 0.6 : 1.0;
   }
@@ -48,12 +49,13 @@ function defaultMoonshotTopP(modelId: string): number | undefined {
   return undefined;
 }
 
-function buildStructuredResponseFormat(jsonSchema?: Record<string, unknown>) {
+function buildStructuredResponseFormat(modelId: string, jsonSchema?: Record<string, unknown>) {
   if (!jsonSchema) return undefined;
   return {
     type: "json_schema",
     json_schema: {
       name: "minebench_output",
+      ...(modelId === "kimi-k3" ? { strict: true } : {}),
       schema: jsonSchema,
     },
   };
@@ -95,7 +97,7 @@ export async function moonshotGenerateText(params: {
 
   try {
     for (const tok of tokenBudgetCandidates(maxTokens)) {
-      const responseFormat = buildStructuredResponseFormat(params.jsonSchema);
+      const responseFormat = buildStructuredResponseFormat(params.modelId, params.jsonSchema);
       const temperature =
         typeof params.temperature === "number"
           ? params.temperature
@@ -117,10 +119,15 @@ export async function moonshotGenerateText(params: {
             { role: "user", content: params.user },
           ],
           stream: Boolean(params.onDelta),
-          temperature,
+          ...(typeof temperature === "number" ? { temperature } : {}),
           ...(typeof topP === "number" ? { top_p: topP } : {}),
           max_completion_tokens: tok,
-          ...(params.thinkingConfig ? { thinking: params.thinkingConfig } : {}),
+          ...(params.thinkingConfig?.type
+            ? { thinking: { type: params.thinkingConfig.type } }
+            : {}),
+          ...(params.thinkingConfig?.reasoningEffort
+            ? { reasoning_effort: params.thinkingConfig.reasoningEffort }
+            : {}),
           ...(responseFormat ? { response_format: responseFormat } : {}),
         }),
       });
@@ -155,11 +162,13 @@ export async function moonshotGenerateText(params: {
   }
 
   const budget = selectedTokenBudget ?? maxTokens;
-  const thinkingLabel = params.thinkingConfig?.type ?? "default";
+  const reasoningLabel = params.thinkingConfig?.reasoningEffort
+    ? `reasoning_effort=${params.thinkingConfig.reasoningEffort}`
+    : `thinking=${params.thinkingConfig?.type ?? "default"}`;
   const structuredLabel = params.jsonSchema ? "json_schema" : "text";
   params.onTrace?.(
     withMaxOutputTokens(
-      `Moonshot request config in use: thinking=${thinkingLabel}, response_format=${structuredLabel}.`,
+      `Moonshot request config in use: ${reasoningLabel}, response_format=${structuredLabel}.`,
       budget,
     ),
   );

--- a/lib/ai/providers/openrouter.ts
+++ b/lib/ai/providers/openrouter.ts
@@ -131,6 +131,7 @@ function openRouterTemperaturePayload(modelId: string, temperature?: number): { 
   const normalized = modelId.toLowerCase();
   const usesDefaultSampling =
     normalized.startsWith("openai/gpt-5.6") ||
+    normalized === "moonshotai/kimi-k3" ||
     normalized === "anthropic/claude-fable-5" ||
     normalized === "anthropic/claude-sonnet-5" ||
     /^anthropic\/claude-(?:opus-4[.-]8|4[.-]8-opus)(?:$|[-:])/.test(normalized);

--- a/lib/ai/providers/openrouter.ts
+++ b/lib/ai/providers/openrouter.ts
@@ -42,6 +42,7 @@ function reasoningConfigFallbacks(opts: {
   enabled?: boolean;
   efforts?: string[];
   maxTokens?: number;
+  failClosed?: boolean;
 }): ReasoningConfigAttempt[] {
   const usesAutomaticReasoning = Boolean(opts.automatic);
   const explicitlyEnabled = Boolean(opts.enabled);
@@ -63,6 +64,12 @@ function reasoningConfigFallbacks(opts: {
   }
 
   if (usesAutomaticReasoning && efforts.length === 0) return ["__automatic__"];
+  if (opts.failClosed) {
+    if (efforts.length === 0) {
+      throw new Error("Fail-closed reasoning requires an explicit reasoning configuration.");
+    }
+    return efforts;
+  }
   if (efforts.length === 0) return [undefined];
   if (explicitlyEnabled && normalized.length === 0 && !(Number.isFinite(rawMaxTokens) && rawMaxTokens > 0)) {
     return efforts;
@@ -197,6 +204,7 @@ export async function openrouterGenerateText(params: {
     enabled: params.enableReasoning,
     efforts: params.reasoningEffortAttempts,
     maxTokens: params.reasoningMaxTokens,
+    failClosed: params.modelId === "moonshotai/kimi-k3",
   });
   let useDefaultVerbosity = Boolean(defaultTextVerbosity(params.modelId));
 

--- a/lib/ai/reasoningProfiles.ts
+++ b/lib/ai/reasoningProfiles.ts
@@ -7,7 +7,8 @@ export type GeminiThinkingConfig = {
 };
 
 export type MoonshotThinkingConfig = {
-  type: "enabled" | "disabled";
+  type?: "enabled" | "disabled";
+  reasoningEffort?: "max";
 };
 
 export type DeepSeekThinkingConfig = {
@@ -219,6 +220,15 @@ export function moonshotThinkingConfigForModel(
   override?: string,
 ): MoonshotThinkingConfig | undefined {
   const normalized = normalizeReasoningOverride(override);
+  if (modelId === "kimi-k3") {
+    if (!normalized || normalized === "default" || normalized === "max") {
+      return { reasoningEffort: "max" };
+    }
+    throw new Error(
+      `Moonshot model ${modelId} does not support reasoning '${override}'. Supported values: max.`,
+    );
+  }
+
   const supportsThinkingToggle = modelId === "kimi-k2.6" || modelId === "kimi-k2.5";
 
   if (!supportsThinkingToggle) {
@@ -352,6 +362,9 @@ export function openRouterReasoningEffortAttempts(
   override?: string,
 ): string[] | undefined {
   const label = `OpenRouter model ${modelId}`;
+  if (modelId === "moonshotai/kimi-k3") {
+    return descendingAttempts(label, ["max"], override);
+  }
   if (modelId.startsWith("openai/gpt-5.6")) {
     return descendingAttempts(
       label,

--- a/scripts/uploadsCatalog.ts
+++ b/scripts/uploadsCatalog.ts
@@ -65,6 +65,7 @@ export const MODEL_SLUG: Record<ModelKey, string> = {
   gemini_3_1_flash_lite: "gemini-3-1-flash-lite",
   gemini_2_5_pro: "gemini-2-5-pro",
   gemma_4_31b: "gemma-4-31b",
+  moonshot_kimi_k3: "kimi-k3",
   moonshot_kimi_k2: "kimi-k2",
   moonshot_kimi_k2_6: "kimi-k2-6",
   moonshot_kimi_k2_5: "kimi-k2-5",

--- a/tests/unit/providers/kimi-k3-config.test.ts
+++ b/tests/unit/providers/kimi-k3-config.test.ts
@@ -13,6 +13,7 @@ type CapturedRequest = {
 };
 
 const capturedRequests: CapturedRequest[] = [];
+let rejectOpenRouterReasoning = false;
 const originalFetch = globalThis.fetch;
 const originalEnv = {
   maxOutputTokens: process.env.MINEBENCH_MAX_OUTPUT_TOKENS,
@@ -31,10 +32,17 @@ function validBuildJson(): string {
 
 globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
   assert.equal(typeof init?.body, "string");
-  capturedRequests.push({
+  const request = {
     url: String(input),
     body: JSON.parse(init?.body as string) as Record<string, unknown>,
-  });
+  };
+  capturedRequests.push(request);
+  if (rejectOpenRouterReasoning && request.url.includes("openrouter.test")) {
+    return new Response(
+      JSON.stringify({ error: { message: "reasoning effort is unsupported" } }),
+      { status: 400, headers: { "Content-Type": "application/json" } },
+    );
+  }
   return new Response(
     JSON.stringify({ choices: [{ message: { content: validBuildJson() } }] }),
     { status: 200, headers: { "Content-Type": "application/json" } },
@@ -42,7 +50,7 @@ globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit): Promis
 }) as typeof fetch;
 
 async function main() {
-  process.env.MINEBENCH_MAX_OUTPUT_TOKENS = "262144";
+  delete process.env.MINEBENCH_MAX_OUTPUT_TOKENS;
   process.env.MOONSHOT_BASE_URL = "https://moonshot.test";
   process.env.OPENROUTER_BASE_URL = "https://openrouter.test/api";
 
@@ -71,7 +79,6 @@ async function main() {
     gridSize: 64,
     palette: "simple",
     enableTools: false,
-    preferOpenRouter: true,
     providerKeys: { openrouter: "test-openrouter-key" },
     allowServerKeys: false,
   });
@@ -79,7 +86,7 @@ async function main() {
   const direct = capturedRequests.find((request) => request.url.includes("moonshot.test"))?.body;
   assert.ok(direct);
   assert.equal(direct.model, "kimi-k3");
-  assert.equal(direct.max_completion_tokens, 262144);
+  assert.equal(direct.max_completion_tokens, 1048576);
   assert.equal(direct.reasoning_effort, "max");
   assert.equal("thinking" in direct, false);
   assert.equal("temperature" in direct, false);
@@ -94,9 +101,61 @@ async function main() {
   )?.body;
   assert.ok(openRouter);
   assert.equal(openRouter.model, "moonshotai/kimi-k3");
-  assert.equal(openRouter.max_tokens, 262144);
+  assert.equal(openRouter.max_tokens, 1048576);
   assert.deepEqual(openRouter.reasoning, { effort: "max" });
   assert.equal("temperature" in openRouter, false);
+  assert.deepEqual(openRouter.provider, { require_parameters: true });
+  const openRouterResponseFormat = openRouter.response_format as {
+    type?: unknown;
+    json_schema?: { name?: unknown; strict?: unknown; schema?: unknown };
+  };
+  assert.equal(openRouterResponseFormat.type, "json_schema");
+  assert.equal(openRouterResponseFormat.json_schema?.name, "voxel_build_response");
+  assert.equal(openRouterResponseFormat.json_schema?.strict, true);
+  assert.ok(openRouterResponseFormat.json_schema?.schema);
+
+  process.env.MINEBENCH_MAX_OUTPUT_TOKENS = "2000000";
+  const requestCountBeforeCapCheck = capturedRequests.length;
+  await generateVoxelBuild({
+    modelKey: model.key,
+    prompt: "small tower",
+    gridSize: 64,
+    palette: "simple",
+    enableTools: false,
+    providerKeys: { moonshot: "test-moonshot-key" },
+    allowServerKeys: false,
+  });
+  const cappedDirect = capturedRequests[requestCountBeforeCapCheck]?.body;
+  assert.ok(cappedDirect);
+  assert.equal(cappedDirect.max_completion_tokens, 1048576);
+  delete process.env.MINEBENCH_MAX_OUTPUT_TOKENS;
+
+  rejectOpenRouterReasoning = true;
+  const requestCountBeforeRejection = capturedRequests.length;
+  const rejected = await (async () => {
+    const originalConsoleError = console.error;
+    console.error = () => {};
+    try {
+      return await generateVoxelBuild({
+        modelKey: model.key,
+        prompt: "small tower",
+        gridSize: 64,
+        palette: "simple",
+        enableTools: false,
+        maxAttempts: 1,
+        providerKeys: { openrouter: "test-openrouter-key" },
+        allowServerKeys: false,
+      });
+    } finally {
+      console.error = originalConsoleError;
+    }
+  })();
+  assert.equal(rejected.ok, false);
+  const rejectedRequests = capturedRequests
+    .slice(requestCountBeforeRejection)
+    .filter((request) => request.url.includes("openrouter.test"));
+  assert.equal(rejectedRequests.length, 1);
+  assert.deepEqual(rejectedRequests[0]?.body.reasoning, { effort: "max" });
 
   console.log("kimi k3 config checks passed");
 }

--- a/tests/unit/providers/kimi-k3-config.test.ts
+++ b/tests/unit/providers/kimi-k3-config.test.ts
@@ -1,0 +1,119 @@
+import assert from "node:assert/strict";
+import { generateVoxelBuild } from "../../../lib/ai/generateVoxelBuild";
+import { getModelByKey } from "../../../lib/ai/modelCatalog";
+import {
+  moonshotThinkingConfigForModel,
+  openRouterReasoningEffortAttempts,
+} from "../../../lib/ai/reasoningProfiles";
+import { MODEL_SLUG } from "../../../scripts/uploadsCatalog";
+
+type CapturedRequest = {
+  url: string;
+  body: Record<string, unknown>;
+};
+
+const capturedRequests: CapturedRequest[] = [];
+const originalFetch = globalThis.fetch;
+const originalEnv = {
+  maxOutputTokens: process.env.MINEBENCH_MAX_OUTPUT_TOKENS,
+  moonshotBaseUrl: process.env.MOONSHOT_BASE_URL,
+  openRouterBaseUrl: process.env.OPENROUTER_BASE_URL,
+};
+
+function validBuildJson(): string {
+  return JSON.stringify({
+    version: "1.0",
+    boxes: [],
+    lines: [],
+    blocks: [{ x: 0, y: 0, z: 0, type: "stone" }],
+  });
+}
+
+globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+  assert.equal(typeof init?.body, "string");
+  capturedRequests.push({
+    url: String(input),
+    body: JSON.parse(init?.body as string) as Record<string, unknown>,
+  });
+  return new Response(
+    JSON.stringify({ choices: [{ message: { content: validBuildJson() } }] }),
+    { status: 200, headers: { "Content-Type": "application/json" } },
+  );
+}) as typeof fetch;
+
+async function main() {
+  process.env.MINEBENCH_MAX_OUTPUT_TOKENS = "262144";
+  process.env.MOONSHOT_BASE_URL = "https://moonshot.test";
+  process.env.OPENROUTER_BASE_URL = "https://openrouter.test/api";
+
+  const model = getModelByKey("moonshot_kimi_k3");
+  assert.equal(model.modelId, "kimi-k3");
+  assert.equal(model.openRouterModelId, "moonshotai/kimi-k3");
+  assert.equal(MODEL_SLUG.moonshot_kimi_k3, "kimi-k3");
+  assert.deepEqual(moonshotThinkingConfigForModel(model.modelId), {
+    reasoningEffort: "max",
+  });
+  assert.throws(() => moonshotThinkingConfigForModel(model.modelId, "disabled"));
+  assert.deepEqual(openRouterReasoningEffortAttempts(model.openRouterModelId), ["max"]);
+
+  await generateVoxelBuild({
+    modelKey: model.key,
+    prompt: "small tower",
+    gridSize: 64,
+    palette: "simple",
+    enableTools: false,
+    providerKeys: { moonshot: "test-moonshot-key" },
+    allowServerKeys: false,
+  });
+  await generateVoxelBuild({
+    modelKey: model.key,
+    prompt: "small tower",
+    gridSize: 64,
+    palette: "simple",
+    enableTools: false,
+    preferOpenRouter: true,
+    providerKeys: { openrouter: "test-openrouter-key" },
+    allowServerKeys: false,
+  });
+
+  const direct = capturedRequests.find((request) => request.url.includes("moonshot.test"))?.body;
+  assert.ok(direct);
+  assert.equal(direct.model, "kimi-k3");
+  assert.equal(direct.max_completion_tokens, 262144);
+  assert.equal(direct.reasoning_effort, "max");
+  assert.equal("thinking" in direct, false);
+  assert.equal("temperature" in direct, false);
+  assert.equal("top_p" in direct, false);
+  assert.equal(
+    ((direct.response_format as { json_schema?: { strict?: unknown } })?.json_schema)?.strict,
+    true,
+  );
+
+  const openRouter = capturedRequests.find((request) =>
+    request.url.includes("openrouter.test"),
+  )?.body;
+  assert.ok(openRouter);
+  assert.equal(openRouter.model, "moonshotai/kimi-k3");
+  assert.equal(openRouter.max_tokens, 262144);
+  assert.deepEqual(openRouter.reasoning, { effort: "max" });
+  assert.equal("temperature" in openRouter, false);
+
+  console.log("kimi k3 config checks passed");
+}
+
+main()
+  .finally(() => {
+    globalThis.fetch = originalFetch;
+    for (const [name, value] of Object.entries({
+      MINEBENCH_MAX_OUTPUT_TOKENS: originalEnv.maxOutputTokens,
+      MOONSHOT_BASE_URL: originalEnv.moonshotBaseUrl,
+      OPENROUTER_BASE_URL: originalEnv.openRouterBaseUrl,
+    })) {
+      if (value === undefined) delete process.env[name];
+      else process.env[name] = value;
+    }
+  })
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });


### PR DESCRIPTION
## What does this PR do?

Adds Kimi K3 as a first-class MineBench model with native Moonshot and OpenRouter routing.

- Native model ID: `kimi-k3`
- OpenRouter model ID: `moonshotai/kimi-k3`
- Uses the required `reasoning_effort=max`
- Uses K3’s published 1,048,576-token completion ceiling on both routes
- Fails closed on OpenRouter if max reasoning is rejected
- Does not send the K2.x `thinking` parameter
- Omits fixed K3 sampling parameters
- Adds strict structured output and request-shape coverage for both routes

## Identifier verification

- Moonshot Kimi K3 quickstart: https://platform.kimi.ai/docs/guide/kimi-k3-quickstart
- OpenRouter model page: https://openrouter.ai/moonshotai/kimi-k3

## How to test

- `corepack pnpm lint`
- `corepack pnpm test`
- `corepack pnpm exec tsc --noEmit`
- `corepack pnpm build`