### PR TITLE
(feat) complete model run details

### DIFF
--- a/components/leaderboard/ModelBenchmarkDetails.tsx
+++ b/components/leaderboard/ModelBenchmarkDetails.tsx
@@ -64,15 +64,13 @@ function InfoIcon() {
 function resolveProfile(modelKey: string): ModelBenchmarkProfile {
   return (
     getModelBenchmarkProfile(modelKey) ?? {
-      parameters: [],
-      note: UNTRACKED_RUN_NOTE,
+      parameters: [{ label: "Configuration", value: "Not recorded" }],
     }
   );
 }
 
-function profileRows(profile: ModelBenchmarkProfile): ModelRunParameter[] {
-  const rows = [...profile.parameters];
-
+function statisticRows(profile: ModelBenchmarkProfile): ModelRunParameter[] {
+  const rows: ModelRunParameter[] = [];
   if (profile.averageInferenceTime) {
     rows.push({ label: "Avg. inference", value: profile.averageInferenceTime });
   }
@@ -81,6 +79,24 @@ function profileRows(profile: ModelBenchmarkProfile): ModelRunParameter[] {
   }
 
   return rows;
+}
+
+function DetailRows({ rows }: { rows: readonly ModelRunParameter[] }) {
+  return (
+    <dl className="mt-1 divide-y divide-border/60 border-y border-border/70">
+      {rows.map((row) => (
+        <div
+          key={row.label}
+          className="grid grid-cols-[minmax(0,1fr)_minmax(0,1.35fr)] gap-4 py-2.5 text-xs"
+        >
+          <dt className="text-muted2">{row.label}</dt>
+          <dd className="text-right font-medium tabular-nums text-fg/95 [overflow-wrap:anywhere]">
+            {row.value}
+          </dd>
+        </div>
+      ))}
+    </dl>
+  );
 }
 
 function DetailsContent({
@@ -93,7 +109,8 @@ function DetailsContent({
   showHeader: boolean;
 }) {
   const profile = resolveProfile(modelKey);
-  const rows = profileRows(profile);
+  const statistics = statisticRows(profile);
+  const sectionId = useId();
 
   return (
     <>
@@ -110,32 +127,37 @@ function DetailsContent({
         </div>
       ) : null}
 
-      {rows.length > 0 ? (
-        <dl
-          className={`${showHeader ? "mt-3" : ""} divide-y divide-border/60 border-y border-border/70`}
+      <section
+        className={showHeader ? "mt-3" : ""}
+        aria-labelledby={`${sectionId}-parameters`}
+      >
+        <h3
+          id={`${sectionId}-parameters`}
+          className="font-mono text-[10px] font-medium uppercase tracking-[0.16em] text-muted2"
         >
-          {rows.map((row) => (
-            <div
-              key={row.label}
-              className="grid grid-cols-[minmax(0,1fr)_minmax(0,1.35fr)] gap-4 py-2.5 text-xs"
-            >
-              <dt className="text-muted2">{row.label}</dt>
-              <dd className="text-right font-medium tabular-nums text-fg/95 [overflow-wrap:anywhere]">
-                {row.value}
-              </dd>
-            </div>
-          ))}
-        </dl>
-      ) : null}
+          Parameters
+        </h3>
+        <DetailRows rows={profile.parameters} />
+      </section>
 
-      {profile.note ? (
-        <p
-          className={`${rows.length > 0 || showHeader ? "mt-3" : ""} text-xs leading-relaxed text-muted`}
+      <section className="mt-4" aria-labelledby={`${sectionId}-statistics`}>
+        <h3
+          id={`${sectionId}-statistics`}
+          className="font-mono text-[10px] font-medium uppercase tracking-[0.16em] text-muted2"
         >
-          {profile.note}
-        </p>
-      ) : null}
-
+          Statistics
+        </h3>
+        {statistics.length > 0 ? (
+          <DetailRows rows={statistics} />
+        ) : (
+          <p className="mt-1 border-y border-border/70 py-2.5 text-xs leading-relaxed text-muted">
+            {UNTRACKED_RUN_NOTE}
+          </p>
+        )}
+        {profile.note ? (
+          <p className="mt-2 text-xs leading-relaxed text-muted">{profile.note}</p>
+        ) : null}
+      </section>
     </>
   );
 }

--- a/lib/ai/modelBenchmarkProfiles.ts
+++ b/lib/ai/modelBenchmarkProfiles.ts
@@ -5,191 +5,302 @@ export type ModelRunParameter = {
   value: string;
 };
 
+export type ModelRunParameters = readonly [ModelRunParameter, ...ModelRunParameter[]];
+
 export type ModelBenchmarkProfile = {
   sourceRelease?: string;
-  parameters: readonly ModelRunParameter[];
+  parameters: ModelRunParameters;
   averageInferenceTime?: string;
   totalCost?: string;
   buildCount?: number;
   note?: string;
 };
 
-export const MODEL_BENCHMARK_PROFILES: Partial<Record<ModelKey, ModelBenchmarkProfile>> = {
+const OPENAI_XHIGH_128K: ModelRunParameters = [
+  { label: "Reasoning effort", value: "XHigh" },
+  { label: "Output cap", value: "128,000 tokens" },
+];
+
+const OPENAI_XHIGH_HIGH_128K: ModelRunParameters = [
+  { label: "Reasoning effort", value: "XHigh" },
+  { label: "Text verbosity", value: "High" },
+  { label: "Output cap", value: "128,000 tokens" },
+];
+
+const PROVIDER_DEFAULT: ModelRunParameters = [
+  { label: "Reasoning", value: "Provider default" },
+];
+
+const ANTHROPIC_LEGACY_THINKING: ModelRunParameters = [
+  { label: "Thinking", value: "Extended" },
+  { label: "Thinking budget", value: "65,535 tokens" },
+];
+
+const GEMINI_HIGH: ModelRunParameters = [
+  { label: "Thinking level", value: "High" },
+];
+
+const OPENROUTER_XHIGH_32K: ModelRunParameters = [
+  { label: "Reasoning effort", value: "XHigh" },
+  { label: "Requested output budget", value: "32,768 tokens" },
+];
+
+const MODEL_RUN_PARAMETERS = {
+  openai_gpt_5_6_sol: [
+    { label: "Reasoning mode", value: "Pro" },
+    { label: "Reasoning effort", value: "Max" },
+    { label: "Text verbosity", value: "High" },
+    { label: "Combined reasoning/output cap", value: "128,000 tokens" },
+  ],
+  openai_gpt_5_5: [
+    { label: "Reasoning effort", value: "Max" },
+    { label: "Text verbosity", value: "High" },
+    { label: "Output cap", value: "128,000 tokens" },
+  ],
+  openai_gpt_5_5_pro: [
+    { label: "Reasoning effort", value: "Max" },
+    { label: "Text verbosity", value: "High" },
+    { label: "Output cap", value: "128,000 tokens" },
+  ],
+  openai_gpt_5_4: OPENAI_XHIGH_HIGH_128K,
+  openai_gpt_5_4_pro: OPENAI_XHIGH_HIGH_128K,
+  openai_gpt_5_4_mini: OPENAI_XHIGH_HIGH_128K,
+  openai_gpt_5_4_nano: OPENAI_XHIGH_HIGH_128K,
+  openai_gpt_5_3_codex: OPENAI_XHIGH_128K,
+  openai_gpt_5_2: OPENAI_XHIGH_128K,
+  openai_gpt_5_2_pro: OPENAI_XHIGH_128K,
+  openai_gpt_5_2_codex: OPENAI_XHIGH_128K,
+  openai_gpt_5_mini: OPENAI_XHIGH_128K,
+  openai_gpt_5_nano: OPENAI_XHIGH_128K,
+  openai_gpt_4_1: PROVIDER_DEFAULT,
+  openai_gpt_4_5_web_harness: [{ label: "Source", value: "ChatGPT web harness" }],
+  openai_gpt_4o: PROVIDER_DEFAULT,
+  openai_gpt_oss_120b: [
+    { label: "Reasoning effort", value: "XHigh" },
+    { label: "Combined reasoning/output budget", value: "131,072 tokens" },
+  ],
+  anthropic_claude_fable_5: [
+    { label: "Thinking", value: "Adaptive" },
+    { label: "Reasoning effort", value: "Max" },
+    { label: "Sampling", value: "Provider default" },
+    { label: "Output cap", value: "128,000 tokens" },
+  ],
+  anthropic_claude_sonnet_5: [
+    { label: "Thinking", value: "Adaptive" },
+    { label: "Reasoning effort", value: "XHigh" },
+    { label: "Output cap", value: "128,000 tokens" },
+  ],
+  anthropic_claude_4_5_sonnet: ANTHROPIC_LEGACY_THINKING,
+  anthropic_claude_4_6_sonnet: [
+    { label: "Thinking", value: "Adaptive" },
+    { label: "Reasoning effort", value: "Max" },
+    { label: "Requested output budget", value: "65,536 tokens" },
+  ],
+  anthropic_claude_4_5_opus: ANTHROPIC_LEGACY_THINKING,
+  anthropic_claude_4_6_opus: [
+    { label: "Thinking", value: "Adaptive" },
+    { label: "Reasoning effort", value: "Max" },
+    { label: "Output cap", value: "131,072 tokens" },
+  ],
+  anthropic_claude_4_7_opus: [
+    { label: "Thinking", value: "Adaptive" },
+    { label: "Reasoning effort", value: "Max" },
+    { label: "Output cap", value: "128,000 tokens" },
+  ],
+  anthropic_claude_4_8_opus: [
+    { label: "Thinking", value: "Adaptive" },
+    { label: "Reasoning effort", value: "Max" },
+    { label: "Output cap", value: "128,000 tokens" },
+  ],
+  gemini_3_5_flash: [
+    { label: "Thinking level", value: "High" },
+    { label: "Output cap", value: "65,536 tokens" },
+  ],
+  gemini_3_0_pro: GEMINI_HIGH,
+  gemini_3_1_pro: GEMINI_HIGH,
+  gemini_3_0_flash: GEMINI_HIGH,
+  gemini_3_1_flash_lite: GEMINI_HIGH,
+  gemini_2_5_pro: [{ label: "Thinking", value: "Dynamic" }],
+  gemma_4_31b: GEMINI_HIGH,
+  moonshot_kimi_k3: [
+    { label: "Reasoning effort", value: "Max" },
+    { label: "Structured output", value: "Strict" },
+    { label: "Completion ceiling", value: "1,048,576 tokens" },
+  ],
+  moonshot_kimi_k2: [{ label: "Reasoning", value: "Model default" }],
+  moonshot_kimi_k2_6: [{ label: "Reasoning", value: "Thinking enabled" }],
+  moonshot_kimi_k2_5: [{ label: "Reasoning", value: "Thinking enabled" }],
+  deepseek_v4_pro: [
+    { label: "Thinking", value: "Enabled" },
+    { label: "Reasoning effort", value: "Max" },
+    { label: "Requested output budget", value: "384,000 tokens" },
+  ],
+  deepseek_v3_2: [
+    { label: "Reasoning", value: "Provider default" },
+    { label: "Output cap", value: "65,536 tokens" },
+  ],
+  xai_grok_4_5: [
+    { label: "Reasoning effort", value: "High" },
+    { label: "Requested output budget", value: "500,000 tokens" },
+    { label: "Accepted output budget", value: "262,144 tokens" },
+  ],
+  xai_grok_4_3: [
+    { label: "Reasoning", value: "Automatic" },
+    { label: "Requested output budget", value: "1,000,000 tokens" },
+    { label: "Accepted output budget", value: "983,040 tokens" },
+  ],
+  xai_grok_4_1: [
+    { label: "Reasoning", value: "Automatic" },
+    { label: "Output cap", value: "30,000 tokens" },
+  ],
+  xai_grok_4_20: [{ label: "Reasoning", value: "Thinking enabled" }],
+  zai_glm_5_2: [
+    { label: "Reasoning effort", value: "XHigh → High" },
+    { label: "Output cap", value: "131,072 tokens" },
+  ],
+  zai_glm_5_1: [
+    { label: "Reasoning", value: "Thinking enabled" },
+    { label: "Output cap", value: "131,072 tokens" },
+  ],
+  zai_glm_5: [
+    { label: "Reasoning effort", value: "XHigh" },
+    { label: "Output cap", value: "131,072 tokens" },
+  ],
+  zai_glm_4_7: PROVIDER_DEFAULT,
+  qwen_qwen3_max_thinking: OPENROUTER_XHIGH_32K,
+  qwen_qwen3_5_397b_a17b: OPENROUTER_XHIGH_32K,
+  minimax_m2_7: [
+    { label: "Reasoning effort", value: "XHigh" },
+    { label: "Output cap", value: "131,072 tokens" },
+  ],
+  minimax_m2_5: [
+    { label: "Reasoning effort", value: "XHigh" },
+    { label: "Requested output budget", value: "131,072 tokens" },
+  ],
+  meta_llama_4_maverick: PROVIDER_DEFAULT,
+} satisfies Record<ModelKey, ModelRunParameters>;
+
+const MODEL_BENCHMARK_METADATA: Partial<
+  Record<ModelKey, Omit<ModelBenchmarkProfile, "parameters">>
+> = {
   openai_gpt_5_6_sol: {
     sourceRelease: "3.9.0",
-    parameters: [
-      { label: "Reasoning mode", value: "Pro" },
-      { label: "Reasoning effort", value: "Max" },
-      { label: "Text verbosity", value: "High" },
-      { label: "Combined reasoning/output cap", value: "128,000 tokens" },
-    ],
     averageInferenceTime: "25m 16.2s (1,516.2s)",
     totalCost: "$710.82",
     buildCount: 15,
   },
   xai_grok_4_5: {
     sourceRelease: "3.9.0",
-    parameters: [
-      { label: "Reasoning effort", value: "High" },
-      { label: "Requested output budget", value: "500,000 tokens" },
-      { label: "Accepted output budget", value: "262,144 tokens" },
-    ],
     averageInferenceTime: "1m 48s (108.2s)",
     totalCost: "$1.69",
     buildCount: 15,
   },
   zai_glm_5_2: {
     sourceRelease: "3.8.0",
-    parameters: [
-      { label: "Reasoning effort", value: "XHigh → High" },
-      { label: "Output cap", value: "131,072 tokens" },
-    ],
     averageInferenceTime: "6m 21s (381.1s)",
     totalCost: "$4.46",
     buildCount: 15,
   },
   anthropic_claude_sonnet_5: {
     sourceRelease: "3.8.0",
-    parameters: [
-      { label: "Thinking", value: "Adaptive" },
-      { label: "Reasoning effort", value: "XHigh" },
-      { label: "Output cap", value: "128,000 tokens" },
-    ],
     averageInferenceTime: "31m 3s (1863.1s)",
     totalCost: "$94.17",
     buildCount: 15,
   },
   openai_gpt_4_5_web_harness: {
     sourceRelease: "3.8.0",
-    parameters: [{ label: "Source", value: "ChatGPT web harness" }],
     note: "Imported from the web harness; not directly comparable to API-generated runs.",
   },
   anthropic_claude_fable_5: {
     sourceRelease: "3.7.0",
-    parameters: [
-      { label: "Thinking", value: "Adaptive" },
-      { label: "Reasoning effort", value: "Max" },
-      { label: "Sampling", value: "Provider default" },
-      { label: "Output cap", value: "128,000 tokens" },
-    ],
     averageInferenceTime: "18m 04.4s (1,084.4s)",
     totalCost: "$54.93",
     buildCount: 15,
   },
   anthropic_claude_4_8_opus: {
     sourceRelease: "3.6.0",
-    parameters: [
-      { label: "Thinking", value: "Adaptive" },
-      { label: "Reasoning effort", value: "Max" },
-      { label: "Output cap", value: "128,000 tokens" },
-    ],
     averageInferenceTime: "24m 47.9s (1,487.9s)",
     totalCost: "$41.52",
     buildCount: 15,
   },
   gemini_3_5_flash: {
     sourceRelease: "3.6.0",
-    parameters: [
-      { label: "Thinking level", value: "High" },
-      { label: "Output cap", value: "65,536 tokens" },
-    ],
     averageInferenceTime: "1m 54s (114.1s)",
     totalCost: "$12.90",
     buildCount: 15,
   },
   xai_grok_4_3: {
     sourceRelease: "3.4.0",
-    parameters: [
-      { label: "Reasoning", value: "Automatic" },
-      { label: "Requested output budget", value: "1,000,000 tokens" },
-      { label: "Fallback output budget", value: "983,040 tokens" },
-    ],
     averageInferenceTime: "3m 43s (223.1s)",
     totalCost: "$0.87",
   },
   xai_grok_4_20: {
     sourceRelease: "v3.0.0",
-    parameters: [{ label: "Reasoning", value: "Thinking enabled" }],
     averageInferenceTime: "~2m 29s",
     totalCost: "$18.44",
     buildCount: 15,
   },
   openai_gpt_5_5: {
     sourceRelease: "3.3.2",
-    parameters: [
-      { label: "Reasoning effort", value: "Max" },
-      { label: "Text verbosity", value: "High" },
-      { label: "Output cap", value: "128,000 tokens" },
-    ],
     averageInferenceTime: "10m 24s (624s)",
     totalCost: "$19.98",
   },
   openai_gpt_5_5_pro: {
     sourceRelease: "3.3.2",
-    parameters: [
-      { label: "Reasoning effort", value: "Max" },
-      { label: "Text verbosity", value: "High" },
-      { label: "Output cap", value: "128,000 tokens" },
-    ],
     averageInferenceTime: "21m 23.3s (1,283.3s)",
     totalCost: "$223.90",
   },
   openai_gpt_5_4: {
-    parameters: [],
     totalCost: "~$25",
   },
   openai_gpt_5_4_pro: {
-    parameters: [],
     averageInferenceTime: "56 minutes",
     totalCost: "$435",
   },
   openai_gpt_5_3_codex: {
-    parameters: [{ label: "Reasoning effort", value: "XHigh" }],
     totalCost: "Under approximately $5",
   },
   deepseek_v4_pro: {
     sourceRelease: "3.3.2",
-    parameters: [],
     totalCost: "$3.92",
-    note: "Run parameters and average inference time were not recorded for this model.",
   },
   anthropic_claude_4_7_opus: {
     sourceRelease: "v3.0.0",
-    parameters: [{ label: "Reasoning effort", value: "Max" }],
     averageInferenceTime: "~43m 20s (~2,600s)",
     totalCost: "~$275",
   },
   anthropic_claude_4_6_opus: {
-    parameters: [],
     totalCost: "~$22",
   },
   zai_glm_5_1: {
     sourceRelease: "v3.0.0",
-    parameters: [
-      { label: "Reasoning", value: "Thinking enabled" },
-      { label: "Output cap", value: "131,072 tokens" },
-    ],
     averageInferenceTime: "~17m 26s",
     totalCost: "$4.18",
     buildCount: 15,
   },
   moonshot_kimi_k2_6: {
     sourceRelease: "v3.0.0",
-    parameters: [{ label: "Reasoning", value: "Thinking enabled" }],
     totalCost: "$2.35",
   },
   moonshot_kimi_k3: {
     sourceRelease: "3.10.0 draft",
-    parameters: [
-      { label: "Reasoning effort", value: "Max" },
-      { label: "Structured output", value: "Strict" },
-      { label: "Completion ceiling", value: "1,048,576 tokens" },
-    ],
     averageInferenceTime: "32m 46s (1966.0s)",
     totalCost: "$12.70",
     buildCount: 15,
   },
 };
+
+export const MODEL_BENCHMARK_PROFILES = Object.fromEntries(
+  (Object.entries(MODEL_RUN_PARAMETERS) as [ModelKey, ModelRunParameters][]).map(
+    ([modelKey, parameters]) => [
+      modelKey,
+      {
+        parameters,
+        ...MODEL_BENCHMARK_METADATA[modelKey],
+      },
+    ],
+  ),
+) as Record<ModelKey, ModelBenchmarkProfile>;
 
 export function getModelBenchmarkProfile(modelKey: string): ModelBenchmarkProfile | null {
   return MODEL_BENCHMARK_PROFILES[modelKey as ModelKey] ?? null;

--- a/tests/ui/model-benchmark-details.test.ts
+++ b/tests/ui/model-benchmark-details.test.ts
@@ -1,5 +1,10 @@
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
+import * as React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { ModelBenchmarkDetailsInline } from "../../components/leaderboard/ModelBenchmarkDetails";
+
+(globalThis as typeof globalThis & { React: typeof React }).React = React;
 
 const detailsSource = readFileSync(
   "components/leaderboard/ModelBenchmarkDetails.tsx",
@@ -59,8 +64,17 @@ assert.ok(
   "models without recorded statistics should still receive a useful details note",
 );
 assert.ok(
-  detailsSource.includes("Avg. inference") && detailsSource.includes("Total cost"),
-  "recorded benchmark details should show inference time and total cost",
+  detailsSource.includes(">\n          Parameters\n        </h3>") &&
+    detailsSource.includes(">\n          Statistics\n        </h3>") &&
+    detailsSource.includes("<DetailRows rows={profile.parameters} />") &&
+    detailsSource.includes("<DetailRows rows={statistics} />"),
+  "run parameters and benchmark statistics should render as distinct sections",
+);
+assert.ok(
+  detailsSource.includes("Avg. inference") &&
+    detailsSource.includes("Total cost") &&
+    detailsSource.includes("statistics.length > 0"),
+  "recorded benchmark details should show available statistics before using the fallback",
 );
 assert.ok(
   !detailsSource.includes('label: "Run size"'),
@@ -83,11 +97,59 @@ assert.ok(
     !detailsSource.includes("Benchmark run") &&
     !detailsSource.includes("Run details") &&
     !detailsSource.includes("Ratings reflect the current prompt set"),
-  "the details hierarchy should remain flat and concise",
+  "the details hierarchy should keep concise, user-facing labels",
 );
 assert.ok(
   leaderboardSource.includes('const LEADERBOARD_CACHE_KEY = "mb-leaderboard-v4"'),
   "the canonical model-name change should invalidate stale client leaderboard data",
+);
+
+const trackedMarkup = renderToStaticMarkup(
+  React.createElement(ModelBenchmarkDetailsInline, {
+    id: "tracked-details",
+    modelKey: "openai_gpt_5_6_sol",
+    displayName: "GPT 5.6 Sol Pro",
+    open: true,
+  }),
+);
+assert.ok(
+  trackedMarkup.includes("Parameters") &&
+    trackedMarkup.includes("Statistics") &&
+    trackedMarkup.includes("25m 16.2s") &&
+    trackedMarkup.includes("$710.82") &&
+    !trackedMarkup.includes("before run statistics were tracked"),
+  "a fully tracked model should render parameters and both benchmark statistics",
+);
+
+const costOnlyMarkup = renderToStaticMarkup(
+  React.createElement(ModelBenchmarkDetailsInline, {
+    id: "cost-only-details",
+    modelKey: "openai_gpt_5_4",
+    displayName: "GPT 5.4",
+    open: true,
+  }),
+);
+assert.ok(
+  costOnlyMarkup.includes("XHigh") &&
+    costOnlyMarkup.includes("Total cost") &&
+    costOnlyMarkup.includes("~$25") &&
+    !costOnlyMarkup.includes("before run statistics were tracked"),
+  "a cost-only model should render its available statistic without the fallback",
+);
+
+const untrackedMarkup = renderToStaticMarkup(
+  React.createElement(ModelBenchmarkDetailsInline, {
+    id: "untracked-details",
+    modelKey: "openai_gpt_4_5_web_harness",
+    displayName: "GPT 4.5 (web harness)",
+    open: true,
+  }),
+);
+assert.ok(
+  untrackedMarkup.includes("ChatGPT web harness") &&
+    untrackedMarkup.includes("before run statistics were tracked") &&
+    untrackedMarkup.includes("not directly comparable to API-generated runs"),
+  "an untracked run should keep its parameters, statistics fallback, and comparability note",
 );
 
 console.log("model benchmark details UI checks passed");

--- a/tests/unit/ai/model-benchmark-profiles.test.ts
+++ b/tests/unit/ai/model-benchmark-profiles.test.ts
@@ -40,6 +40,11 @@ assert.equal(gpt55Pro?.averageInferenceTime, "21m 23.3s (1,283.3s)");
 assert.equal(gpt55Pro?.totalCost, "$223.90");
 
 const gpt54Pro = getModelBenchmarkProfile("openai_gpt_5_4_pro");
+assert.deepEqual(gpt54Pro?.parameters, [
+  { label: "Reasoning effort", value: "XHigh" },
+  { label: "Text verbosity", value: "High" },
+  { label: "Output cap", value: "128,000 tokens" },
+]);
 assert.equal(gpt54Pro?.averageInferenceTime, "56 minutes");
 assert.equal(gpt54Pro?.totalCost, "$435");
 
@@ -48,7 +53,10 @@ assert.equal(gpt54?.averageInferenceTime, undefined);
 assert.equal(gpt54?.totalCost, "~$25");
 
 const gpt53Codex = getModelBenchmarkProfile("openai_gpt_5_3_codex");
-assert.deepEqual(gpt53Codex?.parameters, [{ label: "Reasoning effort", value: "XHigh" }]);
+assert.deepEqual(gpt53Codex?.parameters, [
+  { label: "Reasoning effort", value: "XHigh" },
+  { label: "Output cap", value: "128,000 tokens" },
+]);
 assert.equal(gpt53Codex?.averageInferenceTime, undefined);
 assert.equal(gpt53Codex?.totalCost, "Under approximately $5");
 
@@ -84,11 +92,50 @@ assert.equal(
   "unknown persisted models should keep their database label",
 );
 
-for (const key of Object.keys(MODEL_BENCHMARK_PROFILES)) {
-  assert.ok(
-    MODEL_CATALOG.some((model) => model.key === key),
-    `benchmark profile ${key} should match a catalog model`,
+const catalogKeys = MODEL_CATALOG.map((model) => model.key);
+assert.equal(
+  new Set(catalogKeys).size,
+  catalogKeys.length,
+  "model catalog keys should be unique",
+);
+assert.deepEqual(
+  Object.keys(MODEL_BENCHMARK_PROFILES).sort(),
+  [...catalogKeys].sort(),
+  "every catalog model should have exactly one benchmark profile",
+);
+
+for (const model of MODEL_CATALOG) {
+  const profile = getModelBenchmarkProfile(model.key);
+  assert.ok(profile, `${model.key} should have benchmark details`);
+  assert.ok(profile.parameters.length > 0, `${model.key} should have run parameters`);
+
+  const labels = profile.parameters.map((parameter) => {
+    assert.ok(parameter.label.trim(), `${model.key} parameter labels should not be blank`);
+    assert.ok(parameter.value.trim(), `${model.key} parameter values should not be blank`);
+    return parameter.label;
+  });
+  assert.equal(
+    new Set(labels).size,
+    labels.length,
+    `${model.key} parameter labels should be unique`,
   );
 }
+
+assert.deepEqual(getModelBenchmarkProfile("gemini_3_1_pro")?.parameters, [
+  { label: "Thinking level", value: "High" },
+]);
+assert.equal(
+  Boolean(
+    getModelBenchmarkProfile("openai_gpt_5_4")?.averageInferenceTime ||
+      getModelBenchmarkProfile("openai_gpt_5_4")?.totalCost,
+  ),
+  true,
+  "a cost-only profile should count as having recorded statistics",
+);
+assert.equal(
+  Boolean(gpt45WebHarness?.averageInferenceTime || gpt45WebHarness?.totalCost),
+  false,
+  "the web-harness profile should use the historical statistics fallback",
+);
 
 console.log("model benchmark profile checks passed");


### PR DESCRIPTION
## Summary

- add non-empty run parameter profiles for every model in the catalog
- split model disclosures into Parameters and Statistics sections
- show the pre-tracking message only when both inference time and cost are unavailable
- preserve the GPT 4.5 web-harness comparability warning
- add catalog coverage and rendered disclosure-state regressions

## Validation

- `pnpm lint`
- `pnpm test` — 20 test files passed
- `pnpm exec tsc --noEmit`
- `pnpm build`
- `graphify update .`

*(PR written by Codex)*