### PR TITLE
(feat) expand sandbox model comparisons

### DIFF
--- a/app/api/sandbox/benchmark/route.ts
+++ b/app/api/sandbox/benchmark/route.ts
@@ -10,6 +10,12 @@ import {
   databaseUnavailableHeaders,
   isDatabaseUnavailableError,
 } from "@/lib/db/errors";
+import {
+  SANDBOX_COMPARISON_MODEL_PARAMS,
+  SANDBOX_COMPARISON_SLOTS,
+  type SandboxComparisonSelection,
+  normalizeSandboxComparisonSelection,
+} from "@/lib/sandbox/benchmarkComparison";
 import { prisma } from "@/lib/prisma";
 import { resolveModelDisplayName } from "@/lib/ai/modelCatalog";
 
@@ -63,34 +69,9 @@ type BenchmarkResponse = {
     text: string;
   } | null;
   models: ModelOption[];
-  selectedModels: {
-    a: string | null;
-    b: string | null;
-  };
-  builds: {
-    a: BenchmarkBuild | null;
-    b: BenchmarkBuild | null;
-  };
+  selectedModels: SandboxComparisonSelection<string | null>;
+  builds: SandboxComparisonSelection<BenchmarkBuild | null>;
 };
-
-function pickPair(models: ModelOption[], requestedA?: string, requestedB?: string) {
-  if (models.length < 2) return { a: null as string | null, b: null as string | null };
-
-  const has = (key: string | undefined) => Boolean(key && models.some((m) => m.key === key));
-  const first = models[0]?.key ?? null;
-  const second = models[1]?.key ?? null;
-
-  let a = has(requestedA) ? (requestedA as string) : first;
-  let b = has(requestedB) ? (requestedB as string) : null;
-
-  if (!a) return { a: null, b: null };
-  if (!b || b === a) {
-    b = models.find((m) => m.key !== a)?.key ?? null;
-  }
-
-  if (!b) return { a: null, b: null };
-  return { a, b };
-}
 
 function shouldInlineInAdaptiveMode(hints: ArenaBuildLoadHints): boolean {
   if (getInitialAdaptiveDeliveryClass(hints) !== "inline") return false;
@@ -107,8 +88,12 @@ export async function GET(req: Request) {
   try {
     const url = new URL(req.url);
     const requestedPromptId = url.searchParams.get("promptId") ?? undefined;
-    const requestedModelA = url.searchParams.get("modelA") ?? undefined;
-    const requestedModelB = url.searchParams.get("modelB") ?? undefined;
+    const requestedModels = Object.fromEntries(
+      SANDBOX_COMPARISON_SLOTS.map((slot) => [
+        slot,
+        url.searchParams.get(SANDBOX_COMPARISON_MODEL_PARAMS[slot]) ?? undefined,
+      ]),
+    ) as Partial<SandboxComparisonSelection<string | undefined>>;
 
     const grouped = await prisma.build.groupBy({
       by: ["promptId", "modelId"],
@@ -188,17 +173,23 @@ export async function GET(req: Request) {
       eloRating: Number(m.eloRating),
     }));
 
-    const selection = pickPair(models, requestedModelA, requestedModelB);
+    const selection = normalizeSandboxComparisonSelection(
+      models.map((model) => model.key),
+      requestedModels,
+    );
     const modelIdByKey = new Map(modelRows.map((m) => [m.key, m.id]));
-    const selectedModelAId = selection.a ? modelIdByKey.get(selection.a) ?? null : null;
-    const selectedModelBId = selection.b ? modelIdByKey.get(selection.b) ?? null : null;
+    const selectedModelIds = SANDBOX_COMPARISON_SLOTS.flatMap((slot) => {
+      const modelKey = selection[slot];
+      const modelId = modelKey ? modelIdByKey.get(modelKey) : null;
+      return modelId ? [modelId] : [];
+    });
 
     const compatiblePromptIds =
-      selectedModelAId && selectedModelBId
+      selectedModelIds.length >= 2
         ? promptOptions
             .filter((p) => {
               const ids = modelIdsByPromptId.get(p.id);
-              return Boolean(ids?.has(selectedModelAId) && ids?.has(selectedModelBId));
+              return Boolean(ids && selectedModelIds.every((modelId) => ids.has(modelId)));
             })
             .map((p) => p.id)
         : [];
@@ -209,128 +200,102 @@ export async function GET(req: Request) {
         promptOptions[0]
       : promptOptions.find((p) => compatiblePromptIds.includes(p.id)) ?? promptOptions[0];
 
-    const [buildA, buildB] = await Promise.all([
-      selection.a
-        ? prisma.build.findFirst({
-            where: {
-              promptId: selectedPrompt.id,
-              gridSize: ARENA_GRID_SIZE,
-              palette: ARENA_PALETTE,
-              mode: ARENA_MODE,
-              model: { key: selection.a },
-            },
-            select: {
-              id: true,
-              gridSize: true,
-              palette: true,
-              mode: true,
-              blockCount: true,
-              generationTimeMs: true,
-              voxelByteSize: true,
-              voxelCompressedByteSize: true,
-              voxelSha256: true,
-              arenaBuildHints: true,
-              model: {
-                select: {
-                  key: true,
-                  provider: true,
-                  displayName: true,
-                  eloRating: true,
-                },
-              },
-            },
-          })
-        : null,
-      selection.b
-        ? prisma.build.findFirst({
-            where: {
-              promptId: selectedPrompt.id,
-              gridSize: ARENA_GRID_SIZE,
-              palette: ARENA_PALETTE,
-              mode: ARENA_MODE,
-              model: { key: selection.b },
-            },
-            select: {
-              id: true,
-              gridSize: true,
-              palette: true,
-              mode: true,
-              blockCount: true,
-              generationTimeMs: true,
-              voxelByteSize: true,
-              voxelCompressedByteSize: true,
-              voxelSha256: true,
-              arenaBuildHints: true,
-              model: {
-                select: {
-                  key: true,
-                  provider: true,
-                  displayName: true,
-                  eloRating: true,
-                },
-              },
-            },
-          })
-        : null,
-    ]);
+    const selectedModelKeys = SANDBOX_COMPARISON_SLOTS.flatMap((slot) => {
+      const modelKey = selection[slot];
+      return modelKey ? [modelKey] : [];
+    });
+    const selectedBuildRows = await prisma.build.findMany({
+      where: {
+        promptId: selectedPrompt.id,
+        gridSize: ARENA_GRID_SIZE,
+        palette: ARENA_PALETTE,
+        mode: ARENA_MODE,
+        model: { key: { in: selectedModelKeys } },
+      },
+      select: {
+        id: true,
+        gridSize: true,
+        palette: true,
+        mode: true,
+        blockCount: true,
+        generationTimeMs: true,
+        voxelByteSize: true,
+        voxelCompressedByteSize: true,
+        voxelSha256: true,
+        arenaBuildHints: true,
+        model: {
+          select: {
+            key: true,
+            provider: true,
+            displayName: true,
+            eloRating: true,
+          },
+        },
+      },
+    });
+    const buildByModelKey = new Map(
+      selectedBuildRows.map((build) => [build.model.key, build]),
+    );
+    const buildRows = SANDBOX_COMPARISON_SLOTS.map((slot) => {
+      const modelKey = selection[slot];
+      return modelKey ? buildByModelKey.get(modelKey) ?? null : null;
+    });
+    const builds = Object.fromEntries(
+      SANDBOX_COMPARISON_SLOTS.map((slot, index) => [slot, buildRows[index] ?? null]),
+    ) as SandboxComparisonSelection<(typeof buildRows)[number]>;
+    const hints = Object.fromEntries(
+      SANDBOX_COMPARISON_SLOTS.map((slot) => [
+        slot,
+        builds[slot] ? deriveArenaBuildLoadHints(builds[slot]) : null,
+      ]),
+    ) as SandboxComparisonSelection<ArenaBuildLoadHints | null>;
+    const shouldPrepare = Object.fromEntries(
+      SANDBOX_COMPARISON_SLOTS.map((slot) => {
+        const slotHints = hints[slot];
+        const shouldProbe = Boolean(slotHints && slotHints.initialEstimatedBytes == null);
+        return [slot, slotHints ? shouldInlineInAdaptiveMode(slotHints) || shouldProbe : false];
+      }),
+    ) as SandboxComparisonSelection<boolean>;
+    const prepared = Object.fromEntries(
+      SANDBOX_COMPARISON_SLOTS.map((slot) => [slot, null]),
+    ) as SandboxComparisonSelection<Awaited<ReturnType<typeof prepareArenaBuild>> | null>;
 
-    const hintsA = buildA ? deriveArenaBuildLoadHints(buildA) : null;
-    const hintsB = buildB ? deriveArenaBuildLoadHints(buildB) : null;
-    const shouldProbeA = Boolean(hintsA && hintsA.initialEstimatedBytes == null);
-    const shouldProbeB = Boolean(hintsB && hintsB.initialEstimatedBytes == null);
-    const shouldPrepareA = hintsA ? shouldInlineInAdaptiveMode(hintsA) || shouldProbeA : false;
-    const shouldPrepareB = hintsB ? shouldInlineInAdaptiveMode(hintsB) || shouldProbeB : false;
-
-    let preparedA: Awaited<ReturnType<typeof prepareArenaBuild>> | null = null;
-    let preparedB: Awaited<ReturnType<typeof prepareArenaBuild>> | null = null;
-
-    if (shouldPrepareA || shouldPrepareB) {
+    if (SANDBOX_COMPARISON_SLOTS.some((slot) => shouldPrepare[slot])) {
       try {
-        const [buildAForPrepare, buildBForPrepare] = await Promise.all([
-          shouldPrepareA && buildA
-            ? prisma.build.findUnique({
-                where: { id: buildA.id },
-                select: {
-                  id: true,
-                  gridSize: true,
-                  palette: true,
-                  blockCount: true,
-                  voxelByteSize: true,
-                  voxelCompressedByteSize: true,
-                  voxelSha256: true,
-                  arenaBuildHints: true,
-                  voxelData: true,
-                  voxelStorageBucket: true,
-                  voxelStoragePath: true,
-                  voxelStorageEncoding: true,
-                },
-              })
-            : Promise.resolve(null),
-          shouldPrepareB && buildB
-            ? prisma.build.findUnique({
-                where: { id: buildB.id },
-                select: {
-                  id: true,
-                  gridSize: true,
-                  palette: true,
-                  blockCount: true,
-                  voxelByteSize: true,
-                  voxelCompressedByteSize: true,
-                  voxelSha256: true,
-                  arenaBuildHints: true,
-                  voxelData: true,
-                  voxelStorageBucket: true,
-                  voxelStoragePath: true,
-                  voxelStorageEncoding: true,
-                },
-              })
-            : Promise.resolve(null),
-        ]);
-
-        [preparedA, preparedB] = await Promise.all([
-          buildAForPrepare ? prepareArenaBuild(buildAForPrepare) : Promise.resolve(null),
-          buildBForPrepare ? prepareArenaBuild(buildBForPrepare) : Promise.resolve(null),
-        ]);
+        const prepareBuildIds = SANDBOX_COMPARISON_SLOTS.flatMap((slot) => {
+          const build = builds[slot];
+          return shouldPrepare[slot] && build ? [build.id] : [];
+        });
+        const buildsForPrepare = await prisma.build.findMany({
+          where: { id: { in: prepareBuildIds } },
+          select: {
+            id: true,
+            gridSize: true,
+            palette: true,
+            blockCount: true,
+            voxelByteSize: true,
+            voxelCompressedByteSize: true,
+            voxelSha256: true,
+            arenaBuildHints: true,
+            voxelData: true,
+            voxelStorageBucket: true,
+            voxelStoragePath: true,
+            voxelStorageEncoding: true,
+          },
+        });
+        const prepareBuildById = new Map(
+          buildsForPrepare.map((build) => [build.id, build]),
+        );
+        const preparedRows = await Promise.all(
+          SANDBOX_COMPARISON_SLOTS.map((slot) => {
+            const buildId = builds[slot]?.id;
+            const build = buildId ? prepareBuildById.get(buildId) : null;
+            return build ? prepareArenaBuild(build) : Promise.resolve(null);
+          }),
+        );
+        for (const [index, slot] of SANDBOX_COMPARISON_SLOTS.entries()) {
+          prepared[slot] = preparedRows[index] ?? null;
+        }
       } catch (err) {
         console.warn("sandbox benchmark inline prepare failed", err);
       }
@@ -405,10 +370,12 @@ export async function GET(req: Request) {
       },
       models,
       selectedModels: selection,
-      builds: {
-        a: toBenchmarkBuild(buildA, hintsA, preparedA),
-        b: toBenchmarkBuild(buildB, hintsB, preparedB),
-      },
+      builds: Object.fromEntries(
+        SANDBOX_COMPARISON_SLOTS.map((slot) => [
+          slot,
+          toBenchmarkBuild(builds[slot], hints[slot], prepared[slot]),
+        ]),
+      ) as SandboxComparisonSelection<BenchmarkBuild | null>,
     };
 
     return NextResponse.json(body, { headers: { "Cache-Control": "no-store" } });

--- a/components/sandbox/SandboxBenchmark.tsx
+++ b/components/sandbox/SandboxBenchmark.tsx
@@ -1,6 +1,13 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  type RefObject,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import {
   SandboxGifExportButton,
   type SandboxGifExportTarget,
@@ -16,11 +23,18 @@ import type {
   ArenaBuildStreamEvent,
   ArenaBuildVariant,
 } from "@/lib/arena/types";
+import {
+  SANDBOX_COMPARISON_MODEL_PARAMS,
+  SANDBOX_COMPARISON_SLOTS,
+  type SandboxComparisonSelection,
+  type SandboxComparisonSlot,
+  createSandboxComparisonSelection,
+  getActiveSandboxComparisonSlots,
+} from "@/lib/sandbox/benchmarkComparison";
 import type { VoxelBuild } from "@/lib/voxel/types";
 
 type Palette = "simple" | "advanced";
 type GridSize = 64 | 256 | 512;
-type Slot = "a" | "b";
 
 type BenchmarkPromptOption = {
   id: string;
@@ -62,14 +76,8 @@ type BenchmarkResponse = {
     text: string;
   } | null;
   models: BenchmarkModelOption[];
-  selectedModels: {
-    a: string | null;
-    b: string | null;
-  };
-  builds: {
-    a: BenchmarkBuild | null;
-    b: BenchmarkBuild | null;
-  };
+  selectedModels: SandboxComparisonSelection<string | null>;
+  builds: SandboxComparisonSelection<BenchmarkBuild | null>;
 };
 
 type BuildVariantResponse = {
@@ -119,6 +127,18 @@ type CachedBuild = {
 
 const DEFAULT_MODEL_A = "openai_gpt_5_5";
 const DEFAULT_MODEL_B = "openai_gpt_5_5_pro";
+const DEFAULT_MODEL_SELECTION: SandboxComparisonSelection<string> = {
+  a: DEFAULT_MODEL_A,
+  b: DEFAULT_MODEL_B,
+  c: "",
+  d: "",
+};
+const COMPARISON_SLOT_LABELS: SandboxComparisonSelection<string> = {
+  a: "Model 1",
+  b: "Model 2",
+  c: "Model 3",
+  d: "Model 4",
+};
 const SNAPSHOT_FETCH_TIMEOUT_MS = Number.parseInt(
   process.env.NEXT_PUBLIC_ARENA_SNAPSHOT_TIMEOUT_MS ?? "12000",
   10,
@@ -214,11 +234,13 @@ async function readWithTimeout<T>(
   });
 }
 
-function SelectChevron() {
+function SelectChevron({ withTrailingAction = false }: { withTrailingAction?: boolean }) {
   return (
     <svg
       aria-hidden="true"
-      className="pointer-events-none absolute right-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted"
+      className={`pointer-events-none absolute top-1/2 h-4 w-4 -translate-y-1/2 text-muted ${
+        withTrailingAction ? "right-14" : "right-3"
+      }`}
       viewBox="0 0 24 24"
       fill="none"
     >
@@ -267,6 +289,36 @@ function createEmptySlotState(): SlotHydrationState {
   };
 }
 
+function createEmptySlotStates(): SandboxComparisonSelection<SlotHydrationState> {
+  return {
+    a: createEmptySlotState(),
+    b: createEmptySlotState(),
+    c: createEmptySlotState(),
+    d: createEmptySlotState(),
+  };
+}
+
+function createEmptyBuilds(): SandboxComparisonSelection<null> {
+  return createSandboxComparisonSelection(null);
+}
+
+function createModelSelectionFromKeys(modelKeys: string[]): SandboxComparisonSelection<string> {
+  const selection = createSandboxComparisonSelection("");
+  for (const [index, modelKey] of modelKeys.slice(0, SANDBOX_COMPARISON_SLOTS.length).entries()) {
+    const slot = SANDBOX_COMPARISON_SLOTS[index];
+    if (slot) selection[slot] = modelKey;
+  }
+  return selection;
+}
+
+function toNullableModelSelection(
+  selection: SandboxComparisonSelection<string>,
+): SandboxComparisonSelection<string | null> {
+  return Object.fromEntries(
+    SANDBOX_COMPARISON_SLOTS.map((slot) => [slot, selection[slot] || null]),
+  ) as SandboxComparisonSelection<string | null>;
+}
+
 function toSlotProgressTotal(build: BenchmarkBuild | null): number | null {
   if (!build) return null;
   if (build.metrics.blockCount > 0) return build.metrics.blockCount;
@@ -301,14 +353,15 @@ async function readBuildVariantJson(res: Response): Promise<BuildVariantResponse
 
 async function fetchBenchmarkResponse(args: {
   promptId?: string;
-  modelA?: string;
-  modelB?: string;
+  models?: Partial<SandboxComparisonSelection<string>>;
   signal?: AbortSignal;
 }): Promise<BenchmarkResponse> {
   const params = new URLSearchParams();
   if (args.promptId) params.set("promptId", args.promptId);
-  if (args.modelA) params.set("modelA", args.modelA);
-  if (args.modelB) params.set("modelB", args.modelB);
+  for (const slot of SANDBOX_COMPARISON_SLOTS) {
+    const modelKey = args.models?.[slot];
+    if (modelKey) params.set(SANDBOX_COMPARISON_MODEL_PARAMS[slot], modelKey);
+  }
 
   const query = params.toString();
   const url = query ? `/api/sandbox/benchmark?${query}` : "/api/sandbox/benchmark";
@@ -634,25 +687,36 @@ function getVoxelBlockCount(build: unknown): number {
 
 export function SandboxBenchmark() {
   const [promptId, setPromptId] = useState("");
-  const [modelPair, setModelPair] = useState({ a: DEFAULT_MODEL_A, b: DEFAULT_MODEL_B });
+  const [modelSelection, setModelSelection] =
+    useState<SandboxComparisonSelection<string>>(DEFAULT_MODEL_SELECTION);
   const [data, setData] = useState<BenchmarkResponse | null>(null);
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
   const [selectionReloading, setSelectionReloading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [slotState, setSlotState] = useState<Record<Slot, SlotHydrationState>>({
-    a: createEmptySlotState(),
-    b: createEmptySlotState(),
-  });
+  const [slotState, setSlotState] =
+    useState<SandboxComparisonSelection<SlotHydrationState>>(createEmptySlotStates);
 
   const requestIdRef = useRef(0);
   const hydrationRunIdRef = useRef(0);
   const loadAbortRef = useRef<AbortController | null>(null);
-  const slotAbortRef = useRef<Record<Slot, AbortController | null>>({ a: null, b: null });
+  const slotAbortRef =
+    useRef<SandboxComparisonSelection<AbortController | null>>(
+      createSandboxComparisonSelection(null),
+    );
   const buildCacheRef = useRef<Map<string, CachedBuild>>(new Map());
 
   const viewerARef = useRef<VoxelViewerHandle | null>(null);
   const viewerBRef = useRef<VoxelViewerHandle | null>(null);
+  const viewerCRef = useRef<VoxelViewerHandle | null>(null);
+  const viewerDRef = useRef<VoxelViewerHandle | null>(null);
+  const pendingModelFocusRef = useRef<SandboxComparisonSlot | null>(null);
+  const viewerRefs: SandboxComparisonSelection<RefObject<VoxelViewerHandle | null>> = {
+    a: viewerARef,
+    b: viewerBRef,
+    c: viewerCRef,
+    d: viewerDRef,
+  };
 
   const setCachedBuild = useCallback((ref: ArenaBuildRef, value: CachedBuild) => {
     const cache = buildCacheRef.current;
@@ -671,23 +735,19 @@ export function SandboxBenchmark() {
   }, []);
 
   const clearVisibleBuilds = useCallback(() => {
-    for (const slot of ["a", "b"] as const) {
+    for (const slot of SANDBOX_COMPARISON_SLOTS) {
       slotAbortRef.current[slot]?.abort();
       slotAbortRef.current[slot] = null;
     }
     hydrationRunIdRef.current += 1;
-    setSlotState({
-      a: createEmptySlotState(),
-      b: createEmptySlotState(),
-    });
+    setSlotState(createEmptySlotStates());
   }, []);
 
   const runLoad = useCallback(
     async (
       args: {
         promptId?: string;
-        modelA?: string;
-        modelB?: string;
+        models?: Partial<SandboxComparisonSelection<string>>;
       },
       opts?: { initial?: boolean; bypassCache?: boolean },
     ) => {
@@ -708,10 +768,14 @@ export function SandboxBenchmark() {
         setSelectionReloading(false);
         setData(nextData);
         setPromptId(nextData.selectedPrompt?.id ?? "");
-        setModelPair({
-          a: nextData.selectedModels.a ?? "",
-          b: nextData.selectedModels.b ?? "",
-        });
+        setModelSelection(
+          Object.fromEntries(
+            SANDBOX_COMPARISON_SLOTS.map((slot) => [
+              slot,
+              nextData.selectedModels[slot] ?? "",
+            ]),
+          ) as SandboxComparisonSelection<string>,
+        );
       } catch (err) {
         if (err instanceof Error && err.name === "AbortError") return;
         if (requestId !== requestIdRef.current) return;
@@ -719,10 +783,14 @@ export function SandboxBenchmark() {
           err instanceof Error ? err.message : "Failed to load benchmark comparison data";
         setSelectionReloading(false);
         setError(message);
-        setSlotState({
-          a: { ...createEmptySlotState(), phase: "error", error: message },
-          b: { ...createEmptySlotState(), phase: "error", error: message },
-        });
+        setSlotState(
+          Object.fromEntries(
+            SANDBOX_COMPARISON_SLOTS.map((slot) => [
+              slot,
+              { ...createEmptySlotState(), phase: "error", error: message },
+            ]),
+          ) as SandboxComparisonSelection<SlotHydrationState>,
+        );
       } finally {
         if (requestId !== requestIdRef.current) return;
         if (loadAbortRef.current === loadAbort) {
@@ -738,8 +806,7 @@ export function SandboxBenchmark() {
   useEffect(() => {
     void runLoad(
       {
-        modelA: DEFAULT_MODEL_A,
-        modelB: DEFAULT_MODEL_B,
+        models: DEFAULT_MODEL_SELECTION,
       },
       { initial: true },
     );
@@ -747,29 +814,29 @@ export function SandboxBenchmark() {
 
   useEffect(() => {
     const runId = ++hydrationRunIdRef.current;
-    const effectControllers: Partial<Record<Slot, AbortController>> = {};
+    const effectControllers: Partial<
+      SandboxComparisonSelection<AbortController>
+    > = {};
     const abortRef = slotAbortRef.current;
 
-    for (const slot of ["a", "b"] as const) {
+    for (const slot of SANDBOX_COMPARISON_SLOTS) {
       abortRef[slot]?.abort();
       abortRef[slot] = null;
     }
 
     if (!data) {
-      setSlotState({
-        a: createEmptySlotState(),
-        b: createEmptySlotState(),
-      });
+      setSlotState(createEmptySlotStates());
       return;
     }
 
-    const nextState: Record<Slot, SlotHydrationState> = {
-      a: createEmptySlotState(),
-      b: createEmptySlotState(),
-    };
-    const hydrateQueue: Array<{ slot: Slot; lane: BenchmarkBuild }> = [];
+    const nextState = createEmptySlotStates();
+    const hydrateQueue: Array<{
+      slot: SandboxComparisonSlot;
+      lane: BenchmarkBuild;
+    }> = [];
 
-    for (const slot of ["a", "b"] as const) {
+    for (const slot of SANDBOX_COMPARISON_SLOTS) {
+      if (!data.selectedModels[slot]) continue;
       const lane = data.builds[slot];
       if (!lane) {
         nextState[slot] = {
@@ -951,7 +1018,7 @@ export function SandboxBenchmark() {
     }
 
     return () => {
-      for (const slot of ["a", "b"] as const) {
+      for (const slot of SANDBOX_COMPARISON_SLOTS) {
         const controller = effectControllers[slot];
         controller?.abort();
         if (abortRef[slot] === controller) {
@@ -973,6 +1040,23 @@ export function SandboxBenchmark() {
       .sort(([a], [b]) => a.localeCompare(b))
       .map(([label, models]) => ({ label, models }));
   }, [data?.models]);
+  const activeSlots = getActiveSandboxComparisonSlots(modelSelection);
+  const nextAvailableSlot =
+    activeSlots.length < (data?.models.length ?? 0)
+      ? SANDBOX_COMPARISON_SLOTS.find((slot) => !modelSelection[slot])
+      : undefined;
+  const visibleSelectorSlots = nextAvailableSlot
+    ? [...activeSlots, nextAvailableSlot]
+    : activeSlots;
+
+  useEffect(() => {
+    const slot = pendingModelFocusRef.current;
+    if (!slot || modelSelection[slot] || loading || refreshing) return;
+    const target = document.getElementById(`sandbox-model-${slot}`);
+    if (!target) return;
+    target.focus();
+    pendingModelFocusRef.current = null;
+  }, [loading, modelSelection, refreshing]);
 
   function handlePromptChange(nextPromptId: string) {
     setPromptId(nextPromptId);
@@ -984,44 +1068,56 @@ export function SandboxBenchmark() {
       return {
         ...prev,
         selectedPrompt: selectedPrompt ? { id: selectedPrompt.id, text: selectedPrompt.text } : prev.selectedPrompt,
-        builds: { a: null, b: null },
+        builds: createEmptyBuilds(),
       };
     });
     void runLoad(
       {
         promptId: nextPromptId,
-        modelA: modelPair.a,
-        modelB: modelPair.b,
+        models: modelSelection,
       },
       { initial: false },
     );
   }
 
-  function handleModelChange(slot: "a" | "b", modelKey: string) {
-    if (!modelKey) return;
-    const other = slot === "a" ? modelPair.b : modelPair.a;
-    if (modelKey === other) return;
-    const nextPair = slot === "a" ? { a: modelKey, b: other } : { a: other, b: modelKey };
-    setModelPair(nextPair);
+  function loadModelSelection(nextSelection: SandboxComparisonSelection<string>) {
+    setModelSelection(nextSelection);
     setSelectionReloading(true);
     clearVisibleBuilds();
     setData((prev) =>
       prev
         ? {
             ...prev,
-            selectedModels: nextPair,
-            builds: { a: null, b: null },
+            selectedModels: toNullableModelSelection(nextSelection),
+            builds: createEmptyBuilds(),
           }
         : prev,
     );
     void runLoad(
       {
         promptId,
-        modelA: nextPair.a,
-        modelB: nextPair.b,
+        models: nextSelection,
       },
       { initial: false },
     );
+  }
+
+  function handleModelChange(slot: SandboxComparisonSlot, modelKey: string) {
+    if (!modelKey) return;
+    const duplicate = SANDBOX_COMPARISON_SLOTS.some(
+      (otherSlot) => otherSlot !== slot && modelSelection[otherSlot] === modelKey,
+    );
+    if (duplicate) return;
+    loadModelSelection({ ...modelSelection, [slot]: modelKey });
+  }
+
+  function handleRemoveModel(slot: SandboxComparisonSlot) {
+    if (slot === "a" || slot === "b") return;
+    const remaining = activeSlots
+      .filter((candidate) => candidate !== slot)
+      .map((candidate) => modelSelection[candidate]);
+    pendingModelFocusRef.current = SANDBOX_COMPARISON_SLOTS[remaining.length] ?? null;
+    loadModelSelection(createModelSelectionFromKeys(remaining));
   }
 
   function handleRandomPrompt() {
@@ -1051,15 +1147,14 @@ export function SandboxBenchmark() {
   const gridSize = toGridSize(data?.settings.gridSize ?? 256);
   const palette = toPalette(data?.settings.palette ?? "simple");
 
-  const compareTargets: SandboxGifExportTarget[] = data
-    ? (["a", "b"] as const)
+  const readyCompareTargets: SandboxGifExportTarget[] = data
+    ? activeSlots
         .map((slot) => {
           const build = data.builds[slot];
           const laneState = slotState[slot];
           if (!build || laneState.phase !== "ready" || !laneState.build) return null;
-          const viewerRef = slot === "a" ? viewerARef : viewerBRef;
           return {
-            viewerRef,
+            viewerRef: viewerRefs[slot],
             modelName: build.model.displayName,
             company: providerLabel(build.model.provider),
             blockCount: build.metrics.blockCount,
@@ -1067,16 +1162,18 @@ export function SandboxBenchmark() {
         })
         .filter((target): target is SandboxGifExportTarget => Boolean(target))
     : [];
+  const compareTargets =
+    readyCompareTargets.length === activeSlots.length ? readyCompareTargets : [];
 
   const cards = data
-    ? (["a", "b"] as const).map((slot) => {
+    ? activeSlots.map((slot) => {
         const build = data.builds[slot];
         const laneState = slotState[slot];
-        const selectedModelKey = slot === "a" ? modelPair.a : modelPair.b;
+        const selectedModelKey = modelSelection[slot];
         const fallbackModel = data.models.find((m) => m.key === selectedModelKey);
         const model = build?.model ?? fallbackModel;
-        const viewerRef = slot === "a" ? viewerARef : viewerBRef;
-        const title = model ? model.displayName : slot === "a" ? "Model A" : "Model B";
+        const viewerRef = viewerRefs[slot];
+        const title = model ? model.displayName : COMPARISON_SLOT_LABELS[slot];
 
         const hasRenderableBuild = Boolean(laneState.build);
         const isHydrating = laneState.phase === "loading" || (!build && selectionReloading);
@@ -1159,7 +1256,7 @@ export function SandboxBenchmark() {
               Compare arena builds directly
             </div>
             <div className="text-sm text-muted">
-              Pick a curated benchmark prompt and compare two models side by side.
+              Choose up to four models
             </div>
           </div>
 
@@ -1167,7 +1264,13 @@ export function SandboxBenchmark() {
             <SandboxGifExportButton
               targets={compareTargets}
               promptText={selectedPromptText}
-              cancelKey={`${promptId}:${modelPair.a}:${modelPair.b}:${data?.builds.a?.buildId ?? "none"}:${data?.builds.b?.buildId ?? "none"}`}
+              cancelKey={[
+                promptId,
+                ...activeSlots.flatMap((slot) => [
+                  modelSelection[slot],
+                  data?.builds[slot]?.buildId ?? "none",
+                ]),
+              ].join(":")}
               label="Export GIF"
               className="h-8 px-2.5 text-[11px] sm:h-9 sm:px-3 sm:text-xs"
             />
@@ -1181,8 +1284,7 @@ export function SandboxBenchmark() {
                 void runLoad(
                   {
                     promptId,
-                    modelA: modelPair.a,
-                    modelB: modelPair.b,
+                    models: modelSelection,
                   },
                   { initial: false, bypassCache: true },
                 );
@@ -1228,8 +1330,7 @@ export function SandboxBenchmark() {
                 void runLoad(
                   {
                     promptId,
-                    modelA: modelPair.a || undefined,
-                    modelB: modelPair.b || undefined,
+                    models: modelSelection,
                   },
                   { initial: true },
                 )
@@ -1340,52 +1441,82 @@ export function SandboxBenchmark() {
           </div>
         </div>
 
-        <div className="mt-5 grid grid-cols-1 gap-3 md:grid-cols-2">
-          <label className="flex flex-col gap-1">
-            <span className="text-xs font-medium text-muted">Model A</span>
-            <div className="relative">
-              <select
-                className="mb-field h-11 w-full appearance-none pr-10"
-                value={modelPair.a}
-                onChange={(e) => handleModelChange("a", e.target.value)}
-                disabled={loading || refreshing || (data?.models.length ?? 0) < 2}
-              >
-                {modelGroups.map((group) => (
-                  <optgroup key={group.label} label={group.label}>
-                    {group.models.map((model) => (
-                      <option key={model.key} value={model.key} disabled={model.key === modelPair.b}>
-                        {model.displayName}
+        <div className="mt-4 grid grid-cols-1 gap-3 md:grid-cols-2">
+          {visibleSelectorSlots.map((slot) => {
+            const selectedModelKey = modelSelection[slot];
+            const active = Boolean(selectedModelKey);
+            const removable = slot === "c" || slot === "d";
+            const selectId = `sandbox-model-${slot}`;
+            return (
+              <div key={slot} className="flex min-w-0 flex-col gap-1">
+                <label htmlFor={selectId} className="text-xs font-medium text-muted">
+                  {COMPARISON_SLOT_LABELS[slot]}
+                </label>
+                <div className="relative min-w-0">
+                  <select
+                    id={selectId}
+                    className={`mb-field h-11 w-full appearance-none ${
+                      active && removable ? "pr-20" : "pr-10"
+                    } ${
+                      active ? "" : "border-dashed text-muted"
+                    }`}
+                    value={selectedModelKey ?? ""}
+                    onChange={(event) => handleModelChange(slot, event.target.value)}
+                    disabled={loading || refreshing || (data?.models.length ?? 0) < 2}
+                  >
+                    {!active ? (
+                      <option value="" disabled>
+                        Add model
                       </option>
+                    ) : null}
+                    {modelGroups.map((group) => (
+                      <optgroup key={group.label} label={group.label}>
+                        {group.models.map((model) => {
+                          const selectedElsewhere = SANDBOX_COMPARISON_SLOTS.some(
+                            (otherSlot) =>
+                              otherSlot !== slot &&
+                              modelSelection[otherSlot] === model.key,
+                          );
+                          return (
+                            <option
+                              key={model.key}
+                              value={model.key}
+                              disabled={selectedElsewhere}
+                            >
+                              {model.displayName}
+                            </option>
+                          );
+                        })}
+                      </optgroup>
                     ))}
-                  </optgroup>
-                ))}
-              </select>
-              <SelectChevron />
-            </div>
-          </label>
-
-          <label className="flex flex-col gap-1">
-            <span className="text-xs font-medium text-muted">Model B</span>
-            <div className="relative">
-              <select
-                className="mb-field h-11 w-full appearance-none pr-10"
-                value={modelPair.b}
-                onChange={(e) => handleModelChange("b", e.target.value)}
-                disabled={loading || refreshing || (data?.models.length ?? 0) < 2}
-              >
-                {modelGroups.map((group) => (
-                  <optgroup key={group.label} label={group.label}>
-                    {group.models.map((model) => (
-                      <option key={model.key} value={model.key} disabled={model.key === modelPair.a}>
-                        {model.displayName}
-                      </option>
-                    ))}
-                  </optgroup>
-                ))}
-              </select>
-              <SelectChevron />
-            </div>
-          </label>
+                  </select>
+                  <SelectChevron withTrailingAction={active && removable} />
+                  {active && removable ? (
+                    <button
+                      type="button"
+                      className="absolute inset-y-px right-px inline-flex w-11 items-center justify-center rounded-r-[0.7rem] border-l border-border/60 text-muted transition-colors hover:bg-danger/10 hover:text-danger focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-accent/50 disabled:cursor-not-allowed disabled:opacity-45"
+                      aria-label={`Remove ${COMPARISON_SLOT_LABELS[slot]}`}
+                      onClick={() => handleRemoveModel(slot)}
+                      disabled={loading || refreshing}
+                    >
+                      <svg
+                        aria-hidden="true"
+                        viewBox="0 0 24 24"
+                        className="h-4 w-4"
+                        fill="none"
+                        stroke="currentColor"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth="1.8"
+                      >
+                        <path d="m8 8 8 8M16 8l-8 8" />
+                      </svg>
+                    </button>
+                  ) : null}
+                </div>
+              </div>
+            );
+          })}
         </div>
       </div>
 

--- a/components/sandbox/SandboxGifExportButton.tsx
+++ b/components/sandbox/SandboxGifExportButton.tsx
@@ -3,6 +3,10 @@
 import type { RefObject } from "react";
 import { useEffect, useId, useRef, useState } from "react";
 import type { VoxelViewerHandle } from "@/components/voxel/VoxelViewer";
+import {
+  getSandboxGifExportPanelGrid,
+  type SandboxGifExportLayoutFormat,
+} from "@/lib/sandbox/gifExportLayout";
 
 export type SandboxGifExportTarget = {
   viewerRef: RefObject<VoxelViewerHandle | null>;
@@ -21,7 +25,7 @@ type Props = {
 };
 
 type GifExportFormat = "wide" | "vertical";
-type GifExportLayoutFormat = GifExportFormat | "single";
+type GifExportLayoutFormat = SandboxGifExportLayoutFormat;
 
 const GIF_DELAY_TICK_MS = 10;
 const MAX_IN_FLIGHT_FRAMES = 4;
@@ -63,6 +67,12 @@ const EXPORT_RENDER_PROFILES: Record<
     { width: 540, height: 960 },
   ],
 };
+const MULTI_ROW_WIDE_RENDER_PROFILES = [
+  { width: 1440, height: 1080 },
+  { width: 1280, height: 960 },
+  { width: 960, height: 720 },
+  { width: 800, height: 600 },
+] as const;
 
 const EXPORT_MARGIN_X = 22;
 const EXPORT_MARGIN_BOTTOM = 22;
@@ -96,6 +106,16 @@ type GifExportRuntime = {
   paletteSampleLongEdge: number;
 };
 type GifExportRotationBases = number[];
+
+function getExportRenderProfiles(
+  format: GifExportLayoutFormat,
+  targetCount: number,
+): ReadonlyArray<GifRenderProfile> {
+  if (format === "wide" && targetCount > 2) {
+    return MULTI_ROW_WIDE_RENDER_PROFILES;
+  }
+  return EXPORT_RENDER_PROFILES[format];
+}
 
 function buildFrameDelaySchedule(frameCount: number, frameDelayMs: number): number[] {
   const delayTicks = Math.max(1, Math.round(frameDelayMs / GIF_DELAY_TICK_MS));
@@ -242,49 +262,49 @@ function buildExportLayout(
   promptText: string,
   format: GifExportLayoutFormat,
 ): ExportLayout {
-  const panelGap = count === 1 ? 0 : PANEL_GAP;
+  const safeCount = Math.max(1, Math.min(4, count));
+  const panelGap = safeCount === 1 ? 0 : PANEL_GAP;
+  const grid = getSandboxGifExportPanelGrid(safeCount, format);
   ctx.font = HEADER_PROMPT_FONT;
   const normalizedPrompt = promptText.replace(/\s+/g, " ").trim();
   const promptMaxWidth = width - 56;
   const allPromptLines = wrapTextLines(ctx, `Prompt: ${normalizedPrompt || "sandbox prompt"}`, promptMaxWidth);
   const maxPanelTop =
-    format === "vertical"
-      ? height - EXPORT_MARGIN_BOTTOM - panelGap * (count - 1) - MIN_EXPORT_PANEL_HEIGHT * count
-      : height - EXPORT_MARGIN_BOTTOM - MIN_EXPORT_PANEL_HEIGHT;
+    height -
+    EXPORT_MARGIN_BOTTOM -
+    panelGap * (grid.rows - 1) -
+    MIN_EXPORT_PANEL_HEIGHT * grid.rows;
   // free-form prompts still need room for viewers
   const maxPromptLines = Math.floor((maxPanelTop - 84) / HEADER_PROMPT_LINE_HEIGHT);
   const promptLines = capPromptLines(ctx, allPromptLines, maxPromptLines, promptMaxWidth);
   const panelTop = Math.max(104, 60 + promptLines.length * HEADER_PROMPT_LINE_HEIGHT + 24);
-  const panelRects =
-    format === "vertical"
-      ? Array.from({ length: count }, (_, idx) => {
-          const panelWidth = width - EXPORT_MARGIN_X * 2;
-          const panelHeight =
-            (height - panelTop - EXPORT_MARGIN_BOTTOM - panelGap * (count - 1)) / count;
-          return {
-            x: EXPORT_MARGIN_X,
-            y: panelTop + idx * (panelHeight + panelGap),
-            width: panelWidth,
-            height: panelHeight,
-          };
-        })
-      : Array.from({ length: count }, (_, idx) => {
-          const panelWidth = (width - EXPORT_MARGIN_X * 2 - panelGap * (count - 1)) / count;
-          const panelHeight = height - panelTop - EXPORT_MARGIN_BOTTOM;
-          return {
-            x: EXPORT_MARGIN_X + idx * (panelWidth + panelGap),
-            y: panelTop,
-            width: panelWidth,
-            height: panelHeight,
-          };
-        });
+  const panelWidth =
+    (width - EXPORT_MARGIN_X * 2 - panelGap * (grid.columns - 1)) / grid.columns;
+  const panelHeight =
+    (height - panelTop - EXPORT_MARGIN_BOTTOM - panelGap * (grid.rows - 1)) / grid.rows;
+  const panelRects: ExportLayout["panelRects"] = [];
+
+  for (let row = 0; row < grid.rows; row += 1) {
+    const columnsInRow = grid.rowColumns[row] ?? grid.columns;
+    const rowWidth = panelWidth * columnsInRow + panelGap * Math.max(0, columnsInRow - 1);
+    const rowX = EXPORT_MARGIN_X + (width - EXPORT_MARGIN_X * 2 - rowWidth) / 2;
+
+    for (let column = 0; column < columnsInRow && panelRects.length < safeCount; column += 1) {
+      panelRects.push({
+        x: rowX + column * (panelWidth + panelGap),
+        y: panelTop + row * (panelHeight + panelGap),
+        width: panelWidth,
+        height: panelHeight,
+      });
+    }
+  }
 
   return {
     width,
     height,
     panelRects,
     header: {
-      title: count === 2 ? "MineBench Comparison" : "MineBench Build",
+      title: safeCount > 1 ? "MineBench Comparison" : "MineBench Build",
       promptLines,
       urlText: "minebench.ai",
     },
@@ -459,12 +479,6 @@ function drawPanel(
   ctx.textBaseline = "top";
   ctx.fillText(target.company.toUpperCase(), x + PANEL_PAD, y + 12);
 
-  const modelLine =
-    target.modelName.length > 24 ? `${target.modelName.slice(0, 23)}...` : target.modelName;
-  ctx.fillStyle = "rgba(241, 245, 249, 0.98)";
-  ctx.font = '700 23px "Sora", "Avenir Next", "Segoe UI", sans-serif';
-  ctx.fillText(modelLine, x + PANEL_PAD, y + 27);
-
   const blockLabel = `${target.blockCount.toLocaleString()} blocks`;
   ctx.font = '600 11px "IBM Plex Sans", "Segoe UI", sans-serif';
   const badgeWidth = Math.ceil(ctx.measureText(blockLabel).width + 16);
@@ -478,6 +492,15 @@ function drawPanel(
   ctx.stroke();
   ctx.fillStyle = "rgba(226, 232, 240, 0.96)";
   ctx.fillText(blockLabel, badgeX + 8, badgeY + 5);
+
+  ctx.fillStyle = "rgba(241, 245, 249, 0.98)";
+  ctx.font = '700 23px "Sora", "Avenir Next", "Segoe UI", sans-serif';
+  const modelLine = fitTextWithEllipsis(
+    ctx,
+    target.modelName,
+    Math.max(1, width - PANEL_PAD * 2 - badgeWidth - 8),
+  );
+  ctx.fillText(modelLine, x + PANEL_PAD, y + 27);
 
   ctx.save();
   roundedRectPath(ctx, captureX, captureY, captureWidth, captureHeight, CAPTURE_RADIUS);
@@ -828,7 +851,7 @@ export function SandboxGifExportButton({ targets, promptText, label, iconOnly, c
   const exportAbortRef = useRef<AbortController | null>(null);
 
   const hasTargets = targets.length > 0;
-  const canChooseFormat = targets.length === 2;
+  const canChooseFormat = targets.length > 1;
   const exportFormat: GifExportLayoutFormat = canChooseFormat ? format : "single";
 
   useEffect(() => {
@@ -849,7 +872,7 @@ export function SandboxGifExportButton({ targets, promptText, label, iconOnly, c
     exportAbortRef.current = abortController;
     await waitForNextPaint();
     try {
-      const profiles = EXPORT_RENDER_PROFILES[exportFormat];
+      const profiles = getExportRenderProfiles(exportFormat, targets.length);
       const runtime = getExportRuntime(exportFormat);
       setProgress({ done: 0, total: runtime.frameCount });
       let finalBlob: Blob | null = null;
@@ -915,10 +938,14 @@ export function SandboxGifExportButton({ targets, promptText, label, iconOnly, c
         throw new Error("GIF export failed");
       }
 
-      const modelToken = targets.map((t) => sanitizeFilePart(t.modelName) || "model").join("-vs-");
+      const modelToken = targets
+        .map((target) => sanitizeFilePart(target.modelName) || "model")
+        .join("-vs-")
+        .slice(0, 120)
+        .replace(/-+$/g, "");
       const promptToken = sanitizeFilePart(promptText ?? "sandbox");
       const stamp = new Date().toISOString().replace(/[:.]/g, "-");
-      const typeToken = targets.length === 2 ? "compare" : "build";
+      const typeToken = targets.length > 1 ? "compare" : "build";
       const formatToken =
         exportFormat === "vertical" ? "vertical" : exportFormat === "single" ? "viewer" : "wide";
       const fileName = `minebench-${typeToken}-${formatToken}-${modelToken}-${promptToken}-${stamp}.gif`;
@@ -945,7 +972,7 @@ export function SandboxGifExportButton({ targets, promptText, label, iconOnly, c
       : progress
         ? `Rendering ${Math.max(0, progress.done)}/${progress.total}`
         : "Rendering..."
-    : (label ?? (targets.length === 2 ? "Export comparison GIF" : "Export GIF"));
+    : (label ?? (targets.length > 1 ? "Export comparison GIF" : "Export GIF"));
   const buttonTitle = error ?? displayLabel;
   const busy = exporting || optimizing;
   const isUnavailable = !hasTargets;

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -162,7 +162,7 @@ Reference prompt template:
   - body: `{ matchupId, choice }`
   - `choice`: `A | B | TIE | BOTH_BAD`
 - `GET /api/arena/prompts`
-- `GET /api/sandbox/benchmark?promptId=&modelA=&modelB=`
+- `GET /api/sandbox/benchmark?promptId=&modelA=&modelB=&modelC=&modelD=`
 - `GET /api/leaderboard`
 
 ### Admin Routes

--- a/lib/sandbox/benchmarkComparison.ts
+++ b/lib/sandbox/benchmarkComparison.ts
@@ -1,0 +1,57 @@
+export const SANDBOX_COMPARISON_SLOTS = ["a", "b", "c", "d"] as const;
+
+export type SandboxComparisonSlot = (typeof SANDBOX_COMPARISON_SLOTS)[number];
+export type SandboxComparisonSelection<T> = Record<SandboxComparisonSlot, T>;
+
+export const SANDBOX_COMPARISON_MODEL_PARAMS: SandboxComparisonSelection<string> = {
+  a: "modelA",
+  b: "modelB",
+  c: "modelC",
+  d: "modelD",
+};
+
+export function createSandboxComparisonSelection<T>(value: T): SandboxComparisonSelection<T> {
+  return {
+    a: value,
+    b: value,
+    c: value,
+    d: value,
+  };
+}
+
+export function getActiveSandboxComparisonSlots(
+  selection: SandboxComparisonSelection<string | null>,
+): SandboxComparisonSlot[] {
+  return SANDBOX_COMPARISON_SLOTS.filter((slot) => Boolean(selection[slot]));
+}
+
+export function normalizeSandboxComparisonSelection(
+  availableModelKeys: string[],
+  requested: Partial<SandboxComparisonSelection<string | null | undefined>>,
+): SandboxComparisonSelection<string | null> {
+  const available = new Set(availableModelKeys);
+  const used = new Set<string>();
+  const selectedKeys: string[] = [];
+
+  for (const slot of SANDBOX_COMPARISON_SLOTS) {
+    const requestedKey = requested[slot];
+    if (requestedKey && available.has(requestedKey) && !used.has(requestedKey)) {
+      selectedKeys.push(requestedKey);
+      used.add(requestedKey);
+    }
+  }
+
+  while (selectedKeys.length < 2) {
+    const fallback = availableModelKeys.find((key) => !used.has(key));
+    if (!fallback) break;
+    selectedKeys.push(fallback);
+    used.add(fallback);
+  }
+
+  const selection = createSandboxComparisonSelection<string | null>(null);
+  for (const [index, modelKey] of selectedKeys.entries()) {
+    const slot = SANDBOX_COMPARISON_SLOTS[index];
+    if (slot) selection[slot] = modelKey;
+  }
+  return selection;
+}

--- a/lib/sandbox/gifExportLayout.ts
+++ b/lib/sandbox/gifExportLayout.ts
@@ -1,0 +1,44 @@
+export type SandboxGifExportLayoutFormat = "wide" | "vertical" | "single";
+
+export type SandboxGifExportPanelGrid = {
+  columns: number;
+  rows: number;
+  rowColumns: number[];
+};
+
+export function getSandboxGifExportPanelGrid(
+  count: number,
+  format: SandboxGifExportLayoutFormat,
+): SandboxGifExportPanelGrid {
+  const safeCount = Math.max(1, Math.min(4, Math.floor(count)));
+
+  if (safeCount === 1 || format === "single") {
+    return {
+      columns: 1,
+      rows: 1,
+      rowColumns: [1],
+    };
+  }
+
+  if (safeCount === 2 && format === "vertical") {
+    return {
+      columns: 1,
+      rows: 2,
+      rowColumns: [1, 1],
+    };
+  }
+
+  if (safeCount === 2) {
+    return {
+      columns: 2,
+      rows: 1,
+      rowColumns: [2],
+    };
+  }
+
+  return {
+    columns: 2,
+    rows: 2,
+    rowColumns: [2, safeCount - 2],
+  };
+}

--- a/tests/ui/gif-export-config.test.ts
+++ b/tests/ui/gif-export-config.test.ts
@@ -1,9 +1,11 @@
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import ts from "typescript";
+import { getSandboxGifExportPanelGrid } from "../../lib/sandbox/gifExportLayout";
 
 const SOURCE_PATH = "components/sandbox/SandboxGifExportButton.tsx";
 const sourceText = readFileSync(SOURCE_PATH, "utf8");
+const benchmarkSourceText = readFileSync("components/sandbox/SandboxBenchmark.tsx", "utf8");
 const sourceFile = ts.createSourceFile(SOURCE_PATH, sourceText, ts.ScriptTarget.Latest, true, ts.ScriptKind.TSX);
 
 function readNumericConst(name: string): number {
@@ -36,14 +38,16 @@ function readNumericConst(name: string): number {
   return value;
 }
 
-function readRenderProfiles(): Record<string, Array<{ width: number; height: number }>> {
+function readRenderProfiles(
+  name = "EXPORT_RENDER_PROFILES",
+): Record<string, Array<{ width: number; height: number }>> {
   let profiles: Record<string, Array<{ width: number; height: number }>> | null = null;
 
   const visit = (node: ts.Node) => {
     if (
       ts.isVariableDeclaration(node) &&
       ts.isIdentifier(node.name) &&
-      node.name.text === "EXPORT_RENDER_PROFILES" &&
+      node.name.text === name &&
       node.initializer &&
       ts.isObjectLiteralExpression(node.initializer)
     ) {
@@ -81,7 +85,46 @@ function readRenderProfiles(): Record<string, Array<{ width: number; height: num
   };
 
   visit(sourceFile);
-  assert.ok(profiles, "EXPORT_RENDER_PROFILES should be defined");
+  assert.ok(profiles, `${name} should be defined`);
+  return profiles;
+}
+
+function readProfileArray(name: string): Array<{ width: number; height: number }> {
+  let profiles: Array<{ width: number; height: number }> | null = null;
+
+  const visit = (node: ts.Node) => {
+    if (
+      ts.isVariableDeclaration(node) &&
+      ts.isIdentifier(node.name) &&
+      node.name.text === name &&
+      node.initializer
+    ) {
+      const initializer = ts.isAsExpression(node.initializer)
+        ? node.initializer.expression
+        : node.initializer;
+      if (!ts.isArrayLiteralExpression(initializer)) return;
+      profiles = initializer.elements.map((element) => {
+        assert.ok(ts.isObjectLiteralExpression(element), "render profile entries should be objects");
+        const values = Object.fromEntries(
+          element.properties.flatMap((property) => {
+            if (
+              !ts.isPropertyAssignment(property) ||
+              !ts.isIdentifier(property.name) ||
+              !ts.isNumericLiteral(property.initializer)
+            ) {
+              return [];
+            }
+            return [[property.name.text, Number(property.initializer.text)]];
+          }),
+        );
+        return { width: values.width ?? 0, height: values.height ?? 0 };
+      });
+    }
+    ts.forEachChild(node, visit);
+  };
+
+  visit(sourceFile);
+  assert.ok(profiles, `${name} should be defined`);
   return profiles;
 }
 
@@ -102,9 +145,58 @@ assert.equal(readNumericConst("COMPARISON_PALETTE_SAMPLE_LONG_EDGE"), 640);
 const profiles = readRenderProfiles();
 assert.deepEqual(profiles.wide?.[0], { width: 1440, height: 810 });
 assert.deepEqual(profiles.vertical?.[0], { width: 810, height: 1440 });
+const multiRowWideProfiles = readProfileArray("MULTI_ROW_WIDE_RENDER_PROFILES");
+assert.deepEqual(multiRowWideProfiles[0], { width: 1440, height: 1080 });
+for (const profile of multiRowWideProfiles) {
+  const panelHeight = (profile.height - 107 - 22 - 16) / 2;
+  assert.ok(panelHeight >= 220, "multi-row wide profiles should preserve usable panel height");
+}
+assert.deepEqual(getSandboxGifExportPanelGrid(1, "single"), {
+  columns: 1,
+  rows: 1,
+  rowColumns: [1],
+});
+assert.deepEqual(getSandboxGifExportPanelGrid(2, "wide"), {
+  columns: 2,
+  rows: 1,
+  rowColumns: [2],
+});
+assert.deepEqual(getSandboxGifExportPanelGrid(2, "vertical"), {
+  columns: 1,
+  rows: 2,
+  rowColumns: [1, 1],
+});
+assert.deepEqual(getSandboxGifExportPanelGrid(3, "wide"), {
+  columns: 2,
+  rows: 2,
+  rowColumns: [2, 1],
+});
+assert.deepEqual(getSandboxGifExportPanelGrid(3, "vertical"), {
+  columns: 2,
+  rows: 2,
+  rowColumns: [2, 1],
+});
+assert.deepEqual(getSandboxGifExportPanelGrid(4, "wide"), {
+  columns: 2,
+  rows: 2,
+  rowColumns: [2, 2],
+});
+assert.deepEqual(getSandboxGifExportPanelGrid(4, "vertical"), {
+  columns: 2,
+  rows: 2,
+  rowColumns: [2, 2],
+});
 assert.ok(
   sourceText.includes("frame / runtime.frameCount"),
   "GIF frame sampling should omit the duplicate endpoint for a seamless loop",
+);
+assert.ok(
+  sourceText.includes("targets.length > 1"),
+  "GIF export should treat every multi-model layout as a comparison",
+);
+assert.ok(
+  !benchmarkSourceText.includes("autoRotate="),
+  "comparison cards should use the shared viewer spin control",
 );
 
 console.log("gif export config checks passed");

--- a/tests/unit/sandbox/benchmark-comparison.test.ts
+++ b/tests/unit/sandbox/benchmark-comparison.test.ts
@@ -1,0 +1,68 @@
+import assert from "node:assert/strict";
+import {
+  SANDBOX_COMPARISON_SLOTS,
+  getActiveSandboxComparisonSlots,
+  normalizeSandboxComparisonSelection,
+} from "../../../lib/sandbox/benchmarkComparison";
+
+const available = ["model-a", "model-b", "model-c", "model-d", "model-e"];
+
+const defaults = normalizeSandboxComparisonSelection(available, {});
+assert.deepEqual(defaults, {
+  a: "model-a",
+  b: "model-b",
+  c: null,
+  d: null,
+});
+assert.deepEqual(getActiveSandboxComparisonSlots(defaults), ["a", "b"]);
+
+const fourModels = normalizeSandboxComparisonSelection(available, {
+  a: "model-d",
+  b: "model-a",
+  c: "model-e",
+  d: "model-c",
+});
+assert.deepEqual(fourModels, {
+  a: "model-d",
+  b: "model-a",
+  c: "model-e",
+  d: "model-c",
+});
+assert.deepEqual(getActiveSandboxComparisonSlots(fourModels), SANDBOX_COMPARISON_SLOTS);
+
+const invalidModels = normalizeSandboxComparisonSelection(available, {
+  a: "missing",
+  b: "model-c",
+  c: "model-c",
+  d: "missing",
+});
+assert.deepEqual(invalidModels, {
+  a: "model-c",
+  b: "model-a",
+  c: null,
+  d: null,
+});
+
+assert.deepEqual(
+  normalizeSandboxComparisonSelection(available, {
+    a: "model-a",
+    b: "model-b",
+    c: "missing",
+    d: "model-d",
+  }),
+  {
+    a: "model-a",
+    b: "model-b",
+    c: "model-d",
+    d: null,
+  },
+);
+
+assert.deepEqual(normalizeSandboxComparisonSelection(["model-a"], {}), {
+  a: "model-a",
+  b: null,
+  c: null,
+  d: null,
+});
+
+console.log("sandbox benchmark comparison checks passed");


### PR DESCRIPTION
## Summary

- expand Sandbox benchmark comparisons from two models to two through four distinct models
- batch model build and artifact preparation queries across active comparison slots
- add one intentional optional model field with compact integrated remove actions
- preserve the shared spin preference and `S` shortcut for every active viewer
- compose three and four model GIF exports in usable two-row layouts
- keep aggregate GIF export unavailable until every active viewer is ready

## Verification

- `pnpm exec tsc --noEmit`
- `pnpm test`
- `pnpm lint`
- `node scripts/with-local-env.mjs pnpm build`
- verified two, three, four, duplicate, and invalid model API requests against the isolated Docker database
- verified the production-mode `/sandbox` route returns 200 and the four-model request returns four build lanes

Closes #69

_(PR written by Codex)_
