### PR TITLE
(fix) prevent consistency score collapse

### DIFF
--- a/docs/arena-ranking-system.md
+++ b/docs/arena-ranking-system.md
@@ -339,7 +339,8 @@ Implemented branch version:
 - keep prompts with at least 2 decisive votes
 - if fewer than 5 prompts remain, `consistency = null`
 - fit a global Bradley-Terry baseline across decisive votes
-- fit prompt-local Bradley-Terry strengths and estimate prompt-level variances
+- fit prompt-local Bradley-Terry strengths with a symmetric `0.5`/`0.5` pseudo-point prior on each observed model-pair edge
+- estimate prompt-level variances from the same prior-augmented edge totals
 - shrink prompt-local strengths back toward the global baseline before ranking
 - convert shrunk prompt-local ranks to prompt-strength percentiles
 - sort prompt-strength percentiles ascending

--- a/docs/consistency-metric-percentile-band.md
+++ b/docs/consistency-metric-percentile-band.md
@@ -101,7 +101,9 @@ For each prompt \(p\), MineBench fits a prompt-local Bradley-Terry model on that
 {\exp(\hat{\theta}_{i,p}) + \exp(\hat{\theta}_{j,p})}
 \]
 
-The implementation also estimates \(s_{i,p}^2\), an approximate posterior variance for each prompt-local ability, from the stabilized inverse information matrix of the prompt-local comparison graph. Disconnected prompt components are aligned back onto the global \(\alpha_i\) scale before shrinkage.
+Each observed model-pair edge receives a weak symmetric prior: `0.5` pseudo-points for each model, equivalent to one tied pseudo-comparison. The same augmented edge total is used in the information matrix. This keeps ability and variance estimates finite when observed outcomes have complete or near separation, such as a model with zero wins on a prompt.
+
+The implementation then estimates \(s_{i,p}^2\), an approximate posterior variance for each prompt-local ability, from the stabilized inverse information matrix of the prompt-local comparison graph. Disconnected prompt components are aligned back onto the global \(\alpha_i\) scale before shrinkage.
 
 ## 3. Prompt-Level Shrinkage
 
@@ -133,7 +135,7 @@ And the shrunk prompt-local ability:
 \alpha_i + \rho_{i,p}(\hat{\theta}_{i,p} - \alpha_i)
 \]
 
-High-confidence prompt evidence moves farther from the global anchor. Sparse or noisy prompt evidence stays closer to the model's global ability.
+High-confidence prompt evidence moves farther from the global anchor. Sparse or noisy prompt evidence stays closer to the model's global ability. The symmetric edge prior prevents a separated model from contributing effectively infinite variance and forcing the entire prompt's \(\tau_p^2\) to zero.
 
 ## 4. Prompt-Strength Percentile
 

--- a/lib/arena/stats.ts
+++ b/lib/arena/stats.ts
@@ -26,6 +26,8 @@ const BT_MAX_ITERS = 600;
 const BT_CONVERGENCE_EPSILON = 1e-9;
 const BT_PSEUDOINVERSE_RIDGE = 1e-9;
 const BT_VARIANCE_FLOOR = 1e-6;
+const BT_EDGE_PRIOR_POINTS = 0.5;
+const BT_EDGE_PRIOR_TOTAL = 1;
 
 type NumberLike = number | bigint | string | null;
 
@@ -243,7 +245,7 @@ function percentileFromRank(rank: number, total: number): number {
   return ((total - rank) / (total - 1)) * 100;
 }
 
