### PR TITLE
(feat) normalize benchmark details and metrics

### DIFF
--- a/app/api/admin/import-build/route.ts
+++ b/app/api/admin/import-build/route.ts
@@ -12,6 +12,7 @@ import { createHash } from "node:crypto";
 import { maybePrecomputeArenaArtifactsForBuild } from "@/lib/arena/artifactMaintenance";
 import { invalidateArenaBuildMeta } from "@/lib/arena/buildMetaCache";
 import { invalidateArenaCoverageCache } from "@/lib/arena/coverage";
+import { parseGenerationTimeMs } from "@/lib/arena/importBuildMetrics";
 
 export const runtime = "nodejs";
 
@@ -119,6 +120,10 @@ export async function POST(req: Request) {
   if (denied) return NextResponse.json({ error: denied }, { status: 401 });
 
   const url = new URL(req.url);
+  const generationTime = parseGenerationTimeMs(url.searchParams.get("generationTimeMs"));
+  if (!generationTime.ok) {
+    return NextResponse.json({ error: generationTime.error }, { status: 400 });
+  }
   const modelKeyRaw = (url.searchParams.get("modelKey") ?? "").trim();
   if (!modelKeyRaw) {
     return NextResponse.json({ error: "Missing required query param: modelKey" }, { status: 400 });
@@ -295,7 +300,7 @@ export async function POST(req: Request) {
           voxelCompressedByteSize: storageEnvelope.ok ? storageEnvelope.ref.compressedByteSize ?? null : null,
           voxelSha256: storageEnvelope.ok ? storageEnvelope.ref.sha256 ?? null : inlineSha256,
           blockCount,
-          generationTimeMs: 0,
+          generationTimeMs: generationTime.value ?? existing.generationTimeMs,
         },
       })
     : await prisma.build.create({
@@ -313,7 +318,7 @@ export async function POST(req: Request) {
           voxelCompressedByteSize: storageEnvelope.ok ? storageEnvelope.ref.compressedByteSize ?? null : null,
           voxelSha256: storageEnvelope.ok ? storageEnvelope.ref.sha256 ?? null : inlineSha256,
           blockCount,
-          generationTimeMs: 0,
+          generationTimeMs: generationTime.value ?? 0,
         },
       });
 

--- a/app/api/admin/import-build/route.ts
+++ b/app/api/admin/import-build/route.ts
@@ -12,7 +12,10 @@ import { createHash } from "node:crypto";
 import { maybePrecomputeArenaArtifactsForBuild } from "@/lib/arena/artifactMaintenance";
 import { invalidateArenaBuildMeta } from "@/lib/arena/buildMetaCache";
 import { invalidateArenaCoverageCache } from "@/lib/arena/coverage";
-import { parseGenerationTimeMs } from "@/lib/arena/importBuildMetrics";
+import {
+  parseGenerationTimeMs,
+  resolveImportedGenerationTimeMs,
+} from "@/lib/arena/importBuildMetrics";
 
 export const runtime = "nodejs";
 
@@ -300,7 +303,7 @@ export async function POST(req: Request) {
           voxelCompressedByteSize: storageEnvelope.ok ? storageEnvelope.ref.compressedByteSize ?? null : null,
           voxelSha256: storageEnvelope.ok ? storageEnvelope.ref.sha256 ?? null : inlineSha256,
           blockCount,
-          generationTimeMs: generationTime.value ?? existing.generationTimeMs,
+          generationTimeMs: resolveImportedGenerationTimeMs(generationTime.value),
         },
       })
     : await prisma.build.create({
@@ -318,7 +321,7 @@ export async function POST(req: Request) {
           voxelCompressedByteSize: storageEnvelope.ok ? storageEnvelope.ref.compressedByteSize ?? null : null,
           voxelSha256: storageEnvelope.ok ? storageEnvelope.ref.sha256 ?? null : inlineSha256,
           blockCount,
-          generationTimeMs: generationTime.value ?? 0,
+          generationTimeMs: resolveImportedGenerationTimeMs(generationTime.value),
         },
       });
 

--- a/components/leaderboard/ModelBenchmarkDetails.tsx
+++ b/components/leaderboard/ModelBenchmarkDetails.tsx
@@ -90,10 +90,7 @@ function formatJsonSize(bytes: number): string {
 }
 
 function formatCost(cost: BenchmarkCost): string {
-  const value = `$${cost.usd.toFixed(2)}`;
-  if (cost.qualifier === "approximate") return `~${value}`;
-  if (cost.qualifier === "under-approximately") return `Under approximately ${value}`;
-  return value;
+  return `$${cost.usd.toFixed(2)}`;
 }
 
 function parameterRows(profile: ModelBenchmarkProfile): ModelRunParameter[] {

--- a/components/leaderboard/ModelBenchmarkDetails.tsx
+++ b/components/leaderboard/ModelBenchmarkDetails.tsx
@@ -5,11 +5,12 @@ import { createPortal } from "react-dom";
 
 import {
   getModelBenchmarkProfile,
+  type BenchmarkCost,
+  type BenchmarkDuration,
   type ModelBenchmarkProfile,
   type ModelRunParameter,
 } from "@/lib/ai/modelBenchmarkProfiles";
 
-const UNTRACKED_RUN_NOTE = "This model was benchmarked before run statistics were tracked.";
 const POPOVER_WIDTH = 340;
 const VIEWPORT_GUTTER = 16;
 const POPOVER_GAP = 4;
@@ -69,27 +70,74 @@ function resolveProfile(modelKey: string): ModelBenchmarkProfile {
   );
 }
 
