### PR TITLE
(fix) restore leaderboard row navigation

### DIFF
--- a/components/leaderboard/Leaderboard.tsx
+++ b/components/leaderboard/Leaderboard.tsx
@@ -428,9 +428,12 @@ export function Leaderboard() {
 	                <div
 	                  key={m.key}
 	                  className={`w-full rounded-2xl bg-gradient-to-b from-bg/62 to-bg/44 p-3 text-left ring-1 ring-border/70 transition ${
-                    navigatingModelKey === m.key ? "opacity-75" : ""
+	                    navigatingModelKey === m.key
+	                      ? "opacity-75"
+	                      : "active:ring-accent/45 active:from-bg/72"
 	                  }`}
 	                  onMouseEnter={() => prefetchModel(m.key)}
+	                  onClick={() => navigateToModel(m.key)}
 	                >
 	                  <div className="flex items-start justify-between gap-3">
 	                    <div className="flex min-w-0 items-start gap-3">
@@ -679,7 +682,8 @@ export function Leaderboard() {
 	                    key={m.key}
 	                    data-tier={tier}
 	                    onMouseEnter={() => prefetchModel(m.key)}
-                    className={`mb-leaderboard-row mb-card-enter ${
+	                    onClick={() => navigateToModel(m.key)}
+                    className={`mb-leaderboard-row group mb-card-enter ${
                       navigatingModelKey === m.key ? "opacity-75" : ""
                     }`}
                     style={{ animationDelay: `${Math.min(index, 10) * 34}ms` }}
@@ -696,7 +700,7 @@ export function Leaderboard() {
 	                          <div className="flex min-w-0 items-center gap-1.5">
 	                            <button
 	                              type="button"
-	                              className="min-w-0 truncate text-left font-medium text-fg transition-colors duration-200 hover:text-accent focus-visible:outline-none focus-visible:text-accent"
+	                              className="min-w-0 truncate text-left font-medium text-fg transition-colors duration-200 group-hover:text-accent focus-visible:outline-none focus-visible:text-accent"
 	                              aria-label={`Open ${m.displayName} profile`}
 	                              onFocus={() => prefetchModel(m.key)}
 	                              onClick={(event) => {

--- a/tests/ui/model-benchmark-details.test.ts
+++ b/tests/ui/model-benchmark-details.test.ts
@@ -88,9 +88,11 @@ assert.ok(
   "mobile leaderboard cards should expand inline while desktop and model profiles expose the popover",
 );
 assert.ok(
-  !leaderboardSource.includes("onClick={() => navigateToModel(m.key)}") &&
+  (leaderboardSource.match(/onClick=\{\(\) => navigateToModel\(m\.key\)\}/g)?.length ??
+    0) === 2 &&
+    leaderboardSource.includes("event.stopPropagation();") &&
     leaderboardSource.includes('aria-label={`Open ${m.displayName} profile`}'),
-  "leaderboard navigation should stay on explicit keyboard-accessible model controls",
+  "leaderboard rows and cards should navigate by pointer while preserving isolated accessible controls",
 );
 assert.ok(
   !detailsSource.includes("Run setup") &&


### PR DESCRIPTION
## Summary

- restore click-anywhere navigation for desktop leaderboard rows
- restore click-anywhere navigation for mobile model cards
- keep model-name controls keyboard-accessible
- keep model info controls isolated so opening details never navigates

## Root cause

The prior navigation-affordance cleanup removed the row and card click handlers, leaving only the model-name control as a navigation target.

## Validation

- `pnpm lint`
- `pnpm test` — 20 test files passed
- `pnpm exec tsc --noEmit`
- `pnpm build`
- `graphify update .`

*(PR written by Codex)*