### PR TITLE
(feat) add anchored model benchmark details

### DIFF
--- a/app/api/arena/matchup/route.ts
+++ b/app/api/arena/matchup/route.ts
@@ -31,6 +31,7 @@ import {
 import { enqueueArenaMatchupShownDurably } from "@/lib/arena/shownJobs";
 import { ServerTiming } from "@/lib/serverTiming";
 import { trackServerEventInBackground } from "@/lib/analytics.server";
+import { resolveModelDisplayName } from "@/lib/ai/modelCatalog";
 
 export const runtime = "nodejs";
 
@@ -931,7 +932,7 @@ export async function GET(req: Request) {
       model: {
         key: leftModel.key,
         provider: leftModel.provider,
-        displayName: leftModel.displayName,
+        displayName: resolveModelDisplayName(leftModel.key, leftModel.displayName),
         eloRating: leftModel.eloRating,
       },
       build:
@@ -957,7 +958,7 @@ export async function GET(req: Request) {
       model: {
         key: rightModel.key,
         provider: rightModel.provider,
-        displayName: rightModel.displayName,
+        displayName: resolveModelDisplayName(rightModel.key, rightModel.displayName),
         eloRating: rightModel.eloRating,
       },
       build:

--- a/app/api/leaderboard/route.ts
+++ b/app/api/leaderboard/route.ts
@@ -7,6 +7,7 @@ import { confidenceFromRd, conservativeScore, stabilityTier } from "@/lib/arena/
 import { summarizeArenaVotes } from "@/lib/arena/voteMath";
 import { getArenaEligiblePromptIds } from "@/lib/arena/eligibility";
 import { getArenaPairCoverageByKey } from "@/lib/arena/coverage";
+import { resolveModelDisplayName } from "@/lib/ai/modelCatalog";
 import { ServerTiming } from "@/lib/serverTiming";
 import {
   databaseUnavailableBody,
@@ -165,7 +166,7 @@ export async function GET() {
       return {
         key: m.key,
         provider: m.provider,
-        displayName: m.displayName,
+        displayName: resolveModelDisplayName(m.key, m.displayName),
         stability,
         eloRating: rawRating,
         ratingDeviation,

--- a/app/api/sandbox/benchmark/route.ts
+++ b/app/api/sandbox/benchmark/route.ts
@@ -11,6 +11,7 @@ import {
   isDatabaseUnavailableError,
 } from "@/lib/db/errors";
 import { prisma } from "@/lib/prisma";
+import { resolveModelDisplayName } from "@/lib/ai/modelCatalog";
 
 export const runtime = "nodejs";
 
@@ -183,7 +184,7 @@ export async function GET(req: Request) {
     const models: ModelOption[] = modelRows.map((m) => ({
       key: m.key,
       provider: m.provider,
-      displayName: m.displayName,
+      displayName: resolveModelDisplayName(m.key, m.displayName),
       eloRating: Number(m.eloRating),
     }));
 
@@ -381,7 +382,7 @@ export async function GET(req: Request) {
         model: {
           key: build.model.key,
           provider: build.model.provider,
-          displayName: build.model.displayName,
+          displayName: resolveModelDisplayName(build.model.key, build.model.displayName),
           eloRating: Number(build.model.eloRating),
         },
         metrics: {

--- a/components/leaderboard/Leaderboard.tsx
+++ b/components/leaderboard/Leaderboard.tsx
@@ -8,7 +8,11 @@ import { ErrorState } from "@/components/ErrorState";
 import { getConsistencyBand } from "@/lib/arena/consistencyBands";
 import { FetchError, fetchWithRetry } from "@/lib/fetchWithRetry";
 import { formatAge, readStale, writeStale } from "@/lib/staleCache";
-import { ModelBenchmarkDetails } from "@/components/leaderboard/ModelBenchmarkDetails";
+import {
+  ModelBenchmarkDetails,
+  ModelBenchmarkDetailsInline,
+  ModelBenchmarkDetailsTrigger,
+} from "@/components/leaderboard/ModelBenchmarkDetails";
 
 const LEADERBOARD_CACHE_KEY = "mb-leaderboard-v4";
 // accept cached data up to 10 min — older than that we prefer "loading…" over shipping stale rankings
@@ -188,6 +192,7 @@ export function Leaderboard() {
   const [reloadToken, setReloadToken] = useState(0);
   const [navigatingModelKey, setNavigatingModelKey] = useState<string | null>(null);
   const [showDetailed, setShowDetailed] = useState(false);
+  const [expandedMobileModelKey, setExpandedMobileModelKey] = useState<string | null>(null);
   const router = useRouter();
   const activeModelCount = data?.models.length ?? 0;
   const topModel = data?.models[0] ?? null;
@@ -452,7 +457,16 @@ export function Leaderboard() {
 	                          >
 	                            {m.displayName}
 	                          </button>
-	                          <ModelBenchmarkDetails modelKey={m.key} displayName={m.displayName} />
+	                          <ModelBenchmarkDetailsTrigger
+	                            displayName={m.displayName}
+	                            expanded={expandedMobileModelKey === m.key}
+	                            controlsId={`mobile-model-details-${m.key}`}
+	                            onToggle={() =>
+	                              setExpandedMobileModelKey((current) =>
+	                                current === m.key ? null : m.key,
+	                              )
+	                            }
+	                          />
 	                        </div>
 	                        <div className="mt-0.5 flex flex-wrap items-center gap-1.5">
 	                          <span className="truncate text-xs tracking-wide text-muted2">{m.provider}</span>
@@ -475,6 +489,13 @@ export function Leaderboard() {
                       </div>
                     </div>
                   </div>
+
+                  <ModelBenchmarkDetailsInline
+                    id={`mobile-model-details-${m.key}`}
+                    modelKey={m.key}
+                    displayName={m.displayName}
+                    open={expandedMobileModelKey === m.key}
+                  />
 
                   <div className="mt-2.5 flex flex-wrap items-center gap-1.5 font-mono text-[11px]">
                     <span

--- a/components/leaderboard/Leaderboard.tsx
+++ b/components/leaderboard/Leaderboard.tsx
@@ -428,12 +428,9 @@ export function Leaderboard() {
 	                <div
 	                  key={m.key}
 	                  className={`w-full rounded-2xl bg-gradient-to-b from-bg/62 to-bg/44 p-3 text-left ring-1 ring-border/70 transition ${
-                    navigatingModelKey === m.key
-                      ? "opacity-75"
-                      : "active:ring-accent/45 active:from-bg/72"
+                    navigatingModelKey === m.key ? "opacity-75" : ""
 	                  }`}
 	                  onMouseEnter={() => prefetchModel(m.key)}
-	                  onClick={() => navigateToModel(m.key)}
 	                >
 	                  <div className="flex items-start justify-between gap-3">
 	                    <div className="flex min-w-0 items-start gap-3">
@@ -682,8 +679,7 @@ export function Leaderboard() {
 	                    key={m.key}
 	                    data-tier={tier}
 	                    onMouseEnter={() => prefetchModel(m.key)}
-	                    onClick={() => navigateToModel(m.key)}
-                    className={`mb-leaderboard-row group mb-card-enter cursor-pointer ${
+                    className={`mb-leaderboard-row mb-card-enter ${
                       navigatingModelKey === m.key ? "opacity-75" : ""
                     }`}
                     style={{ animationDelay: `${Math.min(index, 10) * 34}ms` }}
@@ -700,7 +696,7 @@ export function Leaderboard() {
 	                          <div className="flex min-w-0 items-center gap-1.5">
 	                            <button
 	                              type="button"
-	                              className="min-w-0 truncate text-left font-medium text-fg transition-colors duration-200 group-hover:text-accent focus-visible:outline-none focus-visible:text-accent"
+	                              className="min-w-0 truncate text-left font-medium text-fg transition-colors duration-200 hover:text-accent focus-visible:outline-none focus-visible:text-accent"
 	                              aria-label={`Open ${m.displayName} profile`}
 	                              onFocus={() => prefetchModel(m.key)}
 	                              onClick={(event) => {

--- a/components/leaderboard/Leaderboard.tsx
+++ b/components/leaderboard/Leaderboard.tsx
@@ -8,8 +8,9 @@ import { ErrorState } from "@/components/ErrorState";
 import { getConsistencyBand } from "@/lib/arena/consistencyBands";
 import { FetchError, fetchWithRetry } from "@/lib/fetchWithRetry";
 import { formatAge, readStale, writeStale } from "@/lib/staleCache";
+import { ModelBenchmarkDetails } from "@/components/leaderboard/ModelBenchmarkDetails";
 
-const LEADERBOARD_CACHE_KEY = "mb-leaderboard-v3";
+const LEADERBOARD_CACHE_KEY = "mb-leaderboard-v4";
 // accept cached data up to 10 min — older than that we prefer "loading…" over shipping stale rankings
 const LEADERBOARD_STALE_MAX_AGE_MS = 10 * 60 * 1000;
 const LEADERBOARD_SLOW_THRESHOLD_MS = 5_000;
@@ -419,19 +420,16 @@ export function Leaderboard() {
 	              const coveragePercent = Math.round((m.promptCoverage ?? 0) * 100);
 	              const moveBadge = movementBadge(m);
 	              return (
-                <button
-                  key={m.key}
-                  type="button"
-                  className={`w-full rounded-2xl bg-gradient-to-b from-bg/62 to-bg/44 p-3 text-left ring-1 ring-border/70 transition ${
+	                <div
+	                  key={m.key}
+	                  className={`w-full rounded-2xl bg-gradient-to-b from-bg/62 to-bg/44 p-3 text-left ring-1 ring-border/70 transition ${
                     navigatingModelKey === m.key
                       ? "opacity-75"
                       : "active:ring-accent/45 active:from-bg/72"
-                  }`}
-                  onMouseEnter={() => prefetchModel(m.key)}
-                  onFocus={() => prefetchModel(m.key)}
-                  onClick={() => navigateToModel(m.key)}
-                  aria-label={`Open ${m.displayName} profile`}
-                >
+	                  }`}
+	                  onMouseEnter={() => prefetchModel(m.key)}
+	                  onClick={() => navigateToModel(m.key)}
+	                >
 	                  <div className="flex items-start justify-between gap-3">
 	                    <div className="flex min-w-0 items-start gap-3">
 	                      <div className="flex w-9 flex-col items-center gap-0.5 pt-0.5">
@@ -441,8 +439,20 @@ export function Leaderboard() {
 	                        <MovementMark badge={moveBadge} />
 	                      </div>
 	                      <div className="min-w-0">
-	                        <div className="mt-1.5 min-w-0 truncate text-[1rem] font-semibold tracking-tight text-fg">
-	                          {m.displayName}
+	                        <div className="mt-1.5 flex min-w-0 items-center gap-1.5">
+	                          <button
+	                            type="button"
+	                            className="min-w-0 truncate text-left text-[1rem] font-semibold tracking-tight text-fg focus-visible:outline-none focus-visible:text-accent"
+	                            aria-label={`Open ${m.displayName} profile`}
+	                            onFocus={() => prefetchModel(m.key)}
+	                            onClick={(event) => {
+	                              event.stopPropagation();
+	                              navigateToModel(m.key);
+	                            }}
+	                          >
+	                            {m.displayName}
+	                          </button>
+	                          <ModelBenchmarkDetails modelKey={m.key} displayName={m.displayName} />
 	                        </div>
 	                        <div className="mt-0.5 flex flex-wrap items-center gap-1.5">
 	                          <span className="truncate text-xs tracking-wide text-muted2">{m.provider}</span>
@@ -522,7 +532,7 @@ export function Leaderboard() {
                     <span>{voteSummary.totalVotes.toLocaleString()} votes</span>
                     <span>{m.bothBadCount.toLocaleString()} both bad</span>
                   </div>
-                </button>
+	                </div>
               );
             })}
             {!data ? (
@@ -647,20 +657,11 @@ export function Leaderboard() {
 	                const tier = index === 0 ? "champion" : index < 3 ? "top" : "base";
 	                const moveBadge = movementBadge(m);
 	                return (
-                  <tr
-                    key={m.key}
-                    role="link"
-                    tabIndex={0}
-                    data-tier={tier}
-                    aria-label={`Open ${m.displayName} profile`}
-                    onMouseEnter={() => prefetchModel(m.key)}
-                    onFocus={() => prefetchModel(m.key)}
-                    onClick={() => navigateToModel(m.key)}
-                    onKeyDown={(e) => {
-                      if (e.key !== "Enter" && e.key !== " ") return;
-                      e.preventDefault();
-                      navigateToModel(m.key);
-                    }}
+	                  <tr
+	                    key={m.key}
+	                    data-tier={tier}
+	                    onMouseEnter={() => prefetchModel(m.key)}
+	                    onClick={() => navigateToModel(m.key)}
                     className={`mb-leaderboard-row group mb-card-enter cursor-pointer ${
                       navigatingModelKey === m.key ? "opacity-75" : ""
                     }`}
@@ -675,8 +676,20 @@ export function Leaderboard() {
 	                          <MovementMark badge={moveBadge} />
 	                        </div>
 	                        <div className="min-w-0">
-	                          <div className="min-w-0 truncate font-medium text-fg transition-colors duration-200 group-hover:text-accent group-focus-visible:text-accent">
-	                            {m.displayName}
+	                          <div className="flex min-w-0 items-center gap-1.5">
+	                            <button
+	                              type="button"
+	                              className="min-w-0 truncate text-left font-medium text-fg transition-colors duration-200 group-hover:text-accent focus-visible:outline-none focus-visible:text-accent"
+	                              aria-label={`Open ${m.displayName} profile`}
+	                              onFocus={() => prefetchModel(m.key)}
+	                              onClick={(event) => {
+	                                event.stopPropagation();
+	                                navigateToModel(m.key);
+	                              }}
+	                            >
+	                              {m.displayName}
+	                            </button>
+	                            <ModelBenchmarkDetails modelKey={m.key} displayName={m.displayName} />
 	                          </div>
 	                          <div className="mt-0.5 flex flex-wrap items-center gap-1.5">
 	                            <span className="truncate text-xs tracking-wide text-muted2">{m.provider}</span>

--- a/components/leaderboard/ModelBenchmarkDetails.tsx
+++ b/components/leaderboard/ModelBenchmarkDetails.tsx
@@ -158,7 +158,6 @@ export function ModelBenchmarkDetailsTrigger({
         event.stopPropagation();
         onToggle();
       }}
-      onKeyDown={(event) => event.stopPropagation()}
     >
       <InfoIcon />
     </button>

--- a/components/leaderboard/ModelBenchmarkDetails.tsx
+++ b/components/leaderboard/ModelBenchmarkDetails.tsx
@@ -1,44 +1,187 @@
 "use client";
 
-import { useEffect, useId, useRef, useState } from "react";
+import { useCallback, useEffect, useId, useRef, useState } from "react";
 import { createPortal } from "react-dom";
+
 import {
   getModelBenchmarkProfile,
   type ModelBenchmarkProfile,
+  type ModelRunParameter,
 } from "@/lib/ai/modelBenchmarkProfiles";
+
+const UNTRACKED_RUN_NOTE = "This model was benchmarked before run statistics were tracked.";
+const POPOVER_WIDTH = 340;
+const VIEWPORT_GUTTER = 16;
+const POPOVER_GAP = 4;
+
+type DetailsPosition = {
+  arrowLeft: number;
+  left: number;
+  placement: "above" | "below";
+  top: number;
+  width: number;
+};
+
+type ModelBenchmarkDetailsProps = {
+  modelKey: string;
+  displayName: string;
+  className?: string;
+};
+
+type ModelBenchmarkDetailsTriggerProps = {
+  displayName: string;
+  expanded: boolean;
+  controlsId: string;
+  onToggle: () => void;
+  className?: string;
+};
+
+type ModelBenchmarkDetailsInlineProps = {
+  id: string;
+  modelKey: string;
+  displayName: string;
+  open: boolean;
+};
 
 function InfoIcon() {
   return (
     <svg
-      aria-hidden="true"
-      className="h-3.5 w-3.5"
-      viewBox="0 0 20 20"
+      className="h-[15px] w-[15px]"
+      viewBox="0 0 16 16"
       fill="none"
       stroke="currentColor"
-      strokeWidth="1.7"
+      strokeWidth="1.5"
       strokeLinecap="round"
-      strokeLinejoin="round"
+      aria-hidden="true"
     >
-      <circle cx="10" cy="10" r="7.25" />
-      <path d="M10 8.6v4.25" />
-      <path d="M10 6.25h.01" strokeWidth="2.25" />
+      <circle cx="8" cy="8" r="6.25" />
+      <path d="M8 7.25v3.5" />
+      <path d="M8 5.25h.01" strokeWidth="2" />
     </svg>
   );
 }
 
-function CloseIcon() {
+function resolveProfile(modelKey: string): ModelBenchmarkProfile {
   return (
-    <svg
-      aria-hidden="true"
-      className="h-4 w-4"
-      viewBox="0 0 16 16"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="1.8"
-      strokeLinecap="round"
+    getModelBenchmarkProfile(modelKey) ?? {
+      parameters: [],
+      note: UNTRACKED_RUN_NOTE,
+    }
+  );
+}
+
+function profileRows(profile: ModelBenchmarkProfile): ModelRunParameter[] {
+  const rows = [...profile.parameters];
+
+  if (profile.averageInferenceTime) {
+    rows.push({ label: "Avg. inference", value: profile.averageInferenceTime });
+  }
+  if (profile.totalCost) {
+    rows.push({ label: "Total cost", value: profile.totalCost });
+  }
+
+  return rows;
+}
+
+function DetailsContent({
+  modelKey,
+  displayName,
+  showHeader,
+}: {
+  modelKey: string;
+  displayName: string;
+  showHeader: boolean;
+}) {
+  const profile = resolveProfile(modelKey);
+  const rows = profileRows(profile);
+
+  return (
+    <>
+      {showHeader ? (
+        <div className="flex min-w-0 items-baseline justify-between gap-3">
+          <h2 className="min-w-0 truncate text-sm font-semibold tracking-tight text-fg">
+            {displayName}
+          </h2>
+          {profile.sourceRelease ? (
+            <span className="shrink-0 font-mono text-[10px] text-muted2">
+              v{profile.sourceRelease.replace(/^v/, "")}
+            </span>
+          ) : null}
+        </div>
+      ) : null}
+
+      {rows.length > 0 ? (
+        <dl
+          className={`${showHeader ? "mt-3" : ""} divide-y divide-border/60 border-y border-border/70`}
+        >
+          {rows.map((row) => (
+            <div
+              key={row.label}
+              className="grid grid-cols-[minmax(0,1fr)_minmax(0,1.35fr)] gap-4 py-2.5 text-xs"
+            >
+              <dt className="text-muted2">{row.label}</dt>
+              <dd className="text-right font-medium tabular-nums text-fg/95 [overflow-wrap:anywhere]">
+                {row.value}
+              </dd>
+            </div>
+          ))}
+        </dl>
+      ) : null}
+
+      {profile.note ? (
+        <p
+          className={`${rows.length > 0 || showHeader ? "mt-3" : ""} text-xs leading-relaxed text-muted`}
+        >
+          {profile.note}
+        </p>
+      ) : null}
+
+    </>
+  );
+}
+
+export function ModelBenchmarkDetailsTrigger({
+  displayName,
+  expanded,
+  controlsId,
+  onToggle,
+  className = "",
+}: ModelBenchmarkDetailsTriggerProps) {
+  return (
+    <button
+      type="button"
+      className={`relative inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-sm text-muted2 transition-colors before:absolute before:-inset-y-2.5 before:-left-1 before:-right-4 before:content-[''] hover:text-fg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60 focus-visible:ring-offset-2 focus-visible:ring-offset-bg ${className}`}
+      aria-label={`View ${displayName} run details`}
+      aria-expanded={expanded}
+      aria-controls={controlsId}
+      onClick={(event) => {
+        event.stopPropagation();
+        onToggle();
+      }}
+      onKeyDown={(event) => event.stopPropagation()}
     >
-      <path d="m4 4 8 8M12 4l-8 8" />
-    </svg>
+      <InfoIcon />
+    </button>
+  );
+}
+
+export function ModelBenchmarkDetailsInline({
+  id,
+  modelKey,
+  displayName,
+  open,
+}: ModelBenchmarkDetailsInlineProps) {
+  return (
+    <div
+      id={id}
+      role="region"
+      aria-label={`${displayName} run details`}
+      hidden={!open}
+      className="mt-3 border-t border-border/70 pt-3"
+      onClick={(event) => event.stopPropagation()}
+    >
+      <DetailsContent modelKey={modelKey} displayName={displayName} showHeader={false} />
+    </div>
   );
 }
 
@@ -46,178 +189,129 @@ export function ModelBenchmarkDetails({
   modelKey,
   displayName,
   className = "",
-}: {
-  modelKey: string;
-  displayName: string;
-  className?: string;
-}) {
-  const recordedProfile = getModelBenchmarkProfile(modelKey);
-  const profile: ModelBenchmarkProfile = recordedProfile ?? {
-    parameters: [],
-    note: "This model was benchmarked before run statistics were tracked.",
-  };
+}: ModelBenchmarkDetailsProps) {
   const [open, setOpen] = useState(false);
-  const titleId = useId();
-  const triggerRef = useRef<HTMLButtonElement>(null);
-  const closeRef = useRef<HTMLButtonElement>(null);
-  const dialogRef = useRef<HTMLElement>(null);
-  const wasOpenRef = useRef(false);
+  const [position, setPosition] = useState<DetailsPosition | null>(null);
+  const triggerRef = useRef<HTMLSpanElement>(null);
+  const panelRef = useRef<HTMLDivElement>(null);
+  const detailsId = useId();
+
+  const updatePosition = useCallback(() => {
+    const trigger = triggerRef.current?.getBoundingClientRect();
+    if (!trigger) return;
+
+    const width = Math.min(POPOVER_WIDTH, window.innerWidth - VIEWPORT_GUTTER * 2);
+    const panelHeight = panelRef.current?.offsetHeight ?? 300;
+    const spaceBelow = window.innerHeight - trigger.bottom - VIEWPORT_GUTTER;
+    const placeAbove = spaceBelow < panelHeight + POPOVER_GAP && trigger.top > spaceBelow;
+    const preferredTop = placeAbove
+      ? trigger.top - panelHeight - POPOVER_GAP
+      : trigger.bottom + POPOVER_GAP;
+    const top = Math.max(
+      VIEWPORT_GUTTER,
+      Math.min(preferredTop, window.innerHeight - panelHeight - VIEWPORT_GUTTER),
+    );
+    const left = Math.max(
+      VIEWPORT_GUTTER,
+      Math.min(trigger.left - 12, window.innerWidth - width - VIEWPORT_GUTTER),
+    );
+    const arrowLeft = Math.max(
+      12,
+      Math.min(trigger.left + trigger.width / 2 - left, width - 12),
+    );
+
+    setPosition({
+      arrowLeft,
+      left,
+      placement: placeAbove ? "above" : "below",
+      top,
+      width,
+    });
+  }, []);
+
+  useEffect(() => {
+    setOpen(false);
+  }, [modelKey]);
 
   useEffect(() => {
     if (!open) return;
 
-    const onKeyDown = (event: KeyboardEvent) => {
-      if (event.key === "Escape") {
-        event.preventDefault();
-        setOpen(false);
-        return;
-      }
-      if (event.key !== "Tab") return;
-
-      const focusable = Array.from(
-        dialogRef.current?.querySelectorAll<HTMLElement>(
-          'button:not([disabled]), [href], [tabindex]:not([tabindex="-1"])',
-        ) ?? [],
-      );
-      if (focusable.length === 0) return;
-
-      const first = focusable[0];
-      const last = focusable[focusable.length - 1];
-      if (event.shiftKey && document.activeElement === first) {
-        event.preventDefault();
-        last.focus();
-      } else if (!event.shiftKey && document.activeElement === last) {
-        event.preventDefault();
-        first.focus();
-      }
+    const frame = window.requestAnimationFrame(updatePosition);
+    const handlePointerDown = (event: PointerEvent) => {
+      const target = event.target as Node;
+      if (panelRef.current?.contains(target) || triggerRef.current?.contains(target)) return;
+      setOpen(false);
     };
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") setOpen(false);
+    };
+    const handleScroll = (event: Event) => {
+      const target = event.target;
+      if (target instanceof Node && panelRef.current?.contains(target)) return;
+      setOpen(false);
+    };
+    const handleResize = () => setOpen(false);
 
-    document.addEventListener("keydown", onKeyDown);
-    closeRef.current?.focus();
-    return () => document.removeEventListener("keydown", onKeyDown);
-  }, [open]);
+    document.addEventListener("pointerdown", handlePointerDown);
+    document.addEventListener("keydown", handleKeyDown);
+    document.addEventListener("scroll", handleScroll, true);
+    window.addEventListener("resize", handleResize);
 
-  useEffect(() => {
-    if (open) {
-      wasOpenRef.current = true;
-      return;
-    }
-    if (!wasOpenRef.current) return;
-    wasOpenRef.current = false;
-    triggerRef.current?.focus({ preventScroll: true });
-  }, [open]);
-
-  const hasRunStats = Boolean(profile.averageInferenceTime || profile.totalCost);
+    return () => {
+      window.cancelAnimationFrame(frame);
+      document.removeEventListener("pointerdown", handlePointerDown);
+      document.removeEventListener("keydown", handleKeyDown);
+      document.removeEventListener("scroll", handleScroll, true);
+      window.removeEventListener("resize", handleResize);
+    };
+  }, [open, updatePosition]);
 
   return (
-    <>
-      <button
-        ref={triggerRef}
-        type="button"
-        className={`inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-full text-muted2 ring-1 ring-border/80 transition hover:bg-accent/10 hover:text-accent hover:ring-accent/35 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60 ${className}`}
-        aria-label={`View ${displayName} run details`}
-        aria-expanded={open}
-        aria-haspopup="dialog"
-        onClick={(event) => {
-          event.stopPropagation();
-          setOpen(true);
+    <span ref={triggerRef} className={`inline-flex ${className}`}>
+      <ModelBenchmarkDetailsTrigger
+        displayName={displayName}
+        expanded={open}
+        controlsId={detailsId}
+        onToggle={() => {
+          if (!open) updatePosition();
+          setOpen((current) => !current);
         }}
-        onKeyDown={(event) => event.stopPropagation()}
-      >
-        <InfoIcon />
-      </button>
-
+      />
       {open && typeof document !== "undefined"
         ? createPortal(
             <div
-              className="fixed inset-0 z-[120] flex items-end justify-center bg-bg/70 p-3 backdrop-blur-sm sm:items-center sm:p-6"
-              onMouseDown={() => setOpen(false)}
+              ref={panelRef}
+              id={detailsId}
+              role="region"
+              aria-label={`${displayName} run details`}
+              className={`fixed z-30 overflow-visible rounded-lg border border-border bg-card shadow-[0_18px_45px_-30px_rgba(0,0,0,0.65)] ${
+                position ? "opacity-100" : "pointer-events-none opacity-0"
+              }`}
+              style={{
+                left: position?.left ?? VIEWPORT_GUTTER,
+                top: position?.top ?? VIEWPORT_GUTTER,
+                width: position?.width ?? POPOVER_WIDTH,
+              }}
+              onClick={(event) => event.stopPropagation()}
             >
-              <section
-                ref={dialogRef}
-                role="dialog"
-                aria-modal="true"
-                aria-labelledby={titleId}
-                className="max-h-[calc(100dvh-1.5rem)] w-full max-w-md overflow-y-auto rounded-2xl bg-card shadow-soft ring-1 ring-border"
-                onMouseDown={(event) => event.stopPropagation()}
-              >
-                <div className="flex items-start justify-between gap-4 border-b border-border/80 px-4 py-4 sm:px-5">
-                  <div className="min-w-0">
-                    <div className="mb-eyebrow">Run details</div>
-                    <h2 id={titleId} className="mt-1 truncate text-lg font-semibold tracking-tight text-fg">
-                      {displayName}
-                    </h2>
-                  </div>
-                  <button
-                    ref={closeRef}
-                    type="button"
-                    className="mb-btn mb-btn-ghost h-8 w-8 shrink-0 rounded-full p-0"
-                    aria-label="Close run details"
-                    onClick={() => setOpen(false)}
-                  >
-                    <CloseIcon />
-                  </button>
-                </div>
-
-                <div className="space-y-5 px-4 py-4 sm:px-5 sm:py-5">
-                  {profile.parameters.length > 0 ? (
-                    <div>
-                      <h3 className="mb-eyebrow mb-2">Run setup</h3>
-                      <dl className="divide-y divide-border/60 border-y border-border/60">
-                        {profile.parameters.map((parameter) => (
-                          <div
-                            key={parameter.label}
-                            className="flex items-baseline justify-between gap-5 py-2.5 text-sm"
-                          >
-                            <dt className="text-muted">{parameter.label}</dt>
-                            <dd className="text-right font-medium text-fg">{parameter.value}</dd>
-                          </div>
-                        ))}
-                      </dl>
-                    </div>
-                  ) : null}
-
-                  {hasRunStats ? (
-                    <div>
-                      <h3 className="mb-eyebrow mb-2">Benchmark run</h3>
-                      <dl className="grid grid-cols-2 gap-px overflow-hidden rounded-xl bg-border/70 ring-1 ring-border/70">
-                        <div className="bg-bg/70 px-3 py-3">
-                          <dt className="text-[11px] text-muted">Avg. inference</dt>
-                          <dd className="mt-1 font-mono text-sm font-semibold text-fg">
-                            {profile.averageInferenceTime ?? "—"}
-                          </dd>
-                        </div>
-                        <div className="bg-bg/70 px-3 py-3">
-                          <dt className="text-[11px] text-muted">Total cost</dt>
-                          <dd className="mt-1 font-mono text-sm font-semibold text-fg">
-                            {profile.totalCost ?? "—"}
-                          </dd>
-                        </div>
-                      </dl>
-                      <p className="mt-2 text-[11px] text-muted2">
-                        {profile.buildCount
-                          ? `Reported for a ${profile.buildCount}-build benchmark run.`
-                          : "Reported for this benchmark run."}
-                      </p>
-                    </div>
-                  ) : null}
-
-                  {profile.note ? (
-                    <p className="rounded-xl bg-warn/10 px-3 py-2.5 text-xs leading-relaxed text-warn ring-1 ring-warn/20">
-                      {profile.note}
-                    </p>
-                  ) : null}
-                  <p className="border-t border-border/60 pt-3 text-[11px] leading-relaxed text-muted2">
-                    Ratings reflect the current prompt set
-                    {profile.parameters.length > 0 ? " and run configuration shown" : ""}.
-                    {profile.sourceRelease ? ` Source: MineBench ${profile.sourceRelease}.` : ""}
-                  </p>
-                </div>
-              </section>
+              {position ? (
+                <span
+                  aria-hidden="true"
+                  className={`pointer-events-none absolute h-2.5 w-2.5 -translate-x-1/2 rotate-45 bg-card ${
+                    position.placement === "above"
+                      ? "-bottom-[5px] border-b border-r border-border"
+                      : "-top-[5px] border-l border-t border-border"
+                  }`}
+                  style={{ left: position.arrowLeft }}
+                />
+              ) : null}
+              <div className="max-h-[calc(100dvh-2rem)] overflow-y-auto overscroll-contain rounded-[inherit] p-4">
+                <DetailsContent modelKey={modelKey} displayName={displayName} showHeader />
+              </div>
             </div>,
             document.body,
           )
         : null}
-    </>
+    </span>
   );
 }

--- a/components/leaderboard/ModelBenchmarkDetails.tsx
+++ b/components/leaderboard/ModelBenchmarkDetails.tsx
@@ -1,0 +1,223 @@
+"use client";
+
+import { useEffect, useId, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import {
+  getModelBenchmarkProfile,
+  type ModelBenchmarkProfile,
+} from "@/lib/ai/modelBenchmarkProfiles";
+
+function InfoIcon() {
+  return (
+    <svg
+      aria-hidden="true"
+      className="h-3.5 w-3.5"
+      viewBox="0 0 20 20"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.7"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <circle cx="10" cy="10" r="7.25" />
+      <path d="M10 8.6v4.25" />
+      <path d="M10 6.25h.01" strokeWidth="2.25" />
+    </svg>
+  );
+}
+
+function CloseIcon() {
+  return (
+    <svg
+      aria-hidden="true"
+      className="h-4 w-4"
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.8"
+      strokeLinecap="round"
+    >
+      <path d="m4 4 8 8M12 4l-8 8" />
+    </svg>
+  );
+}
+
+export function ModelBenchmarkDetails({
+  modelKey,
+  displayName,
+  className = "",
+}: {
+  modelKey: string;
+  displayName: string;
+  className?: string;
+}) {
+  const recordedProfile = getModelBenchmarkProfile(modelKey);
+  const profile: ModelBenchmarkProfile = recordedProfile ?? {
+    parameters: [],
+    note: "This model was benchmarked before run statistics were tracked.",
+  };
+  const [open, setOpen] = useState(false);
+  const titleId = useId();
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const closeRef = useRef<HTMLButtonElement>(null);
+  const dialogRef = useRef<HTMLElement>(null);
+  const wasOpenRef = useRef(false);
+
+  useEffect(() => {
+    if (!open) return;
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        setOpen(false);
+        return;
+      }
+      if (event.key !== "Tab") return;
+
+      const focusable = Array.from(
+        dialogRef.current?.querySelectorAll<HTMLElement>(
+          'button:not([disabled]), [href], [tabindex]:not([tabindex="-1"])',
+        ) ?? [],
+      );
+      if (focusable.length === 0) return;
+
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      if (event.shiftKey && document.activeElement === first) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && document.activeElement === last) {
+        event.preventDefault();
+        first.focus();
+      }
+    };
+
+    document.addEventListener("keydown", onKeyDown);
+    closeRef.current?.focus();
+    return () => document.removeEventListener("keydown", onKeyDown);
+  }, [open]);
+
+  useEffect(() => {
+    if (open) {
+      wasOpenRef.current = true;
+      return;
+    }
+    if (!wasOpenRef.current) return;
+    wasOpenRef.current = false;
+    triggerRef.current?.focus({ preventScroll: true });
+  }, [open]);
+
+  const hasRunStats = Boolean(profile.averageInferenceTime || profile.totalCost);
+
+  return (
+    <>
+      <button
+        ref={triggerRef}
+        type="button"
+        className={`inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-full text-muted2 ring-1 ring-border/80 transition hover:bg-accent/10 hover:text-accent hover:ring-accent/35 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60 ${className}`}
+        aria-label={`View ${displayName} run details`}
+        aria-expanded={open}
+        aria-haspopup="dialog"
+        onClick={(event) => {
+          event.stopPropagation();
+          setOpen(true);
+        }}
+        onKeyDown={(event) => event.stopPropagation()}
+      >
+        <InfoIcon />
+      </button>
+
+      {open && typeof document !== "undefined"
+        ? createPortal(
+            <div
+              className="fixed inset-0 z-[120] flex items-end justify-center bg-bg/70 p-3 backdrop-blur-sm sm:items-center sm:p-6"
+              onMouseDown={() => setOpen(false)}
+            >
+              <section
+                ref={dialogRef}
+                role="dialog"
+                aria-modal="true"
+                aria-labelledby={titleId}
+                className="max-h-[calc(100dvh-1.5rem)] w-full max-w-md overflow-y-auto rounded-2xl bg-card shadow-soft ring-1 ring-border"
+                onMouseDown={(event) => event.stopPropagation()}
+              >
+                <div className="flex items-start justify-between gap-4 border-b border-border/80 px-4 py-4 sm:px-5">
+                  <div className="min-w-0">
+                    <div className="mb-eyebrow">Run details</div>
+                    <h2 id={titleId} className="mt-1 truncate text-lg font-semibold tracking-tight text-fg">
+                      {displayName}
+                    </h2>
+                  </div>
+                  <button
+                    ref={closeRef}
+                    type="button"
+                    className="mb-btn mb-btn-ghost h-8 w-8 shrink-0 rounded-full p-0"
+                    aria-label="Close run details"
+                    onClick={() => setOpen(false)}
+                  >
+                    <CloseIcon />
+                  </button>
+                </div>
+
+                <div className="space-y-5 px-4 py-4 sm:px-5 sm:py-5">
+                  {profile.parameters.length > 0 ? (
+                    <div>
+                      <h3 className="mb-eyebrow mb-2">Run setup</h3>
+                      <dl className="divide-y divide-border/60 border-y border-border/60">
+                        {profile.parameters.map((parameter) => (
+                          <div
+                            key={parameter.label}
+                            className="flex items-baseline justify-between gap-5 py-2.5 text-sm"
+                          >
+                            <dt className="text-muted">{parameter.label}</dt>
+                            <dd className="text-right font-medium text-fg">{parameter.value}</dd>
+                          </div>
+                        ))}
+                      </dl>
+                    </div>
+                  ) : null}
+
+                  {hasRunStats ? (
+                    <div>
+                      <h3 className="mb-eyebrow mb-2">Benchmark run</h3>
+                      <dl className="grid grid-cols-2 gap-px overflow-hidden rounded-xl bg-border/70 ring-1 ring-border/70">
+                        <div className="bg-bg/70 px-3 py-3">
+                          <dt className="text-[11px] text-muted">Avg. inference</dt>
+                          <dd className="mt-1 font-mono text-sm font-semibold text-fg">
+                            {profile.averageInferenceTime ?? "—"}
+                          </dd>
+                        </div>
+                        <div className="bg-bg/70 px-3 py-3">
+                          <dt className="text-[11px] text-muted">Total cost</dt>
+                          <dd className="mt-1 font-mono text-sm font-semibold text-fg">
+                            {profile.totalCost ?? "—"}
+                          </dd>
+                        </div>
+                      </dl>
+                      <p className="mt-2 text-[11px] text-muted2">
+                        {profile.buildCount
+                          ? `Reported for a ${profile.buildCount}-build benchmark run.`
+                          : "Reported for this benchmark run."}
+                      </p>
+                    </div>
+                  ) : null}
+
+                  {profile.note ? (
+                    <p className="rounded-xl bg-warn/10 px-3 py-2.5 text-xs leading-relaxed text-warn ring-1 ring-warn/20">
+                      {profile.note}
+                    </p>
+                  ) : null}
+                  <p className="border-t border-border/60 pt-3 text-[11px] leading-relaxed text-muted2">
+                    Ratings reflect the current prompt set
+                    {profile.parameters.length > 0 ? " and run configuration shown" : ""}.
+                    {profile.sourceRelease ? ` Source: MineBench ${profile.sourceRelease}.` : ""}
+                  </p>
+                </div>
+              </section>
+            </div>,
+            document.body,
+          )
+        : null}
+    </>
+  );
+}

--- a/components/leaderboard/ModelDetail.tsx
+++ b/components/leaderboard/ModelDetail.tsx
@@ -37,6 +37,7 @@ import {
   type SandboxGifExportTarget,
 } from "@/components/sandbox/SandboxGifExportButton";
 import { getConsistencyBand, getConsistencyLabel } from "@/lib/arena/consistencyBands";
+import { ModelBenchmarkDetails } from "@/components/leaderboard/ModelBenchmarkDetails";
 
 const CHART_WIDTH = 900;
 const CHART_HEIGHT = 304;
@@ -1441,10 +1442,17 @@ export function ModelDetail({ data }: { data: ModelDetailStats }) {
                pushes to the far right at the name's baseline so the dead
                space next to the display-type is used; on mobile it wraps
                underneath. */}
-            <div className="flex flex-wrap items-end justify-between gap-x-8 gap-y-3">
-              <h1 className="max-w-[18ch] font-display text-[2.1rem] font-semibold leading-[0.96] tracking-[-0.02em] text-fg sm:text-[3.2rem]">
-                {data.model.displayName}
-              </h1>
+	            <div className="flex flex-wrap items-end justify-between gap-x-8 gap-y-3">
+	              <div className="flex max-w-full items-end gap-2.5">
+	                <h1 className="max-w-[18ch] font-display text-[2.1rem] font-semibold leading-[0.96] tracking-[-0.02em] text-fg sm:text-[3.2rem]">
+	                  {data.model.displayName}
+	                </h1>
+	                <ModelBenchmarkDetails
+	                  modelKey={data.model.key}
+	                  displayName={data.model.displayName}
+	                  className="mb-0.5 sm:mb-1"
+	                />
+	              </div>
               {/* Colorized meta — stability takes its colored dot+word, the
                  record W–L–D becomes three tinted tokens so you can read
                  the result at a glance instead of parsing one gray string. */}

--- a/lib/ai/modelBenchmarkProfiles.ts
+++ b/lib/ai/modelBenchmarkProfiles.ts
@@ -1,0 +1,181 @@
+import type { ModelKey } from "@/lib/ai/modelCatalog";
+
+export type ModelRunParameter = {
+  label: string;
+  value: string;
+};
+
+export type ModelBenchmarkProfile = {
+  sourceRelease?: string;
+  parameters: readonly ModelRunParameter[];
+  averageInferenceTime?: string;
+  totalCost?: string;
+  buildCount?: number;
+  note?: string;
+};
+
+export const MODEL_BENCHMARK_PROFILES: Partial<Record<ModelKey, ModelBenchmarkProfile>> = {
+  openai_gpt_5_6_sol: {
+    sourceRelease: "3.9.0",
+    parameters: [
+      { label: "Reasoning mode", value: "Pro" },
+      { label: "Reasoning effort", value: "Max" },
+      { label: "Text verbosity", value: "High" },
+      { label: "Combined reasoning/output cap", value: "128,000 tokens" },
+    ],
+    averageInferenceTime: "25m 16s (1516.2s)",
+    totalCost: "$710.82",
+    buildCount: 15,
+  },
+  xai_grok_4_5: {
+    sourceRelease: "3.9.0",
+    parameters: [
+      { label: "Reasoning effort", value: "High" },
+      { label: "Requested output budget", value: "500,000 tokens" },
+      { label: "Accepted output budget", value: "262,144 tokens" },
+    ],
+    averageInferenceTime: "1m 48s (108.2s)",
+    totalCost: "$1.69",
+    buildCount: 15,
+  },
+  zai_glm_5_2: {
+    sourceRelease: "3.8.0",
+    parameters: [
+      { label: "Reasoning effort", value: "XHigh → High" },
+      { label: "Output cap", value: "131,072 tokens" },
+    ],
+    averageInferenceTime: "6m 21s (381.1s)",
+    totalCost: "$4.46",
+    buildCount: 15,
+  },
+  anthropic_claude_sonnet_5: {
+    sourceRelease: "3.8.0",
+    parameters: [
+      { label: "Thinking", value: "Adaptive" },
+      { label: "Reasoning effort", value: "XHigh" },
+      { label: "Output cap", value: "128,000 tokens" },
+    ],
+    averageInferenceTime: "31m 3s (1863.1s)",
+    totalCost: "$94.17",
+    buildCount: 15,
+  },
+  openai_gpt_4_5_web_harness: {
+    sourceRelease: "3.8.0",
+    parameters: [{ label: "Source", value: "ChatGPT web harness" }],
+    note: "Imported from the web harness; not directly comparable to API-generated runs.",
+  },
+  anthropic_claude_fable_5: {
+    sourceRelease: "3.7.0",
+    parameters: [
+      { label: "Thinking", value: "Adaptive" },
+      { label: "Reasoning effort", value: "Max" },
+      { label: "Sampling", value: "Provider default" },
+      { label: "Output cap", value: "128,000 tokens" },
+    ],
+    averageInferenceTime: "18m 4s (1084.4s)",
+    totalCost: "$54.93",
+    buildCount: 15,
+  },
+  anthropic_claude_4_8_opus: {
+    sourceRelease: "3.6.0",
+    parameters: [
+      { label: "Thinking", value: "Adaptive" },
+      { label: "Reasoning effort", value: "Max" },
+      { label: "Output cap", value: "128,000 tokens" },
+    ],
+    averageInferenceTime: "24m 48s (1487.9s)",
+    totalCost: "$41.52",
+    buildCount: 15,
+  },
+  gemini_3_5_flash: {
+    sourceRelease: "3.6.0",
+    parameters: [
+      { label: "Thinking level", value: "High" },
+      { label: "Output cap", value: "65,536 tokens" },
+    ],
+    averageInferenceTime: "1m 54s (114.1s)",
+    totalCost: "$12.90",
+    buildCount: 15,
+  },
+  xai_grok_4_3: {
+    sourceRelease: "3.4.0",
+    parameters: [
+      { label: "Reasoning", value: "Automatic" },
+      { label: "Requested output budget", value: "1,000,000 tokens" },
+      { label: "Fallback output budget", value: "983,040 tokens" },
+    ],
+    averageInferenceTime: "3m 43s (223.1s)",
+    totalCost: "$0.87",
+  },
+  xai_grok_4_20: {
+    sourceRelease: "v3.0.0",
+    parameters: [{ label: "Reasoning", value: "Thinking enabled" }],
+    averageInferenceTime: "~2m 29s",
+    totalCost: "$18.44",
+    buildCount: 15,
+  },
+  openai_gpt_5_5: {
+    sourceRelease: "3.3.2",
+    parameters: [
+      { label: "Reasoning effort", value: "Max" },
+      { label: "Text verbosity", value: "High" },
+      { label: "Output cap", value: "128,000 tokens" },
+    ],
+    averageInferenceTime: "10m 24s (624.0s)",
+    totalCost: "$19.984",
+  },
+  openai_gpt_5_5_pro: {
+    sourceRelease: "3.3.2",
+    parameters: [
+      { label: "Reasoning effort", value: "Max" },
+      { label: "Text verbosity", value: "High" },
+      { label: "Output cap", value: "128,000 tokens" },
+    ],
+    averageInferenceTime: "21m 23s (1283.3s)",
+    totalCost: "$223.889",
+  },
+  deepseek_v4_pro: {
+    sourceRelease: "3.3.2",
+    parameters: [],
+    totalCost: "$3.92",
+    note: "Run parameters and average inference time were not recorded for this model.",
+  },
+  anthropic_claude_4_7_opus: {
+    sourceRelease: "v3.0.0",
+    parameters: [{ label: "Reasoning effort", value: "Max" }],
+    totalCost: "~$275",
+    note: "Average inference time was not recorded for this model.",
+  },
+  zai_glm_5_1: {
+    sourceRelease: "v3.0.0",
+    parameters: [
+      { label: "Reasoning", value: "Thinking enabled" },
+      { label: "Output cap", value: "131,072 tokens" },
+    ],
+    averageInferenceTime: "~17m 26s",
+    totalCost: "$4.18",
+    buildCount: 15,
+  },
+  moonshot_kimi_k2_6: {
+    sourceRelease: "v3.0.0",
+    parameters: [{ label: "Reasoning", value: "Thinking enabled" }],
+    averageInferenceTime: "~43m",
+    totalCost: "$2.35",
+    buildCount: 15,
+  },
+  moonshot_kimi_k3: {
+    sourceRelease: "3.10.0 draft",
+    parameters: [
+      { label: "Reasoning effort", value: "Max" },
+      { label: "Structured output", value: "Strict" },
+      { label: "Completion ceiling", value: "1,048,576 tokens" },
+    ],
+    averageInferenceTime: "32m 46s (1966.0s)",
+    totalCost: "$12.70",
+    buildCount: 15,
+  },
+};
+
+export function getModelBenchmarkProfile(modelKey: string): ModelBenchmarkProfile | null {
+  return MODEL_BENCHMARK_PROFILES[modelKey as ModelKey] ?? null;
+}

--- a/lib/ai/modelBenchmarkProfiles.ts
+++ b/lib/ai/modelBenchmarkProfiles.ts
@@ -23,7 +23,7 @@ export const MODEL_BENCHMARK_PROFILES: Partial<Record<ModelKey, ModelBenchmarkPr
       { label: "Text verbosity", value: "High" },
       { label: "Combined reasoning/output cap", value: "128,000 tokens" },
     ],
-    averageInferenceTime: "25m 16s (1516.2s)",
+    averageInferenceTime: "25m 16.2s (1,516.2s)",
     totalCost: "$710.82",
     buildCount: 15,
   },
@@ -72,7 +72,7 @@ export const MODEL_BENCHMARK_PROFILES: Partial<Record<ModelKey, ModelBenchmarkPr
       { label: "Sampling", value: "Provider default" },
       { label: "Output cap", value: "128,000 tokens" },
     ],
-    averageInferenceTime: "18m 4s (1084.4s)",
+    averageInferenceTime: "18m 04.4s (1,084.4s)",
     totalCost: "$54.93",
     buildCount: 15,
   },
@@ -83,7 +83,7 @@ export const MODEL_BENCHMARK_PROFILES: Partial<Record<ModelKey, ModelBenchmarkPr
       { label: "Reasoning effort", value: "Max" },
       { label: "Output cap", value: "128,000 tokens" },
     ],
-    averageInferenceTime: "24m 48s (1487.9s)",
+    averageInferenceTime: "24m 47.9s (1,487.9s)",
     totalCost: "$41.52",
     buildCount: 15,
   },
@@ -121,8 +121,8 @@ export const MODEL_BENCHMARK_PROFILES: Partial<Record<ModelKey, ModelBenchmarkPr
       { label: "Text verbosity", value: "High" },
       { label: "Output cap", value: "128,000 tokens" },
     ],
-    averageInferenceTime: "10m 24s (624.0s)",
-    totalCost: "$19.984",
+    averageInferenceTime: "10m 24s (624s)",
+    totalCost: "$19.98",
   },
   openai_gpt_5_5_pro: {
     sourceRelease: "3.3.2",
@@ -131,8 +131,21 @@ export const MODEL_BENCHMARK_PROFILES: Partial<Record<ModelKey, ModelBenchmarkPr
       { label: "Text verbosity", value: "High" },
       { label: "Output cap", value: "128,000 tokens" },
     ],
-    averageInferenceTime: "21m 23s (1283.3s)",
-    totalCost: "$223.889",
+    averageInferenceTime: "21m 23.3s (1,283.3s)",
+    totalCost: "$223.90",
+  },
+  openai_gpt_5_4: {
+    parameters: [],
+    totalCost: "~$25",
+  },
+  openai_gpt_5_4_pro: {
+    parameters: [],
+    averageInferenceTime: "56 minutes",
+    totalCost: "$435",
+  },
+  openai_gpt_5_3_codex: {
+    parameters: [{ label: "Reasoning effort", value: "XHigh" }],
+    totalCost: "Under approximately $5",
   },
   deepseek_v4_pro: {
     sourceRelease: "3.3.2",
@@ -143,8 +156,12 @@ export const MODEL_BENCHMARK_PROFILES: Partial<Record<ModelKey, ModelBenchmarkPr
   anthropic_claude_4_7_opus: {
     sourceRelease: "v3.0.0",
     parameters: [{ label: "Reasoning effort", value: "Max" }],
+    averageInferenceTime: "~43m 20s (~2,600s)",
     totalCost: "~$275",
-    note: "Average inference time was not recorded for this model.",
+  },
+  anthropic_claude_4_6_opus: {
+    parameters: [],
+    totalCost: "~$22",
   },
   zai_glm_5_1: {
     sourceRelease: "v3.0.0",
@@ -159,9 +176,7 @@ export const MODEL_BENCHMARK_PROFILES: Partial<Record<ModelKey, ModelBenchmarkPr
   moonshot_kimi_k2_6: {
     sourceRelease: "v3.0.0",
     parameters: [{ label: "Reasoning", value: "Thinking enabled" }],
-    averageInferenceTime: "~43m",
     totalCost: "$2.35",
-    buildCount: 15,
   },
   moonshot_kimi_k3: {
     sourceRelease: "3.10.0 draft",

--- a/lib/ai/modelCatalog.ts
+++ b/lib/ai/modelCatalog.ts
@@ -82,7 +82,7 @@ export const MODEL_CATALOG: ModelCatalogEntry[] = [
     key: "openai_gpt_5_6_sol",
     provider: "openai",
     modelId: "gpt-5.6-sol",
-    displayName: "GPT 5.6 Sol",
+    displayName: "GPT 5.6 Sol Pro",
     enabled: true,
     openRouterModelId: "openai/gpt-5.6-sol-pro",
   },
@@ -500,4 +500,8 @@ export function getModelByKey(key: ModelKey): ModelCatalogEntry {
   const found = MODEL_CATALOG.find((m) => m.key === key);
   if (!found) throw new Error(`Unknown model key: ${key}`);
   return found;
+}
+
+export function resolveModelDisplayName(key: string, fallback: string): string {
+  return MODEL_CATALOG.find((model) => model.key === key)?.displayName ?? fallback;
 }

--- a/lib/arena/stats.ts
+++ b/lib/arena/stats.ts
@@ -1,5 +1,6 @@
 import { Prisma } from "@prisma/client";
 import { prisma } from "@/lib/prisma";
+import { resolveModelDisplayName } from "@/lib/ai/modelCatalog";
 import { summarizeArenaVotes } from "@/lib/arena/voteMath";
 import { confidenceFromRd, conservativeScore, stabilityTier } from "@/lib/arena/rating";
 import {
@@ -1206,7 +1207,7 @@ async function queryModelDetailStats(modelKey: string): Promise<ModelDetailStats
   const opponents: ModelOpponentBreakdown[] = opponentRows
     .map((row) => ({
       key: row.key,
-      displayName: row.displayName,
+      displayName: resolveModelDisplayName(row.key, row.displayName),
       votes: toNumber(row.votes),
       averageScore: toNumber(row.averageScore),
       wins: toNumber(row.wins),
@@ -1241,7 +1242,7 @@ async function queryModelDetailStats(modelKey: string): Promise<ModelDetailStats
     model: {
       key: model.key,
       provider: model.provider,
-      displayName: model.displayName,
+      displayName: resolveModelDisplayName(model.key, model.displayName),
       eloRating: rawRating,
       ratingDeviation,
       rankScore,

--- a/tests/ui/model-benchmark-details.test.ts
+++ b/tests/ui/model-benchmark-details.test.ts
@@ -31,7 +31,8 @@ assert.ok(
 assert.ok(
   detailsSource.includes('document.addEventListener("pointerdown"') &&
     detailsSource.includes('event.key === "Escape"') &&
-    detailsSource.includes("event.stopPropagation()"),
+    detailsSource.includes("event.stopPropagation()") &&
+    !detailsSource.includes("onKeyDown={(event) => event.stopPropagation()}"),
   "the desktop popover should dismiss cleanly without activating its leaderboard row",
 );
 assert.ok(

--- a/tests/ui/model-benchmark-details.test.ts
+++ b/tests/ui/model-benchmark-details.test.ts
@@ -9,13 +9,49 @@ const leaderboardSource = readFileSync("components/leaderboard/Leaderboard.tsx",
 const modelDetailSource = readFileSync("components/leaderboard/ModelDetail.tsx", "utf8");
 
 assert.ok(
-  detailsSource.includes('aria-haspopup="dialog"') &&
+  detailsSource.includes("aria-expanded={expanded}") &&
+    detailsSource.includes("aria-controls={controlsId}") &&
     detailsSource.includes('aria-label={`View ${displayName} run details`}'),
-  "model details trigger should expose its dialog semantics and accessible name",
+  "model details trigger should expose its disclosure state and accessible name",
 );
 assert.ok(
-  detailsSource.includes('role="dialog"') && detailsSource.includes('aria-modal="true"'),
-  "model run details should render as an accessible dialog",
+  detailsSource.includes('role="region"') &&
+    !detailsSource.includes('aria-modal="true"') &&
+    !detailsSource.includes("backdrop-blur") &&
+    !detailsSource.includes("fixed inset-0"),
+  "model run details should use a nonmodal region without a full-screen backdrop",
+);
+assert.ok(
+  detailsSource.includes("h-6 w-6") &&
+    detailsSource.includes("before:-inset-y-2.5") &&
+    detailsSource.includes("before:-left-1 before:-right-4") &&
+    detailsSource.includes("h-[15px] w-[15px]"),
+  "the quiet info glyph should retain a 44px touch target without widening its layout box",
+);
+assert.ok(
+  detailsSource.includes('document.addEventListener("pointerdown"') &&
+    detailsSource.includes('event.key === "Escape"') &&
+    detailsSource.includes("event.stopPropagation()"),
+  "the desktop popover should dismiss cleanly without activating its leaderboard row",
+);
+assert.ok(
+  detailsSource.includes('document.addEventListener("scroll", handleScroll, true)') &&
+    detailsSource.includes("panelRef.current?.contains(target)") &&
+    !detailsSource.includes('window.addEventListener("scroll", updatePosition, true)'),
+  "leaderboard scrolling should dismiss the popover while preserving its own internal scroll",
+);
+assert.ok(
+  detailsSource.includes('placement: "above" | "below"') &&
+    detailsSource.includes("style={{ left: position.arrowLeft }}") &&
+    detailsSource.includes('aria-hidden="true"'),
+  "the popover should render a placement-aware pointer aligned with its trigger",
+);
+assert.ok(
+  detailsSource.includes("const POPOVER_GAP = 4") &&
+    detailsSource.includes("fixed z-30 overflow-visible") &&
+    detailsSource.includes("max-h-[calc(100dvh-2rem)] overflow-y-auto") &&
+    detailsSource.includes("rounded-[inherit] p-4"),
+  "the anchored shell should expose its pointer while an inner viewport owns overflow",
 );
 assert.ok(
   detailsSource.includes("This model was benchmarked before run statistics were tracked."),
@@ -26,9 +62,22 @@ assert.ok(
   "recorded benchmark details should show inference time and total cost",
 );
 assert.ok(
-  leaderboardSource.includes("<ModelBenchmarkDetails") &&
+  !detailsSource.includes('label: "Run size"'),
+  "benchmark tables should expose only the two reported statistics",
+);
+assert.ok(
+  leaderboardSource.includes("<ModelBenchmarkDetailsTrigger") &&
+    leaderboardSource.includes("<ModelBenchmarkDetailsInline") &&
+    leaderboardSource.includes("<ModelBenchmarkDetails") &&
     modelDetailSource.includes("<ModelBenchmarkDetails"),
-  "the leaderboard and model profile should both expose model run details",
+  "mobile leaderboard cards should expand inline while desktop and model profiles expose the popover",
+);
+assert.ok(
+  !detailsSource.includes("Run setup") &&
+    !detailsSource.includes("Benchmark run") &&
+    !detailsSource.includes("Run details") &&
+    !detailsSource.includes("Ratings reflect the current prompt set"),
+  "the details hierarchy should remain flat and concise",
 );
 assert.ok(
   leaderboardSource.includes('const LEADERBOARD_CACHE_KEY = "mb-leaderboard-v4"'),

--- a/tests/ui/model-benchmark-details.test.ts
+++ b/tests/ui/model-benchmark-details.test.ts
@@ -1,0 +1,38 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const detailsSource = readFileSync(
+  "components/leaderboard/ModelBenchmarkDetails.tsx",
+  "utf8",
+);
+const leaderboardSource = readFileSync("components/leaderboard/Leaderboard.tsx", "utf8");
+const modelDetailSource = readFileSync("components/leaderboard/ModelDetail.tsx", "utf8");
+
+assert.ok(
+  detailsSource.includes('aria-haspopup="dialog"') &&
+    detailsSource.includes('aria-label={`View ${displayName} run details`}'),
+  "model details trigger should expose its dialog semantics and accessible name",
+);
+assert.ok(
+  detailsSource.includes('role="dialog"') && detailsSource.includes('aria-modal="true"'),
+  "model run details should render as an accessible dialog",
+);
+assert.ok(
+  detailsSource.includes("This model was benchmarked before run statistics were tracked."),
+  "models without recorded statistics should still receive a useful details note",
+);
+assert.ok(
+  detailsSource.includes("Avg. inference") && detailsSource.includes("Total cost"),
+  "recorded benchmark details should show inference time and total cost",
+);
+assert.ok(
+  leaderboardSource.includes("<ModelBenchmarkDetails") &&
+    modelDetailSource.includes("<ModelBenchmarkDetails"),
+  "the leaderboard and model profile should both expose model run details",
+);
+assert.ok(
+  leaderboardSource.includes('const LEADERBOARD_CACHE_KEY = "mb-leaderboard-v4"'),
+  "the canonical model-name change should invalidate stale client leaderboard data",
+);
+
+console.log("model benchmark details UI checks passed");

--- a/tests/ui/model-benchmark-details.test.ts
+++ b/tests/ui/model-benchmark-details.test.ts
@@ -74,6 +74,11 @@ assert.ok(
   "mobile leaderboard cards should expand inline while desktop and model profiles expose the popover",
 );
 assert.ok(
+  !leaderboardSource.includes("onClick={() => navigateToModel(m.key)}") &&
+    leaderboardSource.includes('aria-label={`Open ${m.displayName} profile`}'),
+  "leaderboard navigation should stay on explicit keyboard-accessible model controls",
+);
+assert.ok(
   !detailsSource.includes("Run setup") &&
     !detailsSource.includes("Benchmark run") &&
     !detailsSource.includes("Run details") &&

--- a/tests/unit/ai/model-benchmark-profiles.test.ts
+++ b/tests/unit/ai/model-benchmark-profiles.test.ts
@@ -1,0 +1,42 @@
+import assert from "node:assert/strict";
+import {
+  MODEL_BENCHMARK_PROFILES,
+  getModelBenchmarkProfile,
+} from "../../../lib/ai/modelBenchmarkProfiles";
+import {
+  MODEL_CATALOG,
+  resolveModelDisplayName,
+} from "../../../lib/ai/modelCatalog";
+
+const gpt56 = getModelBenchmarkProfile("openai_gpt_5_6_sol");
+assert.ok(gpt56, "GPT 5.6 Sol Pro should have verified benchmark details");
+assert.deepEqual(gpt56.parameters, [
+  { label: "Reasoning mode", value: "Pro" },
+  { label: "Reasoning effort", value: "Max" },
+  { label: "Text verbosity", value: "High" },
+  { label: "Combined reasoning/output cap", value: "128,000 tokens" },
+]);
+assert.equal(gpt56.sourceRelease, "3.9.0");
+assert.equal(gpt56.averageInferenceTime, "25m 16s (1516.2s)");
+assert.equal(gpt56.totalCost, "$710.82");
+assert.equal(gpt56.buildCount, 15);
+
+assert.equal(
+  resolveModelDisplayName("openai_gpt_5_6_sol", "stale database label"),
+  "GPT 5.6 Sol Pro",
+  "public responses should prefer the canonical catalog label",
+);
+assert.equal(
+  resolveModelDisplayName("unknown_model", "Imported model"),
+  "Imported model",
+  "unknown persisted models should keep their database label",
+);
+
+for (const key of Object.keys(MODEL_BENCHMARK_PROFILES)) {
+  assert.ok(
+    MODEL_CATALOG.some((model) => model.key === key),
+    `benchmark profile ${key} should match a catalog model`,
+  );
+}
+
+console.log("model benchmark profile checks passed");

--- a/tests/unit/ai/model-benchmark-profiles.test.ts
+++ b/tests/unit/ai/model-benchmark-profiles.test.ts
@@ -17,9 +17,61 @@ assert.deepEqual(gpt56.parameters, [
   { label: "Combined reasoning/output cap", value: "128,000 tokens" },
 ]);
 assert.equal(gpt56.sourceRelease, "3.9.0");
-assert.equal(gpt56.averageInferenceTime, "25m 16s (1516.2s)");
+assert.equal(gpt56.averageInferenceTime, "25m 16.2s (1,516.2s)");
 assert.equal(gpt56.totalCost, "$710.82");
 assert.equal(gpt56.buildCount, 15);
+
+const fable5 = getModelBenchmarkProfile("anthropic_claude_fable_5");
+assert.equal(fable5?.averageInferenceTime, "18m 04.4s (1,084.4s)");
+assert.equal(fable5?.totalCost, "$54.93");
+assert.equal(fable5?.buildCount, 15);
+
+const opus48 = getModelBenchmarkProfile("anthropic_claude_4_8_opus");
+assert.equal(opus48?.averageInferenceTime, "24m 47.9s (1,487.9s)");
+assert.equal(opus48?.totalCost, "$41.52");
+assert.equal(opus48?.buildCount, 15);
+
+const gpt55 = getModelBenchmarkProfile("openai_gpt_5_5");
+assert.equal(gpt55?.averageInferenceTime, "10m 24s (624s)");
+assert.equal(gpt55?.totalCost, "$19.98");
+
+const gpt55Pro = getModelBenchmarkProfile("openai_gpt_5_5_pro");
+assert.equal(gpt55Pro?.averageInferenceTime, "21m 23.3s (1,283.3s)");
+assert.equal(gpt55Pro?.totalCost, "$223.90");
+
+const gpt54Pro = getModelBenchmarkProfile("openai_gpt_5_4_pro");
+assert.equal(gpt54Pro?.averageInferenceTime, "56 minutes");
+assert.equal(gpt54Pro?.totalCost, "$435");
+
+const gpt54 = getModelBenchmarkProfile("openai_gpt_5_4");
+assert.equal(gpt54?.averageInferenceTime, undefined);
+assert.equal(gpt54?.totalCost, "~$25");
+
+const gpt53Codex = getModelBenchmarkProfile("openai_gpt_5_3_codex");
+assert.deepEqual(gpt53Codex?.parameters, [{ label: "Reasoning effort", value: "XHigh" }]);
+assert.equal(gpt53Codex?.averageInferenceTime, undefined);
+assert.equal(gpt53Codex?.totalCost, "Under approximately $5");
+
+const opus47 = getModelBenchmarkProfile("anthropic_claude_4_7_opus");
+assert.equal(opus47?.averageInferenceTime, "~43m 20s (~2,600s)");
+assert.equal(opus47?.totalCost, "~$275");
+
+const opus46 = getModelBenchmarkProfile("anthropic_claude_4_6_opus");
+assert.equal(opus46?.averageInferenceTime, undefined);
+assert.equal(opus46?.totalCost, "~$22");
+
+const kimi26 = getModelBenchmarkProfile("moonshot_kimi_k2_6");
+assert.equal(kimi26?.averageInferenceTime, undefined);
+assert.equal(kimi26?.totalCost, "$2.35");
+
+const gpt45WebHarness = getModelBenchmarkProfile("openai_gpt_4_5_web_harness");
+assert.deepEqual(gpt45WebHarness?.parameters, [
+  { label: "Source", value: "ChatGPT web harness" },
+]);
+assert.equal(
+  gpt45WebHarness?.note,
+  "Imported from the web harness; not directly comparable to API-generated runs.",
+);
 
 assert.equal(
   resolveModelDisplayName("openai_gpt_5_6_sol", "stale database label"),

--- a/tests/unit/providers/gpt-5-6-sol-config.test.ts
+++ b/tests/unit/providers/gpt-5-6-sol-config.test.ts
@@ -70,7 +70,7 @@ async function main() {
 
   assert.equal(model.provider, "openai");
   assert.equal(model.modelId, "gpt-5.6-sol");
-  assert.equal(model.displayName, "GPT 5.6 Sol");
+  assert.equal(model.displayName, "GPT 5.6 Sol Pro");
   assert.equal(model.openRouterModelId, "openai/gpt-5.6-sol-pro");
   assert.equal(MODEL_SLUG.openai_gpt_5_6_sol, "gpt-5-6-sol");
   assert.deepEqual(openAiReasoningEffortAttempts(model.modelId), [


### PR DESCRIPTION
## Summary

- rename the canonical frontend label to `GPT 5.6 Sol Pro` and normalize database-backed public responses so stale persisted labels do not remain visible
- add model run-details controls across leaderboard and model-profile surfaces
- use an anchored desktop popover that dismisses on page scroll, resize, Escape, or outside interaction, with an inline disclosure on mobile
- show the recorded model parameters, average inference time, and total cost without additional run commentary
- preserve the GPT-4.5 web-harness disclaimer: it is not directly comparable to API-generated runs
- add focused regressions for the disclosure behavior, benchmark statistics, canonical label, and web-harness disclaimer

## Verification

- `pnpm exec tsc --noEmit`
- `pnpm lint`
- `pnpm test` — 20 test files passed
- `pnpm build`
- `git diff --check`
- `graphify update .`

*(PR written by Codex)*