### PR TITLE
(fix) restore benchmark metadata clarity

### DIFF
--- a/components/leaderboard/ModelBenchmarkDetails.tsx
+++ b/components/leaderboard/ModelBenchmarkDetails.tsx
@@ -14,6 +14,7 @@ import {
 const POPOVER_WIDTH = 340;
 const VIEWPORT_GUTTER = 16;
 const POPOVER_GAP = 4;
+const BENCHMARK_PREDATES_TRACKING = "Benchmark predates tracking";
 
 type DetailsPosition = {
   arrowLeft: number;
@@ -100,7 +101,7 @@ function parameterRows(profile: ModelBenchmarkProfile): ModelRunParameter[] {
       label: "Output cap",
       value:
         profile.outputCapTokens === undefined
-          ? "Not tracked"
+          ? BENCHMARK_PREDATES_TRACKING
           : `${formatInteger(profile.outputCapTokens)} tokens`,
     },
   ];
@@ -110,18 +111,20 @@ function statisticRows(profile: ModelBenchmarkProfile): ModelRunParameter[] {
   return [
     {
       label: "Average inference time",
-      value: profile.averageInference ? formatDuration(profile.averageInference) : "Not tracked",
+      value: profile.averageInference
+        ? formatDuration(profile.averageInference)
+        : BENCHMARK_PREDATES_TRACKING,
     },
     {
       label: "Average JSON size",
       value:
         profile.averageJsonSizeBytes === undefined
-          ? "Not tracked"
+          ? BENCHMARK_PREDATES_TRACKING
           : formatJsonSize(profile.averageJsonSizeBytes),
     },
     {
       label: "Total cost",
-      value: profile.totalCost ? formatCost(profile.totalCost) : "Not tracked",
+      value: profile.totalCost ? formatCost(profile.totalCost) : BENCHMARK_PREDATES_TRACKING,
     },
   ];
 }

--- a/lib/ai/modelBenchmarkProfiles.ts
+++ b/lib/ai/modelBenchmarkProfiles.ts
@@ -214,6 +214,7 @@ const MODEL_BENCHMARK_METADATA: Partial<
   openai_gpt_5_6_sol: {
     sourceRelease: "3.9.0",
     averageInference: { milliseconds: 1_516_200 },
+    totalCost: { usd: 710.82 },
     buildCount: 15,
   },
   xai_grok_4_5: {

--- a/tests/ui/model-benchmark-details.test.ts
+++ b/tests/ui/model-benchmark-details.test.ts
@@ -73,8 +73,9 @@ assert.ok(
     detailsSource.includes('label: "Average JSON size"') &&
     detailsSource.includes('label: "Total cost"') &&
     detailsSource.includes('label: "Output cap"') &&
-    detailsSource.includes('"Not tracked"'),
-  "every normalized field should render its own explicit untracked state",
+    detailsSource.includes('"Benchmark predates tracking"') &&
+    !detailsSource.includes('"Not tracked"'),
+  "every normalized field should explain when its benchmark predates tracking",
 );
 assert.ok(
   detailsSource.includes('v{profile.sourceRelease.replace(/^v/, "")}') &&
@@ -163,9 +164,9 @@ assert.ok(
     trackedMarkup.includes("25m 16.2s") &&
     trackedMarkup.includes("Average JSON size") &&
     trackedMarkup.includes("91.58 MiB") &&
-    !trackedMarkup.includes("$710.82") &&
-    trackedMarkup.includes("Not tracked"),
-  "GPT 5.6 Sol Pro should render tracked run metrics with untracked cost",
+    trackedMarkup.includes("$710.82") &&
+    !trackedMarkup.includes("Benchmark predates tracking"),
+  "GPT 5.6 Sol Pro should render all recorded benchmark statistics",
 );
 assert.ok(
   trackedMarkup.includes('<h2 class="sr-only">GPT 5.6 Sol Pro run details</h2>'),
@@ -185,8 +186,8 @@ assert.ok(
     removedEstimateMarkup.includes("Output cap") &&
     removedEstimateMarkup.includes("Total cost") &&
     !removedEstimateMarkup.includes("$25.00") &&
-    (removedEstimateMarkup.match(/Not tracked/g)?.length ?? 0) >= 2,
-  "removed GPT 5.4 estimates should render as explicitly untracked",
+    (removedEstimateMarkup.match(/Benchmark predates tracking/g)?.length ?? 0) === 2,
+  "removed GPT 5.4 estimates should explain that their benchmark predates tracking",
 );
 
 const geminiMarkup = renderToStaticMarkup(
@@ -217,9 +218,9 @@ const untrackedMarkup = renderToStaticMarkup(
 );
 assert.ok(
   untrackedMarkup.includes("ChatGPT web harness") &&
-    (untrackedMarkup.match(/Not tracked/g)?.length ?? 0) >= 3 &&
+    (untrackedMarkup.match(/Benchmark predates tracking/g)?.length ?? 0) === 3 &&
     untrackedMarkup.includes("not directly comparable to API-generated runs"),
-  "an untracked run should keep its parameters, explicit missing values, and comparability note",
+  "a historical web benchmark should explain missing values and keep its comparability note",
 );
 
 const exactGlmMarkup = renderToStaticMarkup(

--- a/tests/unit/ai/model-benchmark-profiles.test.ts
+++ b/tests/unit/ai/model-benchmark-profiles.test.ts
@@ -23,7 +23,7 @@ assert.ok(
   Number.isInteger(gpt56.averageJsonSizeBytes) && (gpt56.averageJsonSizeBytes ?? 0) > 0,
   "GPT 5.6 Sol Pro should use the generated exact JSON-size aggregate",
 );
-assert.equal(gpt56.totalCost, undefined);
+assert.deepEqual(gpt56.totalCost, { usd: 710.82 });
 assert.equal(gpt56.buildCount, 15);
 
 const gemini36Flash = getModelBenchmarkProfile("gemini_3_6_flash");


### PR DESCRIPTION
## Summary

- restore GPT 5.6 Sol Pro's exact recorded `$710.82` total cost
- replace vague `Not tracked` popup values with `Benchmark predates tracking`
- preserve accepted-cap semantics instead of presenting historical requested budgets as accepted output caps
- update focused model-profile and rendered-popup regression coverage

## Output-cap audit

The 22 missing cap rows cannot be safely reconstructed as one exact accepted value. GPT 4.5 is import-only, and several older 15-build cohorts span multiple configured request caps while the successful provider retry budget was not persisted. New benchmark runs already record the accepted cap automatically.

## Verification

- `pnpm test` (24 test files)
- `pnpm lint`
- `pnpm exec tsc --noEmit`
- `pnpm build`
- `git diff --check`
- `graphify update .`

*(PR written by Codex)*