-function statisticRows(profile: ModelBenchmarkProfile): ModelRunParameter[] {
-  const rows: ModelRunParameter[] = [];
-  if (profile.averageInferenceTime) {
-    rows.push({ label: "Avg. inference", value: profile.averageInferenceTime });
-  }
-  if (profile.totalCost) {
-    rows.push({ label: "Total cost", value: profile.totalCost });
-  }
+function formatInteger(value: number): string {
+  return new Intl.NumberFormat("en-US", { maximumFractionDigits: 0 }).format(value);
+}
 
-  return rows;
+function formatDuration(duration: BenchmarkDuration): string {
+  const totalSeconds = duration.milliseconds / 1000;
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds - minutes * 60;
+  const secondsLabel = Number.isInteger(seconds) ? seconds.toFixed(0) : seconds.toFixed(1);
+  const value = minutes > 0 ? `${minutes}m ${secondsLabel}s` : `${secondsLabel}s`;
+  return duration.approximate ? `~${value}` : value;
+}
+
+function formatJsonSize(bytes: number): string {
+  const mebibytes = bytes / (1024 * 1024);
+  if (mebibytes >= 1) return `${mebibytes.toFixed(2)} MiB`;
+  return `${(bytes / 1024).toFixed(1)} KiB`;
+}
+
+function formatCost(cost: BenchmarkCost): string {
+  const value = `$${cost.usd.toFixed(2)}`;
+  if (cost.qualifier === "approximate") return `~${value}`;
+  if (cost.qualifier === "under-approximately") return `Under approximately ${value}`;
+  return value;
+}
+
+function parameterRows(profile: ModelBenchmarkProfile): ModelRunParameter[] {
+  return [
+    ...profile.parameters,
+    {
+      label: "Output cap",
+      value:
+        profile.outputCapTokens === undefined
+          ? "Not tracked"
+          : `${formatInteger(profile.outputCapTokens)} tokens`,
+    },
+  ];
+}
+
+function statisticRows(profile: ModelBenchmarkProfile): ModelRunParameter[] {
+  return [
+    {
+      label: "Average inference time",
+      value: profile.averageInference ? formatDuration(profile.averageInference) : "Not tracked",
+    },
+    {
+      label: "Average JSON size",
+      value:
+        profile.averageJsonSizeBytes === undefined
+          ? "Not tracked"
+          : formatJsonSize(profile.averageJsonSizeBytes),
+    },
+    {
+      label: "Total cost",
+      value: profile.totalCost ? formatCost(profile.totalCost) : "Not tracked",
+    },
+  ];
 }
 
 function DetailRows({ rows }: { rows: readonly ModelRunParameter[] }) {
   return (
-    <dl className="mt-1 divide-y divide-border/60 border-y border-border/70">
+    <dl className="mt-1 divide-y divide-border/60">
       {rows.map((row) => (
         <div
           key={row.label}
-          className="grid grid-cols-[minmax(0,1fr)_minmax(0,1.35fr)] gap-4 py-2.5 text-xs"
+          className="grid grid-cols-[minmax(0,1fr)_minmax(0,1.35fr)] gap-4 py-2.5 text-[13px]"
         >
-          <dt className="text-muted2">{row.label}</dt>
+          <dt className="text-muted">{row.label}</dt>
           <dd className="text-right font-medium tabular-nums text-fg/95 [overflow-wrap:anywhere]">
             {row.value}
           </dd>
@@ -109,6 +157,7 @@ function DetailsContent({
   showHeader: boolean;
 }) {
   const profile = resolveProfile(modelKey);
+  const parameters = parameterRows(profile);
   const statistics = statisticRows(profile);
   const sectionId = useId();
 
@@ -120,12 +169,14 @@ function DetailsContent({
             {displayName}
           </h2>
           {profile.sourceRelease ? (
-            <span className="shrink-0 font-mono text-[10px] text-muted2">
+            <span className="shrink-0 font-mono text-[11px] text-muted">
               v{profile.sourceRelease.replace(/^v/, "")}
             </span>
           ) : null}
         </div>
-      ) : null}
+      ) : (
+        <h2 className="sr-only">{displayName} run details</h2>
+      )}
 
       <section
         className={showHeader ? "mt-3" : ""}
@@ -133,29 +184,26 @@ function DetailsContent({
       >
         <h3
           id={`${sectionId}-parameters`}
-          className="font-mono text-[10px] font-medium uppercase tracking-[0.16em] text-muted2"
+          className="font-mono text-[11px] font-medium uppercase tracking-[0.14em] text-muted"
         >
           Parameters
         </h3>
-        <DetailRows rows={profile.parameters} />
+        <DetailRows rows={parameters} />
       </section>
 
-      <section className="mt-4" aria-labelledby={`${sectionId}-statistics`}>
+      <section
+        className="mt-4 border-t border-border/70 pt-4"
+        aria-labelledby={`${sectionId}-statistics`}
+      >
         <h3
           id={`${sectionId}-statistics`}
-          className="font-mono text-[10px] font-medium uppercase tracking-[0.16em] text-muted2"
+          className="font-mono text-[11px] font-medium uppercase tracking-[0.14em] text-muted"
         >
           Statistics
         </h3>
-        {statistics.length > 0 ? (
-          <DetailRows rows={statistics} />
-        ) : (
-          <p className="mt-1 border-y border-border/70 py-2.5 text-xs leading-relaxed text-muted">
-            {UNTRACKED_RUN_NOTE}
-          </p>
-        )}
+        <DetailRows rows={statistics} />
         {profile.note ? (
-          <p className="mt-2 text-xs leading-relaxed text-muted">{profile.note}</p>
+          <p className="mt-2 text-[13px] leading-relaxed text-muted">{profile.note}</p>
         ) : null}
       </section>
     </>
@@ -294,8 +342,12 @@ export function ModelBenchmarkDetails({
         expanded={open}
         controlsId={detailsId}
         onToggle={() => {
-          if (!open) updatePosition();
-          setOpen((current) => !current);
+          if (open) {
+            setOpen(false);
+            return;
+          }
+          setPosition(null);
+          setOpen(true);
         }}
       />
       {open && typeof document !== "undefined"
@@ -305,7 +357,7 @@ export function ModelBenchmarkDetails({
               id={detailsId}
               role="region"
               aria-label={`${displayName} run details`}
-              className={`fixed z-30 overflow-visible rounded-lg border border-border bg-card shadow-[0_18px_45px_-30px_rgba(0,0,0,0.65)] ${
+              className={`fixed z-30 overflow-visible rounded-lg border border-border bg-card shadow-soft ${
                 position ? "opacity-100" : "pointer-events-none opacity-0"
               }`}
               style={{

--- a/lib/ai/generateVoxelBuild.ts
+++ b/lib/ai/generateVoxelBuild.ts
@@ -492,9 +492,18 @@ export type GenerateVoxelBuildResult =
       warnings: string[];
       blockCount: number;
       generationTimeMs: number;
+      acceptedOutputTokens?: number;
+      providerRoute?: "direct" | "openrouter";
       rawText: string;
     }
-  | { ok: false; error: string; rawText?: string; generationTimeMs: number };
+  | {
+      ok: false;
+      error: string;
+      rawText?: string;
+      generationTimeMs: number;
+      acceptedOutputTokens?: number;
+      providerRoute?: "direct" | "openrouter";
+    };
 
 // call the direct provider (OpenAI, Anthropic, etc.)
 async function callDirectProvider(args: {
@@ -526,6 +535,7 @@ async function callDirectProvider(args: {
   signal?: AbortSignal;
   onDelta?: (delta: string) => void;
   onTrace?: (message: string) => void;
+  onAcceptedOutputTokens?: (tokens: number) => void;
 }): Promise<{ text: string }> {
   if (args.provider === "openai") {
     return openaiGenerateText({
@@ -541,6 +551,7 @@ async function callDirectProvider(args: {
       signal: args.signal,
       onDelta: args.onDelta,
       onTrace: args.onTrace,
+      onAcceptedOutputTokens: args.onAcceptedOutputTokens,
     });
   }
 
@@ -557,6 +568,7 @@ async function callDirectProvider(args: {
       signal: args.signal,
       onDelta: args.onDelta,
       onTrace: args.onTrace,
+      onAcceptedOutputTokens: args.onAcceptedOutputTokens,
     });
   }
 
@@ -573,6 +585,7 @@ async function callDirectProvider(args: {
       signal: args.signal,
       onDelta: args.onDelta,
       onTrace: args.onTrace,
+      onAcceptedOutputTokens: args.onAcceptedOutputTokens,
     });
   }
 
@@ -588,6 +601,7 @@ async function callDirectProvider(args: {
       signal: args.signal,
       onDelta: args.onDelta,
       onTrace: args.onTrace,
+      onAcceptedOutputTokens: args.onAcceptedOutputTokens,
     });
   }
 
@@ -604,6 +618,7 @@ async function callDirectProvider(args: {
       signal: args.signal,
       onDelta: args.onDelta,
       onTrace: args.onTrace,
+      onAcceptedOutputTokens: args.onAcceptedOutputTokens,
     });
   }
 
@@ -620,6 +635,7 @@ async function callDirectProvider(args: {
       signal: args.signal,
       onDelta: args.onDelta,
       onTrace: args.onTrace,
+      onAcceptedOutputTokens: args.onAcceptedOutputTokens,
     });
   }
 
@@ -636,6 +652,7 @@ async function callDirectProvider(args: {
       signal: args.signal,
       onDelta: args.onDelta,
       onTrace: args.onTrace,
+      onAcceptedOutputTokens: args.onAcceptedOutputTokens,
     });
   }
 
@@ -660,6 +677,7 @@ async function callDirectProvider(args: {
       signal: args.signal,
       onDelta: args.onDelta,
       onTrace: args.onTrace,
+      onAcceptedOutputTokens: args.onAcceptedOutputTokens,
     });
   }
 
@@ -682,6 +700,8 @@ async function providerGenerateText(args: {
   signal?: AbortSignal;
   onDelta?: (delta: string) => void;
   onProviderTrace?: (message: string) => void;
+  onAcceptedOutputTokens?: (tokens: number) => void;
+  onProviderRoute?: (route: "direct" | "openrouter") => void;
 }): Promise<{ text: string }> {
   const { model } = args;
   const forceOpenRouter = Boolean(model.forceOpenRouter);
@@ -784,6 +804,7 @@ async function providerGenerateText(args: {
           deepseekThinkingConfig: directDeepSeekThinkingConfig,
         }),
     );
+    args.onProviderRoute?.("direct");
     try {
       return await callDirectProvider({
         provider: model.provider,
@@ -804,6 +825,7 @@ async function providerGenerateText(args: {
         signal: args.signal,
         onDelta: args.onDelta,
         onTrace: args.onProviderTrace,
+        onAcceptedOutputTokens: args.onAcceptedOutputTokens,
       });
     } catch (directErr) {
       // If a direct provider key is present, do not fall back to OpenRouter.
@@ -867,6 +889,7 @@ async function providerGenerateText(args: {
         openRouterReasoningEnabled,
       }),
   );
+  args.onProviderRoute?.("openrouter");
 
   return openrouterGenerateText({
     modelId: model.openRouterModelId,
@@ -883,6 +906,7 @@ async function providerGenerateText(args: {
     signal: args.signal,
     onDelta: args.onDelta,
     onTrace: args.onProviderTrace,
+    onAcceptedOutputTokens: args.onAcceptedOutputTokens,
   });
 }
 
@@ -995,6 +1019,8 @@ export async function generateVoxelBuild(
 
   let previousText = "";
   let lastError = "";
+  let acceptedOutputTokens: number | undefined;
+  let providerRoute: "direct" | "openrouter" | undefined;
   const start = Date.now();
 
   for (let attempt = 1; attempt <= maxAttempts; attempt++) {
@@ -1027,6 +1053,12 @@ export async function generateVoxelBuild(
         signal: params.abortSignal,
         onDelta: params.onDelta,
         onProviderTrace: params.onProviderTrace,
+        onAcceptedOutputTokens: (tokens) => {
+          acceptedOutputTokens = tokens;
+        },
+        onProviderRoute: (route) => {
+          providerRoute = route;
+        },
       });
       previousText = text;
 
@@ -1117,6 +1149,8 @@ export async function generateVoxelBuild(
         warnings: validated.value.warnings,
         blockCount,
         generationTimeMs,
+        acceptedOutputTokens,
+        providerRoute,
         rawText: text,
       };
     } catch (err) {
@@ -1134,6 +1168,8 @@ export async function generateVoxelBuild(
     error: lastError || "Generation failed",
     rawText: previousText,
     generationTimeMs: Date.now() - start,
+    acceptedOutputTokens,
+    providerRoute,
   };
 }
 

--- a/lib/ai/modelBenchmarkMetrics.generated.json
+++ b/lib/ai/modelBenchmarkMetrics.generated.json
@@ -1,0 +1,429 @@
+{
+  "version": 1,
+  "models": {
+    "openai_gpt_5_6_sol": {
+      "expectedBuildCount": 15,
+      "finalizedBuildCount": 15,
+      "inferenceSampleCount": 0,
+      "configurationSampleCount": 0,
+      "configurationIsConsistent": false,
+      "averageJsonSizeBytes": 96024838
+    },
+    "openai_gpt_5_5": {
+      "expectedBuildCount": 15,
+      "finalizedBuildCount": 15,
+      "inferenceSampleCount": 0,
+      "configurationSampleCount": 0,
+      "configurationIsConsistent": false,
+      "averageJsonSizeBytes": 44122801
+    },
+    "openai_gpt_5_5_pro": {
+      "expectedBuildCount": 15,
+      "finalizedBuildCount": 15,
+      "inferenceSampleCount": 0,
+      "configurationSampleCount": 0,
+      "configurationIsConsistent": false,
+      "averageJsonSizeBytes": 80476585
+    },
+    "openai_gpt_5_4": {
+      "expectedBuildCount": 15,
+      "finalizedBuildCount": 15,
+      "inferenceSampleCount": 0,
+      "configurationSampleCount": 0,
+      "configurationIsConsistent": false,
+      "averageJsonSizeBytes": 20315356
+    },
+    "openai_gpt_5_4_pro": {
+      "expectedBuildCount": 15,
+      "finalizedBuildCount": 15,
+      "inferenceSampleCount": 0,
+      "configurationSampleCount": 0,
+      "configurationIsConsistent": false,
+      "averageJsonSizeBytes": 35598742
+    },
+    "openai_gpt_5_4_mini": {
+      "expectedBuildCount": 15,
+      "finalizedBuildCount": 15,
+      "inferenceSampleCount": 0,
+      "configurationSampleCount": 0,
+      "configurationIsConsistent": false,
+      "averageJsonSizeBytes": 16877680
+    },
+    "openai_gpt_5_4_nano": {
+      "expectedBuildCount": 15,
+      "finalizedBuildCount": 15,
+      "inferenceSampleCount": 0,
+      "configurationSampleCount": 0,
+      "configurationIsConsistent": false,
+      "averageJsonSizeBytes": 40953722
+    },
+    "openai_gpt_5_3_codex": {
+      "expectedBuildCount": 15,
+      "finalizedBuildCount": 15,
+      "inferenceSampleCount": 0,
+      "configurationSampleCount": 0,
+      "configurationIsConsistent": false,
+      "averageJsonSizeBytes": 8442964
+    },
+    "openai_gpt_5_2": {
+      "expectedBuildCount": 15,
+      "finalizedBuildCount": 15,
+      "inferenceSampleCount": 0,
+      "configurationSampleCount": 0,
+      "configurationIsConsistent": false,
+      "averageJsonSizeBytes": 419836
+    },
+    "openai_gpt_5_2_pro": {
+      "expectedBuildCount": 15,
+      "finalizedBuildCount": 15,
+      "inferenceSampleCount": 0,
+      "configurationSampleCount": 0,
+      "configurationIsConsistent": false,
+      "averageJsonSizeBytes": 1779464
+    },
+    "openai_gpt_5_2_codex": {
+      "expectedBuildCount": 15,
+      "finalizedBuildCount": 15,
+      "inferenceSampleCount": 0,
+      "configurationSampleCount": 0,
+      "configurationIsConsistent": false,
+      "averageJsonSizeBytes": 33921
+    },
+    "openai_gpt_5_mini": {
+      "expectedBuildCount": 15,
+      "finalizedBuildCount": 15,
+      "inferenceSampleCount": 0,
+      "configurationSampleCount": 0,
+      "configurationIsConsistent": false,
+      "averageJsonSizeBytes": 44951
+    },
+    "openai_gpt_5_nano": {
+      "expectedBuildCount": 15,
+      "finalizedBuildCount": 15,
+      "inferenceSampleCount": 0,
+      "configurationSampleCount": 0,
+      "configurationIsConsistent": false,
+      "averageJsonSizeBytes": 5648
+    },
+    "openai_gpt_4_1": {
+      "expectedBuildCount": 15,
+      "finalizedBuildCount": 15,
+      "inferenceSampleCount": 0,
+      "configurationSampleCount": 0,
+      "configurationIsConsistent": false,
+      "averageJsonSizeBytes": 1097348
+    },
+    "openai_gpt_4_5_web_harness": {
+      "expectedBuildCount": 15,
+      "finalizedBuildCount": 15,
+      "inferenceSampleCount": 0,
+      "configurationSampleCount": 0,
+      "configurationIsConsistent": false,
+      "averageJsonSizeBytes": 1265171
+    },
+    "openai_gpt_4o": {
+      "expectedBuildCount": 15,
+      "finalizedBuildCount": 15,
+      "inferenceSampleCount": 0,
+      "configurationSampleCount": 0,
+      "configurationIsConsistent": false,
+      "averageJsonSizeBytes": 3671
+    },
+    "openai_gpt_oss_120b": {
+      "expectedBuildCount": 15,
+      "finalizedBuildCount": 15,
+      "inferenceSampleCount": 0,
+      "configurationSampleCount": 0,
+      "configurationIsConsistent": false,
+      "averageJsonSizeBytes": 24083
+    },
+    "anthropic_claude_fable_5": {
+      "expectedBuildCount": 15,
+      "finalizedBuildCount": 15,
+      "inferenceSampleCount": 0,
+      "configurationSampleCount": 0,
+      "configurationIsConsistent": false,
+      "averageJsonSizeBytes": 32141218
+    },
+    "anthropic_claude_sonnet_5": {
+      "expectedBuildCount": 15,
+      "finalizedBuildCount": 15,
+      "inferenceSampleCount": 0,
+      "configurationSampleCount": 0,
+      "configurationIsConsistent": false,
+      "averageJsonSizeBytes": 17070108
+    },
+    "anthropic_claude_4_5_sonnet": {
+      "expectedBuildCount": 15,
+      "finalizedBuildCount": 15,
+      "inferenceSampleCount": 0,
+      "configurationSampleCount": 0,
+      "configurationIsConsistent": false,
+      "averageJsonSizeBytes": 700330
+    },
+    "anthropic_claude_4_6_sonnet": {
+      "expectedBuildCount": 15,
+      "finalizedBuildCount": 15,
+      "inferenceSampleCount": 0,
+      "configurationSampleCount": 0,
+      "configurationIsConsistent": false,
+      "averageJsonSizeBytes": 244621
+    },
+    "anthropic_claude_4_5_opus": {
+      "expectedBuildCount": 15,
+      "finalizedBuildCount": 15,
+      "inferenceSampleCount": 0,
+      "configurationSampleCount": 0,
+      "configurationIsConsistent": false,
+      "averageJsonSizeBytes": 510035
+    },
+    "anthropic_claude_4_6_opus": {
+      "expectedBuildCount": 15,
+      "finalizedBuildCount": 15,
+      "inferenceSampleCount": 0,
+      "configurationSampleCount": 0,
+      "configurationIsConsistent": false,
+      "averageJsonSizeBytes": 1888206
+    },
+    "anthropic_claude_4_7_opus": {
+      "expectedBuildCount": 15,
+      "finalizedBuildCount": 15,
+      "inferenceSampleCount": 0,
+      "configurationSampleCount": 0,
+      "configurationIsConsistent": false,
+      "averageJsonSizeBytes": 33287244
+    },
+    "anthropic_claude_4_8_opus": {
+      "expectedBuildCount": 15,
+      "finalizedBuildCount": 15,
+      "inferenceSampleCount": 0,
+      "configurationSampleCount": 0,
+      "configurationIsConsistent": false,
+      "averageJsonSizeBytes": 41892685
+    },
+    "gemini_3_6_flash": {
+      "expectedBuildCount": 15,
+      "finalizedBuildCount": 15,
+      "inferenceSampleCount": 0,
+      "configurationSampleCount": 0,
+      "configurationIsConsistent": false,
+      "averageJsonSizeBytes": 40685116
+    },
+    "gemini_3_5_flash_lite": {
+      "expectedBuildCount": 15,
+      "finalizedBuildCount": 15,
+      "inferenceSampleCount": 0,
+      "configurationSampleCount": 0,
+      "configurationIsConsistent": false,
+      "averageJsonSizeBytes": 28596980
+    },
+    "gemini_3_5_flash": {
+      "expectedBuildCount": 15,
+      "finalizedBuildCount": 15,
+      "inferenceSampleCount": 0,
+      "configurationSampleCount": 0,
+      "configurationIsConsistent": false,
+      "averageJsonSizeBytes": 41597630
+    },
+    "gemini_3_1_pro": {
+      "expectedBuildCount": 15,
+      "finalizedBuildCount": 15,
+      "inferenceSampleCount": 0,
+      "configurationSampleCount": 0,
+      "configurationIsConsistent": false,
+      "averageJsonSizeBytes": 28654084
+    },
+    "gemini_3_0_flash": {
+      "expectedBuildCount": 15,
+      "finalizedBuildCount": 15,
+      "inferenceSampleCount": 0,
+      "configurationSampleCount": 0,
+      "configurationIsConsistent": false,
+      "averageJsonSizeBytes": 22514741
+    },
+    "gemini_3_1_flash_lite": {
+      "expectedBuildCount": 15,
+      "finalizedBuildCount": 15,
+      "inferenceSampleCount": 0,
+      "configurationSampleCount": 0,
+      "configurationIsConsistent": false,
+      "averageJsonSizeBytes": 2383285
+    },
+    "gemini_2_5_pro": {
+      "expectedBuildCount": 15,
+      "finalizedBuildCount": 15,
+      "inferenceSampleCount": 0,
+      "configurationSampleCount": 0,
+      "configurationIsConsistent": false,
+      "averageJsonSizeBytes": 11666
+    },
+    "gemma_4_31b": {
+      "expectedBuildCount": 15,
+      "finalizedBuildCount": 15,
+      "inferenceSampleCount": 0,
+      "configurationSampleCount": 0,
+      "configurationIsConsistent": false,
+      "averageJsonSizeBytes": 12140912
+    },
+    "moonshot_kimi_k3": {
+      "expectedBuildCount": 15,
+      "finalizedBuildCount": 15,
+      "inferenceSampleCount": 0,
+      "configurationSampleCount": 0,
+      "configurationIsConsistent": false,
+      "averageJsonSizeBytes": 21536057
+    },
+    "moonshot_kimi_k2": {
+      "expectedBuildCount": 15,
+      "finalizedBuildCount": 15,
+      "inferenceSampleCount": 0,
+      "configurationSampleCount": 0,
+      "configurationIsConsistent": false,
+      "averageJsonSizeBytes": 315132
+    },
+    "moonshot_kimi_k2_6": {
+      "expectedBuildCount": 15,
+      "finalizedBuildCount": 15,
+      "inferenceSampleCount": 0,
+      "configurationSampleCount": 0,
+      "configurationIsConsistent": false,
+      "averageJsonSizeBytes": 11896480
+    },
+    "moonshot_kimi_k2_5": {
+      "expectedBuildCount": 15,
+      "finalizedBuildCount": 15,
+      "inferenceSampleCount": 0,
+      "configurationSampleCount": 0,
+      "configurationIsConsistent": false,
+      "averageJsonSizeBytes": 2554755
+    },
+    "deepseek_v4_pro": {
+      "expectedBuildCount": 15,
+      "finalizedBuildCount": 15,
+      "inferenceSampleCount": 0,
+      "configurationSampleCount": 0,
+      "configurationIsConsistent": false,
+      "averageJsonSizeBytes": 24223465
+    },
+    "deepseek_v3_2": {
+      "expectedBuildCount": 15,
+      "finalizedBuildCount": 15,
+      "inferenceSampleCount": 0,
+      "configurationSampleCount": 0,
+      "configurationIsConsistent": false,
+      "averageJsonSizeBytes": 2691428
+    },
+    "xai_grok_4_5": {
+      "expectedBuildCount": 15,
+      "finalizedBuildCount": 15,
+      "inferenceSampleCount": 0,
+      "configurationSampleCount": 0,
+      "configurationIsConsistent": false,
+      "averageJsonSizeBytes": 50629098
+    },
+    "xai_grok_4_3": {
+      "expectedBuildCount": 15,
+      "finalizedBuildCount": 15,
+      "inferenceSampleCount": 0,
+      "configurationSampleCount": 0,
+      "configurationIsConsistent": false,
+      "averageJsonSizeBytes": 9733939
+    },
+    "xai_grok_4_1": {
+      "expectedBuildCount": 15,
+      "finalizedBuildCount": 15,
+      "inferenceSampleCount": 0,
+      "configurationSampleCount": 0,
+      "configurationIsConsistent": false,
+      "averageJsonSizeBytes": 458395
+    },
+    "xai_grok_4_20": {
+      "expectedBuildCount": 15,
+      "finalizedBuildCount": 15,
+      "inferenceSampleCount": 0,
+      "configurationSampleCount": 0,
+      "configurationIsConsistent": false,
+      "averageJsonSizeBytes": 52227991
+    },
+    "zai_glm_5_2": {
+      "expectedBuildCount": 15,
+      "finalizedBuildCount": 15,
+      "inferenceSampleCount": 0,
+      "configurationSampleCount": 0,
+      "configurationIsConsistent": false,
+      "averageJsonSizeBytes": 20756795
+    },
+    "zai_glm_5_1": {
+      "expectedBuildCount": 15,
+      "finalizedBuildCount": 15,
+      "inferenceSampleCount": 0,
+      "configurationSampleCount": 0,
+      "configurationIsConsistent": false,
+      "averageJsonSizeBytes": 5453430
+    },
+    "zai_glm_5": {
+      "expectedBuildCount": 15,
+      "finalizedBuildCount": 15,
+      "inferenceSampleCount": 0,
+      "configurationSampleCount": 0,
+      "configurationIsConsistent": false,
+      "averageJsonSizeBytes": 339113
+    },
+    "zai_glm_4_7": {
+      "expectedBuildCount": 15,
+      "finalizedBuildCount": 15,
+      "inferenceSampleCount": 0,
+      "configurationSampleCount": 0,
+      "configurationIsConsistent": false,
+      "averageJsonSizeBytes": 29346
+    },
+    "qwen_qwen3_max_thinking": {
+      "expectedBuildCount": 15,
+      "finalizedBuildCount": 15,
+      "inferenceSampleCount": 0,
+      "configurationSampleCount": 0,
+      "configurationIsConsistent": false,
+      "averageJsonSizeBytes": 54136
+    },
+    "qwen_qwen3_5_397b_a17b": {
+      "expectedBuildCount": 15,
+      "finalizedBuildCount": 15,
+      "inferenceSampleCount": 0,
+      "configurationSampleCount": 0,
+      "configurationIsConsistent": false,
+      "averageJsonSizeBytes": 1516336
+    },
+    "minimax_m2_7": {
+      "expectedBuildCount": 15,
+      "finalizedBuildCount": 15,
+      "inferenceSampleCount": 0,
+      "configurationSampleCount": 0,
+      "configurationIsConsistent": false,
+      "averageJsonSizeBytes": 8165693
+    },
+    "minimax_m2_5": {
+      "expectedBuildCount": 15,
+      "finalizedBuildCount": 15,
+      "inferenceSampleCount": 0,
+      "configurationSampleCount": 0,
+      "configurationIsConsistent": false,
+      "averageJsonSizeBytes": 948040
+    },
+    "meta_llama_4_maverick": {
+      "expectedBuildCount": 15,
+      "finalizedBuildCount": 15,
+      "inferenceSampleCount": 0,
+      "configurationSampleCount": 0,
+      "configurationIsConsistent": false,
+      "averageJsonSizeBytes": 495800
+    },
+    "gemini_3_0_pro": {
+      "expectedBuildCount": 15,
+      "finalizedBuildCount": 15,
+      "inferenceSampleCount": 0,
+      "configurationSampleCount": 0,
+      "configurationIsConsistent": false,
+      "averageJsonSizeBytes": 2087458
+    }
+  }
+}

--- a/lib/ai/modelBenchmarkProfiles.ts
+++ b/lib/ai/modelBenchmarkProfiles.ts
@@ -15,7 +15,6 @@ export type BenchmarkDuration = {
 
 export type BenchmarkCost = {
   usd: number;
-  qualifier?: "approximate" | "under-approximately";
 };
 
 export type ModelBenchmarkProfile = {
@@ -214,7 +213,6 @@ const MODEL_BENCHMARK_METADATA: Partial<
   openai_gpt_5_6_sol: {
     sourceRelease: "3.9.0",
     averageInference: { milliseconds: 1_516_200 },
-    totalCost: { usd: 710.82 },
     buildCount: 15,
   },
   xai_grok_4_5: {
@@ -276,7 +274,7 @@ const MODEL_BENCHMARK_METADATA: Partial<
   },
   xai_grok_4_20: {
     sourceRelease: "v3.0.0",
-    averageInference: { milliseconds: 149_000, approximate: true },
+    averageInference: { milliseconds: 149_000 },
     totalCost: { usd: 18.44 },
     buildCount: 15,
   },
@@ -290,15 +288,9 @@ const MODEL_BENCHMARK_METADATA: Partial<
     averageInference: { milliseconds: 1_283_300 },
     totalCost: { usd: 223.9 },
   },
-  openai_gpt_5_4: {
-    totalCost: { usd: 25, qualifier: "approximate" },
-  },
   openai_gpt_5_4_pro: {
     averageInference: { milliseconds: 3_360_000 },
     totalCost: { usd: 435 },
-  },
-  openai_gpt_5_3_codex: {
-    totalCost: { usd: 5, qualifier: "under-approximately" },
   },
   deepseek_v4_pro: {
     sourceRelease: "3.3.2",
@@ -307,10 +299,6 @@ const MODEL_BENCHMARK_METADATA: Partial<
   anthropic_claude_4_7_opus: {
     sourceRelease: "v3.0.0",
     averageInference: { milliseconds: 2_600_000, approximate: true },
-    totalCost: { usd: 275, qualifier: "approximate" },
-  },
-  anthropic_claude_4_6_opus: {
-    totalCost: { usd: 22, qualifier: "approximate" },
   },
   zai_glm_5_1: {
     sourceRelease: "v3.0.0",

--- a/lib/ai/modelBenchmarkProfiles.ts
+++ b/lib/ai/modelBenchmarkProfiles.ts
@@ -50,7 +50,7 @@ const GEMINI_HIGH: ModelRunParameters = [
   { label: "Thinking level", value: "High" },
 ];
 
-const OPENROUTER_XHIGH_32K: ModelRunParameters = [
+const OPENROUTER_XHIGH: ModelRunParameters = [
   { label: "Reasoning effort", value: "XHigh" },
 ];
 
@@ -162,8 +162,8 @@ const MODEL_RUN_PARAMETERS = {
     { label: "Reasoning effort", value: "XHigh" },
   ],
   zai_glm_4_7: PROVIDER_DEFAULT,
-  qwen_qwen3_max_thinking: OPENROUTER_XHIGH_32K,
-  qwen_qwen3_5_397b_a17b: OPENROUTER_XHIGH_32K,
+  qwen_qwen3_max_thinking: OPENROUTER_XHIGH,
+  qwen_qwen3_5_397b_a17b: OPENROUTER_XHIGH,
   minimax_m2_7: [
     { label: "Reasoning effort", value: "XHigh" },
   ],
@@ -173,7 +173,8 @@ const MODEL_RUN_PARAMETERS = {
   meta_llama_4_maverick: PROVIDER_DEFAULT,
 } satisfies Record<ModelKey, ModelRunParameters>;
 
-const STATIC_OUTPUT_CAP_TOKENS: Partial<Record<ModelKey, number>> = {
+// Historical fallback values must be accepted caps, never requested-only budgets.
+export const HISTORICAL_ACCEPTED_OUTPUT_CAP_TOKENS: Partial<Record<ModelKey, number>> = {
   openai_gpt_5_6_sol: 128_000,
   openai_gpt_5_5: 128_000,
   openai_gpt_5_5_pro: 128_000,
@@ -353,7 +354,7 @@ export const MODEL_BENCHMARK_PROFILES = Object.fromEntries(
           outputCapTokens:
             generatedTimingCohortIsComplete
               ? generated.outputCapTokens
-              : STATIC_OUTPUT_CAP_TOKENS[modelKey],
+              : HISTORICAL_ACCEPTED_OUTPUT_CAP_TOKENS[modelKey],
           averageInference:
             generatedTimingCohortIsComplete
               ? generated.averageInferenceMs === undefined

--- a/lib/ai/modelBenchmarkProfiles.ts
+++ b/lib/ai/modelBenchmarkProfiles.ts
@@ -1,4 +1,5 @@
 import type { ModelKey } from "@/lib/ai/modelCatalog";
+import generatedMetrics from "@/lib/ai/modelBenchmarkMetrics.generated.json";
 
 export type ModelRunParameter = {
   label: string;
@@ -7,24 +8,34 @@ export type ModelRunParameter = {
 
 export type ModelRunParameters = readonly [ModelRunParameter, ...ModelRunParameter[]];
 
+export type BenchmarkDuration = {
+  milliseconds: number;
+  approximate?: true;
+};
+
+export type BenchmarkCost = {
+  usd: number;
+  qualifier?: "approximate" | "under-approximately";
+};
+
 export type ModelBenchmarkProfile = {
   sourceRelease?: string;
   parameters: ModelRunParameters;
-  averageInferenceTime?: string;
-  totalCost?: string;
+  outputCapTokens?: number;
+  averageInference?: BenchmarkDuration;
+  averageJsonSizeBytes?: number;
+  totalCost?: BenchmarkCost;
   buildCount?: number;
   note?: string;
 };
 
 const OPENAI_XHIGH_128K: ModelRunParameters = [
   { label: "Reasoning effort", value: "XHigh" },
-  { label: "Output cap", value: "128,000 tokens" },
 ];
 
 const OPENAI_XHIGH_HIGH_128K: ModelRunParameters = [
   { label: "Reasoning effort", value: "XHigh" },
   { label: "Text verbosity", value: "High" },
-  { label: "Output cap", value: "128,000 tokens" },
 ];
 
 const PROVIDER_DEFAULT: ModelRunParameters = [
@@ -42,7 +53,6 @@ const GEMINI_HIGH: ModelRunParameters = [
 
 const OPENROUTER_XHIGH_32K: ModelRunParameters = [
   { label: "Reasoning effort", value: "XHigh" },
-  { label: "Requested output budget", value: "32,768 tokens" },
 ];
 
 const MODEL_RUN_PARAMETERS = {
@@ -50,17 +60,14 @@ const MODEL_RUN_PARAMETERS = {
     { label: "Reasoning mode", value: "Pro" },
     { label: "Reasoning effort", value: "Max" },
     { label: "Text verbosity", value: "High" },
-    { label: "Combined reasoning/output cap", value: "128,000 tokens" },
   ],
   openai_gpt_5_5: [
     { label: "Reasoning effort", value: "Max" },
     { label: "Text verbosity", value: "High" },
-    { label: "Output cap", value: "128,000 tokens" },
   ],
   openai_gpt_5_5_pro: [
     { label: "Reasoning effort", value: "Max" },
     { label: "Text verbosity", value: "High" },
-    { label: "Output cap", value: "128,000 tokens" },
   ],
   openai_gpt_5_4: OPENAI_XHIGH_HIGH_128K,
   openai_gpt_5_4_pro: OPENAI_XHIGH_HIGH_128K,
@@ -77,54 +84,44 @@ const MODEL_RUN_PARAMETERS = {
   openai_gpt_4o: PROVIDER_DEFAULT,
   openai_gpt_oss_120b: [
     { label: "Reasoning effort", value: "XHigh" },
-    { label: "Combined reasoning/output budget", value: "131,072 tokens" },
   ],
   anthropic_claude_fable_5: [
     { label: "Thinking", value: "Adaptive" },
     { label: "Reasoning effort", value: "Max" },
     { label: "Sampling", value: "Provider default" },
-    { label: "Output cap", value: "128,000 tokens" },
   ],
   anthropic_claude_sonnet_5: [
     { label: "Thinking", value: "Adaptive" },
     { label: "Reasoning effort", value: "XHigh" },
-    { label: "Output cap", value: "128,000 tokens" },
   ],
   anthropic_claude_4_5_sonnet: ANTHROPIC_LEGACY_THINKING,
   anthropic_claude_4_6_sonnet: [
     { label: "Thinking", value: "Adaptive" },
     { label: "Reasoning effort", value: "Max" },
-    { label: "Requested output budget", value: "65,536 tokens" },
   ],
   anthropic_claude_4_5_opus: ANTHROPIC_LEGACY_THINKING,
   anthropic_claude_4_6_opus: [
     { label: "Thinking", value: "Adaptive" },
     { label: "Reasoning effort", value: "Max" },
-    { label: "Output cap", value: "131,072 tokens" },
   ],
   anthropic_claude_4_7_opus: [
     { label: "Thinking", value: "Adaptive" },
     { label: "Reasoning effort", value: "Max" },
-    { label: "Output cap", value: "128,000 tokens" },
   ],
   anthropic_claude_4_8_opus: [
     { label: "Thinking", value: "Adaptive" },
     { label: "Reasoning effort", value: "Max" },
-    { label: "Output cap", value: "128,000 tokens" },
   ],
   gemini_3_6_flash: [
     { label: "Thinking level", value: "High" },
     { label: "Sampling", value: "Provider default" },
-    { label: "Output cap", value: "65,536 tokens" },
   ],
   gemini_3_5_flash_lite: [
     { label: "Thinking level", value: "High" },
     { label: "Sampling", value: "Provider default" },
-    { label: "Output cap", value: "65,536 tokens" },
   ],
   gemini_3_5_flash: [
     { label: "Thinking level", value: "High" },
-    { label: "Output cap", value: "65,536 tokens" },
   ],
   gemini_3_0_pro: GEMINI_HIGH,
   gemini_3_1_pro: GEMINI_HIGH,
@@ -135,7 +132,6 @@ const MODEL_RUN_PARAMETERS = {
   moonshot_kimi_k3: [
     { label: "Reasoning effort", value: "Max" },
     { label: "Structured output", value: "Strict" },
-    { label: "Completion ceiling", value: "1,048,576 tokens" },
   ],
   moonshot_kimi_k2: [{ label: "Reasoning", value: "Model default" }],
   moonshot_kimi_k2_6: [{ label: "Reasoning", value: "Thinking enabled" }],
@@ -143,78 +139,100 @@ const MODEL_RUN_PARAMETERS = {
   deepseek_v4_pro: [
     { label: "Thinking", value: "Enabled" },
     { label: "Reasoning effort", value: "Max" },
-    { label: "Requested output budget", value: "384,000 tokens" },
   ],
   deepseek_v3_2: [
     { label: "Reasoning", value: "Provider default" },
-    { label: "Output cap", value: "65,536 tokens" },
   ],
   xai_grok_4_5: [
     { label: "Reasoning effort", value: "High" },
-    { label: "Requested output budget", value: "500,000 tokens" },
-    { label: "Accepted output budget", value: "262,144 tokens" },
   ],
   xai_grok_4_3: [
     { label: "Reasoning", value: "Automatic" },
-    { label: "Requested output budget", value: "1,000,000 tokens" },
-    { label: "Accepted output budget", value: "983,040 tokens" },
   ],
   xai_grok_4_1: [
     { label: "Reasoning", value: "Automatic" },
-    { label: "Output cap", value: "30,000 tokens" },
   ],
   xai_grok_4_20: [{ label: "Reasoning", value: "Thinking enabled" }],
   zai_glm_5_2: [
     { label: "Reasoning effort", value: "XHigh → High" },
-    { label: "Output cap", value: "131,072 tokens" },
   ],
   zai_glm_5_1: [
     { label: "Reasoning", value: "Thinking enabled" },
-    { label: "Output cap", value: "131,072 tokens" },
   ],
   zai_glm_5: [
     { label: "Reasoning effort", value: "XHigh" },
-    { label: "Output cap", value: "131,072 tokens" },
   ],
   zai_glm_4_7: PROVIDER_DEFAULT,
   qwen_qwen3_max_thinking: OPENROUTER_XHIGH_32K,
   qwen_qwen3_5_397b_a17b: OPENROUTER_XHIGH_32K,
   minimax_m2_7: [
     { label: "Reasoning effort", value: "XHigh" },
-    { label: "Output cap", value: "131,072 tokens" },
   ],
   minimax_m2_5: [
     { label: "Reasoning effort", value: "XHigh" },
-    { label: "Requested output budget", value: "131,072 tokens" },
   ],
   meta_llama_4_maverick: PROVIDER_DEFAULT,
 } satisfies Record<ModelKey, ModelRunParameters>;
+
+const STATIC_OUTPUT_CAP_TOKENS: Partial<Record<ModelKey, number>> = {
+  openai_gpt_5_6_sol: 128_000,
+  openai_gpt_5_5: 128_000,
+  openai_gpt_5_5_pro: 128_000,
+  openai_gpt_5_4: 128_000,
+  openai_gpt_5_4_pro: 128_000,
+  openai_gpt_5_4_mini: 128_000,
+  openai_gpt_5_4_nano: 128_000,
+  openai_gpt_5_3_codex: 128_000,
+  openai_gpt_5_2: 128_000,
+  openai_gpt_5_2_pro: 128_000,
+  openai_gpt_5_2_codex: 128_000,
+  openai_gpt_5_mini: 128_000,
+  openai_gpt_5_nano: 128_000,
+  openai_gpt_oss_120b: 131_072,
+  anthropic_claude_fable_5: 128_000,
+  anthropic_claude_sonnet_5: 128_000,
+  anthropic_claude_4_6_opus: 131_072,
+  anthropic_claude_4_7_opus: 128_000,
+  anthropic_claude_4_8_opus: 128_000,
+  gemini_3_6_flash: 65_536,
+  gemini_3_5_flash_lite: 65_536,
+  gemini_3_5_flash: 65_536,
+  moonshot_kimi_k3: 1_048_576,
+  deepseek_v3_2: 65_536,
+  xai_grok_4_5: 262_144,
+  xai_grok_4_3: 983_040,
+  xai_grok_4_1: 30_000,
+  zai_glm_5_2: 131_072,
+  zai_glm_5_1: 131_072,
+  zai_glm_5: 131_072,
+  minimax_m2_7: 131_072,
+};
 
 const MODEL_BENCHMARK_METADATA: Partial<
   Record<ModelKey, Omit<ModelBenchmarkProfile, "parameters">>
 > = {
   openai_gpt_5_6_sol: {
     sourceRelease: "3.9.0",
-    averageInferenceTime: "25m 16.2s (1,516.2s)",
-    totalCost: "$710.82",
+    averageInference: { milliseconds: 1_516_200 },
+    totalCost: { usd: 710.82 },
     buildCount: 15,
   },
   xai_grok_4_5: {
     sourceRelease: "3.9.0",
-    averageInferenceTime: "1m 48s (108.2s)",
-    totalCost: "$1.69",
+    averageInference: { milliseconds: 108_200 },
+    totalCost: { usd: 1.69 },
     buildCount: 15,
   },
   zai_glm_5_2: {
     sourceRelease: "3.8.0",
-    averageInferenceTime: "6m 21s (381.1s)",
-    totalCost: "$4.46",
+    averageInference: { milliseconds: 381_100 },
+    totalCost: { usd: 4.46 },
     buildCount: 15,
   },
   anthropic_claude_sonnet_5: {
     sourceRelease: "3.8.0",
-    averageInferenceTime: "31m 3s (1863.1s)",
-    totalCost: "$94.17",
+    averageInference: { milliseconds: 1_863_100 },
+    totalCost: { usd: 94.17 },
     buildCount: 15,
   },
   openai_gpt_4_5_web_harness: {
@@ -223,104 +241,144 @@ const MODEL_BENCHMARK_METADATA: Partial<
   },
   anthropic_claude_fable_5: {
     sourceRelease: "3.7.0",
-    averageInferenceTime: "18m 04.4s (1,084.4s)",
-    totalCost: "$54.93",
+    averageInference: { milliseconds: 1_084_400 },
+    totalCost: { usd: 54.93 },
     buildCount: 15,
   },
   anthropic_claude_4_8_opus: {
     sourceRelease: "3.6.0",
-    averageInferenceTime: "24m 47.9s (1,487.9s)",
-    totalCost: "$41.52",
+    averageInference: { milliseconds: 1_487_900 },
+    totalCost: { usd: 41.52 },
     buildCount: 15,
   },
   gemini_3_6_flash: {
     sourceRelease: "3.10.0",
-    averageInferenceTime: "1m 41.9s (101.9s)",
-    totalCost: "$2.84",
+    averageInference: { milliseconds: 101_900 },
+    totalCost: { usd: 2.84 },
     buildCount: 15,
   },
   gemini_3_5_flash_lite: {
     sourceRelease: "3.10.0",
-    averageInferenceTime: "25.7s",
-    totalCost: "$0.38",
+    averageInference: { milliseconds: 25_700 },
+    totalCost: { usd: 0.38 },
     buildCount: 15,
   },
   gemini_3_5_flash: {
     sourceRelease: "3.6.0",
-    averageInferenceTime: "1m 54s (114.1s)",
-    totalCost: "$12.90",
+    averageInference: { milliseconds: 114_100 },
+    totalCost: { usd: 12.9 },
     buildCount: 15,
   },
   xai_grok_4_3: {
     sourceRelease: "3.4.0",
-    averageInferenceTime: "3m 43s (223.1s)",
-    totalCost: "$0.87",
+    averageInference: { milliseconds: 223_100 },
+    totalCost: { usd: 0.87 },
   },
   xai_grok_4_20: {
     sourceRelease: "v3.0.0",
-    averageInferenceTime: "~2m 29s",
-    totalCost: "$18.44",
+    averageInference: { milliseconds: 149_000, approximate: true },
+    totalCost: { usd: 18.44 },
     buildCount: 15,
   },
   openai_gpt_5_5: {
     sourceRelease: "3.3.2",
-    averageInferenceTime: "10m 24s (624s)",
-    totalCost: "$19.98",
+    averageInference: { milliseconds: 624_000 },
+    totalCost: { usd: 19.98 },
   },
   openai_gpt_5_5_pro: {
     sourceRelease: "3.3.2",
-    averageInferenceTime: "21m 23.3s (1,283.3s)",
-    totalCost: "$223.90",
+    averageInference: { milliseconds: 1_283_300 },
+    totalCost: { usd: 223.9 },
   },
   openai_gpt_5_4: {
-    totalCost: "~$25",
+    totalCost: { usd: 25, qualifier: "approximate" },
   },
   openai_gpt_5_4_pro: {
-    averageInferenceTime: "56 minutes",
-    totalCost: "$435",
+    averageInference: { milliseconds: 3_360_000 },
+    totalCost: { usd: 435 },
   },
   openai_gpt_5_3_codex: {
-    totalCost: "Under approximately $5",
+    totalCost: { usd: 5, qualifier: "under-approximately" },
   },
   deepseek_v4_pro: {
     sourceRelease: "3.3.2",
-    totalCost: "$3.92",
+    totalCost: { usd: 3.92 },
   },
   anthropic_claude_4_7_opus: {
     sourceRelease: "v3.0.0",
-    averageInferenceTime: "~43m 20s (~2,600s)",
-    totalCost: "~$275",
+    averageInference: { milliseconds: 2_600_000, approximate: true },
+    totalCost: { usd: 275, qualifier: "approximate" },
   },
   anthropic_claude_4_6_opus: {
-    totalCost: "~$22",
+    totalCost: { usd: 22, qualifier: "approximate" },
   },
   zai_glm_5_1: {
     sourceRelease: "v3.0.0",
-    averageInferenceTime: "~17m 26s",
-    totalCost: "$4.18",
+    averageInference: { milliseconds: 1_046_000 },
+    totalCost: { usd: 4.18 },
     buildCount: 15,
   },
   moonshot_kimi_k2_6: {
     sourceRelease: "v3.0.0",
-    totalCost: "$2.35",
+    totalCost: { usd: 2.35 },
   },
   moonshot_kimi_k3: {
     sourceRelease: "3.10.0",
-    averageInferenceTime: "32m 46s (1966.0s)",
-    totalCost: "$12.70",
+    averageInference: { milliseconds: 1_966_000 },
+    totalCost: { usd: 12.7 },
     buildCount: 15,
   },
 };
 
+type GeneratedModelBenchmarkMetrics = {
+  expectedBuildCount: number;
+  finalizedBuildCount: number;
+  inferenceSampleCount: number;
+  averageInferenceMs?: number;
+  averageJsonSizeBytes?: number;
+  outputCapTokens?: number;
+  configurationSampleCount?: number;
+  configurationIsConsistent?: boolean;
+};
+
+const GENERATED_MODEL_METRICS = generatedMetrics.models as Partial<
+  Record<ModelKey, GeneratedModelBenchmarkMetrics>
+>;
+
 export const MODEL_BENCHMARK_PROFILES = Object.fromEntries(
   (Object.entries(MODEL_RUN_PARAMETERS) as [ModelKey, ModelRunParameters][]).map(
-    ([modelKey, parameters]) => [
-      modelKey,
-      {
-        parameters,
-        ...MODEL_BENCHMARK_METADATA[modelKey],
-      },
-    ],
+    ([modelKey, parameters]) => {
+      const generated = GENERATED_MODEL_METRICS[modelKey];
+      const metadata = MODEL_BENCHMARK_METADATA[modelKey];
+      const generatedIsComplete =
+        generated && generated.finalizedBuildCount === generated.expectedBuildCount;
+      const generatedTimingCohortIsComplete =
+        generated &&
+        generated.expectedBuildCount > 0 &&
+        generated.inferenceSampleCount === generated.expectedBuildCount;
+
+      return [
+        modelKey,
+        {
+          parameters,
+          ...metadata,
+          outputCapTokens:
+            generatedTimingCohortIsComplete
+              ? generated.outputCapTokens
+              : STATIC_OUTPUT_CAP_TOKENS[modelKey],
+          averageInference:
+            generatedTimingCohortIsComplete
+              ? generated.averageInferenceMs === undefined
+                ? undefined
+                : { milliseconds: generated.averageInferenceMs }
+              : metadata?.averageInference,
+          averageJsonSizeBytes:
+            generatedIsComplete ? generated.averageJsonSizeBytes : undefined,
+          buildCount:
+            generatedIsComplete ? generated.finalizedBuildCount : metadata?.buildCount,
+        },
+      ];
+    },
   ),
 ) as Record<ModelKey, ModelBenchmarkProfile>;
 

--- a/lib/ai/providers/anthropic.ts
+++ b/lib/ai/providers/anthropic.ts
@@ -279,6 +279,7 @@ export async function anthropicGenerateText(params: {
   signal?: AbortSignal;
   onDelta?: (delta: string) => void;
   onTrace?: (message: string) => void;
+  onAcceptedOutputTokens?: (tokens: number) => void;
 }): Promise<{ text: string }> {
   const apiKey = params.apiKey ?? process.env.ANTHROPIC_API_KEY;
   if (!apiKey) throw new Error("Missing ANTHROPIC_API_KEY");
@@ -329,7 +330,7 @@ export async function anthropicGenerateText(params: {
   let structuredMode: "native_format" | "forced_tool" = "native_format";
   let didUseStreaming = false;
   let selectedAdaptiveEffort: AnthropicEffort | null = null;
-  let selectedAdaptiveTokenBudget: number | null = null;
+  let selectedTokenBudget: number | null = null;
   try {
     requestLoop: for (const tok of tokenBudgetCandidates(maxTokens)) {
       betaLoop: for (const betaHeader of betaHeaders) {
@@ -399,7 +400,7 @@ export async function anthropicGenerateText(params: {
 
           if (res.ok) {
             if (usesAdaptiveThinking) selectedAdaptiveEffort = effort ?? null;
-            if (usesAdaptiveThinking) selectedAdaptiveTokenBudget = tok;
+            selectedTokenBudget = tok;
             break requestLoop;
           }
           lastBody = await res.text().catch(() => "");
@@ -454,10 +455,15 @@ export async function anthropicGenerateText(params: {
     throw new Error(`Anthropic error ${res.status}: ${body}`);
   }
 
+  const acceptedOutputTokens = selectedTokenBudget ?? maxTokens;
+  params.onAcceptedOutputTokens?.(acceptedOutputTokens);
+
   if (usesAdaptiveThinking && selectedAdaptiveEffort) {
-    const budget = selectedAdaptiveTokenBudget ?? maxTokens;
     params.onTrace?.(
-      withMaxOutputTokens(`Anthropic reasoning effort in use: '${selectedAdaptiveEffort}'.`, budget),
+      withMaxOutputTokens(
+        `Anthropic reasoning effort in use: '${selectedAdaptiveEffort}'.`,
+        acceptedOutputTokens,
+      ),
     );
   }
 

--- a/lib/ai/providers/deepseek.ts
+++ b/lib/ai/providers/deepseek.ts
@@ -76,6 +76,7 @@ export async function deepseekGenerateText(params: {
   signal?: AbortSignal;
   onDelta?: (delta: string) => void;
   onTrace?: (message: string) => void;
+  onAcceptedOutputTokens?: (tokens: number) => void;
 }): Promise<{ text: string }> {
   const apiKey = params.apiKey ?? process.env.DEEPSEEK_API_KEY;
   if (!apiKey) throw new Error("Missing DEEPSEEK_API_KEY");
@@ -153,6 +154,7 @@ export async function deepseekGenerateText(params: {
   }
 
   const budget = selectedTokenBudget ?? maxTokens;
+  params.onAcceptedOutputTokens?.(budget);
   params.onTrace?.(
     withMaxOutputTokens(
       `DeepSeek reasoning mode in use: ${describeThinkingConfig(thinkingConfig)}; structured_output=${useJsonOutput ? "json_object" : "none"}.`,

--- a/lib/ai/providers/gemini.ts
+++ b/lib/ai/providers/gemini.ts
@@ -105,6 +105,7 @@ export async function geminiGenerateText(params: {
   signal?: AbortSignal;
   onDelta?: (delta: string) => void;
   onTrace?: (message: string) => void;
+  onAcceptedOutputTokens?: (tokens: number) => void;
 }): Promise<{ text: string }> {
   const apiKey = params.apiKey ?? process.env.GOOGLE_AI_API_KEY;
   if (!apiKey) throw new Error("Missing GOOGLE_AI_API_KEY");
@@ -176,6 +177,7 @@ export async function geminiGenerateText(params: {
     }
 
     const budget = successBudget ?? basePayload.generationConfig.maxOutputTokens;
+    params.onAcceptedOutputTokens?.(budget);
     params.onTrace?.(withMaxOutputTokens(thinkingConfigLine, budget));
   } catch (err) {
     if (err instanceof Error && err.name === "AbortError") {

--- a/lib/ai/providers/minimax.ts
+++ b/lib/ai/providers/minimax.ts
@@ -74,6 +74,7 @@ export async function minimaxGenerateText(params: {
   signal?: AbortSignal;
   onDelta?: (delta: string) => void;
   onTrace?: (message: string) => void;
+  onAcceptedOutputTokens?: (tokens: number) => void;
 }): Promise<{ text: string }> {
   const apiKey = params.apiKey ?? process.env.MINIMAX_API_KEY;
   if (!apiKey) throw new Error("Missing MINIMAX_API_KEY");
@@ -147,6 +148,7 @@ export async function minimaxGenerateText(params: {
   }
 
   const budget = selectedTokenBudget ?? maxTokens;
+  params.onAcceptedOutputTokens?.(budget);
   params.onTrace?.(withMaxOutputTokens("MiniMax reasoning config in use: default.", budget));
 
   if (params.onDelta) {

--- a/lib/ai/providers/moonshot.ts
+++ b/lib/ai/providers/moonshot.ts
@@ -79,6 +79,7 @@ export async function moonshotGenerateText(params: {
   signal?: AbortSignal;
   onDelta?: (delta: string) => void;
   onTrace?: (message: string) => void;
+  onAcceptedOutputTokens?: (tokens: number) => void;
 }): Promise<{ text: string }> {
   const apiKey = params.apiKey ?? process.env.MOONSHOT_API_KEY;
   if (!apiKey) throw new Error("Missing MOONSHOT_API_KEY");
@@ -162,6 +163,7 @@ export async function moonshotGenerateText(params: {
   }
 
   const budget = selectedTokenBudget ?? maxTokens;
+  params.onAcceptedOutputTokens?.(budget);
   const reasoningLabel = params.thinkingConfig?.reasoningEffort
     ? `reasoning_effort=${params.thinkingConfig.reasoningEffort}`
     : `thinking=${params.thinkingConfig?.type ?? "default"}`;

--- a/lib/ai/providers/nvidia.ts
+++ b/lib/ai/providers/nvidia.ts
@@ -478,6 +478,7 @@ export async function openAiCompatibleGenerateText(params: {
   signal?: AbortSignal;
   onDelta?: (delta: string) => void;
   onTrace?: (message: string) => void;
+  onAcceptedOutputTokens?: (tokens: number) => void;
 }): Promise<{ text: string }> {
   const serviceLabel = params.serviceLabel ?? "Custom API";
   const apiKey = params.apiKey ?? process.env.CUSTOM_API_KEY;
@@ -564,6 +565,7 @@ export async function openAiCompatibleGenerateText(params: {
   }
 
   const budget = selectedTokenBudget ?? maxTokens;
+  params.onAcceptedOutputTokens?.(budget);
   params.onTrace?.(
     withMaxOutputTokens(
       useStructuredOutput

--- a/lib/ai/providers/openai.ts
+++ b/lib/ai/providers/openai.ts
@@ -437,6 +437,7 @@ export async function openaiGenerateText(params: {
   signal?: AbortSignal;
   onDelta?: (delta: string) => void;
   onTrace?: (message: string) => void;
+  onAcceptedOutputTokens?: (tokens: number) => void;
 }): Promise<{ text: string }> {
   const apiKey = params.apiKey ?? process.env.OPENAI_API_KEY;
   if (!apiKey) throw new Error("Missing OPENAI_API_KEY");
@@ -572,6 +573,7 @@ export async function openaiGenerateText(params: {
           );
 
           if (res.ok) {
+            params.onAcceptedOutputTokens?.(tok);
             params.onTrace?.(
               withMaxOutputTokens(
                 `OpenAI Responses reasoning config in use: '${currentReasoningLabel}'.`,
@@ -822,6 +824,7 @@ export async function openaiGenerateText(params: {
 
   if (res.ok && selectedChatEffortLabel) {
     const budget = selectedChatTokenBudget ?? maxOutputTokens;
+    params.onAcceptedOutputTokens?.(budget);
     params.onTrace?.(
       withMaxOutputTokens(
         `OpenAI Chat reasoning config in use: '${selectedChatEffortLabel}'.`,

--- a/lib/ai/providers/openrouter.ts
+++ b/lib/ai/providers/openrouter.ts
@@ -195,6 +195,7 @@ export async function openrouterGenerateText(params: {
   signal?: AbortSignal;
   onDelta?: (delta: string) => void;
   onTrace?: (message: string) => void;
+  onAcceptedOutputTokens?: (tokens: number) => void;
 }): Promise<{ text: string }> {
   const apiKey = params.apiKey ?? process.env.OPENROUTER_API_KEY;
   if (!apiKey) throw new Error("Missing OPENROUTER_API_KEY");
@@ -343,6 +344,7 @@ export async function openrouterGenerateText(params: {
 
     if (res.ok && selectedReasoningLabel) {
       const budget = selectedReasoningTokenBudget ?? maxTokens;
+      params.onAcceptedOutputTokens?.(budget);
       params.onTrace?.(
         withMaxOutputTokens(
           `OpenRouter reasoning config in use: '${selectedReasoningLabel}'.`,

--- a/lib/ai/providers/xai.ts
+++ b/lib/ai/providers/xai.ts
@@ -28,6 +28,7 @@ export async function xaiGenerateText(params: {
   signal?: AbortSignal;
   onDelta?: (delta: string) => void;
   onTrace?: (message: string) => void;
+  onAcceptedOutputTokens?: (tokens: number) => void;
 }): Promise<{ text: string }> {
   const apiKey = params.apiKey ?? process.env.XAI_API_KEY;
   if (!apiKey) throw new Error("Missing XAI_API_KEY");
@@ -53,5 +54,6 @@ export async function xaiGenerateText(params: {
     signal: params.signal,
     onDelta: params.onDelta,
     onTrace: params.onTrace,
+    onAcceptedOutputTokens: params.onAcceptedOutputTokens,
   });
 }

--- a/lib/arena/importBuildMetrics.ts
+++ b/lib/arena/importBuildMetrics.ts
@@ -1,0 +1,13 @@
+export function parseGenerationTimeMs(
+  raw: string | null,
+): { ok: true; value: number | null } | { ok: false; error: string } {
+  if (raw === null || raw.trim() === "") return { ok: true, value: null };
+  if (!/^\d+$/.test(raw.trim())) {
+    return { ok: false, error: "generationTimeMs must be a non-negative integer" };
+  }
+  const value = Number(raw);
+  if (!Number.isSafeInteger(value) || value > 2_147_483_647) {
+    return { ok: false, error: "generationTimeMs is outside the supported integer range" };
+  }
+  return { ok: true, value };
+}

--- a/lib/arena/importBuildMetrics.ts
+++ b/lib/arena/importBuildMetrics.ts
@@ -11,3 +11,7 @@ export function parseGenerationTimeMs(
   }
   return { ok: true, value };
 }
+
+export function resolveImportedGenerationTimeMs(value: number | null): number {
+  return value ?? 0;
+}

--- a/scripts/batch-generate.ts
+++ b/scripts/batch-generate.ts
@@ -38,6 +38,11 @@ import { isArtifactEligibleBuild } from "../lib/arena/buildDeliveryPolicy";
 import { iterateArenaBuildStreamEvents, uploadArenaBuildStreamArtifact, encodeArenaBuildStreamEvent } from "../lib/arena/buildStream";
 import type { ArenaBuildStreamEvent, ArenaBuildVariant } from "../lib/arena/types";
 import { MODEL_SLUG, PROMPT_MAP, listUploadPromptSlugs, readUploadPromptText } from "./uploadsCatalog";
+import {
+  BenchmarkMetricsStore,
+  createBenchmarkRunConfiguration,
+  type BenchmarkModelSummary,
+} from "./benchmarkMetrics";
 import type { VoxelBuild } from "../lib/voxel/types";
 import { validateVoxelBuild } from "../lib/voxel/validate";
 
@@ -393,6 +398,9 @@ function buildJobList(
 
 function isEmptyPlaceholder(filePath: string): boolean {
   if (!fs.existsSync(filePath)) return true;
+  const size = fs.statSync(filePath).size;
+  if (size === 0) return true;
+  if (size > 2) return false;
   const content = fs.readFileSync(filePath, "utf-8").trim();
   return content === "{}" || content === "";
 }
@@ -414,13 +422,25 @@ async function generateAndSave(
   enableTools: boolean,
   preferOpenRouter: boolean,
   reasoning: string | null,
-): Promise<{ ok: boolean; error?: string; blockCount?: number; generationTimeMs?: number }> {
+  metricsStore: BenchmarkMetricsStore,
+  signal: AbortSignal,
+): Promise<{
+  ok: boolean;
+  error?: string;
+  blockCount?: number;
+  generationTimeMs?: number;
+  jsonBytes?: number;
+  attemptCount?: number;
+}> {
 
   if (!job.promptText) {
-    return { ok: false, error: `Missing prompt text for "${job.promptSlug}". Add uploads/${job.promptSlug}/prompt.txt or pass --promptText/--promptTextFile.` };
+    const error = `Missing prompt text for "${job.promptSlug}". Add uploads/${job.promptSlug}/prompt.txt or pass --promptText/--promptTextFile.`;
+    metricsStore.markFailed(job, error, 0);
+    return { ok: false, error, generationTimeMs: 0, attemptCount: 0 };
   }
 
   const label = jobLabel(job);
+  let attemptCount = 1;
   const result = await generateVoxelBuild({
     modelKey: job.modelKey,
     prompt: job.promptText,
@@ -430,7 +450,10 @@ async function generateAndSave(
     enableTools,
     preferOpenRouter,
     reasoning: reasoning ?? undefined,
+    abortSignal: signal,
     onRetry: (attempt, reason) => {
+      attemptCount = Math.max(attemptCount, attempt);
+      metricsStore.markRetry(job, attempt);
       const msg = (reason ?? "").trim();
       if (!msg) return;
       console.log(`    ↻ [${label}] retry ${attempt}: ${msg}`);
@@ -456,16 +479,44 @@ async function generateAndSave(
         fs.writeFileSync(failedJsonPath, JSON.stringify(extracted, null, 2));
       }
     }
-    return { ok: false, error: result.error, generationTimeMs: result.generationTimeMs };
+    if (!signal.aborted) {
+      metricsStore.markFailed(job, result.error, result.generationTimeMs);
+    }
+    return {
+      ok: false,
+      error: result.error,
+      generationTimeMs: result.generationTimeMs,
+      attemptCount,
+    };
   }
 
-  // ensure prompt directory exists
-  ensureDir(path.dirname(job.filePath));
+  const serializedBuild = JSON.stringify(result.build, null, 2);
+  const sample = metricsStore.finalizeSuccess(job, serializedBuild, {
+    inferenceTimeMs: result.generationTimeMs,
+    attemptCount,
+    acceptedOutputTokens: result.acceptedOutputTokens,
+    configuration:
+      result.providerRoute && job.promptText
+        ? createBenchmarkRunConfiguration({
+            promptText: job.promptText,
+            providerRoute: result.providerRoute,
+            reasoningOverride: reasoning,
+            toolsEnabled: enableTools,
+          })
+        : undefined,
+  });
+  const failedJsonPath = job.filePath.endsWith(".json")
+    ? job.filePath.replace(/\.json$/, ".failed.json")
+    : `${job.filePath}.failed.json`;
+  if (fs.existsSync(failedJsonPath)) fs.unlinkSync(failedJsonPath);
 
-  // write the build json
-  fs.writeFileSync(job.filePath, JSON.stringify(result.build, null, 2));
-
-  return { ok: true, blockCount: result.blockCount, generationTimeMs: result.generationTimeMs };
+  return {
+    ok: true,
+    blockCount: result.blockCount,
+    generationTimeMs: result.generationTimeMs,
+    jsonBytes: sample.jsonBytes,
+    attemptCount,
+  };
 }
 
 function getUploadCommand(job: Job): string {
@@ -498,12 +549,16 @@ async function uploadBuildLegacy(
   job: Job,
   token: string,
   jsonBytes: Buffer<ArrayBufferLike>,
-  gzipped: Buffer<ArrayBufferLike>
+  gzipped: Buffer<ArrayBufferLike>,
+  generationTimeMs?: number,
 ): Promise<{ ok: boolean; error?: string }> {
   const url = new URL(`${PROD_URL}/api/admin/import-build`);
   url.searchParams.set("modelKey", job.modelKey);
   url.searchParams.set("promptText", job.promptText as string);
   url.searchParams.set("overwrite", "1");
+  if (generationTimeMs !== undefined) {
+    url.searchParams.set("generationTimeMs", String(generationTimeMs));
+  }
 
   async function doUpload(opts: { body: Uint8Array<ArrayBufferLike>; headers: Record<string, string> }) {
     // Next's `fetch` typings only accept non-shared `ArrayBuffer` views, so coerce the buffer type
@@ -664,12 +719,16 @@ async function uploadToSupabaseStorage(
 async function finalizeStorageImport(
   job: Job,
   token: string,
-  ref: BuildStorageReference
+  ref: BuildStorageReference,
+  generationTimeMs?: number,
 ): Promise<{ ok: boolean; error?: string }> {
   const url = new URL(`${PROD_URL}/api/admin/import-build`);
   url.searchParams.set("modelKey", job.modelKey);
   url.searchParams.set("promptText", job.promptText as string);
   url.searchParams.set("overwrite", "1");
+  if (generationTimeMs !== undefined) {
+    url.searchParams.set("generationTimeMs", String(generationTimeMs));
+  }
 
   const resp = await fetch(url.toString(), {
     method: "POST",
@@ -685,7 +744,10 @@ async function finalizeStorageImport(
   return { ok: false, error: `Finalize import failed (HTTP ${resp.status}): ${text}` };
 }
 
-async function uploadBuild(job: Job): Promise<{ ok: boolean; error?: string }> {
+async function uploadBuild(
+  job: Job,
+  generationTimeMs?: number,
+): Promise<{ ok: boolean; error?: string }> {
   if (!job.promptText) {
     return { ok: false, error: `Missing prompt text for "${job.promptSlug}". Add uploads/${job.promptSlug}/prompt.txt or pass --promptText/--promptTextFile.` };
   }
@@ -708,10 +770,16 @@ async function uploadBuild(job: Job): Promise<{ ok: boolean; error?: string }> {
     if (!artifactAttempt.ok) {
       return { ok: false, error: `Stream artifact upload failed: ${artifactAttempt.error}` };
     }
-    return finalizeStorageImport(job, token, storageAttempt.ref);
+    return finalizeStorageImport(job, token, storageAttempt.ref, generationTimeMs);
   }
 
-  const legacy = await uploadBuildLegacy(job, token, prepared.jsonBytes, prepared.gzipped);
+  const legacy = await uploadBuildLegacy(
+    job,
+    token,
+    prepared.jsonBytes,
+    prepared.gzipped,
+    generationTimeMs,
+  );
   if (legacy.ok) return legacy;
 
   return {
@@ -756,6 +824,61 @@ function printUploadCommands(jobs: Job[]) {
       console.log(getUploadCommand(job));
       console.log("");
     }
+  }
+}
+
+function buildBenchmarkMetricJobs(
+  promptSlugs: string[],
+  promptTextBySlug: Map<string, string | null>,
+  modelKeys: ModelKey[],
+): Job[] {
+  return promptSlugs.flatMap((promptSlug) =>
+    modelKeys.map((modelKey) => {
+      const modelSlug = MODEL_SLUG[modelKey];
+      return {
+        promptSlug,
+        promptText: promptTextBySlug.get(promptSlug) ?? null,
+        modelKey,
+        modelSlug,
+        filePath: getJsonPath(promptSlug, modelSlug),
+      };
+    }),
+  );
+}
+
+function formatDuration(milliseconds: number | undefined): string {
+  if (milliseconds === undefined) return "Not tracked";
+  const totalSeconds = milliseconds / 1000;
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds - minutes * 60;
+  const secondsLabel = Number.isInteger(seconds) ? seconds.toFixed(0) : seconds.toFixed(1);
+  return minutes > 0 ? `${minutes}m ${secondsLabel}s` : `${secondsLabel}s`;
+}
+
+function formatBytes(bytes: number | undefined): string {
+  if (bytes === undefined) return "Not tracked";
+  return `${(bytes / (1024 * 1024)).toFixed(2)} MiB`;
+}
+
+function printBenchmarkSummary(
+  summaries: Map<ModelKey, BenchmarkModelSummary>,
+): void {
+  if (summaries.size === 0) return;
+  console.log("\n📈 Benchmark metrics:\n");
+  for (const [modelKey, summary] of summaries) {
+    const model = getModel(modelKey);
+    console.log(`  ${model?.displayName ?? modelKey}`);
+    console.log(
+      `    Finalized builds: ${summary.finalizedBuildCount}/${summary.expectedBuildCount}`,
+    );
+    console.log(
+      `    Average inference time: ${formatDuration(summary.averageInferenceMs)} (${summary.inferenceSampleCount}/${summary.expectedBuildCount} tracked)`,
+    );
+    console.log(`    Average JSON size: ${formatBytes(summary.averageJsonSizeBytes)}`);
+    console.log(
+      `    Failed: ${summary.failedCount} · Interrupted: ${summary.interruptedCount} · Running: ${summary.runningCount}`,
+    );
+    console.log("    Total cost: Manual");
   }
 }
 
@@ -840,6 +963,15 @@ Upload notes:
 
   const allJobs = buildJobList(promptSlugs, promptTextBySlug, opts.promptFilters, opts.modelFilters);
   const selectedModelKeys = Array.from(new Set(allJobs.map((j) => j.modelKey)));
+  const metricJobs = buildBenchmarkMetricJobs(
+    promptSlugs,
+    promptTextBySlug,
+    selectedModelKeys,
+  );
+  const metricsStore = new BenchmarkMetricsStore();
+  const metricWarnings = metricsStore.reconcile(metricJobs);
+  for (const warning of metricWarnings) console.warn(`  ⚠️  ${warning}`);
+  metricsStore.refreshGeneratedMetrics(metricJobs);
 
   if (opts.openrouter && opts.generate) {
     if (!process.env.OPENROUTER_API_KEY) {
@@ -849,7 +981,7 @@ Upload notes:
   }
 
   const modelCountForSummary = selectedModelKeys.length;
-  console.log(`📋 Total jobs: ${allJobs.length} (${promptSlugs.length} prompts × ${modelCountForSummary} models)`);
+  console.log(`📋 Total jobs: ${allJobs.length} (${filteredPromptSlugs.length} prompts × ${modelCountForSummary} models)`);
 
   if (opts.promptFilters.length > 0) console.log(`   Filtered by prompt(s): ${opts.promptFilters.join(", ")}`);
   if (opts.modelFilters.length > 0) console.log(`   Filtered by model(s): ${opts.modelFilters.join(", ")}`);
@@ -870,7 +1002,7 @@ Upload notes:
       console.log("\n📤 Uploading existing builds...");
       for (const job of existing) {
         process.stdout.write(`  Uploading ${job.promptSlug} × ${job.modelSlug}...`);
-        const result = await uploadBuild(job);
+        const result = await uploadBuild(job, metricsStore.getSample(job)?.inferenceTimeMs);
         console.log(result.ok ? " ✅" : ` ❌ ${result.error}`);
       }
     }
@@ -924,71 +1056,110 @@ Upload notes:
 
     const queue = [...jobsToGenerate];
     let inFlight = 0;
-    await new Promise<void>((resolve) => {
-      const launchNext = () => {
-        while (inFlight < opts.concurrency && queue.length > 0) {
-          const job = queue.shift()!;
-          started += 1;
-          const startOrdinal = started;
-          console.log(`  ▶ [${startOrdinal}/${total}] ${jobLabel(job)}`);
-          inFlight += 1;
-          void (async () => {
-            const result = await generateAndSave(
-              job,
-              opts.attempts,
-              !opts.notools,
-              opts.openrouter,
-              opts.reasoning,
-            );
-            const elapsed = result.generationTimeMs ? `${(result.generationTimeMs / 1000).toFixed(1)}s` : "-";
-            if (result.ok) {
-              const fileLink = formatFileLink(job.filePath);
-              console.log(
-                `    ✅ [${jobLabel(job)}] Saved ${fileLink.displayPath} (${result.blockCount} blocks, ${elapsed})`,
-              );
-              console.log(`    🔗 [${jobLabel(job)}] Open: ${fileLink.absoluteUrl}`);
-              success++;
+    let stopRequested = false;
+    let stopSignal: NodeJS.Signals | null = null;
+    const active = new Map<string, { job: Job; controller: AbortController }>();
+    const handleStop = (signal: NodeJS.Signals) => {
+      if (stopRequested) {
+        console.error(`\n  ⏹ ${signal} received again. Exiting immediately.`);
+        process.exit(130);
+      }
+      stopRequested = true;
+      stopSignal = signal;
+      console.log(`\n  ⏸ ${signal} received. Stopping new jobs and recording active jobs as interrupted...`);
+      for (const { job, controller } of active.values()) {
+        metricsStore.markInterrupted(job, `Interrupted by ${signal}.`);
+        controller.abort();
+      }
+    };
+    const handleSigint = () => handleStop("SIGINT");
+    const handleSigterm = () => handleStop("SIGTERM");
+    process.on("SIGINT", handleSigint);
+    process.on("SIGTERM", handleSigterm);
 
-              if (opts.upload) {
-                console.log(`    📤 [${jobLabel(job)}] Uploading...`);
-                const uploadResult = await uploadBuild(job);
+    try {
+      await new Promise<void>((resolve) => {
+        const launchNext = () => {
+          while (!stopRequested && inFlight < opts.concurrency && queue.length > 0) {
+            const job = queue.shift()!;
+            started += 1;
+            const startOrdinal = started;
+            console.log(`  ▶ [${startOrdinal}/${total}] ${jobLabel(job)}`);
+            inFlight += 1;
+            const controller = new AbortController();
+            active.set(jobLabel(job), { job, controller });
+            metricsStore.markRunning(job);
+            void (async () => {
+              const result = await generateAndSave(
+                job,
+                opts.attempts,
+                !opts.notools,
+                opts.openrouter,
+                opts.reasoning,
+                metricsStore,
+                controller.signal,
+              );
+              const elapsed = formatDuration(result.generationTimeMs);
+              if (result.ok) {
+                const fileLink = formatFileLink(job.filePath);
                 console.log(
-                  uploadResult.ok
-                    ? `    ✅ [${jobLabel(job)}] Upload complete`
-                    : `    ❌ [${jobLabel(job)}] Upload failed: ${uploadResult.error}`,
+                  `    ✅ [${jobLabel(job)}] Saved ${fileLink.displayPath} (${result.blockCount} blocks, ${elapsed}, ${formatBytes(result.jsonBytes)}, ${result.attemptCount} attempt${result.attemptCount === 1 ? "" : "s"})`,
                 );
-              }
-            } else {
-              console.log(
-                `    ❌ [${jobLabel(job)}] Failed after ${opts.attempts} attempts (${elapsed}): ${result.error}`,
-              );
-              failed++;
-            }
-            completed += 1;
-            console.log(`    • Progress: ${completed}/${total} complete (${inFlight - 1} still running)`);
-          })()
-            .catch((err) => {
-              failed++;
-              completed += 1;
-              console.log(
-                `    ❌ [${jobLabel(job)}] Failed after ${opts.attempts} attempts: ${err instanceof Error ? err.message : err}`,
-              );
-              console.log(`    • Progress: ${completed}/${total} complete (${inFlight - 1} still running)`);
-            })
-            .finally(() => {
-              inFlight -= 1;
-              if (queue.length === 0 && inFlight === 0) {
-                resolve();
+                console.log(`    🔗 [${jobLabel(job)}] Open: ${fileLink.absoluteUrl}`);
+                success++;
+
+                if (opts.upload) {
+                  console.log(`    📤 [${jobLabel(job)}] Uploading...`);
+                  const uploadResult = await uploadBuild(job, result.generationTimeMs);
+                  console.log(
+                    uploadResult.ok
+                      ? `    ✅ [${jobLabel(job)}] Upload complete`
+                      : `    ❌ [${jobLabel(job)}] Upload failed: ${uploadResult.error}`,
+                  );
+                }
+              } else if (controller.signal.aborted) {
+                console.log(`    ⏸ [${jobLabel(job)}] Interrupted after ${elapsed}`);
               } else {
-                launchNext();
+                console.log(
+                  `    ❌ [${jobLabel(job)}] Failed after ${elapsed}: ${result.error}`,
+                );
+                failed++;
               }
-            });
-        }
-      };
-      launchNext();
-    });
+              completed += 1;
+              console.log(`    • Progress: ${completed}/${total} complete (${inFlight - 1} still running)`);
+            })()
+              .catch((err) => {
+                const message = err instanceof Error ? err.message : String(err);
+                if (controller.signal.aborted) {
+                  console.log(`    ⏸ [${jobLabel(job)}] Interrupted: ${message}`);
+                } else {
+                  metricsStore.markFailed(job, message);
+                  failed++;
+                  console.log(`    ❌ [${jobLabel(job)}] Failed: ${message}`);
+                }
+                completed += 1;
+                console.log(`    • Progress: ${completed}/${total} complete (${inFlight - 1} still running)`);
+              })
+              .finally(() => {
+                active.delete(jobLabel(job));
+                inFlight -= 1;
+                if ((queue.length === 0 || stopRequested) && inFlight === 0) {
+                  resolve();
+                } else {
+                  launchNext();
+                }
+              });
+          }
+        };
+        launchNext();
+      });
+    } finally {
+      process.off("SIGINT", handleSigint);
+      process.off("SIGTERM", handleSigterm);
+    }
 
     console.log(`\n📊 Results: ${success} succeeded, ${failed} failed`);
+    if (stopSignal) process.exitCode = 130;
   } else if (missing.length > 0 && !opts.generate) {
     console.log("\n💡 Use --generate to generate missing builds.");
   } else if (missing.length === 0) {
@@ -998,6 +1169,7 @@ Upload notes:
   if (!opts.upload) {
     printUploadCommands(allJobs);
   }
+  printBenchmarkSummary(metricsStore.summarize(metricJobs));
 }
 
 const isDirectRun = process.argv[1]

--- a/scripts/batch-generate.ts
+++ b/scripts/batch-generate.ts
@@ -37,7 +37,13 @@ import { prepareArenaBuildFromBuild, type ArenaBuildSource } from "../lib/arena/
 import { isArtifactEligibleBuild } from "../lib/arena/buildDeliveryPolicy";
 import { iterateArenaBuildStreamEvents, uploadArenaBuildStreamArtifact, encodeArenaBuildStreamEvent } from "../lib/arena/buildStream";
 import type { ArenaBuildStreamEvent, ArenaBuildVariant } from "../lib/arena/types";
-import { MODEL_SLUG, PROMPT_MAP, listUploadPromptSlugs, readUploadPromptText } from "./uploadsCatalog";
+import {
+  BENCHMARK_PROMPT_MAP,
+  MODEL_SLUG,
+  PROMPT_MAP,
+  listUploadPromptSlugs,
+  readUploadPromptText,
+} from "./uploadsCatalog";
 import {
   BenchmarkMetricsStore,
   createBenchmarkRunConfiguration,
@@ -338,6 +344,10 @@ function getAllPromptSlugs(): string[] {
   const slugs = new Set<string>(Object.keys(PROMPT_MAP));
   for (const slug of listUploadPromptSlugs()) slugs.add(slug);
   return Array.from(slugs).sort();
+}
+
+export function getBenchmarkPromptSlugs(): string[] {
+  return Object.keys(BENCHMARK_PROMPT_MAP).sort();
 }
 
 function resolvePromptText(promptSlug: string): string | null {
@@ -823,12 +833,11 @@ function printUploadCommands(jobs: Job[]) {
   }
 }
 
-function buildBenchmarkMetricJobs(
-  promptSlugs: string[],
+export function buildBenchmarkMetricJobs(
   promptTextBySlug: Map<string, string | null>,
   modelKeys: ModelKey[],
 ): Job[] {
-  return promptSlugs.flatMap((promptSlug) =>
+  return getBenchmarkPromptSlugs().flatMap((promptSlug) =>
     modelKeys.map((modelKey) => {
       const modelSlug = MODEL_SLUG[modelKey];
       return {
@@ -960,7 +969,6 @@ Upload notes:
   const allJobs = buildJobList(promptSlugs, promptTextBySlug, opts.promptFilters, opts.modelFilters);
   const selectedModelKeys = Array.from(new Set(allJobs.map((j) => j.modelKey)));
   const metricJobs = buildBenchmarkMetricJobs(
-    promptSlugs,
     promptTextBySlug,
     selectedModelKeys,
   );
@@ -1095,6 +1103,7 @@ Upload notes:
                 metricsStore,
                 controller.signal,
               );
+              active.delete(jobLabel(job));
               const elapsed = formatDuration(result.generationTimeMs);
               if (result.ok) {
                 const fileLink = formatFileLink(job.filePath);

--- a/scripts/batch-generate.ts
+++ b/scripts/batch-generate.ts
@@ -834,7 +834,6 @@ function printUploadCommands(jobs: Job[]) {
 }
 
 export function buildBenchmarkMetricJobs(
-  promptTextBySlug: Map<string, string | null>,
   modelKeys: ModelKey[],
 ): Job[] {
   return getBenchmarkPromptSlugs().flatMap((promptSlug) =>
@@ -842,7 +841,7 @@ export function buildBenchmarkMetricJobs(
       const modelSlug = MODEL_SLUG[modelKey];
       return {
         promptSlug,
-        promptText: promptTextBySlug.get(promptSlug) ?? null,
+        promptText: BENCHMARK_PROMPT_MAP[promptSlug],
         modelKey,
         modelSlug,
         filePath: getJsonPath(promptSlug, modelSlug),
@@ -968,10 +967,7 @@ Upload notes:
 
   const allJobs = buildJobList(promptSlugs, promptTextBySlug, opts.promptFilters, opts.modelFilters);
   const selectedModelKeys = Array.from(new Set(allJobs.map((j) => j.modelKey)));
-  const metricJobs = buildBenchmarkMetricJobs(
-    promptTextBySlug,
-    selectedModelKeys,
-  );
+  const metricJobs = buildBenchmarkMetricJobs(selectedModelKeys);
   const metricsStore = new BenchmarkMetricsStore();
   const metricWarnings = metricsStore.reconcile(metricJobs);
   for (const warning of metricWarnings) console.warn(`  ⚠️  ${warning}`);

--- a/scripts/batch-generate.ts
+++ b/scripts/batch-generate.ts
@@ -41,6 +41,7 @@ import { MODEL_SLUG, PROMPT_MAP, listUploadPromptSlugs, readUploadPromptText } f
 import {
   BenchmarkMetricsStore,
   createBenchmarkRunConfiguration,
+  isMissingBenchmarkArtifact,
   type BenchmarkModelSummary,
 } from "./benchmarkMetrics";
 import type { VoxelBuild } from "../lib/voxel/types";
@@ -396,13 +397,8 @@ function buildJobList(
   return jobs;
 }
 
-function isEmptyPlaceholder(filePath: string): boolean {
-  if (!fs.existsSync(filePath)) return true;
-  const size = fs.statSync(filePath).size;
-  if (size === 0) return true;
-  if (size > 2) return false;
-  const content = fs.readFileSync(filePath, "utf-8").trim();
-  return content === "{}" || content === "";
+export function isEmptyPlaceholder(filePath: string): boolean {
+  return isMissingBenchmarkArtifact(filePath);
 }
 
 function getMissingJobs(jobs: Job[]): Job[] {

--- a/scripts/benchmarkMetrics.ts
+++ b/scripts/benchmarkMetrics.ts
@@ -3,6 +3,7 @@ import * as path from "node:path";
 import { createHash, randomUUID } from "node:crypto";
 
 import type { ModelKey } from "../lib/ai/modelCatalog";
+import { parseVoxelBuildSpec } from "../lib/voxel/validate";
 
 export type BenchmarkMetricJob = {
   promptSlug: string;
@@ -172,7 +173,8 @@ function verifiedArtifact(filePath: string): { bytes: number; hash: string } | n
   if (!finalizedArtifact(filePath)) return null;
   const text = fs.readFileSync(filePath, "utf8");
   try {
-    JSON.parse(text);
+    const parsed: unknown = JSON.parse(text);
+    if (!parseVoxelBuildSpec(parsed).ok) return null;
   } catch {
     return null;
   }
@@ -535,15 +537,10 @@ export class BenchmarkMetricsStore {
       const uniqueJobs = Array.from(
         new Map(modelJobs.map((job) => [job.promptSlug, job])).values(),
       );
-      const artifacts = uniqueJobs.map((job) => {
-        const sample = ledger.jobs[jobKey(job)]?.sample;
-        return {
-          job,
-          artifact: isBenchmarkSample(sample)
-            ? verifiedArtifact(job.filePath)
-            : finalizedArtifact(job.filePath),
-        };
-      });
+      const artifacts = uniqueJobs.map((job) => ({
+        job,
+        artifact: verifiedArtifact(job.filePath),
+      }));
       const finalized = artifacts.filter(({ artifact }) => artifact !== null);
       const timingSamples: BenchmarkSample[] = [];
       const configuredSamples: BenchmarkSample[] = [];

--- a/scripts/benchmarkMetrics.ts
+++ b/scripts/benchmarkMetrics.ts
@@ -1,0 +1,621 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { createHash, randomUUID } from "node:crypto";
+
+import type { ModelKey } from "../lib/ai/modelCatalog";
+
+export type BenchmarkMetricJob = {
+  promptSlug: string;
+  promptText?: string | null;
+  modelKey: ModelKey;
+  modelSlug: string;
+  filePath: string;
+};
+
+export type BenchmarkRunConfiguration = {
+  promptSha256: string;
+  providerRoute: "direct" | "openrouter";
+  reasoningOverride: string | null;
+  toolsEnabled: boolean;
+};
+
+export type BenchmarkSample = {
+  inferenceTimeMs: number;
+  jsonBytes: number;
+  artifactSha256: string;
+  attemptCount: number;
+  acceptedOutputTokens?: number;
+  configuration?: BenchmarkRunConfiguration;
+};
+
+type BenchmarkJobState = "running" | "finalizing" | "succeeded" | "failed" | "interrupted";
+
+type BenchmarkJobRecord = {
+  state: BenchmarkJobState;
+  startedAt: string;
+  endedAt?: string;
+  retryCount: number;
+  error?: string;
+  lastRunDurationMs?: number;
+  failedRunCount?: number;
+  interruptedRunCount?: number;
+  ownerPid?: number;
+  sample?: BenchmarkSample;
+  pendingSample?: BenchmarkSample;
+};
+
+type BenchmarkLedger = {
+  version: 1;
+  jobs: Record<string, BenchmarkJobRecord>;
+};
+
+export type GeneratedModelBenchmarkMetrics = {
+  expectedBuildCount: number;
+  finalizedBuildCount: number;
+  inferenceSampleCount: number;
+  averageInferenceMs?: number;
+  averageJsonSizeBytes?: number;
+  outputCapTokens?: number;
+  configurationSampleCount?: number;
+  configurationIsConsistent?: boolean;
+};
+
+type GeneratedBenchmarkMetrics = {
+  version: 1;
+  models: Partial<Record<ModelKey, GeneratedModelBenchmarkMetrics>>;
+};
+
+export type BenchmarkModelSummary = GeneratedModelBenchmarkMetrics & {
+  failedCount: number;
+  interruptedCount: number;
+  runningCount: number;
+};
+
+function jobKey(job: Pick<BenchmarkMetricJob, "modelKey" | "promptSlug">): string {
+  return `${job.modelKey}/${job.promptSlug}`;
+}
+
+function sha256(text: string): string {
+  return createHash("sha256").update(text).digest("hex");
+}
+
+export function createBenchmarkRunConfiguration(args: {
+  promptText: string;
+  providerRoute: "direct" | "openrouter";
+  reasoningOverride: string | null;
+  toolsEnabled: boolean;
+}): BenchmarkRunConfiguration {
+  return {
+    promptSha256: sha256(args.promptText),
+    providerRoute: args.providerRoute,
+    reasoningOverride: args.reasoningOverride,
+    toolsEnabled: args.toolsEnabled,
+  };
+}
+
+function isNonNegativeInteger(value: unknown): value is number {
+  return typeof value === "number" && Number.isInteger(value) && value >= 0;
+}
+
+function isPositiveInteger(value: unknown): value is number {
+  return isNonNegativeInteger(value) && value > 0;
+}
+
+function isBenchmarkSample(value: unknown): value is BenchmarkSample {
+  if (!value || typeof value !== "object") return false;
+  const sample = value as Partial<BenchmarkSample>;
+  return (
+    isNonNegativeInteger(sample.inferenceTimeMs) &&
+    isNonNegativeInteger(sample.jsonBytes) &&
+    typeof sample.artifactSha256 === "string" &&
+    /^[a-f0-9]{64}$/.test(sample.artifactSha256) &&
+    isPositiveInteger(sample.attemptCount) &&
+    (sample.acceptedOutputTokens === undefined || isPositiveInteger(sample.acceptedOutputTokens)) &&
+    (sample.configuration === undefined || isBenchmarkRunConfiguration(sample.configuration))
+  );
+}
+
+function isBenchmarkRunConfiguration(value: unknown): value is BenchmarkRunConfiguration {
+  if (!value || typeof value !== "object") return false;
+  const configuration = value as Partial<BenchmarkRunConfiguration>;
+  return (
+    typeof configuration.promptSha256 === "string" &&
+    /^[a-f0-9]{64}$/.test(configuration.promptSha256) &&
+    (configuration.providerRoute === "direct" || configuration.providerRoute === "openrouter") &&
+    (configuration.reasoningOverride === null ||
+      typeof configuration.reasoningOverride === "string") &&
+    typeof configuration.toolsEnabled === "boolean"
+  );
+}
+
+function readJsonFile<T>(filePath: string, fallback: T): T {
+  if (!fs.existsSync(filePath)) return fallback;
+  try {
+    return JSON.parse(fs.readFileSync(filePath, "utf8")) as T;
+  } catch {
+    return fallback;
+  }
+}
+
+export function atomicWriteText(filePath: string, contents: string): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  const temporaryPath = `${filePath}.${process.pid}.${randomUUID()}.tmp`;
+  const descriptor = fs.openSync(temporaryPath, "w");
+  try {
+    fs.writeFileSync(descriptor, contents, "utf8");
+    fs.fsyncSync(descriptor);
+  } finally {
+    fs.closeSync(descriptor);
+  }
+  fs.renameSync(temporaryPath, filePath);
+}
+
+function atomicWriteJson(filePath: string, value: unknown): void {
+  atomicWriteText(filePath, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function finalizedArtifact(filePath: string): { bytes: number } | null {
+  if (!fs.existsSync(filePath)) return null;
+  const size = fs.statSync(filePath).size;
+  if (size === 0) return null;
+  if (size <= 2) {
+    const text = fs.readFileSync(filePath, "utf8").trim();
+    if (!text || text === "{}") return null;
+  }
+  return { bytes: size };
+}
+
+function verifiedArtifact(filePath: string): { bytes: number; hash: string } | null {
+  if (!finalizedArtifact(filePath)) return null;
+  const text = fs.readFileSync(filePath, "utf8");
+  try {
+    JSON.parse(text);
+  } catch {
+    return null;
+  }
+  return { bytes: Buffer.byteLength(text), hash: sha256(text) };
+}
+
+function average(values: number[]): number | undefined {
+  if (values.length === 0) return undefined;
+  return Math.round(values.reduce((sum, value) => sum + value, 0) / values.length);
+}
+
+function comparableConfigurationKey(configuration: BenchmarkRunConfiguration): string {
+  return JSON.stringify({
+    providerRoute: configuration.providerRoute,
+    reasoningOverride: configuration.reasoningOverride,
+    toolsEnabled: configuration.toolsEnabled,
+  });
+}
+
+function configurationMatchesJob(
+  configuration: BenchmarkRunConfiguration | undefined,
+  job: BenchmarkMetricJob,
+): configuration is BenchmarkRunConfiguration {
+  return (
+    isBenchmarkRunConfiguration(configuration) &&
+    typeof job.promptText === "string" &&
+    configuration.promptSha256 === sha256(job.promptText)
+  );
+}
+
+function processIsAlive(pid: number | undefined): boolean {
+  if (!isPositiveInteger(pid)) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code === "EPERM";
+  }
+}
+
+export class BenchmarkMetricsStore {
+  readonly ledgerPath: string;
+  readonly generatedMetricsPath: string;
+
+  constructor(options?: { ledgerPath?: string; generatedMetricsPath?: string }) {
+    this.ledgerPath =
+      options?.ledgerPath ?? path.join(process.cwd(), "uploads", ".benchmark-metrics.json");
+    this.generatedMetricsPath =
+      options?.generatedMetricsPath ??
+      path.join(process.cwd(), "lib", "ai", "modelBenchmarkMetrics.generated.json");
+  }
+
+  private readLedger(): BenchmarkLedger {
+    const ledger = readJsonFile<BenchmarkLedger>(this.ledgerPath, { version: 1, jobs: {} });
+    if (ledger.version !== 1 || !ledger.jobs || typeof ledger.jobs !== "object") {
+      return { version: 1, jobs: {} };
+    }
+    return ledger;
+  }
+
+  private writeLedger(ledger: BenchmarkLedger): void {
+    atomicWriteJson(this.ledgerPath, ledger);
+  }
+
+  private withLedgerLock<T>(operation: () => T): T {
+    const lockPath = `${this.ledgerPath}.lock`;
+    fs.mkdirSync(path.dirname(lockPath), { recursive: true });
+    const waitBuffer = new Int32Array(new SharedArrayBuffer(4));
+    let descriptor: number | undefined;
+
+    for (let attempt = 0; attempt < 500; attempt += 1) {
+      try {
+        descriptor = fs.openSync(lockPath, "wx");
+        fs.writeFileSync(descriptor, String(process.pid), "utf8");
+        break;
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
+        try {
+          const ownerPid = Number(fs.readFileSync(lockPath, "utf8"));
+          if (isPositiveInteger(ownerPid) && !processIsAlive(ownerPid)) {
+            fs.unlinkSync(lockPath);
+            continue;
+          }
+        } catch (lockError) {
+          if ((lockError as NodeJS.ErrnoException).code !== "ENOENT") throw lockError;
+        }
+        Atomics.wait(waitBuffer, 0, 0, 10);
+      }
+    }
+
+    if (descriptor === undefined) {
+      throw new Error(`Timed out waiting for benchmark metric ledger lock: ${lockPath}`);
+    }
+
+    try {
+      return operation();
+    } finally {
+      fs.closeSync(descriptor);
+      try {
+        fs.unlinkSync(lockPath);
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+      }
+    }
+  }
+
+  getSample(job: BenchmarkMetricJob): BenchmarkSample | undefined {
+    const sample = this.readLedger().jobs[jobKey(job)]?.sample;
+    return isBenchmarkSample(sample) ? sample : undefined;
+  }
+
+  private updateRecord(
+    job: BenchmarkMetricJob,
+    update: (current: BenchmarkJobRecord | undefined) => BenchmarkJobRecord,
+  ): BenchmarkJobRecord {
+    return this.withLedgerLock(() => {
+      const ledger = this.readLedger();
+      const key = jobKey(job);
+      const next = update(ledger.jobs[key]);
+      ledger.jobs[key] = next;
+      this.writeLedger(ledger);
+      return next;
+    });
+  }
+
+  markRunning(job: BenchmarkMetricJob, now = new Date()): void {
+    this.updateRecord(job, (current) => {
+      if (
+        current &&
+        (current.state === "running" || current.state === "finalizing") &&
+        current.ownerPid !== process.pid &&
+        processIsAlive(current.ownerPid)
+      ) {
+        throw new Error(`${job.promptSlug} × ${job.modelSlug} is already running in process ${current.ownerPid}.`);
+      }
+      return {
+        state: "running",
+        startedAt: now.toISOString(),
+        retryCount: 0,
+        failedRunCount: current?.failedRunCount ?? 0,
+        interruptedRunCount: current?.interruptedRunCount ?? 0,
+        ownerPid: process.pid,
+        sample: current?.sample,
+      };
+    });
+  }
+
+  markRetry(job: BenchmarkMetricJob, attempt: number): void {
+    this.updateRecord(job, (current) => ({
+      ...current,
+      state: current?.state ?? "running",
+      startedAt: current?.startedAt ?? new Date().toISOString(),
+      retryCount: Math.max(current?.retryCount ?? 0, attempt - 1),
+      failedRunCount: current?.failedRunCount ?? 0,
+      interruptedRunCount: current?.interruptedRunCount ?? 0,
+      ownerPid: current?.ownerPid ?? process.pid,
+    }));
+  }
+
+  markFailed(
+    job: BenchmarkMetricJob,
+    error: string,
+    durationMs?: number,
+    now = new Date(),
+  ): void {
+    this.updateRecord(job, (current) => {
+      const failedRunCount =
+        (current?.failedRunCount ?? 0) + (current?.state === "failed" ? 0 : 1);
+      return {
+        state: "failed",
+        startedAt: current?.startedAt ?? now.toISOString(),
+        endedAt: now.toISOString(),
+        retryCount: current?.retryCount ?? 0,
+        error,
+        lastRunDurationMs: isNonNegativeInteger(durationMs) ? durationMs : undefined,
+        failedRunCount,
+        interruptedRunCount: current?.interruptedRunCount ?? 0,
+        sample: current?.sample,
+      };
+    });
+  }
+
+  markInterrupted(job: BenchmarkMetricJob, reason: string, now = new Date()): void {
+    this.updateRecord(job, (current) => {
+      const startedAt = current?.startedAt ?? now.toISOString();
+      const elapsed = Math.max(0, now.getTime() - Date.parse(startedAt));
+      return {
+        state: "interrupted",
+        startedAt,
+        endedAt: now.toISOString(),
+        retryCount: current?.retryCount ?? 0,
+        error: reason,
+        lastRunDurationMs: Number.isFinite(elapsed) ? Math.round(elapsed) : undefined,
+        failedRunCount: current?.failedRunCount ?? 0,
+        interruptedRunCount:
+          (current?.interruptedRunCount ?? 0) +
+          (current?.state === "interrupted" ? 0 : 1),
+        sample: current?.sample,
+      };
+    });
+  }
+
+  finalizeSuccess(
+    job: BenchmarkMetricJob,
+    serializedBuild: string,
+    details: {
+      inferenceTimeMs: number;
+      attemptCount: number;
+      acceptedOutputTokens?: number;
+      configuration?: BenchmarkRunConfiguration;
+    },
+    now = new Date(),
+  ): BenchmarkSample {
+    const sample: BenchmarkSample = {
+      inferenceTimeMs: Math.max(0, Math.round(details.inferenceTimeMs)),
+      jsonBytes: Buffer.byteLength(serializedBuild),
+      artifactSha256: sha256(serializedBuild),
+      attemptCount: Math.max(1, Math.round(details.attemptCount)),
+      ...(isPositiveInteger(details.acceptedOutputTokens)
+        ? { acceptedOutputTokens: details.acceptedOutputTokens }
+        : {}),
+      ...(isBenchmarkRunConfiguration(details.configuration)
+        ? { configuration: details.configuration }
+        : {}),
+    };
+
+    this.updateRecord(job, (current) => ({
+      state: "finalizing",
+      startedAt: current?.startedAt ?? now.toISOString(),
+      retryCount: current?.retryCount ?? Math.max(0, sample.attemptCount - 1),
+      failedRunCount: current?.failedRunCount ?? 0,
+      interruptedRunCount: current?.interruptedRunCount ?? 0,
+      ownerPid: process.pid,
+      sample: current?.sample,
+      pendingSample: sample,
+    }));
+    atomicWriteText(job.filePath, serializedBuild);
+    this.updateRecord(job, (current) => ({
+      state: "succeeded",
+      startedAt: current?.startedAt ?? now.toISOString(),
+      endedAt: now.toISOString(),
+      retryCount: Math.max(0, sample.attemptCount - 1),
+      failedRunCount: current?.failedRunCount ?? 0,
+      interruptedRunCount: current?.interruptedRunCount ?? 0,
+      sample,
+    }));
+    return sample;
+  }
+
+  reconcile(jobs: BenchmarkMetricJob[], now = new Date()): string[] {
+    return this.withLedgerLock(() => {
+      const ledger = this.readLedger();
+      const warnings: string[] = [];
+      let changed = false;
+
+      for (const job of jobs) {
+        const key = jobKey(job);
+        const current = ledger.jobs[key];
+        if (!current) continue;
+
+        if (
+          (current.state === "running" || current.state === "finalizing") &&
+          current.ownerPid !== process.pid &&
+          processIsAlive(current.ownerPid)
+        ) {
+          warnings.push(
+            `${job.promptSlug} × ${job.modelSlug}: active in process ${current.ownerPid}; lifecycle state was left unchanged.`,
+          );
+          continue;
+        }
+
+        if (current.state === "running") {
+          ledger.jobs[key] = {
+            ...current,
+            state: "interrupted",
+            endedAt: now.toISOString(),
+            error: "Previous process ended before this job finalized.",
+            lastRunDurationMs: Math.max(0, now.getTime() - Date.parse(current.startedAt)),
+            interruptedRunCount: (current.interruptedRunCount ?? 0) + 1,
+            ownerPid: undefined,
+          };
+          changed = true;
+          continue;
+        }
+
+        if (current.state === "finalizing" && isBenchmarkSample(current.pendingSample)) {
+          const artifact = verifiedArtifact(job.filePath);
+          if (artifact?.hash === current.pendingSample.artifactSha256) {
+            ledger.jobs[key] = {
+              state: "succeeded",
+              startedAt: current.startedAt,
+              endedAt: now.toISOString(),
+              retryCount: current.retryCount,
+              failedRunCount: current.failedRunCount ?? 0,
+              interruptedRunCount: current.interruptedRunCount ?? 0,
+              sample: current.pendingSample,
+            };
+          } else {
+            ledger.jobs[key] = {
+              state: "interrupted",
+              startedAt: current.startedAt,
+              endedAt: now.toISOString(),
+              retryCount: current.retryCount,
+              error: "Final artifact did not match the pending benchmark sample.",
+              failedRunCount: current.failedRunCount ?? 0,
+              interruptedRunCount: (current.interruptedRunCount ?? 0) + 1,
+              sample: current.sample,
+            };
+          }
+          changed = true;
+          continue;
+        }
+
+        if (!isBenchmarkSample(current.sample)) continue;
+        const artifact = verifiedArtifact(job.filePath);
+        if (!artifact) {
+          warnings.push(`${job.promptSlug} × ${job.modelSlug}: final JSON is missing or invalid.`);
+          continue;
+        }
+        if (
+          artifact.hash !== current.sample.artifactSha256 ||
+          artifact.bytes !== current.sample.jsonBytes
+        ) {
+          ledger.jobs[key] = {
+            ...current,
+            sample: {
+              ...current.sample,
+              jsonBytes: artifact.bytes,
+              artifactSha256: artifact.hash,
+            },
+          };
+          changed = true;
+        }
+      }
+
+      if (changed) this.writeLedger(ledger);
+      return warnings;
+    });
+  }
+
+  refreshGeneratedMetrics(jobs: BenchmarkMetricJob[]): GeneratedBenchmarkMetrics {
+    const ledger = this.readLedger();
+    const generated = readJsonFile<GeneratedBenchmarkMetrics>(
+      this.generatedMetricsPath,
+      { version: 1, models: {} },
+    );
+    const jobsByModel = new Map<ModelKey, BenchmarkMetricJob[]>();
+    for (const job of jobs) {
+      const group = jobsByModel.get(job.modelKey) ?? [];
+      group.push(job);
+      jobsByModel.set(job.modelKey, group);
+    }
+
+    for (const [modelKey, modelJobs] of jobsByModel) {
+      const uniqueJobs = Array.from(
+        new Map(modelJobs.map((job) => [job.promptSlug, job])).values(),
+      );
+      const artifacts = uniqueJobs.map((job) => {
+        const sample = ledger.jobs[jobKey(job)]?.sample;
+        return {
+          job,
+          artifact: isBenchmarkSample(sample)
+            ? verifiedArtifact(job.filePath)
+            : finalizedArtifact(job.filePath),
+        };
+      });
+      const finalized = artifacts.filter(({ artifact }) => artifact !== null);
+      const timingSamples: BenchmarkSample[] = [];
+      const configuredSamples: BenchmarkSample[] = [];
+      const outputCaps: number[] = [];
+
+      for (const { job, artifact } of artifacts) {
+        if (!artifact) continue;
+        const sample = ledger.jobs[jobKey(job)]?.sample;
+        if (!isBenchmarkSample(sample)) continue;
+        if (!("hash" in artifact) || sample.artifactSha256 !== artifact.hash) continue;
+        timingSamples.push(sample);
+        if (!configurationMatchesJob(sample.configuration, job)) continue;
+        configuredSamples.push(sample);
+        if (sample.acceptedOutputTokens !== undefined) outputCaps.push(sample.acceptedOutputTokens);
+      }
+
+      const expectedBuildCount = uniqueJobs.length;
+      const finalizedBuildCount = finalized.length;
+      const completeArtifacts = finalizedBuildCount === expectedBuildCount && expectedBuildCount > 0;
+      const completeConfigurations =
+        configuredSamples.length === expectedBuildCount && expectedBuildCount > 0;
+      const configurationKeys = new Set(
+        configuredSamples.map((sample) => comparableConfigurationKey(sample.configuration!)),
+      );
+      const uniqueOutputCaps = new Set(outputCaps);
+      const configurationIsConsistent =
+        completeConfigurations &&
+        configurationKeys.size === 1 &&
+        outputCaps.length === expectedBuildCount &&
+        uniqueOutputCaps.size === 1;
+      generated.models[modelKey] = {
+        expectedBuildCount,
+        finalizedBuildCount,
+        inferenceSampleCount: timingSamples.length,
+        configurationSampleCount: configuredSamples.length,
+        configurationIsConsistent,
+        ...(completeArtifacts
+          ? { averageJsonSizeBytes: average(finalized.map(({ artifact }) => artifact!.bytes)) }
+          : {}),
+        ...(configurationIsConsistent
+          ? {
+              averageInferenceMs: average(
+                configuredSamples.map((sample) => sample.inferenceTimeMs),
+              ),
+            }
+          : {}),
+        ...(configurationIsConsistent
+          ? { outputCapTokens: outputCaps[0] }
+          : {}),
+      };
+    }
+
+    atomicWriteJson(this.generatedMetricsPath, generated);
+    return generated;
+  }
+
+  summarize(jobs: BenchmarkMetricJob[]): Map<ModelKey, BenchmarkModelSummary> {
+    const generated = this.refreshGeneratedMetrics(jobs);
+    const ledger = this.readLedger();
+    const summaries = new Map<ModelKey, BenchmarkModelSummary>();
+
+    for (const job of jobs) {
+      if (summaries.has(job.modelKey)) continue;
+      const metrics = generated.models[job.modelKey];
+      if (!metrics) continue;
+      const modelJobs = jobs.filter((candidate) => candidate.modelKey === job.modelKey);
+      const records = modelJobs.map((candidate) => ledger.jobs[jobKey(candidate)]);
+      summaries.set(job.modelKey, {
+        ...metrics,
+        failedCount: records.reduce((sum, record) => sum + (record?.failedRunCount ?? 0), 0),
+        interruptedCount: records.reduce(
+          (sum, record) => sum + (record?.interruptedRunCount ?? 0),
+          0,
+        ),
+        runningCount: records.filter(
+          (record) => record?.state === "running" || record?.state === "finalizing",
+        ).length,
+      });
+    }
+
+    return summaries;
+  }
+}

--- a/scripts/benchmarkMetrics.ts
+++ b/scripts/benchmarkMetrics.ts
@@ -154,15 +154,18 @@ function atomicWriteJson(filePath: string, value: unknown): void {
   atomicWriteText(filePath, `${JSON.stringify(value, null, 2)}\n`);
 }
 
-function finalizedArtifact(filePath: string): { bytes: number } | null {
-  if (!fs.existsSync(filePath)) return null;
+export function isMissingBenchmarkArtifact(filePath: string): boolean {
+  if (!fs.existsSync(filePath)) return true;
   const size = fs.statSync(filePath).size;
-  if (size === 0) return null;
-  if (size <= 2) {
-    const text = fs.readFileSync(filePath, "utf8").trim();
-    if (!text || text === "{}") return null;
-  }
-  return { bytes: size };
+  if (size === 0) return true;
+  if (size > Buffer.byteLength("{}\r\n")) return false;
+  const text = fs.readFileSync(filePath, "utf8").trim();
+  return !text || text === "{}";
+}
+
+function finalizedArtifact(filePath: string): { bytes: number } | null {
+  if (isMissingBenchmarkArtifact(filePath)) return null;
+  return { bytes: fs.statSync(filePath).size };
 }
 
 function verifiedArtifact(filePath: string): { bytes: number; hash: string } | null {

--- a/scripts/benchmarkMetrics.ts
+++ b/scripts/benchmarkMetrics.ts
@@ -359,6 +359,13 @@ export class BenchmarkMetricsStore {
 
   markInterrupted(job: BenchmarkMetricJob, reason: string, now = new Date()): void {
     this.updateRecord(job, (current) => {
+      if (
+        current &&
+        current.state !== "running" &&
+        current.state !== "finalizing"
+      ) {
+        return current;
+      }
       const startedAt = current?.startedAt ?? now.toISOString();
       const elapsed = Math.max(0, now.getTime() - Date.parse(startedAt));
       return {

--- a/scripts/benchmarkMetrics.ts
+++ b/scripts/benchmarkMetrics.ts
@@ -512,10 +512,15 @@ export class BenchmarkMetricsStore {
 
   refreshGeneratedMetrics(jobs: BenchmarkMetricJob[]): GeneratedBenchmarkMetrics {
     const ledger = this.readLedger();
-    const generated = readJsonFile<GeneratedBenchmarkMetrics>(
+    const persisted = readJsonFile<GeneratedBenchmarkMetrics>(
       this.generatedMetricsPath,
       { version: 1, models: {} },
     );
+    const computed: GeneratedBenchmarkMetrics = {
+      version: 1,
+      models: { ...persisted.models },
+    };
+    let persistedChanged = false;
     const jobsByModel = new Map<ModelKey, BenchmarkMetricJob[]>();
     for (const job of jobs) {
       const group = jobsByModel.get(job.modelKey) ?? [];
@@ -566,7 +571,7 @@ export class BenchmarkMetricsStore {
         configurationKeys.size === 1 &&
         outputCaps.length === expectedBuildCount &&
         uniqueOutputCaps.size === 1;
-      generated.models[modelKey] = {
+      const metrics: GeneratedModelBenchmarkMetrics = {
         expectedBuildCount,
         finalizedBuildCount,
         inferenceSampleCount: timingSamples.length,
@@ -586,10 +591,48 @@ export class BenchmarkMetricsStore {
           ? { outputCapTokens: outputCaps[0] }
           : {}),
       };
+      computed.models[modelKey] = metrics;
+
+      if (!completeArtifacts) continue;
+
+      const previous = persisted.models[modelKey];
+      const completeTimingCohort =
+        timingSamples.length === expectedBuildCount && expectedBuildCount > 0;
+      const next: GeneratedModelBenchmarkMetrics = {
+        expectedBuildCount,
+        finalizedBuildCount,
+        inferenceSampleCount: previous?.inferenceSampleCount ?? metrics.inferenceSampleCount,
+        configurationSampleCount:
+          previous?.configurationSampleCount ?? metrics.configurationSampleCount,
+        configurationIsConsistent:
+          previous?.configurationIsConsistent ?? metrics.configurationIsConsistent,
+        averageJsonSizeBytes: metrics.averageJsonSizeBytes,
+        ...(previous?.averageInferenceMs === undefined
+          ? {}
+          : { averageInferenceMs: previous.averageInferenceMs }),
+        ...(previous?.outputCapTokens === undefined
+          ? {}
+          : { outputCapTokens: previous.outputCapTokens }),
+      };
+
+      if (completeTimingCohort) {
+        next.inferenceSampleCount = metrics.inferenceSampleCount;
+        next.configurationSampleCount = metrics.configurationSampleCount;
+        next.configurationIsConsistent = metrics.configurationIsConsistent;
+        if (metrics.averageInferenceMs === undefined) delete next.averageInferenceMs;
+        else next.averageInferenceMs = metrics.averageInferenceMs;
+        if (metrics.outputCapTokens === undefined) delete next.outputCapTokens;
+        else next.outputCapTokens = metrics.outputCapTokens;
+      }
+
+      if (JSON.stringify(previous) !== JSON.stringify(next)) {
+        persisted.models[modelKey] = next;
+        persistedChanged = true;
+      }
     }
 
-    atomicWriteJson(this.generatedMetricsPath, generated);
-    return generated;
+    if (persistedChanged) atomicWriteJson(this.generatedMetricsPath, persisted);
+    return computed;
   }
 
   summarize(jobs: BenchmarkMetricJob[]): Map<ModelKey, BenchmarkModelSummary> {

--- a/scripts/uploadsCatalog.ts
+++ b/scripts/uploadsCatalog.ts
@@ -6,9 +6,11 @@ export const UPLOADS_DIR = path.join(process.cwd(), "uploads");
 export const PROMPT_TEXT_FILENAME = "prompt.txt";
 const IGNORED_UPLOAD_DIRS = new Set(["tool-runs", "local"]);
 
-// All curated prompts with short slugs for filenames.
-// Add your custom prompts here to make them importable by scripts.
-export const PROMPT_MAP: Record<string, string> = {
+// The fixed prompt cohort used to publish model-level benchmark metrics.
+export const BENCHMARK_PROMPT_MAP: Record<string, string> = {
+  arcade:
+    "A classic arcade cabinet with a joystick and three buttons on the control panel, a screen showing simple graphics, coin slot on the front, and artwork on the sides",
+  astronaut: "An astronaut",
   steampunk:
     "A steampunk airship with a wooden hull, large brass propellers on each side, a balloon made of patchwork fabric above the deck, hanging ropes and ladders, and a glass-enclosed bridge at the front",
   carrier:
@@ -20,6 +22,7 @@ export const PROMPT_MAP: Record<string, string> = {
   cottage: "A cozy cottage",
   worldtree:
     "A massive world tree: an enormous trunk with roots visible above ground forming archways, multiple levels of thick branches like platforms, glowing fruit hanging from smaller branches, and vines draping down",
+  "fighter-jet": "A fighter jet",
   floating:
     "A floating island ecosystem: a chunk of earth suspended in air with waterfalls pouring off multiple edges, a small forest on top, exposed roots and rocks hanging underneath, and smaller floating rocks nearby connected by ancient chain bridges",
   shipwreck:
@@ -29,6 +32,11 @@ export const PROMPT_MAP: Record<string, string> = {
   knight: "A knight in armor",
   castle:
     "A medieval stone castle with curtain walls forming a square, four tall corner towers with battlements, a central keep, a gatehouse with an archway and portcullis, and a surrounding moat with a small drawbridge.",
+};
+
+// Add custom prompts here to make them importable by scripts without changing the benchmark cohort.
+export const PROMPT_MAP: Record<string, string> = {
+  ...BENCHMARK_PROMPT_MAP,
 };
 
 // Model key to short filename slug.

--- a/tests/ui/model-benchmark-details.test.ts
+++ b/tests/ui/model-benchmark-details.test.ts
@@ -163,15 +163,16 @@ assert.ok(
     trackedMarkup.includes("25m 16.2s") &&
     trackedMarkup.includes("Average JSON size") &&
     trackedMarkup.includes("91.58 MiB") &&
-    trackedMarkup.includes("$710.82"),
-  "a tracked model should render normalized parameters and all benchmark statistics",
+    !trackedMarkup.includes("$710.82") &&
+    trackedMarkup.includes("Not tracked"),
+  "GPT 5.6 Sol Pro should render tracked run metrics with untracked cost",
 );
 assert.ok(
   trackedMarkup.includes('<h2 class="sr-only">GPT 5.6 Sol Pro run details</h2>'),
   "inline details should establish an h2 before their h3 section headings",
 );
 
-const costOnlyMarkup = renderToStaticMarkup(
+const removedEstimateMarkup = renderToStaticMarkup(
   React.createElement(ModelBenchmarkDetailsInline, {
     id: "cost-only-details",
     modelKey: "openai_gpt_5_4",
@@ -180,12 +181,12 @@ const costOnlyMarkup = renderToStaticMarkup(
   }),
 );
 assert.ok(
-  costOnlyMarkup.includes("XHigh") &&
-    costOnlyMarkup.includes("Output cap") &&
-    costOnlyMarkup.includes("Total cost") &&
-    costOnlyMarkup.includes("~$25.00") &&
-    (costOnlyMarkup.match(/Not tracked/g)?.length ?? 0) >= 1,
-  "a cost-only model should explain its untracked inference statistic",
+  removedEstimateMarkup.includes("XHigh") &&
+    removedEstimateMarkup.includes("Output cap") &&
+    removedEstimateMarkup.includes("Total cost") &&
+    !removedEstimateMarkup.includes("$25.00") &&
+    (removedEstimateMarkup.match(/Not tracked/g)?.length ?? 0) >= 2,
+  "removed GPT 5.4 estimates should render as explicitly untracked",
 );
 
 const geminiMarkup = renderToStaticMarkup(
@@ -232,6 +233,33 @@ const exactGlmMarkup = renderToStaticMarkup(
 assert.ok(
   exactGlmMarkup.includes("17m 26s") && !exactGlmMarkup.includes("~17m 26s"),
   "the exact GLM 5.1 duration should not carry an approximation marker",
+);
+
+const exactGrokMarkup = renderToStaticMarkup(
+  React.createElement(ModelBenchmarkDetailsInline, {
+    id: "exact-grok-details",
+    modelKey: "xai_grok_4_20",
+    displayName: "Grok 4.20",
+    open: true,
+  }),
+);
+assert.ok(
+  exactGrokMarkup.includes("2m 29s") && !exactGrokMarkup.includes("~2m 29s"),
+  "Grok 4.20's recorded duration should render as exact",
+);
+
+const approximateOpusMarkup = renderToStaticMarkup(
+  React.createElement(ModelBenchmarkDetailsInline, {
+    id: "approximate-opus-details",
+    modelKey: "anthropic_claude_4_7_opus",
+    displayName: "Claude 4.7 Opus",
+    open: true,
+  }),
+);
+assert.ok(
+  approximateOpusMarkup.includes("~43m 20s") &&
+    !approximateOpusMarkup.includes("$275.00"),
+  "Opus 4.7 should retain its approximate time while leaving cost untracked",
 );
 
 console.log("model benchmark details UI checks passed");

--- a/tests/ui/model-benchmark-details.test.ts
+++ b/tests/ui/model-benchmark-details.test.ts
@@ -60,8 +60,21 @@ assert.ok(
   "the anchored shell should expose its pointer while an inner viewport owns overflow",
 );
 assert.ok(
-  detailsSource.includes("This model was benchmarked before run statistics were tracked."),
-  "models without recorded statistics should still receive a useful details note",
+  detailsSource.includes("setPosition(null);") &&
+    detailsSource.includes("setOpen(true);") &&
+    !detailsSource.includes("if (!open) updatePosition();") &&
+    detailsSource.includes(
+      'position ? "opacity-100" : "pointer-events-none opacity-0"',
+    ),
+  "the popover should stay hidden until its mounted height is measured",
+);
+assert.ok(
+  detailsSource.includes('label: "Average inference time"') &&
+    detailsSource.includes('label: "Average JSON size"') &&
+    detailsSource.includes('label: "Total cost"') &&
+    detailsSource.includes('label: "Output cap"') &&
+    detailsSource.includes('"Not tracked"'),
+  "every normalized field should render its own explicit untracked state",
 );
 assert.ok(
   detailsSource.includes('v{profile.sourceRelease.replace(/^v/, "")}') &&
@@ -71,19 +84,42 @@ assert.ok(
 assert.ok(
   detailsSource.includes(">\n          Parameters\n        </h3>") &&
     detailsSource.includes(">\n          Statistics\n        </h3>") &&
-    detailsSource.includes("<DetailRows rows={profile.parameters} />") &&
+    detailsSource.includes('<h2 className="sr-only">{displayName} run details</h2>') &&
+    detailsSource.includes("<DetailRows rows={parameters} />") &&
     detailsSource.includes("<DetailRows rows={statistics} />"),
   "run parameters and benchmark statistics should render as distinct sections",
 );
 assert.ok(
-  detailsSource.includes("Avg. inference") &&
+  detailsSource.includes("Average inference") &&
+    detailsSource.includes("Average JSON size") &&
     detailsSource.includes("Total cost") &&
-    detailsSource.includes("statistics.length > 0"),
-  "recorded benchmark details should show available statistics before using the fallback",
+    !detailsSource.includes("statistics.length > 0"),
+  "the statistics section should always render the same normalized rows",
 );
 assert.ok(
-  !detailsSource.includes('label: "Run size"'),
-  "benchmark tables should expose only the two reported statistics",
+  !detailsSource.includes('label: "Run size"') && !detailsSource.includes("Avg."),
+  "benchmark tables should use the full, specific statistic labels",
+);
+assert.ok(
+  detailsSource.includes('className="mt-1 divide-y divide-border/60"') &&
+    !detailsSource.includes("divide-y divide-border/60 border-y") &&
+    detailsSource.includes("mt-4 border-t border-border/70 pt-4") &&
+    detailsSource.includes(
+      'className="grid grid-cols-[minmax(0,1fr)_minmax(0,1.35fr)] gap-4 py-2.5 text-[13px]"',
+    ) &&
+    detailsSource.includes('<dt className="text-muted">{row.label}</dt>') &&
+    !detailsSource.includes('<dt className="text-muted2">{row.label}</dt>') &&
+    detailsSource.includes('className="shrink-0 font-mono text-[11px] text-muted"') &&
+    detailsSource.includes("shadow-soft") &&
+    !detailsSource.includes("rgba(0,0,0"),
+  "details should use one section rule, readable metadata type, and the shared shadow token",
+);
+assert.equal(
+  detailsSource.match(
+    /text-\[11px\] font-medium uppercase tracking-\[0\.14em\] text-muted/g,
+  )?.length,
+  2,
+  "both section headings should use the readable metadata treatment",
 );
 assert.ok(
   leaderboardSource.includes("<ModelBenchmarkDetailsTrigger") &&
@@ -122,10 +158,17 @@ const trackedMarkup = renderToStaticMarkup(
 assert.ok(
   trackedMarkup.includes("Parameters") &&
     trackedMarkup.includes("Statistics") &&
+    trackedMarkup.includes("Output cap") &&
+    trackedMarkup.includes("128,000 tokens") &&
     trackedMarkup.includes("25m 16.2s") &&
-    trackedMarkup.includes("$710.82") &&
-    !trackedMarkup.includes("before run statistics were tracked"),
-  "a fully tracked model should render parameters and both benchmark statistics",
+    trackedMarkup.includes("Average JSON size") &&
+    trackedMarkup.includes("91.58 MiB") &&
+    trackedMarkup.includes("$710.82"),
+  "a tracked model should render normalized parameters and all benchmark statistics",
+);
+assert.ok(
+  trackedMarkup.includes('<h2 class="sr-only">GPT 5.6 Sol Pro run details</h2>'),
+  "inline details should establish an h2 before their h3 section headings",
 );
 
 const costOnlyMarkup = renderToStaticMarkup(
@@ -138,10 +181,11 @@ const costOnlyMarkup = renderToStaticMarkup(
 );
 assert.ok(
   costOnlyMarkup.includes("XHigh") &&
+    costOnlyMarkup.includes("Output cap") &&
     costOnlyMarkup.includes("Total cost") &&
-    costOnlyMarkup.includes("~$25") &&
-    !costOnlyMarkup.includes("before run statistics were tracked"),
-  "a cost-only model should render its available statistic without the fallback",
+    costOnlyMarkup.includes("~$25.00") &&
+    (costOnlyMarkup.match(/Not tracked/g)?.length ?? 0) >= 1,
+  "a cost-only model should explain its untracked inference statistic",
 );
 
 const geminiMarkup = renderToStaticMarkup(
@@ -154,12 +198,12 @@ const geminiMarkup = renderToStaticMarkup(
 );
 assert.ok(
   geminiMarkup.includes("High") &&
-    geminiMarkup.includes("Avg. inference") &&
+    geminiMarkup.includes("Average inference") &&
     geminiMarkup.includes("1m 41.9s") &&
+    geminiMarkup.includes("Average JSON size") &&
     geminiMarkup.includes("Total cost") &&
-    geminiMarkup.includes("$2.84") &&
-    !geminiMarkup.includes("before run statistics were tracked"),
-  "a fully tracked Gemini model should render both measured statistics",
+    geminiMarkup.includes("$2.84"),
+  "a fully tracked Gemini model should render every normalized statistic row",
 );
 
 const untrackedMarkup = renderToStaticMarkup(
@@ -172,9 +216,22 @@ const untrackedMarkup = renderToStaticMarkup(
 );
 assert.ok(
   untrackedMarkup.includes("ChatGPT web harness") &&
-    untrackedMarkup.includes("before run statistics were tracked") &&
+    (untrackedMarkup.match(/Not tracked/g)?.length ?? 0) >= 3 &&
     untrackedMarkup.includes("not directly comparable to API-generated runs"),
-  "an untracked run should keep its parameters, statistics fallback, and comparability note",
+  "an untracked run should keep its parameters, explicit missing values, and comparability note",
+);
+
+const exactGlmMarkup = renderToStaticMarkup(
+  React.createElement(ModelBenchmarkDetailsInline, {
+    id: "exact-glm-details",
+    modelKey: "zai_glm_5_1",
+    displayName: "Z.AI GLM 5.1",
+    open: true,
+  }),
+);
+assert.ok(
+  exactGlmMarkup.includes("17m 26s") && !exactGlmMarkup.includes("~17m 26s"),
+  "the exact GLM 5.1 duration should not carry an approximation marker",
 );
 
 console.log("model benchmark details UI checks passed");

--- a/tests/unit/admin/import-build-metrics.test.ts
+++ b/tests/unit/admin/import-build-metrics.test.ts
@@ -1,0 +1,22 @@
+import assert from "node:assert/strict";
+
+import { parseGenerationTimeMs } from "../../../lib/arena/importBuildMetrics";
+
+assert.deepEqual(parseGenerationTimeMs(null), { ok: true, value: null });
+assert.deepEqual(parseGenerationTimeMs(""), { ok: true, value: null });
+assert.deepEqual(parseGenerationTimeMs("1046000"), { ok: true, value: 1_046_000 });
+assert.deepEqual(parseGenerationTimeMs("0"), { ok: true, value: 0 });
+assert.deepEqual(parseGenerationTimeMs("-1"), {
+  ok: false,
+  error: "generationTimeMs must be a non-negative integer",
+});
+assert.deepEqual(parseGenerationTimeMs("1.5"), {
+  ok: false,
+  error: "generationTimeMs must be a non-negative integer",
+});
+assert.deepEqual(parseGenerationTimeMs("2147483648"), {
+  ok: false,
+  error: "generationTimeMs is outside the supported integer range",
+});
+
+console.log("import build generation metric checks passed");

--- a/tests/unit/admin/import-build-metrics.test.ts
+++ b/tests/unit/admin/import-build-metrics.test.ts
@@ -1,6 +1,9 @@
 import assert from "node:assert/strict";
 
-import { parseGenerationTimeMs } from "../../../lib/arena/importBuildMetrics";
+import {
+  parseGenerationTimeMs,
+  resolveImportedGenerationTimeMs,
+} from "../../../lib/arena/importBuildMetrics";
 
 assert.deepEqual(parseGenerationTimeMs(null), { ok: true, value: null });
 assert.deepEqual(parseGenerationTimeMs(""), { ok: true, value: null });
@@ -18,5 +21,11 @@ assert.deepEqual(parseGenerationTimeMs("2147483648"), {
   ok: false,
   error: "generationTimeMs is outside the supported integer range",
 });
+assert.equal(
+  resolveImportedGenerationTimeMs(null),
+  0,
+  "an import without a measurement must clear any replaced artifact timing",
+);
+assert.equal(resolveImportedGenerationTimeMs(1_046_000), 1_046_000);
 
 console.log("import build generation metric checks passed");

--- a/tests/unit/ai/model-benchmark-profiles.test.ts
+++ b/tests/unit/ai/model-benchmark-profiles.test.ts
@@ -22,7 +22,7 @@ assert.ok(
   Number.isInteger(gpt56.averageJsonSizeBytes) && (gpt56.averageJsonSizeBytes ?? 0) > 0,
   "GPT 5.6 Sol Pro should use the generated exact JSON-size aggregate",
 );
-assert.deepEqual(gpt56.totalCost, { usd: 710.82 });
+assert.equal(gpt56.totalCost, undefined);
 assert.equal(gpt56.buildCount, 15);
 
 const gemini36Flash = getModelBenchmarkProfile("gemini_3_6_flash");
@@ -66,7 +66,7 @@ assert.deepEqual(gpt54Pro?.totalCost, { usd: 435 });
 
 const gpt54 = getModelBenchmarkProfile("openai_gpt_5_4");
 assert.equal(gpt54?.averageInference, undefined);
-assert.deepEqual(gpt54?.totalCost, { usd: 25, qualifier: "approximate" });
+assert.equal(gpt54?.totalCost, undefined);
 
 const gpt53Codex = getModelBenchmarkProfile("openai_gpt_5_3_codex");
 assert.deepEqual(gpt53Codex?.parameters, [
@@ -74,21 +74,21 @@ assert.deepEqual(gpt53Codex?.parameters, [
 ]);
 assert.equal(gpt53Codex?.outputCapTokens, 128_000);
 assert.equal(gpt53Codex?.averageInference, undefined);
-assert.deepEqual(gpt53Codex?.totalCost, {
-  usd: 5,
-  qualifier: "under-approximately",
-});
+assert.equal(gpt53Codex?.totalCost, undefined);
+
+const grok420 = getModelBenchmarkProfile("xai_grok_4_20");
+assert.deepEqual(grok420?.averageInference, { milliseconds: 149_000 });
 
 const opus47 = getModelBenchmarkProfile("anthropic_claude_4_7_opus");
 assert.deepEqual(opus47?.averageInference, {
   milliseconds: 2_600_000,
   approximate: true,
 });
-assert.deepEqual(opus47?.totalCost, { usd: 275, qualifier: "approximate" });
+assert.equal(opus47?.totalCost, undefined);
 
 const opus46 = getModelBenchmarkProfile("anthropic_claude_4_6_opus");
 assert.equal(opus46?.averageInference, undefined);
-assert.deepEqual(opus46?.totalCost, { usd: 22, qualifier: "approximate" });
+assert.equal(opus46?.totalCost, undefined);
 
 const kimi26 = getModelBenchmarkProfile("moonshot_kimi_k2_6");
 assert.equal(kimi26?.averageInference, undefined);
@@ -183,8 +183,8 @@ assert.equal(
     getModelBenchmarkProfile("openai_gpt_5_4")?.averageInference ||
       getModelBenchmarkProfile("openai_gpt_5_4")?.totalCost,
   ),
-  true,
-  "a cost-only profile should count as having recorded statistics",
+  false,
+  "removed non-exact GPT 5.4 statistics should remain untracked",
 );
 assert.equal(
   Boolean(gpt45WebHarness?.averageInference || gpt45WebHarness?.totalCost),

--- a/tests/unit/ai/model-benchmark-profiles.test.ts
+++ b/tests/unit/ai/model-benchmark-profiles.test.ts
@@ -14,75 +14,92 @@ assert.deepEqual(gpt56.parameters, [
   { label: "Reasoning mode", value: "Pro" },
   { label: "Reasoning effort", value: "Max" },
   { label: "Text verbosity", value: "High" },
-  { label: "Combined reasoning/output cap", value: "128,000 tokens" },
 ]);
+assert.equal(gpt56.outputCapTokens, 128_000);
 assert.equal(gpt56.sourceRelease, "3.9.0");
-assert.equal(gpt56.averageInferenceTime, "25m 16.2s (1,516.2s)");
-assert.equal(gpt56.totalCost, "$710.82");
+assert.deepEqual(gpt56.averageInference, { milliseconds: 1_516_200 });
+assert.ok(
+  Number.isInteger(gpt56.averageJsonSizeBytes) && (gpt56.averageJsonSizeBytes ?? 0) > 0,
+  "GPT 5.6 Sol Pro should use the generated exact JSON-size aggregate",
+);
+assert.deepEqual(gpt56.totalCost, { usd: 710.82 });
 assert.equal(gpt56.buildCount, 15);
 
 const gemini36Flash = getModelBenchmarkProfile("gemini_3_6_flash");
 assert.equal(gemini36Flash?.sourceRelease, "3.10.0");
-assert.equal(gemini36Flash?.averageInferenceTime, "1m 41.9s (101.9s)");
-assert.equal(gemini36Flash?.totalCost, "$2.84");
+assert.deepEqual(gemini36Flash?.averageInference, { milliseconds: 101_900 });
+assert.deepEqual(gemini36Flash?.totalCost, { usd: 2.84 });
 assert.equal(gemini36Flash?.buildCount, 15);
 
 const gemini35FlashLite = getModelBenchmarkProfile("gemini_3_5_flash_lite");
 assert.equal(gemini35FlashLite?.sourceRelease, "3.10.0");
-assert.equal(gemini35FlashLite?.averageInferenceTime, "25.7s");
-assert.equal(gemini35FlashLite?.totalCost, "$0.38");
+assert.deepEqual(gemini35FlashLite?.averageInference, { milliseconds: 25_700 });
+assert.deepEqual(gemini35FlashLite?.totalCost, { usd: 0.38 });
 assert.equal(gemini35FlashLite?.buildCount, 15);
 
 const fable5 = getModelBenchmarkProfile("anthropic_claude_fable_5");
-assert.equal(fable5?.averageInferenceTime, "18m 04.4s (1,084.4s)");
-assert.equal(fable5?.totalCost, "$54.93");
+assert.deepEqual(fable5?.averageInference, { milliseconds: 1_084_400 });
+assert.deepEqual(fable5?.totalCost, { usd: 54.93 });
 assert.equal(fable5?.buildCount, 15);
 
 const opus48 = getModelBenchmarkProfile("anthropic_claude_4_8_opus");
-assert.equal(opus48?.averageInferenceTime, "24m 47.9s (1,487.9s)");
-assert.equal(opus48?.totalCost, "$41.52");
+assert.deepEqual(opus48?.averageInference, { milliseconds: 1_487_900 });
+assert.deepEqual(opus48?.totalCost, { usd: 41.52 });
 assert.equal(opus48?.buildCount, 15);
 
 const gpt55 = getModelBenchmarkProfile("openai_gpt_5_5");
-assert.equal(gpt55?.averageInferenceTime, "10m 24s (624s)");
-assert.equal(gpt55?.totalCost, "$19.98");
+assert.deepEqual(gpt55?.averageInference, { milliseconds: 624_000 });
+assert.deepEqual(gpt55?.totalCost, { usd: 19.98 });
 
 const gpt55Pro = getModelBenchmarkProfile("openai_gpt_5_5_pro");
-assert.equal(gpt55Pro?.averageInferenceTime, "21m 23.3s (1,283.3s)");
-assert.equal(gpt55Pro?.totalCost, "$223.90");
+assert.deepEqual(gpt55Pro?.averageInference, { milliseconds: 1_283_300 });
+assert.deepEqual(gpt55Pro?.totalCost, { usd: 223.9 });
 
 const gpt54Pro = getModelBenchmarkProfile("openai_gpt_5_4_pro");
 assert.deepEqual(gpt54Pro?.parameters, [
   { label: "Reasoning effort", value: "XHigh" },
   { label: "Text verbosity", value: "High" },
-  { label: "Output cap", value: "128,000 tokens" },
 ]);
-assert.equal(gpt54Pro?.averageInferenceTime, "56 minutes");
-assert.equal(gpt54Pro?.totalCost, "$435");
+assert.equal(gpt54Pro?.outputCapTokens, 128_000);
+assert.deepEqual(gpt54Pro?.averageInference, { milliseconds: 3_360_000 });
+assert.deepEqual(gpt54Pro?.totalCost, { usd: 435 });
 
 const gpt54 = getModelBenchmarkProfile("openai_gpt_5_4");
-assert.equal(gpt54?.averageInferenceTime, undefined);
-assert.equal(gpt54?.totalCost, "~$25");
+assert.equal(gpt54?.averageInference, undefined);
+assert.deepEqual(gpt54?.totalCost, { usd: 25, qualifier: "approximate" });
 
 const gpt53Codex = getModelBenchmarkProfile("openai_gpt_5_3_codex");
 assert.deepEqual(gpt53Codex?.parameters, [
   { label: "Reasoning effort", value: "XHigh" },
-  { label: "Output cap", value: "128,000 tokens" },
 ]);
-assert.equal(gpt53Codex?.averageInferenceTime, undefined);
-assert.equal(gpt53Codex?.totalCost, "Under approximately $5");
+assert.equal(gpt53Codex?.outputCapTokens, 128_000);
+assert.equal(gpt53Codex?.averageInference, undefined);
+assert.deepEqual(gpt53Codex?.totalCost, {
+  usd: 5,
+  qualifier: "under-approximately",
+});
 
 const opus47 = getModelBenchmarkProfile("anthropic_claude_4_7_opus");
-assert.equal(opus47?.averageInferenceTime, "~43m 20s (~2,600s)");
-assert.equal(opus47?.totalCost, "~$275");
+assert.deepEqual(opus47?.averageInference, {
+  milliseconds: 2_600_000,
+  approximate: true,
+});
+assert.deepEqual(opus47?.totalCost, { usd: 275, qualifier: "approximate" });
 
 const opus46 = getModelBenchmarkProfile("anthropic_claude_4_6_opus");
-assert.equal(opus46?.averageInferenceTime, undefined);
-assert.equal(opus46?.totalCost, "~$22");
+assert.equal(opus46?.averageInference, undefined);
+assert.deepEqual(opus46?.totalCost, { usd: 22, qualifier: "approximate" });
 
 const kimi26 = getModelBenchmarkProfile("moonshot_kimi_k2_6");
-assert.equal(kimi26?.averageInferenceTime, undefined);
-assert.equal(kimi26?.totalCost, "$2.35");
+assert.equal(kimi26?.averageInference, undefined);
+assert.deepEqual(kimi26?.totalCost, { usd: 2.35 });
+
+const glm51 = getModelBenchmarkProfile("zai_glm_5_1");
+assert.deepEqual(
+  glm51?.averageInference,
+  { milliseconds: 1_046_000 },
+  "GLM 5.1's reported 17m 26s is exact",
+);
 
 assert.equal(
   getModelBenchmarkProfile("moonshot_kimi_k3")?.sourceRelease,
@@ -137,6 +154,25 @@ for (const model of MODEL_CATALOG) {
     labels.length,
     `${model.key} parameter labels should be unique`,
   );
+  assert.ok(
+    labels.every(
+      (label) =>
+        !/requested output|accepted output|combined reasoning\/output|completion ceiling|output cap/i.test(
+          label,
+        ),
+    ),
+    `${model.key} should keep the normalized output cap outside free-form parameters`,
+  );
+  if (profile.outputCapTokens !== undefined) {
+    assert.ok(
+      Number.isInteger(profile.outputCapTokens) && profile.outputCapTokens > 0,
+      `${model.key} output cap should be a positive integer`,
+    );
+  }
+  assert.ok(
+    Number.isInteger(profile.averageJsonSizeBytes) && (profile.averageJsonSizeBytes ?? 0) > 0,
+    `${model.key} should have a generated average JSON size for its finalized cohort`,
+  );
 }
 
 assert.deepEqual(getModelBenchmarkProfile("gemini_3_1_pro")?.parameters, [
@@ -144,16 +180,16 @@ assert.deepEqual(getModelBenchmarkProfile("gemini_3_1_pro")?.parameters, [
 ]);
 assert.equal(
   Boolean(
-    getModelBenchmarkProfile("openai_gpt_5_4")?.averageInferenceTime ||
+    getModelBenchmarkProfile("openai_gpt_5_4")?.averageInference ||
       getModelBenchmarkProfile("openai_gpt_5_4")?.totalCost,
   ),
   true,
   "a cost-only profile should count as having recorded statistics",
 );
 assert.equal(
-  Boolean(gpt45WebHarness?.averageInferenceTime || gpt45WebHarness?.totalCost),
+  Boolean(gpt45WebHarness?.averageInference || gpt45WebHarness?.totalCost),
   false,
-  "the web-harness profile should use the historical statistics fallback",
+  "the web-harness profile should keep all benchmark statistics untracked",
 );
 
 console.log("model benchmark profile checks passed");

--- a/tests/unit/ai/model-benchmark-profiles.test.ts
+++ b/tests/unit/ai/model-benchmark-profiles.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import {
+  HISTORICAL_ACCEPTED_OUTPUT_CAP_TOKENS,
   MODEL_BENCHMARK_PROFILES,
   getModelBenchmarkProfile,
 } from "../../../lib/ai/modelBenchmarkProfiles";
@@ -126,6 +127,21 @@ assert.equal(
   "Imported model",
   "unknown persisted models should keep their database label",
 );
+
+const requestedOnlyOutputBudgets = [
+  "anthropic_claude_4_6_sonnet",
+  "deepseek_v4_pro",
+  "qwen_qwen3_max_thinking",
+  "qwen_qwen3_5_397b_a17b",
+  "minimax_m2_5",
+] as const;
+for (const modelKey of requestedOnlyOutputBudgets) {
+  assert.equal(
+    HISTORICAL_ACCEPTED_OUTPUT_CAP_TOKENS[modelKey],
+    undefined,
+    `${modelKey} should not promote a requested-only budget to an accepted cap`,
+  );
+}
 
 const catalogKeys = MODEL_CATALOG.map((model) => model.key);
 assert.equal(

--- a/tests/unit/providers/gpt-5-6-sol-config.test.ts
+++ b/tests/unit/providers/gpt-5-6-sol-config.test.ts
@@ -99,7 +99,7 @@ async function main() {
   ]);
 
   const traces: string[] = [];
-  await generateVoxelBuild({
+  const directResult = await generateVoxelBuild({
     modelKey: "openai_gpt_5_6_sol",
     prompt: "small tower",
     gridSize: 64,
@@ -109,6 +109,8 @@ async function main() {
     allowServerKeys: false,
     onProviderTrace: (message) => traces.push(message),
   });
+  assert.equal(directResult.acceptedOutputTokens, 128_000);
+  assert.equal(directResult.providerRoute, "direct");
 
   const request = capturedRequests.find((candidate) =>
     candidate.url.includes("api.openai.com/v1/responses"),
@@ -134,7 +136,7 @@ async function main() {
   );
 
   const openRouterTraces: string[] = [];
-  await generateVoxelBuild({
+  const openRouterResult = await generateVoxelBuild({
     modelKey: "openai_gpt_5_6_sol",
     prompt: "small tower",
     gridSize: 64,
@@ -144,6 +146,8 @@ async function main() {
     allowServerKeys: false,
     onProviderTrace: (message) => openRouterTraces.push(message),
   });
+  assert.equal(openRouterResult.acceptedOutputTokens, 128_000);
+  assert.equal(openRouterResult.providerRoute, "openrouter");
 
   const openRouterRequest = capturedRequests.find((candidate) =>
     candidate.url.includes("/chat/completions"),

--- a/tests/unit/scripts/batch-benchmark-metrics.test.ts
+++ b/tests/unit/scripts/batch-benchmark-metrics.test.ts
@@ -285,6 +285,20 @@ assert.equal(
 );
 
 mkdirSync(join(checkoutRoot, "uploads", "castle"), { recursive: true });
+writeFileSync(checkoutJob.filePath, "{}\n");
+const placeholderMetrics = checkoutStore.refreshGeneratedMetrics([checkoutJob]);
+assert.equal(placeholderMetrics.models.openai_gpt_5_6_sol?.finalizedBuildCount, 0);
+assert.equal(
+  placeholderMetrics.models.openai_gpt_5_6_sol?.averageJsonSizeBytes,
+  undefined,
+  "newline-terminated placeholders must not contribute JSON-size metrics",
+);
+assert.equal(
+  readFileSync(checkoutMetricsPath, "utf8"),
+  committedContents,
+  "a placeholder cohort must not rewrite committed metrics",
+);
+
 const checkoutJson = JSON.stringify({ version: "1.0", blocks: [{ x: 1, y: 1, z: 1 }] });
 writeFileSync(checkoutJob.filePath, checkoutJson);
 const localCompleteMetrics = checkoutStore.refreshGeneratedMetrics([checkoutJob]);

--- a/tests/unit/scripts/batch-benchmark-metrics.test.ts
+++ b/tests/unit/scripts/batch-benchmark-metrics.test.ts
@@ -1,0 +1,249 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import {
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  BenchmarkMetricsStore,
+  createBenchmarkRunConfiguration,
+  type BenchmarkMetricJob,
+} from "../../../scripts/benchmarkMetrics";
+
+const root = mkdtempSync(join(tmpdir(), "minebench-benchmark-metrics-"));
+const uploads = join(root, "uploads");
+const ledgerPath = join(uploads, ".benchmark-metrics.json");
+const generatedMetricsPath = join(root, "modelBenchmarkMetrics.generated.json");
+const store = new BenchmarkMetricsStore({ ledgerPath, generatedMetricsPath });
+
+function job(promptSlug: string): BenchmarkMetricJob {
+  return {
+    promptSlug,
+    promptText: `Build prompt for ${promptSlug}`,
+    modelKey: "openai_gpt_5_6_sol",
+    modelSlug: "gpt-5-6-sol",
+    filePath: join(uploads, promptSlug, `${promptSlug}-gpt-5-6-sol.json`),
+  };
+}
+
+function readLedger() {
+  return JSON.parse(readFileSync(ledgerPath, "utf8")) as {
+    jobs: Record<string, Record<string, unknown>>;
+  };
+}
+
+const castle = job("castle");
+const castleJson = JSON.stringify({ version: "1.0", blocks: [{ x: 1, y: 2, z: 3 }] }, null, 2);
+const castleConfiguration = createBenchmarkRunConfiguration({
+  promptText: castle.promptText!,
+  providerRoute: "direct",
+  reasoningOverride: null,
+  toolsEnabled: true,
+});
+
+store.markRunning(castle, new Date("2026-07-22T18:00:00.000Z"));
+store.markRetry(castle, 2);
+store.markRetry(castle, 3);
+const castleSample = store.finalizeSuccess(
+  castle,
+  castleJson,
+  {
+    inferenceTimeMs: 1_046_000,
+    attemptCount: 3,
+    acceptedOutputTokens: 128_000,
+    configuration: castleConfiguration,
+  },
+  new Date("2026-07-22T18:17:26.000Z"),
+);
+
+assert.equal(readFileSync(castle.filePath, "utf8"), castleJson);
+assert.equal(castleSample.inferenceTimeMs, 1_046_000);
+assert.equal(castleSample.jsonBytes, Buffer.byteLength(castleJson));
+assert.equal(castleSample.attemptCount, 3);
+assert.equal(castleSample.acceptedOutputTokens, 128_000);
+assert.equal(
+  castleSample.artifactSha256,
+  createHash("sha256").update(castleJson).digest("hex"),
+);
+assert.equal(readLedger().jobs["openai_gpt_5_6_sol/castle"]?.state, "succeeded");
+assert.equal(
+  readdirSync(join(uploads, "castle")).some((name) => name.endsWith(".tmp")),
+  false,
+  "atomic finalization should not leave temporary files",
+);
+
+let generated = store.refreshGeneratedMetrics([castle]);
+assert.deepEqual(generated.models.openai_gpt_5_6_sol, {
+  expectedBuildCount: 1,
+  finalizedBuildCount: 1,
+  inferenceSampleCount: 1,
+  configurationSampleCount: 1,
+  configurationIsConsistent: true,
+  averageJsonSizeBytes: Buffer.byteLength(castleJson),
+  averageInferenceMs: 1_046_000,
+  outputCapTokens: 128_000,
+});
+
+store.markRunning(castle, new Date("2026-07-22T19:00:00.000Z"));
+store.markFailed(
+  castle,
+  "Provider quota exhausted",
+  25_000,
+  new Date("2026-07-22T19:00:25.000Z"),
+);
+assert.equal(
+  store.getSample(castle)?.inferenceTimeMs,
+  1_046_000,
+  "a failed overwrite should retain the finalized artifact measurement",
+);
+let summary = store.summarize([castle]).get("openai_gpt_5_6_sol");
+assert.equal(summary?.failedCount, 1);
+assert.equal(summary?.averageInferenceMs, 1_046_000);
+
+store.markRunning(castle, new Date("2026-07-22T20:00:00.000Z"));
+store.reconcile([castle], new Date("2026-07-22T20:00:10.000Z"));
+assert.equal(readLedger().jobs["openai_gpt_5_6_sol/castle"]?.state, "interrupted");
+summary = store.summarize([castle]).get("openai_gpt_5_6_sol");
+assert.equal(summary?.interruptedCount, 1);
+assert.equal(summary?.averageInferenceMs, 1_046_000);
+
+store.markRunning(castle, new Date("2026-07-22T20:30:00.000Z"));
+store.finalizeSuccess(
+  castle,
+  castleJson,
+  {
+    inferenceTimeMs: 1_046_000,
+    attemptCount: 1,
+    acceptedOutputTokens: 128_000,
+    configuration: castleConfiguration,
+  },
+  new Date("2026-07-22T20:47:26.000Z"),
+);
+summary = store.summarize([castle]).get("openai_gpt_5_6_sol");
+assert.equal(summary?.failedCount, 1, "a later success should retain the failed run count");
+assert.equal(
+  summary?.interruptedCount,
+  1,
+  "a later success should retain the interrupted run count",
+);
+
+const correctedCastleJson = JSON.stringify(
+  { version: "1.0", blocks: [{ x: 1, y: 2, z: 3 }, { x: 4, y: 5, z: 6 }] },
+  null,
+  2,
+);
+writeFileSync(castle.filePath, correctedCastleJson);
+store.reconcile([castle]);
+assert.equal(store.getSample(castle)?.jsonBytes, Buffer.byteLength(correctedCastleJson));
+assert.equal(
+  store.getSample(castle)?.inferenceTimeMs,
+  1_046_000,
+  "a valid artifact correction should not rewrite its generation time",
+);
+
+const phoenix = job("phoenix");
+const phoenixJson = JSON.stringify({ version: "1.0", blocks: [{ x: 7, y: 8, z: 9 }] }, null, 2);
+mkdirSync(join(uploads, "phoenix"), { recursive: true });
+writeFileSync(phoenix.filePath, phoenixJson, { flag: "w" });
+const phoenixSample = {
+  inferenceTimeMs: 100_000,
+  jsonBytes: Buffer.byteLength(phoenixJson),
+  artifactSha256: createHash("sha256").update(phoenixJson).digest("hex"),
+  attemptCount: 1,
+  acceptedOutputTokens: 128_000,
+  configuration: createBenchmarkRunConfiguration({
+    promptText: phoenix.promptText!,
+    providerRoute: "direct",
+    reasoningOverride: null,
+    toolsEnabled: true,
+  }),
+};
+const ledger = readLedger();
+ledger.jobs["openai_gpt_5_6_sol/phoenix"] = {
+  state: "finalizing",
+  startedAt: "2026-07-22T21:00:00.000Z",
+  retryCount: 0,
+  pendingSample: phoenixSample,
+};
+writeFileSync(ledgerPath, `${JSON.stringify({ version: 1, jobs: ledger.jobs }, null, 2)}\n`);
+store.reconcile([castle, phoenix], new Date("2026-07-22T21:02:00.000Z"));
+assert.equal(
+  readLedger().jobs["openai_gpt_5_6_sol/phoenix"]?.state,
+  "succeeded",
+  "matching finalization state should recover after a process crash",
+);
+
+generated = store.refreshGeneratedMetrics([castle, phoenix]);
+assert.equal(generated.models.openai_gpt_5_6_sol?.finalizedBuildCount, 2);
+assert.equal(generated.models.openai_gpt_5_6_sol?.inferenceSampleCount, 2);
+assert.equal(
+  generated.models.openai_gpt_5_6_sol?.averageInferenceMs,
+  Math.round((1_046_000 + 100_000) / 2),
+);
+
+const mixedRoute = job("mixed-route");
+store.markRunning(mixedRoute);
+store.finalizeSuccess(
+  mixedRoute,
+  JSON.stringify({ version: "1.0", blocks: [{ x: 10, y: 11, z: 12 }] }, null, 2),
+  {
+    inferenceTimeMs: 200_000,
+    attemptCount: 1,
+    acceptedOutputTokens: 128_000,
+    configuration: createBenchmarkRunConfiguration({
+      promptText: mixedRoute.promptText!,
+      providerRoute: "openrouter",
+      reasoningOverride: null,
+      toolsEnabled: true,
+    }),
+  },
+);
+generated = store.refreshGeneratedMetrics([castle, phoenix, mixedRoute]);
+assert.equal(generated.models.openai_gpt_5_6_sol?.configurationIsConsistent, false);
+assert.equal(generated.models.openai_gpt_5_6_sol?.averageInferenceMs, undefined);
+assert.equal(generated.models.openai_gpt_5_6_sol?.outputCapTokens, undefined);
+
+const mixedCap = job("mixed-cap");
+store.markRunning(mixedCap);
+store.finalizeSuccess(
+  mixedCap,
+  JSON.stringify({ version: "1.0", blocks: [{ x: 13, y: 14, z: 15 }] }, null, 2),
+  {
+    inferenceTimeMs: 300_000,
+    attemptCount: 1,
+    acceptedOutputTokens: 64_000,
+    configuration: createBenchmarkRunConfiguration({
+      promptText: mixedCap.promptText!,
+      providerRoute: "direct",
+      reasoningOverride: null,
+      toolsEnabled: true,
+    }),
+  },
+);
+generated = store.refreshGeneratedMetrics([castle, phoenix, mixedCap]);
+assert.equal(generated.models.openai_gpt_5_6_sol?.configurationIsConsistent, false);
+assert.equal(
+  generated.models.openai_gpt_5_6_sol?.averageInferenceMs,
+  undefined,
+  "timings from different accepted caps must not be averaged together",
+);
+assert.equal(
+  generated.models.openai_gpt_5_6_sol?.outputCapTokens,
+  undefined,
+  "mixed accepted caps must not publish a static-looking cap",
+);
+
+writeFileSync(phoenix.filePath, "not json");
+store.reconcile([phoenix]);
+generated = store.refreshGeneratedMetrics([castle, phoenix]);
+assert.equal(generated.models.openai_gpt_5_6_sol?.finalizedBuildCount, 1);
+assert.equal(generated.models.openai_gpt_5_6_sol?.averageInferenceMs, undefined);
+assert.equal(generated.models.openai_gpt_5_6_sol?.averageJsonSizeBytes, undefined);
+
+console.log("batch benchmark metric lifecycle checks passed");

--- a/tests/unit/scripts/batch-benchmark-metrics.test.ts
+++ b/tests/unit/scripts/batch-benchmark-metrics.test.ts
@@ -246,4 +246,65 @@ assert.equal(generated.models.openai_gpt_5_6_sol?.finalizedBuildCount, 1);
 assert.equal(generated.models.openai_gpt_5_6_sol?.averageInferenceMs, undefined);
 assert.equal(generated.models.openai_gpt_5_6_sol?.averageJsonSizeBytes, undefined);
 
+const checkoutRoot = mkdtempSync(join(tmpdir(), "minebench-benchmark-checkout-"));
+const checkoutMetricsPath = join(checkoutRoot, "modelBenchmarkMetrics.generated.json");
+const checkoutJob: BenchmarkMetricJob = {
+  promptSlug: "castle",
+  promptText: "Build prompt for castle",
+  modelKey: "openai_gpt_5_6_sol",
+  modelSlug: "gpt-5-6-sol",
+  filePath: join(checkoutRoot, "uploads", "castle", "castle-gpt-5-6-sol.json"),
+};
+const committedMetrics = {
+  version: 1,
+  models: {
+    openai_gpt_5_6_sol: {
+      expectedBuildCount: 1,
+      finalizedBuildCount: 1,
+      inferenceSampleCount: 1,
+      configurationSampleCount: 1,
+      configurationIsConsistent: true,
+      averageInferenceMs: 456_000,
+      averageJsonSizeBytes: 123_456,
+      outputCapTokens: 128_000,
+    },
+  },
+};
+writeFileSync(checkoutMetricsPath, `${JSON.stringify(committedMetrics, null, 2)}\n`);
+const checkoutStore = new BenchmarkMetricsStore({
+  ledgerPath: join(checkoutRoot, "uploads", ".benchmark-metrics.json"),
+  generatedMetricsPath: checkoutMetricsPath,
+});
+const committedContents = readFileSync(checkoutMetricsPath, "utf8");
+const emptyCheckoutMetrics = checkoutStore.refreshGeneratedMetrics([checkoutJob]);
+assert.equal(emptyCheckoutMetrics.models.openai_gpt_5_6_sol?.finalizedBuildCount, 0);
+assert.equal(
+  readFileSync(checkoutMetricsPath, "utf8"),
+  committedContents,
+  "a status run with an incomplete local artifact cohort must not rewrite committed metrics",
+);
+
+mkdirSync(join(checkoutRoot, "uploads", "castle"), { recursive: true });
+const checkoutJson = JSON.stringify({ version: "1.0", blocks: [{ x: 1, y: 1, z: 1 }] });
+writeFileSync(checkoutJob.filePath, checkoutJson);
+const localCompleteMetrics = checkoutStore.refreshGeneratedMetrics([checkoutJob]);
+assert.equal(localCompleteMetrics.models.openai_gpt_5_6_sol?.inferenceSampleCount, 0);
+const refreshedCommittedMetrics = JSON.parse(readFileSync(checkoutMetricsPath, "utf8")) as {
+  models: { openai_gpt_5_6_sol: Record<string, number | boolean> };
+};
+assert.equal(
+  refreshedCommittedMetrics.models.openai_gpt_5_6_sol.averageJsonSizeBytes,
+  Buffer.byteLength(checkoutJson),
+);
+assert.equal(
+  refreshedCommittedMetrics.models.openai_gpt_5_6_sol.averageInferenceMs,
+  456_000,
+  "a complete artifact cohort without its gitignored ledger should preserve committed timing",
+);
+assert.equal(
+  refreshedCommittedMetrics.models.openai_gpt_5_6_sol.outputCapTokens,
+  128_000,
+  "a complete artifact cohort without its gitignored ledger should preserve the committed cap",
+);
+
 console.log("batch benchmark metric lifecycle checks passed");

--- a/tests/unit/scripts/batch-benchmark-metrics.test.ts
+++ b/tests/unit/scripts/batch-benchmark-metrics.test.ts
@@ -39,7 +39,11 @@ function readLedger() {
 }
 
 const castle = job("castle");
-const castleJson = JSON.stringify({ version: "1.0", blocks: [{ x: 1, y: 2, z: 3 }] }, null, 2);
+const castleJson = JSON.stringify(
+  { version: "1.0", blocks: [{ x: 1, y: 2, z: 3, type: "stone" }] },
+  null,
+  2,
+);
 const castleConfiguration = createBenchmarkRunConfiguration({
   promptText: castle.promptText!,
   providerRoute: "direct",
@@ -134,7 +138,13 @@ assert.equal(
 );
 
 const correctedCastleJson = JSON.stringify(
-  { version: "1.0", blocks: [{ x: 1, y: 2, z: 3 }, { x: 4, y: 5, z: 6 }] },
+  {
+    version: "1.0",
+    blocks: [
+      { x: 1, y: 2, z: 3, type: "stone" },
+      { x: 4, y: 5, z: 6, type: "stone" },
+    ],
+  },
   null,
   2,
 );
@@ -148,7 +158,11 @@ assert.equal(
 );
 
 const phoenix = job("phoenix");
-const phoenixJson = JSON.stringify({ version: "1.0", blocks: [{ x: 7, y: 8, z: 9 }] }, null, 2);
+const phoenixJson = JSON.stringify(
+  { version: "1.0", blocks: [{ x: 7, y: 8, z: 9, type: "stone" }] },
+  null,
+  2,
+);
 mkdirSync(join(uploads, "phoenix"), { recursive: true });
 writeFileSync(phoenix.filePath, phoenixJson, { flag: "w" });
 const phoenixSample = {
@@ -191,7 +205,11 @@ const mixedRoute = job("mixed-route");
 store.markRunning(mixedRoute);
 store.finalizeSuccess(
   mixedRoute,
-  JSON.stringify({ version: "1.0", blocks: [{ x: 10, y: 11, z: 12 }] }, null, 2),
+  JSON.stringify(
+    { version: "1.0", blocks: [{ x: 10, y: 11, z: 12, type: "stone" }] },
+    null,
+    2,
+  ),
   {
     inferenceTimeMs: 200_000,
     attemptCount: 1,
@@ -213,7 +231,11 @@ const mixedCap = job("mixed-cap");
 store.markRunning(mixedCap);
 store.finalizeSuccess(
   mixedCap,
-  JSON.stringify({ version: "1.0", blocks: [{ x: 13, y: 14, z: 15 }] }, null, 2),
+  JSON.stringify(
+    { version: "1.0", blocks: [{ x: 13, y: 14, z: 15, type: "stone" }] },
+    null,
+    2,
+  ),
   {
     inferenceTimeMs: 300_000,
     attemptCount: 1,
@@ -299,7 +321,24 @@ assert.equal(
   "a placeholder cohort must not rewrite committed metrics",
 );
 
-const checkoutJson = JSON.stringify({ version: "1.0", blocks: [{ x: 1, y: 1, z: 1 }] });
+writeFileSync(checkoutJob.filePath, JSON.stringify({ error: "provider request failed" }));
+const providerErrorMetrics = checkoutStore.refreshGeneratedMetrics([checkoutJob]);
+assert.equal(providerErrorMetrics.models.openai_gpt_5_6_sol?.finalizedBuildCount, 0);
+assert.equal(
+  providerErrorMetrics.models.openai_gpt_5_6_sol?.averageJsonSizeBytes,
+  undefined,
+  "structured provider errors must not contribute JSON-size metrics",
+);
+assert.equal(
+  readFileSync(checkoutMetricsPath, "utf8"),
+  committedContents,
+  "an invalid artifact cohort must not rewrite committed metrics",
+);
+
+const checkoutJson = JSON.stringify({
+  version: "1.0",
+  blocks: [{ x: 1, y: 1, z: 1, type: "stone" }],
+});
 writeFileSync(checkoutJob.filePath, checkoutJson);
 const localCompleteMetrics = checkoutStore.refreshGeneratedMetrics([checkoutJob]);
 assert.equal(localCompleteMetrics.models.openai_gpt_5_6_sol?.inferenceSampleCount, 0);

--- a/tests/unit/scripts/batch-benchmark-metrics.test.ts
+++ b/tests/unit/scripts/batch-benchmark-metrics.test.ts
@@ -76,6 +76,17 @@ assert.equal(
   createHash("sha256").update(castleJson).digest("hex"),
 );
 assert.equal(readLedger().jobs["openai_gpt_5_6_sol/castle"]?.state, "succeeded");
+store.markInterrupted(castle, "Interrupted after generation finalized.");
+assert.equal(
+  readLedger().jobs["openai_gpt_5_6_sol/castle"]?.state,
+  "succeeded",
+  "an upload-window signal must not overwrite a finalized generation",
+);
+assert.equal(
+  readLedger().jobs["openai_gpt_5_6_sol/castle"]?.interruptedRunCount,
+  0,
+  "a finalized generation must not add an interrupted run",
+);
 assert.equal(
   readdirSync(join(uploads, "castle")).some((name) => name.endsWith(".tmp")),
   false,

--- a/tests/unit/scripts/batch-generate-import-only.test.ts
+++ b/tests/unit/scripts/batch-generate-import-only.test.ts
@@ -11,6 +11,7 @@ import {
   isEmptyPlaceholder,
 } from "../../../scripts/batch-generate";
 import type { ModelKey } from "../../../lib/ai/modelCatalog";
+import { BENCHMARK_PROMPT_MAP } from "../../../scripts/uploadsCatalog";
 
 function job(modelKey: ModelKey) {
   return { modelKey };
@@ -35,11 +36,7 @@ async function main() {
     "treehouse",
     "worldtree",
   ]);
-  const metricPromptTexts = new Map<string, string | null>(
-    benchmarkPromptSlugs.map((slug) => [slug, `Build prompt for ${slug}`]),
-  );
-  metricPromptTexts.set("local-only", "A local-only prompt");
-  const metricJobs = buildBenchmarkMetricJobs(metricPromptTexts, ["openai_gpt_5_6_sol"]);
+  const metricJobs = buildBenchmarkMetricJobs(["openai_gpt_5_6_sol"]);
   assert.deepEqual(
     metricJobs.map((candidate) => candidate.promptSlug),
     benchmarkPromptSlugs,
@@ -49,6 +46,11 @@ async function main() {
     metricJobs.some((candidate) => candidate.promptSlug === "local-only"),
     false,
     "custom upload folders must not change the published benchmark cohort",
+  );
+  assert.equal(
+    metricJobs.find((candidate) => candidate.promptSlug === "castle")?.promptText,
+    BENCHMARK_PROMPT_MAP.castle,
+    "CLI prompt overrides must not change the canonical metric prompt hash",
   );
 
   const placeholderRoot = mkdtempSync(join(tmpdir(), "minebench-batch-placeholder-"));

--- a/tests/unit/scripts/batch-generate-import-only.test.ts
+++ b/tests/unit/scripts/batch-generate-import-only.test.ts
@@ -3,6 +3,8 @@ import { mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
+  buildBenchmarkMetricJobs,
+  getBenchmarkPromptSlugs,
   getCandidateModels,
   getImportOnlyModelsForGenerationJobs,
   getJobsToGenerate,
@@ -15,6 +17,40 @@ function job(modelKey: ModelKey) {
 }
 
 async function main() {
+  const benchmarkPromptSlugs = getBenchmarkPromptSlugs();
+  assert.deepEqual(benchmarkPromptSlugs, [
+    "arcade",
+    "astronaut",
+    "carrier",
+    "castle",
+    "cottage",
+    "fighter-jet",
+    "floating",
+    "knight",
+    "locomotive",
+    "phoenix",
+    "shipwreck",
+    "skyscraper",
+    "steampunk",
+    "treehouse",
+    "worldtree",
+  ]);
+  const metricPromptTexts = new Map<string, string | null>(
+    benchmarkPromptSlugs.map((slug) => [slug, `Build prompt for ${slug}`]),
+  );
+  metricPromptTexts.set("local-only", "A local-only prompt");
+  const metricJobs = buildBenchmarkMetricJobs(metricPromptTexts, ["openai_gpt_5_6_sol"]);
+  assert.deepEqual(
+    metricJobs.map((candidate) => candidate.promptSlug),
+    benchmarkPromptSlugs,
+    "generated metrics must stay tied to the canonical benchmark prompt cohort",
+  );
+  assert.equal(
+    metricJobs.some((candidate) => candidate.promptSlug === "local-only"),
+    false,
+    "custom upload folders must not change the published benchmark cohort",
+  );
+
   const placeholderRoot = mkdtempSync(join(tmpdir(), "minebench-batch-placeholder-"));
   const placeholderPath = join(placeholderRoot, "build.json");
   writeFileSync(placeholderPath, "{}\n");

--- a/tests/unit/scripts/batch-generate-import-only.test.ts
+++ b/tests/unit/scripts/batch-generate-import-only.test.ts
@@ -1,8 +1,12 @@
 import assert from "node:assert/strict";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import {
   getCandidateModels,
   getImportOnlyModelsForGenerationJobs,
   getJobsToGenerate,
+  isEmptyPlaceholder,
 } from "../../../scripts/batch-generate";
 import type { ModelKey } from "../../../lib/ai/modelCatalog";
 
@@ -11,6 +15,21 @@ function job(modelKey: ModelKey) {
 }
 
 async function main() {
+  const placeholderRoot = mkdtempSync(join(tmpdir(), "minebench-batch-placeholder-"));
+  const placeholderPath = join(placeholderRoot, "build.json");
+  writeFileSync(placeholderPath, "{}\n");
+  assert.equal(
+    isEmptyPlaceholder(placeholderPath),
+    true,
+    "LF-terminated placeholders should remain missing generation jobs",
+  );
+  writeFileSync(placeholderPath, "{}\r\n");
+  assert.equal(
+    isEmptyPlaceholder(placeholderPath),
+    true,
+    "CRLF-terminated placeholders should remain missing generation jobs",
+  );
+
   assert.ok(
     getCandidateModels([]).includes("openai_gpt_4_5_web_harness"),
     "default batch candidates should include import-only models for status/upload",


### PR DESCRIPTION
## Summary

- normalize every model detail popup around one accepted `Output cap` row and the same three statistic rows: `Average inference time`, `Average JSON size`, and `Total cost`
- replace free-form metric strings with typed numeric durations, byte sizes, token caps, and costs; backfill exact average JSON sizes for all 53 catalog models
- automatically persist benchmark time, final JSON bytes and checksum, attempt count, accepted output cap, actual provider route, prompt hash, reasoning override, and tool mode
- preserve failed and interrupted run counts across resumes, recover atomic finalization, avoid conflicting concurrent jobs, and upload tracked generation times
- keep finalized generation records succeeded when SIGINT/SIGTERM arrives during the subsequent upload phase
- withhold automatic averages and caps when a complete prompt cohort mixes configurations or accepted caps
- pin published automatic metrics to the canonical 15-prompt cohort and its fixed text while leaving custom local prompts and CLI overrides available for generation and upload
- preserve committed generated metrics during status runs with empty, partial, or ledger-less local artifacts
- consistently treat LF/CRLF-terminated empty JSON placeholders as missing across status, upload selection, generation selection, and metric aggregation
- require every counted artifact, including ledger-less imports, to match the voxel-build schema before publishing coverage or average JSON size
- reset generation timing to untracked when an imported replacement has no timing measurement
- restrict historical output-cap fallbacks to accepted values; requested-only budgets remain untracked until acceptance is recorded
- apply the popup audit fixes for contrast, hierarchy, responsive placement, typography, and divider density

## Verification

- `pnpm test` — 23 test files passed
- `pnpm lint`
- `pnpm exec tsc --noEmit`
- `pnpm build`
- focused empty-checkout, ledger-less complete-cohort, canonical-prompt and CLI-override isolation, upload-window interruption, newline-placeholder, invalid-artifact, untimed-import, and requested-only output-cap regression coverage
- `graphify update .`
- Impeccable popup audit: 19/20, no P0 or P1 findings

## Notes

- Cost remains the only manually entered statistic for new benchmark runs.
- GPT 5.6 Sol Pro cost is now untracked. The unsupported non-exact historical costs for GPT 5.4, GPT 5.3 Codex, Claude Opus 4.7, and Claude Opus 4.6 are also untracked.
- Grok 4.20's `2m 29s` is treated as exact. Claude Opus 4.7 retains its source-qualified `~43m 20s`; this is the only remaining approximate figure.
- Live Chrome inspection was unavailable in the current browser runtime; the supplied screenshots, server-rendered markup, interaction checks, contrast calculations, and production build were verified instead.

*(PR written by Codex)*