### PR TITLE
(feat) add model run details

### DIFF
--- a/app/api/arena/matchup/route.ts
+++ b/app/api/arena/matchup/route.ts
@@ -31,6 +31,7 @@ import {
 import { enqueueArenaMatchupShownDurably } from "@/lib/arena/shownJobs";
 import { ServerTiming } from "@/lib/serverTiming";
 import { trackServerEventInBackground } from "@/lib/analytics.server";
+import { resolveModelDisplayName } from "@/lib/ai/modelCatalog";
 
 export const runtime = "nodejs";
 
@@ -931,7 +932,7 @@ export async function GET(req: Request) {
       model: {
         key: leftModel.key,
         provider: leftModel.provider,
-        displayName: leftModel.displayName,
+        displayName: resolveModelDisplayName(leftModel.key, leftModel.displayName),
         eloRating: leftModel.eloRating,
       },
       build:
@@ -957,7 +958,7 @@ export async function GET(req: Request) {
       model: {
         key: rightModel.key,
         provider: rightModel.provider,
-        displayName: rightModel.displayName,
+        displayName: resolveModelDisplayName(rightModel.key, rightModel.displayName),
         eloRating: rightModel.eloRating,
       },
       build:

--- a/app/api/leaderboard/route.ts
+++ b/app/api/leaderboard/route.ts
@@ -7,6 +7,7 @@ import { confidenceFromRd, conservativeScore, stabilityTier } from "@/lib/arena/
 import { summarizeArenaVotes } from "@/lib/arena/voteMath";
 import { getArenaEligiblePromptIds } from "@/lib/arena/eligibility";
 import { getArenaPairCoverageByKey } from "@/lib/arena/coverage";
+import { resolveModelDisplayName } from "@/lib/ai/modelCatalog";
 import { ServerTiming } from "@/lib/serverTiming";
 import {
   databaseUnavailableBody,
@@ -165,7 +166,7 @@ export async function GET() {
       return {
         key: m.key,
         provider: m.provider,
-        displayName: m.displayName,
+        displayName: resolveModelDisplayName(m.key, m.displayName),
         stability,
         eloRating: rawRating,
         ratingDeviation,

--- a/app/api/sandbox/benchmark/route.ts
+++ b/app/api/sandbox/benchmark/route.ts
@@ -11,6 +11,7 @@ import {
   isDatabaseUnavailableError,
 } from "@/lib/db/errors";
 import { prisma } from "@/lib/prisma";
+import { resolveModelDisplayName } from "@/lib/ai/modelCatalog";
 
 export const runtime = "nodejs";
 
@@ -183,7 +184,7 @@ export async function GET(req: Request) {
     const models: ModelOption[] = modelRows.map((m) => ({
       key: m.key,
       provider: m.provider,
-      displayName: m.displayName,
+      displayName: resolveModelDisplayName(m.key, m.displayName),
       eloRating: Number(m.eloRating),
     }));
 
@@ -381,7 +382,7 @@ export async function GET(req: Request) {
         model: {
           key: build.model.key,
           provider: build.model.provider,
-          displayName: build.model.displayName,
+          displayName: resolveModelDisplayName(build.model.key, build.model.displayName),
           eloRating: Number(build.model.eloRating),
         },
         metrics: {

--- a/components/leaderboard/Leaderboard.tsx
+++ b/components/leaderboard/Leaderboard.tsx
@@ -8,8 +8,9 @@ import { ErrorState } from "@/components/ErrorState";
 import { getConsistencyBand } from "@/lib/arena/consistencyBands";
 import { FetchError, fetchWithRetry } from "@/lib/fetchWithRetry";
 import { formatAge, readStale, writeStale } from "@/lib/staleCache";
+import { ModelBenchmarkDetails } from "@/components/leaderboard/ModelBenchmarkDetails";
 
-const LEADERBOARD_CACHE_KEY = "mb-leaderboard-v3";
+const LEADERBOARD_CACHE_KEY = "mb-leaderboard-v4";
 // accept cached data up to 10 min — older than that we prefer "loading…" over shipping stale rankings
 const LEADERBOARD_STALE_MAX_AGE_MS = 10 * 60 * 1000;
 const LEADERBOARD_SLOW_THRESHOLD_MS = 5_000;
@@ -419,19 +420,16 @@ export function Leaderboard() {
 	              const coveragePercent = Math.round((m.promptCoverage ?? 0) * 100);
 	              const moveBadge = movementBadge(m);
 	              return (
-                <button
-                  key={m.key}
-                  type="button"
-                  className={`w-full rounded-2xl bg-gradient-to-b from-bg/62 to-bg/44 p-3 text-left ring-1 ring-border/70 transition ${
+	                <div
+	                  key={m.key}
+	                  className={`w-full rounded-2xl bg-gradient-to-b from-bg/62 to-bg/44 p-3 text-left ring-1 ring-border/70 transition ${
                     navigatingModelKey === m.key
                       ? "opacity-75"
                       : "active:ring-accent/45 active:from-bg/72"
-                  }`}
-                  onMouseEnter={() => prefetchModel(m.key)}
-                  onFocus={() => prefetchModel(m.key)}
-                  onClick={() => navigateToModel(m.key)}
-                  aria-label={`Open ${m.displayName} profile`}
-                >
+	                  }`}
+	                  onMouseEnter={() => prefetchModel(m.key)}
+	                  onClick={() => navigateToModel(m.key)}
+	                >
 	                  <div className="flex items-start justify-between gap-3">
 	                    <div className="flex min-w-0 items-start gap-3">
 	                      <div className="flex w-9 flex-col items-center gap-0.5 pt-0.5">
@@ -441,8 +439,20 @@ export function Leaderboard() {
 	                        <MovementMark badge={moveBadge} />
 	                      </div>
 	                      <div className="min-w-0">
-	                        <div className="mt-1.5 min-w-0 truncate text-[1rem] font-semibold tracking-tight text-fg">
-	                          {m.displayName}
+	                        <div className="mt-1.5 flex min-w-0 items-center gap-1.5">
+	                          <button
+	                            type="button"
+	                            className="min-w-0 truncate text-left text-[1rem] font-semibold tracking-tight text-fg focus-visible:outline-none focus-visible:text-accent"
+	                            aria-label={`Open ${m.displayName} profile`}
+	                            onFocus={() => prefetchModel(m.key)}
+	                            onClick={(event) => {
+	                              event.stopPropagation();
+	                              navigateToModel(m.key);
+	                            }}
+	                          >
+	                            {m.displayName}
+	                          </button>
+	                          <ModelBenchmarkDetails modelKey={m.key} displayName={m.displayName} />
 	                        </div>
 	                        <div className="mt-0.5 flex flex-wrap items-center gap-1.5">
 	                          <span className="truncate text-xs tracking-wide text-muted2">{m.provider}</span>
@@ -522,7 +532,7 @@ export function Leaderboard() {
                     <span>{voteSummary.totalVotes.toLocaleString()} votes</span>
                     <span>{m.bothBadCount.toLocaleString()} both bad</span>
                   </div>
-                </button>
+	                </div>
               );
             })}
             {!data ? (
@@ -647,20 +657,11 @@ export function Leaderboard() {
 	                const tier = index === 0 ? "champion" : index < 3 ? "top" : "base";
 	                const moveBadge = movementBadge(m);
 	                return (
-                  <tr
-                    key={m.key}
-                    role="link"
-                    tabIndex={0}
-                    data-tier={tier}
-                    aria-label={`Open ${m.displayName} profile`}
-                    onMouseEnter={() => prefetchModel(m.key)}
-                    onFocus={() => prefetchModel(m.key)}
-                    onClick={() => navigateToModel(m.key)}
-                    onKeyDown={(e) => {
-                      if (e.key !== "Enter" && e.key !== " ") return;
-                      e.preventDefault();
-                      navigateToModel(m.key);
-                    }}
+	                  <tr
+	                    key={m.key}
+	                    data-tier={tier}
+	                    onMouseEnter={() => prefetchModel(m.key)}
+	                    onClick={() => navigateToModel(m.key)}
                     className={`mb-leaderboard-row group mb-card-enter cursor-pointer ${
                       navigatingModelKey === m.key ? "opacity-75" : ""
                     }`}
@@ -675,8 +676,20 @@ export function Leaderboard() {
 	                          <MovementMark badge={moveBadge} />
 	                        </div>
 	                        <div className="min-w-0">
-	                          <div className="min-w-0 truncate font-medium text-fg transition-colors duration-200 group-hover:text-accent group-focus-visible:text-accent">
-	                            {m.displayName}
+	                          <div className="flex min-w-0 items-center gap-1.5">
+	                            <button
+	                              type="button"
+	                              className="min-w-0 truncate text-left font-medium text-fg transition-colors duration-200 group-hover:text-accent focus-visible:outline-none focus-visible:text-accent"
+	                              aria-label={`Open ${m.displayName} profile`}
+	                              onFocus={() => prefetchModel(m.key)}
+	                              onClick={(event) => {
+	                                event.stopPropagation();
+	                                navigateToModel(m.key);
+	                              }}
+	                            >
+	                              {m.displayName}
+	                            </button>
+	                            <ModelBenchmarkDetails modelKey={m.key} displayName={m.displayName} />
 	                          </div>
 	                          <div className="mt-0.5 flex flex-wrap items-center gap-1.5">
 	                            <span className="truncate text-xs tracking-wide text-muted2">{m.provider}</span>

--- a/components/leaderboard/ModelBenchmarkDetails.tsx
+++ b/components/leaderboard/ModelBenchmarkDetails.tsx
@@ -1,0 +1,223 @@
+"use client";
+
+import { useEffect, useId, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import {
+  getModelBenchmarkProfile,
+  type ModelBenchmarkProfile,
+} from "@/lib/ai/modelBenchmarkProfiles";
+
+function InfoIcon() {
+  return (
+    <svg
+      aria-hidden="true"
+      className="h-3.5 w-3.5"
+      viewBox="0 0 20 20"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.7"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <circle cx="10" cy="10" r="7.25" />
+      <path d="M10 8.6v4.25" />
+      <path d="M10 6.25h.01" strokeWidth="2.25" />
+    </svg>
+  );
+}
+
+function CloseIcon() {
+  return (
+    <svg
+      aria-hidden="true"
+      className="h-4 w-4"
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.8"
+      strokeLinecap="round"
+    >
+      <path d="m4 4 8 8M12 4l-8 8" />
+    </svg>
+  );
+}
+
+export function ModelBenchmarkDetails({
+  modelKey,
+  displayName,
+  className = "",
+}: {
+  modelKey: string;
+  displayName: string;
+  className?: string;
+}) {
+  const recordedProfile = getModelBenchmarkProfile(modelKey);
+  const profile: ModelBenchmarkProfile = recordedProfile ?? {
+    parameters: [],
+    note: "This model was benchmarked before run statistics were tracked.",
+  };
+  const [open, setOpen] = useState(false);
+  const titleId = useId();
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const closeRef = useRef<HTMLButtonElement>(null);
+  const dialogRef = useRef<HTMLElement>(null);
+  const wasOpenRef = useRef(false);
+
+  useEffect(() => {
+    if (!open) return;
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        setOpen(false);
+        return;
+      }
+      if (event.key !== "Tab") return;
+
+      const focusable = Array.from(
+        dialogRef.current?.querySelectorAll<HTMLElement>(
+          'button:not([disabled]), [href], [tabindex]:not([tabindex="-1"])',
+        ) ?? [],
+      );
+      if (focusable.length === 0) return;
+
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      if (event.shiftKey && document.activeElement === first) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && document.activeElement === last) {
+        event.preventDefault();
+        first.focus();
+      }
+    };
+
+    document.addEventListener("keydown", onKeyDown);
+    closeRef.current?.focus();
+    return () => document.removeEventListener("keydown", onKeyDown);
+  }, [open]);
+
+  useEffect(() => {
+    if (open) {
+      wasOpenRef.current = true;
+      return;
+    }
+    if (!wasOpenRef.current) return;
+    wasOpenRef.current = false;
+    triggerRef.current?.focus({ preventScroll: true });
+  }, [open]);
+
+  const hasRunStats = Boolean(profile.averageInferenceTime || profile.totalCost);
+
+  return (
+    <>
+      <button
+        ref={triggerRef}
+        type="button"
+        className={`inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-full text-muted2 ring-1 ring-border/80 transition hover:bg-accent/10 hover:text-accent hover:ring-accent/35 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60 ${className}`}
+        aria-label={`View ${displayName} run details`}
+        aria-expanded={open}
+        aria-haspopup="dialog"
+        onClick={(event) => {
+          event.stopPropagation();
+          setOpen(true);
+        }}
+        onKeyDown={(event) => event.stopPropagation()}
+      >
+        <InfoIcon />
+      </button>
+
+      {open && typeof document !== "undefined"
+        ? createPortal(
+            <div
+              className="fixed inset-0 z-[120] flex items-end justify-center bg-bg/70 p-3 backdrop-blur-sm sm:items-center sm:p-6"
+              onMouseDown={() => setOpen(false)}
+            >
+              <section
+                ref={dialogRef}
+                role="dialog"
+                aria-modal="true"
+                aria-labelledby={titleId}
+                className="max-h-[calc(100dvh-1.5rem)] w-full max-w-md overflow-y-auto rounded-2xl bg-card shadow-soft ring-1 ring-border"
+                onMouseDown={(event) => event.stopPropagation()}
+              >
+                <div className="flex items-start justify-between gap-4 border-b border-border/80 px-4 py-4 sm:px-5">
+                  <div className="min-w-0">
+                    <div className="mb-eyebrow">Run details</div>
+                    <h2 id={titleId} className="mt-1 truncate text-lg font-semibold tracking-tight text-fg">
+                      {displayName}
+                    </h2>
+                  </div>
+                  <button
+                    ref={closeRef}
+                    type="button"
+                    className="mb-btn mb-btn-ghost h-8 w-8 shrink-0 rounded-full p-0"
+                    aria-label="Close run details"
+                    onClick={() => setOpen(false)}
+                  >
+                    <CloseIcon />
+                  </button>
+                </div>
+
+                <div className="space-y-5 px-4 py-4 sm:px-5 sm:py-5">
+                  {profile.parameters.length > 0 ? (
+                    <div>
+                      <h3 className="mb-eyebrow mb-2">Run setup</h3>
+                      <dl className="divide-y divide-border/60 border-y border-border/60">
+                        {profile.parameters.map((parameter) => (
+                          <div
+                            key={parameter.label}
+                            className="flex items-baseline justify-between gap-5 py-2.5 text-sm"
+                          >
+                            <dt className="text-muted">{parameter.label}</dt>
+                            <dd className="text-right font-medium text-fg">{parameter.value}</dd>
+                          </div>
+                        ))}
+                      </dl>
+                    </div>
+                  ) : null}
+
+                  {hasRunStats ? (
+                    <div>
+                      <h3 className="mb-eyebrow mb-2">Benchmark run</h3>
+                      <dl className="grid grid-cols-2 gap-px overflow-hidden rounded-xl bg-border/70 ring-1 ring-border/70">
+                        <div className="bg-bg/70 px-3 py-3">
+                          <dt className="text-[11px] text-muted">Avg. inference</dt>
+                          <dd className="mt-1 font-mono text-sm font-semibold text-fg">
+                            {profile.averageInferenceTime ?? "—"}
+                          </dd>
+                        </div>
+                        <div className="bg-bg/70 px-3 py-3">
+                          <dt className="text-[11px] text-muted">Total cost</dt>
+                          <dd className="mt-1 font-mono text-sm font-semibold text-fg">
+                            {profile.totalCost ?? "—"}
+                          </dd>
+                        </div>
+                      </dl>
+                      <p className="mt-2 text-[11px] text-muted2">
+                        {profile.buildCount
+                          ? `Reported for a ${profile.buildCount}-build benchmark run.`
+                          : "Reported for this benchmark run."}
+                      </p>
+                    </div>
+                  ) : null}
+
+                  {profile.note ? (
+                    <p className="rounded-xl bg-warn/10 px-3 py-2.5 text-xs leading-relaxed text-warn ring-1 ring-warn/20">
+                      {profile.note}
+                    </p>
+                  ) : null}
+                  <p className="border-t border-border/60 pt-3 text-[11px] leading-relaxed text-muted2">
+                    Ratings reflect the current prompt set
+                    {profile.parameters.length > 0 ? " and run configuration shown" : ""}.
+                    {profile.sourceRelease ? ` Source: MineBench ${profile.sourceRelease}.` : ""}
+                  </p>
+                </div>
+              </section>
+            </div>,
+            document.body,
+          )
+        : null}
+    </>
+  );
+}

--- a/components/leaderboard/ModelDetail.tsx
+++ b/components/leaderboard/ModelDetail.tsx
@@ -37,6 +37,7 @@ import {
   type SandboxGifExportTarget,
 } from "@/components/sandbox/SandboxGifExportButton";
 import { getConsistencyBand, getConsistencyLabel } from "@/lib/arena/consistencyBands";
+import { ModelBenchmarkDetails } from "@/components/leaderboard/ModelBenchmarkDetails";
 
 const CHART_WIDTH = 900;
 const CHART_HEIGHT = 304;
@@ -1441,10 +1442,17 @@ export function ModelDetail({ data }: { data: ModelDetailStats }) {
                pushes to the far right at the name's baseline so the dead
                space next to the display-type is used; on mobile it wraps
                underneath. */}
-            <div className="flex flex-wrap items-end justify-between gap-x-8 gap-y-3">
-              <h1 className="max-w-[18ch] font-display text-[2.1rem] font-semibold leading-[0.96] tracking-[-0.02em] text-fg sm:text-[3.2rem]">
-                {data.model.displayName}
-              </h1>
+	            <div className="flex flex-wrap items-end justify-between gap-x-8 gap-y-3">
+	              <div className="flex max-w-full items-end gap-2.5">
+	                <h1 className="max-w-[18ch] font-display text-[2.1rem] font-semibold leading-[0.96] tracking-[-0.02em] text-fg sm:text-[3.2rem]">
+	                  {data.model.displayName}
+	                </h1>
+	                <ModelBenchmarkDetails
+	                  modelKey={data.model.key}
+	                  displayName={data.model.displayName}
+	                  className="mb-0.5 sm:mb-1"
+	                />
+	              </div>
               {/* Colorized meta — stability takes its colored dot+word, the
                  record W–L–D becomes three tinted tokens so you can read
                  the result at a glance instead of parsing one gray string. */}

--- a/lib/ai/modelBenchmarkProfiles.ts
+++ b/lib/ai/modelBenchmarkProfiles.ts
@@ -1,0 +1,181 @@
+import type { ModelKey } from "@/lib/ai/modelCatalog";
+
+export type ModelRunParameter = {
+  label: string;
+  value: string;
+};
+
+export type ModelBenchmarkProfile = {
+  sourceRelease?: string;
+  parameters: readonly ModelRunParameter[];
+  averageInferenceTime?: string;
+  totalCost?: string;
+  buildCount?: number;
+  note?: string;
+};
+
+export const MODEL_BENCHMARK_PROFILES: Partial<Record<ModelKey, ModelBenchmarkProfile>> = {
+  openai_gpt_5_6_sol: {
+    sourceRelease: "3.9.0",
+    parameters: [
+      { label: "Reasoning mode", value: "Pro" },
+      { label: "Reasoning effort", value: "Max" },
+      { label: "Text verbosity", value: "High" },
+      { label: "Combined reasoning/output cap", value: "128,000 tokens" },
+    ],
+    averageInferenceTime: "25m 16s (1516.2s)",
+    totalCost: "$710.82",
+    buildCount: 15,
+  },
+  xai_grok_4_5: {
+    sourceRelease: "3.9.0",
+    parameters: [
+      { label: "Reasoning effort", value: "High" },
+      { label: "Requested output budget", value: "500,000 tokens" },
+      { label: "Accepted output budget", value: "262,144 tokens" },
+    ],
+    averageInferenceTime: "1m 48s (108.2s)",
+    totalCost: "$1.69",
+    buildCount: 15,
+  },
+  zai_glm_5_2: {
+    sourceRelease: "3.8.0",
+    parameters: [
+      { label: "Reasoning effort", value: "XHigh → High" },
+      { label: "Output cap", value: "131,072 tokens" },
+    ],
+    averageInferenceTime: "6m 21s (381.1s)",
+    totalCost: "$4.46",
+    buildCount: 15,
+  },
+  anthropic_claude_sonnet_5: {
+    sourceRelease: "3.8.0",
+    parameters: [
+      { label: "Thinking", value: "Adaptive" },
+      { label: "Reasoning effort", value: "XHigh" },
+      { label: "Output cap", value: "128,000 tokens" },
+    ],
+    averageInferenceTime: "31m 3s (1863.1s)",
+    totalCost: "$94.17",
+    buildCount: 15,
+  },
+  openai_gpt_4_5_web_harness: {
+    sourceRelease: "3.8.0",
+    parameters: [{ label: "Source", value: "ChatGPT web harness" }],
+    note: "Imported from the web harness; not directly comparable to API-generated runs.",
+  },
+  anthropic_claude_fable_5: {
+    sourceRelease: "3.7.0",
+    parameters: [
+      { label: "Thinking", value: "Adaptive" },
+      { label: "Reasoning effort", value: "Max" },
+      { label: "Sampling", value: "Provider default" },
+      { label: "Output cap", value: "128,000 tokens" },
+    ],
+    averageInferenceTime: "18m 4s (1084.4s)",
+    totalCost: "$54.93",
+    buildCount: 15,
+  },
+  anthropic_claude_4_8_opus: {
+    sourceRelease: "3.6.0",
+    parameters: [
+      { label: "Thinking", value: "Adaptive" },
+      { label: "Reasoning effort", value: "Max" },
+      { label: "Output cap", value: "128,000 tokens" },
+    ],
+    averageInferenceTime: "24m 48s (1487.9s)",
+    totalCost: "$41.52",
+    buildCount: 15,
+  },
+  gemini_3_5_flash: {
+    sourceRelease: "3.6.0",
+    parameters: [
+      { label: "Thinking level", value: "High" },
+      { label: "Output cap", value: "65,536 tokens" },
+    ],
+    averageInferenceTime: "1m 54s (114.1s)",
+    totalCost: "$12.90",
+    buildCount: 15,
+  },
+  xai_grok_4_3: {
+    sourceRelease: "3.4.0",
+    parameters: [
+      { label: "Reasoning", value: "Automatic" },
+      { label: "Requested output budget", value: "1,000,000 tokens" },
+      { label: "Fallback output budget", value: "983,040 tokens" },
+    ],
+    averageInferenceTime: "3m 43s (223.1s)",
+    totalCost: "$0.87",
+  },
+  xai_grok_4_20: {
+    sourceRelease: "v3.0.0",
+    parameters: [{ label: "Reasoning", value: "Thinking enabled" }],
+    averageInferenceTime: "~2m 29s",
+    totalCost: "$18.44",
+    buildCount: 15,
+  },
+  openai_gpt_5_5: {
+    sourceRelease: "3.3.2",
+    parameters: [
+      { label: "Reasoning effort", value: "Max" },
+      { label: "Text verbosity", value: "High" },
+      { label: "Output cap", value: "128,000 tokens" },
+    ],
+    averageInferenceTime: "10m 24s (624.0s)",
+    totalCost: "$19.984",
+  },
+  openai_gpt_5_5_pro: {
+    sourceRelease: "3.3.2",
+    parameters: [
+      { label: "Reasoning effort", value: "Max" },
+      { label: "Text verbosity", value: "High" },
+      { label: "Output cap", value: "128,000 tokens" },
+    ],
+    averageInferenceTime: "21m 23s (1283.3s)",
+    totalCost: "$223.889",
+  },
+  deepseek_v4_pro: {
+    sourceRelease: "3.3.2",
+    parameters: [],
+    totalCost: "$3.92",
+    note: "Run parameters and average inference time were not recorded for this model.",
+  },
+  anthropic_claude_4_7_opus: {
+    sourceRelease: "v3.0.0",
+    parameters: [{ label: "Reasoning effort", value: "Max" }],
+    totalCost: "~$275",
+    note: "Average inference time was not recorded for this model.",
+  },
+  zai_glm_5_1: {
+    sourceRelease: "v3.0.0",
+    parameters: [
+      { label: "Reasoning", value: "Thinking enabled" },
+      { label: "Output cap", value: "131,072 tokens" },
+    ],
+    averageInferenceTime: "~17m 26s",
+    totalCost: "$4.18",
+    buildCount: 15,
+  },
+  moonshot_kimi_k2_6: {
+    sourceRelease: "v3.0.0",
+    parameters: [{ label: "Reasoning", value: "Thinking enabled" }],
+    averageInferenceTime: "~43m",
+    totalCost: "$2.35",
+    buildCount: 15,
+  },
+  moonshot_kimi_k3: {
+    sourceRelease: "3.10.0 draft",
+    parameters: [
+      { label: "Reasoning effort", value: "Max" },
+      { label: "Structured output", value: "Strict" },
+      { label: "Completion ceiling", value: "1,048,576 tokens" },
+    ],
+    averageInferenceTime: "32m 46s (1966.0s)",
+    totalCost: "$12.70",
+    buildCount: 15,
+  },
+};
+
+export function getModelBenchmarkProfile(modelKey: string): ModelBenchmarkProfile | null {
+  return MODEL_BENCHMARK_PROFILES[modelKey as ModelKey] ?? null;
+}

--- a/lib/ai/modelCatalog.ts
+++ b/lib/ai/modelCatalog.ts
@@ -82,7 +82,7 @@ export const MODEL_CATALOG: ModelCatalogEntry[] = [
     key: "openai_gpt_5_6_sol",
     provider: "openai",
     modelId: "gpt-5.6-sol",
-    displayName: "GPT 5.6 Sol",
+    displayName: "GPT 5.6 Sol Pro",
     enabled: true,
     openRouterModelId: "openai/gpt-5.6-sol-pro",
   },
@@ -500,4 +500,8 @@ export function getModelByKey(key: ModelKey): ModelCatalogEntry {
   const found = MODEL_CATALOG.find((m) => m.key === key);
   if (!found) throw new Error(`Unknown model key: ${key}`);
   return found;
+}
+
+export function resolveModelDisplayName(key: string, fallback: string): string {
+  return MODEL_CATALOG.find((model) => model.key === key)?.displayName ?? fallback;
 }

--- a/lib/arena/stats.ts
+++ b/lib/arena/stats.ts
@@ -1,5 +1,6 @@
 import { Prisma } from "@prisma/client";
 import { prisma } from "@/lib/prisma";
+import { resolveModelDisplayName } from "@/lib/ai/modelCatalog";
 import { summarizeArenaVotes } from "@/lib/arena/voteMath";
 import { confidenceFromRd, conservativeScore, stabilityTier } from "@/lib/arena/rating";
 import {
@@ -1206,7 +1207,7 @@ async function queryModelDetailStats(modelKey: string): Promise<ModelDetailStats
   const opponents: ModelOpponentBreakdown[] = opponentRows
     .map((row) => ({
       key: row.key,
-      displayName: row.displayName,
+      displayName: resolveModelDisplayName(row.key, row.displayName),
       votes: toNumber(row.votes),
       averageScore: toNumber(row.averageScore),
       wins: toNumber(row.wins),
@@ -1241,7 +1242,7 @@ async function queryModelDetailStats(modelKey: string): Promise<ModelDetailStats
     model: {
       key: model.key,
       provider: model.provider,
-      displayName: model.displayName,
+      displayName: resolveModelDisplayName(model.key, model.displayName),
       eloRating: rawRating,
       ratingDeviation,
       rankScore,

--- a/tests/ui/model-benchmark-details.test.ts
+++ b/tests/ui/model-benchmark-details.test.ts
@@ -1,0 +1,38 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const detailsSource = readFileSync(
+  "components/leaderboard/ModelBenchmarkDetails.tsx",
+  "utf8",
+);
+const leaderboardSource = readFileSync("components/leaderboard/Leaderboard.tsx", "utf8");
+const modelDetailSource = readFileSync("components/leaderboard/ModelDetail.tsx", "utf8");
+
+assert.ok(
+  detailsSource.includes('aria-haspopup="dialog"') &&
+    detailsSource.includes('aria-label={`View ${displayName} run details`}'),
+  "model details trigger should expose its dialog semantics and accessible name",
+);
+assert.ok(
+  detailsSource.includes('role="dialog"') && detailsSource.includes('aria-modal="true"'),
+  "model run details should render as an accessible dialog",
+);
+assert.ok(
+  detailsSource.includes("This model was benchmarked before run statistics were tracked."),
+  "models without recorded statistics should still receive a useful details note",
+);
+assert.ok(
+  detailsSource.includes("Avg. inference") && detailsSource.includes("Total cost"),
+  "recorded benchmark details should show inference time and total cost",
+);
+assert.ok(
+  leaderboardSource.includes("<ModelBenchmarkDetails") &&
+    modelDetailSource.includes("<ModelBenchmarkDetails"),
+  "the leaderboard and model profile should both expose model run details",
+);
+assert.ok(
+  leaderboardSource.includes('const LEADERBOARD_CACHE_KEY = "mb-leaderboard-v4"'),
+  "the canonical model-name change should invalidate stale client leaderboard data",
+);
+
+console.log("model benchmark details UI checks passed");

--- a/tests/unit/ai/model-benchmark-profiles.test.ts
+++ b/tests/unit/ai/model-benchmark-profiles.test.ts
@@ -1,0 +1,42 @@
+import assert from "node:assert/strict";
+import {
+  MODEL_BENCHMARK_PROFILES,
+  getModelBenchmarkProfile,
+} from "../../../lib/ai/modelBenchmarkProfiles";
+import {
+  MODEL_CATALOG,
+  resolveModelDisplayName,
+} from "../../../lib/ai/modelCatalog";
+
+const gpt56 = getModelBenchmarkProfile("openai_gpt_5_6_sol");
+assert.ok(gpt56, "GPT 5.6 Sol Pro should have verified benchmark details");
+assert.deepEqual(gpt56.parameters, [
+  { label: "Reasoning mode", value: "Pro" },
+  { label: "Reasoning effort", value: "Max" },
+  { label: "Text verbosity", value: "High" },
+  { label: "Combined reasoning/output cap", value: "128,000 tokens" },
+]);
+assert.equal(gpt56.sourceRelease, "3.9.0");
+assert.equal(gpt56.averageInferenceTime, "25m 16s (1516.2s)");
+assert.equal(gpt56.totalCost, "$710.82");
+assert.equal(gpt56.buildCount, 15);
+
+assert.equal(
+  resolveModelDisplayName("openai_gpt_5_6_sol", "stale database label"),
+  "GPT 5.6 Sol Pro",
+  "public responses should prefer the canonical catalog label",
+);
+assert.equal(
+  resolveModelDisplayName("unknown_model", "Imported model"),
+  "Imported model",
+  "unknown persisted models should keep their database label",
+);
+
+for (const key of Object.keys(MODEL_BENCHMARK_PROFILES)) {
+  assert.ok(
+    MODEL_CATALOG.some((model) => model.key === key),
+    `benchmark profile ${key} should match a catalog model`,
+  );
+}
+
+console.log("model benchmark profile checks passed");

--- a/tests/unit/providers/gpt-5-6-sol-config.test.ts
+++ b/tests/unit/providers/gpt-5-6-sol-config.test.ts
@@ -70,7 +70,7 @@ async function main() {
 
   assert.equal(model.provider, "openai");
   assert.equal(model.modelId, "gpt-5.6-sol");
-  assert.equal(model.displayName, "GPT 5.6 Sol");
+  assert.equal(model.displayName, "GPT 5.6 Sol Pro");
   assert.equal(model.openRouterModelId, "openai/gpt-5.6-sol-pro");
   assert.equal(MODEL_SLUG.openai_gpt_5_6_sol, "gpt-5-6-sol");
   assert.deepEqual(openAiReasoningEffortAttempts(model.modelId), [


### PR DESCRIPTION
## Summary

- rename the canonical frontend label to `GPT 5.6 Sol Pro` and normalize database-backed public responses so the existing persisted label cannot remain visible
- add an accessible model run-details control to every leaderboard entry and model profile
- show release-backed run parameters, average inference time, total cost, release provenance, and the GPT 4.5 comparability warning where available
- show a concise historical-data note for models benchmarked before these statistics were tracked
- invalidate stale client leaderboard data and add focused UI/data regressions

## Verification

- `pnpm exec tsc --noEmit`
- `pnpm lint`
- `pnpm test` — 20 test files passed
- `pnpm build`
- `graphify update .`

## Notes

- The production build passed after allowing the configured Google Fonts fetch.
- Live browser screenshots were unavailable because neither connected browser surface was available in this session; dialog semantics, placement, fallback copy, and cache invalidation are covered by focused regressions.

*(PR written by Codex)*