-function promptStrengthConsistency(values: number[]): number | null {
+export function promptStrengthConsistency(values: number[]): number | null {
   if (values.length < MIN_PROMPTS_FOR_CONSISTENCY) return null;
   const sorted = [...values].sort((a, b) => a - b);
   const tailCount = Math.max(1, Math.ceil(CONSISTENCY_TAIL_SHARE * sorted.length));
@@ -417,7 +419,7 @@ type BradleyTerryFitRow = {
   displayName: string;
 };
 
-function fitBradleyTerryConnectedComponent(
+export function fitBradleyTerryConnectedComponent(
   modelIds: string[],
   pairRows: PairwiseRow[],
   displayNames: Map<string, string>,
@@ -445,10 +447,10 @@ function fitBradleyTerryConnectedComponent(
     const i = indexById.get(row.modelAId);
     const j = indexById.get(row.modelBId);
     if (i == null || j == null) continue;
-    points[i][j] += row.pointsA;
-    points[j][i] += row.pointsB;
-    totals[i][j] += row.total;
-    totals[j][i] += row.total;
+    points[i][j] += row.pointsA + BT_EDGE_PRIOR_POINTS;
+    points[j][i] += row.pointsB + BT_EDGE_PRIOR_POINTS;
+    totals[i][j] += row.total + BT_EDGE_PRIOR_TOTAL;
+    totals[j][i] += row.total + BT_EDGE_PRIOR_TOTAL;
   }
 
   let pi = Array(n).fill(1);
@@ -529,14 +531,16 @@ function fitBradleyTerry(
   return rows.sort((a, b) => b.theta - a.theta || a.displayName.localeCompare(b.displayName));
 }
 
-function shrinkPromptStrengthRows(
+export function shrinkPromptStrengthRows(
   rows: BradleyTerryFitRow[],
   displayNames: Map<string, string>,
   alphaByModelId: Map<string, number>,
 ): RankedPromptStrengthRow[] {
   if (rows.length === 0) return [];
 
-  const rawSorted = [...rows].sort((a, b) => b.theta - a.theta || a.displayName.localeCompare(b.displayName));
+  const rawSorted = [...rows].sort((a, b) =>
+    b.theta - a.theta || a.displayName.localeCompare(b.displayName),
+  );
   const rawRankById = new Map(
     rawSorted.map((row, index) => [
       row.id,

--- a/tests/unit/arena/model-consistency.test.ts
+++ b/tests/unit/arena/model-consistency.test.ts
@@ -1,0 +1,57 @@
+import assert from "node:assert/strict";
+import {
+  fitBradleyTerryConnectedComponent,
+  promptStrengthConsistency,
+  shrinkPromptStrengthRows,
+} from "../../../lib/arena/stats";
+
+const displayNames = new Map([
+  ["model-a", "Model A"],
+  ["model-b", "Model B"],
+]);
+const separatedFit = fitBradleyTerryConnectedComponent(
+  ["model-a", "model-b"],
+  [
+    {
+      modelAId: "model-a",
+      modelBId: "model-b",
+      pointsA: 20,
+      pointsB: 0,
+      total: 20,
+    },
+  ],
+  displayNames,
+);
+
+assert.ok(
+  separatedFit.every(
+    (row) =>
+      Number.isFinite(row.theta) &&
+      Number.isFinite(row.strength) &&
+      Number.isFinite(row.variance),
+  ),
+  "complete separation must still produce finite Bradley-Terry estimates",
+);
+assert.ok(
+  separatedFit.every((row) => Math.abs(row.theta) < 5 && row.variance < 10),
+  "the symmetric edge prior must keep a zero-win model from creating extreme variance",
+);
+
+const shrunk = shrinkPromptStrengthRows(
+  separatedFit,
+  displayNames,
+  new Map([
+    ["model-a", 0],
+    ["model-b", 0],
+  ]),
+);
+assert.ok(
+  shrunk.every((row) => row.shrinkage != null && row.shrinkage > 0),
+  "finite separated fits must retain prompt-local signal after shrinkage",
+);
+
+assert.equal(promptStrengthConsistency([100, 100, 75, 50, 0]), 0);
+assert.equal(promptStrengthConsistency([80, 80, 80, 80, 80]), 100);
+assert.equal(promptStrengthConsistency([100, 90, 80, 70]), null);
+
+console.log("model consistency checks passed");


### PR DESCRIPTION
## Summary

- regularize each observed Bradley-Terry comparison edge with one weak tied pseudo-comparison
- use the same augmented totals for the MM fit and information-matrix variance
- add a complete-separation regression test and document the exact statistical method

## What broke

A zero-win model could drive its fitted strength toward zero and its variance toward `1e9`. That outlier entered the prompt-wide mean posterior variance, forcing `tauSquared` to zero on 12 of 15 prompts. Zero `tauSquared` replaced every prompt-local ability with global ability, so each model held one rank across prompts, the tail gap became zero, and consistency returned `100`. Cached responses preserved one all-100 snapshot after votes moved.

The Gemini onboarding PR did not change the consistency calculation, API mapping, or UI formatting.

## Current-data result

The patched route was executed read-only against the configured production database:

- 53 models
- range: 30.1-96.0
- 33 distinct scores
- 0 models at exactly 100

| Rank | Model | Consistency |
| ---: | --- | ---: |
| 1 | GPT 5.6 Sol Pro | 91.1 |
| 2 | Claude Fable 5 | 87.5 |
| 3 | GPT 5.5 Pro | 88.2 |
| 4 | GPT 5.5 | 78.0 |
| 5 | Claude 4.8 Opus | 73.8 |
| 6 | GPT 5.4 Pro | 88.2 |
| 7 | Kimi K3 | 78.8 |
| 8 | Gemini 3.1 Pro | 67.6 |
| 9 | GPT 5.4 | 73.8 |
| 10 | Claude Sonnet 5 | 85.9 |

Exact values will continue to move as votes and the active model field change.

## Verification

- `pnpm exec tsx tests/unit/arena/model-consistency.test.ts`
- `pnpm test:unit` (17 files passed in the active worktree)
- `pnpm test` (22 files passed in a clean worktree at this commit)
- `pnpm exec tsc --noEmit`
- targeted ESLint passed
- `pnpm build`
- patched production-data distribution and Sol Pro prompt-rank audit

*(PR written by Codex)*