### PR TITLE
(feat) add comparison and build deep links

### DIFF
--- a/app/sandbox/page.tsx
+++ b/app/sandbox/page.tsx
@@ -42,7 +42,9 @@ export default async function SandboxPage({
 }) {
   const sp = (await searchParams) ?? {};
   const promptParam = sp.prompt;
-  const prompt = typeof promptParam === "string" ? promptParam : undefined;
+  const hasComparisonState = sp.models !== undefined || sp.promptId !== undefined;
+  const prompt =
+    !hasComparisonState && typeof promptParam === "string" ? promptParam : undefined;
   return (
     <>
       <script

--- a/components/leaderboard/ModelDetail.tsx
+++ b/components/leaderboard/ModelDetail.tsx
@@ -3,6 +3,7 @@
 import dynamic from "next/dynamic";
 import { memo, useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import Link from "next/link";
+import { usePathname, useSearchParams } from "next/navigation";
 import type {
   ModelDetailStats,
   ModelOpponentBreakdown,
@@ -38,6 +39,7 @@ import {
 } from "@/components/sandbox/SandboxGifExportButton";
 import { getConsistencyBand, getConsistencyLabel } from "@/lib/arena/consistencyBands";
 import { ModelBenchmarkDetails } from "@/components/leaderboard/ModelBenchmarkDetails";
+import { buildLeaderboardBuildPath } from "@/lib/deepLinks";
 
 const CHART_WIDTH = 900;
 const CHART_HEIGHT = 304;
@@ -1098,6 +1100,9 @@ function SectionHeader({
 }
 
 export function ModelDetail({ data }: { data: ModelDetailStats }) {
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const requestedBuildId = searchParams.get("build");
   const [hoveredCurveIndex, setHoveredCurveIndex] = useState<number | null>(null);
   const [showAllOpponents, setShowAllOpponents] = useState(false);
   const [showAllPrompts, setShowAllPrompts] = useState(false);
@@ -1204,16 +1209,57 @@ export function ModelDetail({ data }: { data: ModelDetailStats }) {
           ? "mb-curve-tooltip-right"
           : "mb-curve-tooltip-center";
 
+  const setPromptWithUrl = useCallback(
+    (prompt: ModelPromptBreakdown | null) => {
+      setActivePrompt(prompt);
+      const nextPath = buildLeaderboardBuildPath(
+        pathname,
+        new URLSearchParams(window.location.search),
+        prompt?.build?.buildId ?? null,
+      );
+      const currentPath = `${window.location.pathname}${window.location.search}`;
+      if (nextPath !== currentPath) {
+        window.history.pushState(null, "", nextPath);
+      }
+    },
+    [pathname],
+  );
+
+  useEffect(() => {
+    if (!requestedBuildId) {
+      setActivePrompt((current) => (current?.build ? null : current));
+      return;
+    }
+
+    const requestedPrompt =
+      promptBreakdown.find((prompt) => prompt.build?.buildId === requestedBuildId) ?? null;
+    if (requestedPrompt) {
+      setActivePrompt(requestedPrompt);
+      return;
+    }
+
+    setActivePrompt(null);
+    const nextPath = buildLeaderboardBuildPath(
+      pathname,
+      new URLSearchParams(window.location.search),
+      null,
+    );
+    const currentPath = `${window.location.pathname}${window.location.search}`;
+    if (nextPath !== currentPath) {
+      window.history.replaceState(null, "", nextPath);
+    }
+  }, [pathname, promptBreakdown, requestedBuildId]);
+
   useEffect(() => {
     if (!activePrompt) return;
     const onKeyDown = (event: KeyboardEvent) => {
       if (event.key !== "Escape") return;
       event.preventDefault();
-      setActivePrompt(null);
+      setPromptWithUrl(null);
     };
     window.addEventListener("keydown", onKeyDown);
     return () => window.removeEventListener("keydown", onKeyDown);
-  }, [activePrompt]);
+  }, [activePrompt, setPromptWithUrl]);
 
   const activePromptIndex = useMemo(() => {
     if (!activePrompt) return -1;
@@ -1234,13 +1280,13 @@ export function ModelDetail({ data }: { data: ModelDetailStats }) {
 
   const handlePromptPrev = useCallback(() => {
     if (activePromptIndex <= 0) return;
-    setActivePrompt(promptBreakdown[activePromptIndex - 1]);
-  }, [activePromptIndex, promptBreakdown]);
+    setPromptWithUrl(promptBreakdown[activePromptIndex - 1]);
+  }, [activePromptIndex, promptBreakdown, setPromptWithUrl]);
 
   const handlePromptNext = useCallback(() => {
     if (activePromptIndex < 0 || activePromptIndex >= promptBreakdown.length - 1) return;
-    setActivePrompt(promptBreakdown[activePromptIndex + 1]);
-  }, [activePromptIndex, promptBreakdown]);
+    setPromptWithUrl(promptBreakdown[activePromptIndex + 1]);
+  }, [activePromptIndex, promptBreakdown, setPromptWithUrl]);
 
   // focus close on open, return focus to the prompt card on close so keyboard
   // users resume where they were. only fires on the open/close transitions so
@@ -1943,13 +1989,13 @@ export function ModelDetail({ data }: { data: ModelDetailStats }) {
                   aria-label={`Open prompt details for ${prompt.promptText}`}
                   onClick={(event) => {
                     lastPromptTriggerRef.current = event.currentTarget;
-                    setActivePrompt(prompt);
+                    setPromptWithUrl(prompt);
                   }}
                   onKeyDown={(event) => {
                     if (event.key !== "Enter" && event.key !== " ") return;
                     event.preventDefault();
                     lastPromptTriggerRef.current = event.currentTarget;
-                    setActivePrompt(prompt);
+                    setPromptWithUrl(prompt);
                   }}
                   className="relative mb-card-enter h-full cursor-pointer rounded-2xl bg-bg/40 p-3.5 ring-1 ring-border/60 transition duration-200 hover:-translate-y-0.5 hover:bg-bg/55 hover:ring-accent/45 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/50 sm:p-4"
                 >
@@ -2061,7 +2107,7 @@ export function ModelDetail({ data }: { data: ModelDetailStats }) {
             type="button"
             aria-label="Close"
             className="absolute inset-0 bg-bg/60 backdrop-blur-sm"
-            onClick={() => setActivePrompt(null)}
+            onClick={() => setPromptWithUrl(null)}
           />
           <div
             ref={modalSurfaceRef}
@@ -2083,7 +2129,7 @@ export function ModelDetail({ data }: { data: ModelDetailStats }) {
                 type="button"
                 ref={modalCloseRef}
                 className="mb-btn mb-btn-ghost h-9 shrink-0 rounded-full px-3 text-xs sm:px-4"
-                onClick={() => setActivePrompt(null)}
+                onClick={() => setPromptWithUrl(null)}
                 aria-label="Close prompt details"
               >
                 <svg

--- a/components/sandbox/Sandbox.tsx
+++ b/components/sandbox/Sandbox.tsx
@@ -1,8 +1,10 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
+import { useSearchParams } from "next/navigation";
 import { SandboxBenchmark } from "@/components/sandbox/SandboxBenchmark";
 import { SandboxLive } from "@/components/sandbox/SandboxLive";
+import { buildSandboxModePath, readSandboxUrlMode } from "@/lib/deepLinks";
 
 type SandboxMode = "benchmark" | "live";
 
@@ -63,18 +65,46 @@ function ModeSegmentedControl({
 }
 
 export function Sandbox({ initialPrompt }: { initialPrompt?: string }) {
+  const searchParams = useSearchParams();
+  const searchKey = searchParams.toString();
+  const livePrompt =
+    searchParams.get("prompt") ?? (searchKey ? undefined : initialPrompt);
   const [mode, setMode] = useState<SandboxMode>(() =>
-    initialPrompt && initialPrompt.trim() ? "live" : "benchmark",
+    readSandboxUrlMode(new URLSearchParams(searchKey)),
   );
+
+  useEffect(() => {
+    setMode(readSandboxUrlMode(new URLSearchParams(searchKey)));
+  }, [searchKey]);
+
+  function handleModeChange(nextMode: SandboxMode) {
+    setMode(nextMode);
+    const nextPath = buildSandboxModePath(
+      new URLSearchParams(window.location.search),
+      nextMode,
+    );
+    const currentPath = `${window.location.pathname}${window.location.search}`;
+    if (nextPath !== currentPath) {
+      window.history.pushState(null, "", nextPath);
+    }
+  }
 
   return (
     <div className="flex flex-col gap-4">
       <div className="flex flex-col items-start gap-3 sm:flex-row sm:items-center sm:justify-between">
         <span className="mb-eyebrow">Sandbox</span>
-        <ModeSegmentedControl value={mode} onChange={setMode} className="w-full sm:w-[360px]" />
+        <ModeSegmentedControl
+          value={mode}
+          onChange={handleModeChange}
+          className="w-full sm:w-[360px]"
+        />
       </div>
 
-      {mode === "benchmark" ? <SandboxBenchmark /> : <SandboxLive initialPrompt={initialPrompt} />}
+      {mode === "benchmark" ? (
+        <SandboxBenchmark />
+      ) : (
+        <SandboxLive key={livePrompt ?? "default"} initialPrompt={livePrompt} />
+      )}
     </div>
   );
 }

--- a/components/sandbox/SandboxBenchmark.tsx
+++ b/components/sandbox/SandboxBenchmark.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useSearchParams } from "next/navigation";
 import {
   type RefObject,
   useCallback,
@@ -31,6 +32,10 @@ import {
   createSandboxComparisonSelection,
   getActiveSandboxComparisonSlots,
 } from "@/lib/sandbox/benchmarkComparison";
+import {
+  buildSandboxComparisonPath,
+  parseSandboxComparisonDeepLink,
+} from "@/lib/deepLinks";
 import type { VoxelBuild } from "@/lib/voxel/types";
 
 type Palette = "simple" | "advanced";
@@ -309,6 +314,13 @@ function createModelSelectionFromKeys(modelKeys: string[]): SandboxComparisonSel
     if (slot) selection[slot] = modelKey;
   }
   return selection;
+}
+
+function getSelectedModelKeys(selection: SandboxComparisonSelection<string>): string[] {
+  return SANDBOX_COMPARISON_SLOTS.flatMap((slot) => {
+    const modelKey = selection[slot];
+    return modelKey ? [modelKey] : [];
+  });
 }
 
 function toNullableModelSelection(
@@ -686,6 +698,12 @@ function getVoxelBlockCount(build: unknown): number {
 }
 
 export function SandboxBenchmark() {
+  const searchParams = useSearchParams();
+  const searchKey = searchParams.toString();
+  const requestedDeepLink = useMemo(
+    () => parseSandboxComparisonDeepLink(new URLSearchParams(searchKey)),
+    [searchKey],
+  );
   const [promptId, setPromptId] = useState("");
   const [modelSelection, setModelSelection] =
     useState<SandboxComparisonSelection<string>>(DEFAULT_MODEL_SELECTION);
@@ -699,6 +717,8 @@ export function SandboxBenchmark() {
 
   const requestIdRef = useRef(0);
   const hydrationRunIdRef = useRef(0);
+  const hasLoadedRef = useRef(false);
+  const skippedSearchKeyRef = useRef<string | null>(null);
   const loadAbortRef = useRef<AbortController | null>(null);
   const slotAbortRef =
     useRef<SandboxComparisonSelection<AbortController | null>>(
@@ -717,6 +737,17 @@ export function SandboxBenchmark() {
     c: viewerCRef,
     d: viewerDRef,
   };
+
+  useEffect(() => {
+    const abortRef = slotAbortRef.current;
+    return () => {
+      loadAbortRef.current?.abort();
+      for (const slot of SANDBOX_COMPARISON_SLOTS) {
+        abortRef[slot]?.abort();
+      }
+      hydrationRunIdRef.current += 1;
+    };
+  }, []);
 
   const setCachedBuild = useCallback((ref: ArenaBuildRef, value: CachedBuild) => {
     const cache = buildCacheRef.current;
@@ -749,7 +780,7 @@ export function SandboxBenchmark() {
         promptId?: string;
         models?: Partial<SandboxComparisonSelection<string>>;
       },
-      opts?: { initial?: boolean; bypassCache?: boolean },
+      opts?: { initial?: boolean; bypassCache?: boolean; syncUrl?: boolean },
     ) => {
       const requestId = ++requestIdRef.current;
       loadAbortRef.current?.abort();
@@ -776,6 +807,25 @@ export function SandboxBenchmark() {
             ]),
           ) as SandboxComparisonSelection<string>,
         );
+
+        if (opts?.syncUrl) {
+          const nextPath = buildSandboxComparisonPath(
+            new URLSearchParams(window.location.search),
+            SANDBOX_COMPARISON_SLOTS.flatMap((slot) => {
+              const modelKey = nextData.selectedModels[slot];
+              return modelKey ? [modelKey] : [];
+            }),
+            nextData.selectedPrompt?.id ?? null,
+          );
+          const currentPath = `${window.location.pathname}${window.location.search}`;
+          if (nextPath !== currentPath) {
+            skippedSearchKeyRef.current = new URL(
+              nextPath,
+              window.location.origin,
+            ).searchParams.toString();
+            window.history.replaceState(null, "", nextPath);
+          }
+        }
       } catch (err) {
         if (err instanceof Error && err.name === "AbortError") return;
         if (requestId !== requestIdRef.current) return;
@@ -804,13 +854,29 @@ export function SandboxBenchmark() {
   );
 
   useEffect(() => {
+    if (skippedSearchKeyRef.current === searchKey) {
+      skippedSearchKeyRef.current = null;
+      return;
+    }
+    skippedSearchKeyRef.current = null;
+
+    const initial = !hasLoadedRef.current;
+    hasLoadedRef.current = true;
+    if (!initial) {
+      setSelectionReloading(true);
+      clearVisibleBuilds();
+    }
     void runLoad(
       {
-        models: DEFAULT_MODEL_SELECTION,
+        promptId: requestedDeepLink.promptId ?? undefined,
+        models:
+          requestedDeepLink.modelKeys.length > 0
+            ? createModelSelectionFromKeys(requestedDeepLink.modelKeys)
+            : DEFAULT_MODEL_SELECTION,
       },
-      { initial: true },
+      { initial, syncUrl: true },
     );
-  }, [runLoad]);
+  }, [clearVisibleBuilds, requestedDeepLink, runLoad, searchKey]);
 
   useEffect(() => {
     const runId = ++hydrationRunIdRef.current;
@@ -1058,6 +1124,21 @@ export function SandboxBenchmark() {
     pendingModelFocusRef.current = null;
   }, [loading, modelSelection, refreshing]);
 
+  function pushComparisonUrl(
+    nextPromptId: string,
+    nextSelection: SandboxComparisonSelection<string>,
+  ) {
+    const nextPath = buildSandboxComparisonPath(
+      new URLSearchParams(window.location.search),
+      getSelectedModelKeys(nextSelection),
+      nextPromptId || null,
+    );
+    const currentPath = `${window.location.pathname}${window.location.search}`;
+    if (nextPath !== currentPath) {
+      window.history.pushState(null, "", nextPath);
+    }
+  }
+
   function handlePromptChange(nextPromptId: string) {
     setPromptId(nextPromptId);
     setSelectionReloading(true);
@@ -1071,13 +1152,7 @@ export function SandboxBenchmark() {
         builds: createEmptyBuilds(),
       };
     });
-    void runLoad(
-      {
-        promptId: nextPromptId,
-        models: modelSelection,
-      },
-      { initial: false },
-    );
+    pushComparisonUrl(nextPromptId, modelSelection);
   }
 
   function loadModelSelection(nextSelection: SandboxComparisonSelection<string>) {
@@ -1093,13 +1168,7 @@ export function SandboxBenchmark() {
           }
         : prev,
     );
-    void runLoad(
-      {
-        promptId,
-        models: nextSelection,
-      },
-      { initial: false },
-    );
+    pushComparisonUrl(promptId, nextSelection);
   }
 
   function handleModelChange(slot: SandboxComparisonSlot, modelKey: string) {
@@ -1326,15 +1395,18 @@ export function SandboxBenchmark() {
               error={new Error(error)}
               title="Couldn't load benchmark"
               hint={error}
-              onRetry={() =>
+              onRetry={() => {
                 void runLoad(
                   {
-                    promptId,
-                    models: modelSelection,
+                    promptId: requestedDeepLink.promptId ?? undefined,
+                    models:
+                      requestedDeepLink.modelKeys.length > 0
+                        ? createModelSelectionFromKeys(requestedDeepLink.modelKeys)
+                        : DEFAULT_MODEL_SELECTION,
                   },
-                  { initial: true },
-                )
-              }
+                  { initial: true, syncUrl: true },
+                );
+              }}
               retrying={loading || refreshing}
             />
           </div>

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -154,6 +154,13 @@ Reference prompt template:
 
 ### Public Routes
 
+- Sandbox comparison:
+  - `/sandbox?models=openai_gpt_5_6_sol,openai_gpt_5_5_pro&promptId=cmk5zdnbr0009kx270qtc8zh3`
+  - `models` preserves the order of two to four distinct model keys
+  - invalid model or prompt values are replaced with the canonical comparison state
+- Leaderboard build:
+  - `/leaderboard/anthropic_claude_opus_5?build=cms0r3yrd001al7adwbzwha24`
+  - invalid or model-mismatched build IDs are removed while the model page remains visible
 - `POST /api/generate`
   - body: `{ prompt, gridSize, palette, modelKeys, providerKeys? }`
   - response: `application/x-ndjson` stream (`hello`, `start`, `retry`, `delta`, `result`, `error`, `ping`)

--- a/lib/deepLinks.ts
+++ b/lib/deepLinks.ts
@@ -1,0 +1,99 @@
+const MAX_SANDBOX_COMPARISON_MODELS = 4;
+const SANDBOX_LEGACY_MODEL_PARAMS = ["modelA", "modelB", "modelC", "modelD"];
+
+export type SandboxComparisonDeepLink = {
+  modelKeys: string[];
+  promptId: string | null;
+};
+export type SandboxUrlMode = "benchmark" | "live";
+
+function buildPath(pathname: string, params: URLSearchParams): string {
+  const query = params.toString();
+  return query ? `${pathname}?${query}` : pathname;
+}
+
+export function parseSandboxComparisonDeepLink(
+  params: URLSearchParams,
+): SandboxComparisonDeepLink {
+  const modelKeys: string[] = [];
+  const used = new Set<string>();
+
+  for (const modelKey of (params.get("models") ?? "").split(",")) {
+    const normalized = modelKey.trim();
+    if (!normalized || used.has(normalized)) continue;
+    modelKeys.push(normalized);
+    used.add(normalized);
+    if (modelKeys.length === MAX_SANDBOX_COMPARISON_MODELS) break;
+  }
+
+  const requestedPromptId = params.get("promptId")?.trim();
+  return {
+    modelKeys,
+    promptId: requestedPromptId || null,
+  };
+}
+
+export function buildSandboxComparisonPath(
+  currentParams: URLSearchParams,
+  modelKeys: string[],
+  promptId: string | null,
+): string {
+  const params = new URLSearchParams(currentParams);
+  const normalizedModelKeys = Array.from(
+    new Set(modelKeys.map((modelKey) => modelKey.trim()).filter(Boolean)),
+  ).slice(0, MAX_SANDBOX_COMPARISON_MODELS);
+
+  params.delete("prompt");
+  params.delete("mode");
+  for (const param of SANDBOX_LEGACY_MODEL_PARAMS) params.delete(param);
+  if (normalizedModelKeys.length > 0) {
+    params.set("models", normalizedModelKeys.join(","));
+  } else {
+    params.delete("models");
+  }
+
+  if (promptId?.trim()) {
+    params.set("promptId", promptId.trim());
+  } else {
+    params.delete("promptId");
+  }
+
+  return buildPath("/sandbox", params);
+}
+
+export function readSandboxUrlMode(params: URLSearchParams): SandboxUrlMode {
+  if (params.has("models") || params.has("promptId")) return "benchmark";
+  if (params.get("mode") === "live" || params.get("prompt")?.trim()) return "live";
+  return "benchmark";
+}
+
+export function buildSandboxModePath(
+  currentParams: URLSearchParams,
+  mode: SandboxUrlMode,
+): string {
+  const params = new URLSearchParams(currentParams);
+  if (mode === "live") {
+    params.delete("models");
+    params.delete("promptId");
+    for (const param of SANDBOX_LEGACY_MODEL_PARAMS) params.delete(param);
+    params.set("mode", "live");
+  } else {
+    params.delete("prompt");
+    params.delete("mode");
+  }
+  return buildPath("/sandbox", params);
+}
+
+export function buildLeaderboardBuildPath(
+  pathname: string,
+  currentParams: URLSearchParams,
+  buildId: string | null,
+): string {
+  const params = new URLSearchParams(currentParams);
+  if (buildId?.trim()) {
+    params.set("build", buildId.trim());
+  } else {
+    params.delete("build");
+  }
+  return buildPath(pathname, params);
+}

--- a/tests/unit/deep-links.test.ts
+++ b/tests/unit/deep-links.test.ts
@@ -1,0 +1,106 @@
+import assert from "node:assert/strict";
+import {
+  buildLeaderboardBuildPath,
+  buildSandboxModePath,
+  buildSandboxComparisonPath,
+  parseSandboxComparisonDeepLink,
+  readSandboxUrlMode,
+} from "../../lib/deepLinks";
+
+assert.deepEqual(
+  parseSandboxComparisonDeepLink(
+    new URLSearchParams("models=model-a,model-b,model-c,model-d&promptId=prompt-1"),
+  ),
+  {
+    modelKeys: ["model-a", "model-b", "model-c", "model-d"],
+    promptId: "prompt-1",
+  },
+);
+
+assert.deepEqual(
+  parseSandboxComparisonDeepLink(
+    new URLSearchParams("models=model-a,,model-a,model-b,model-c,model-d,model-e"),
+  ),
+  {
+    modelKeys: ["model-a", "model-b", "model-c", "model-d"],
+    promptId: null,
+  },
+);
+
+assert.equal(
+  buildSandboxComparisonPath(
+    new URLSearchParams("prompt=old+prompt&utm_source=share"),
+    ["openai/gpt-5", "anthropic/claude"],
+    "prompt id",
+  ),
+  "/sandbox?utm_source=share&models=openai%2Fgpt-5%2Canthropic%2Fclaude&promptId=prompt+id",
+);
+
+assert.equal(
+  buildSandboxComparisonPath(
+    new URLSearchParams("mode=live&modelA=legacy-a&modelB=legacy-b"),
+    ["model-a", "model-b"],
+    null,
+  ),
+  "/sandbox?models=model-a%2Cmodel-b",
+);
+
+assert.deepEqual(
+  parseSandboxComparisonDeepLink(
+    new URL(
+      buildSandboxComparisonPath(
+        new URLSearchParams(),
+        ["openai/gpt-5", "anthropic/claude"],
+        "prompt id",
+      ),
+      "https://minebench.ai",
+    ).searchParams,
+  ),
+  {
+    modelKeys: ["openai/gpt-5", "anthropic/claude"],
+    promptId: "prompt id",
+  },
+);
+
+assert.equal(
+  readSandboxUrlMode(new URLSearchParams("prompt=build+a+castle")),
+  "live",
+);
+assert.equal(
+  readSandboxUrlMode(new URLSearchParams("prompt=build+a+castle&models=model-a,model-b")),
+  "benchmark",
+);
+assert.equal(
+  buildSandboxModePath(
+    new URLSearchParams("models=model-a,model-b&promptId=prompt-1&utm_source=share"),
+    "live",
+  ),
+  "/sandbox?utm_source=share&mode=live",
+);
+assert.equal(
+  buildSandboxModePath(
+    new URLSearchParams("prompt=build+a+castle&mode=live"),
+    "benchmark",
+  ),
+  "/sandbox",
+);
+
+assert.equal(
+  buildLeaderboardBuildPath(
+    "/leaderboard/model-a",
+    new URLSearchParams("tab=prompts"),
+    "build-1",
+  ),
+  "/leaderboard/model-a?tab=prompts&build=build-1",
+);
+
+assert.equal(
+  buildLeaderboardBuildPath(
+    "/leaderboard/model-a",
+    new URLSearchParams("tab=prompts&build=build-1"),
+    null,
+  ),
+  "/leaderboard/model-a?tab=prompts",
+);
+
+console.log("deep link checks passed");


### PR DESCRIPTION
## Summary

- add canonical shareable URLs for ordered two through four model Sandbox comparisons and prompts
- make the URL the source of comparison navigation for refresh and Back or Forward restoration without duplicate metadata requests
- keep Live Generate mode and prompt state consistent with browser history
- open exact Leaderboard builds through the existing prompt modal and artifact loading path
- remove invalid or model-mismatched build parameters without hiding the model page
- preserve unrelated query parameters during comparison and modal navigation

## Verification

- `pnpm exec tsc --noEmit`
- `pnpm test`
- `pnpm lint`
- `node scripts/with-local-env.mjs pnpm build`
- verified canonical sparse-model normalization against the isolated Docker database
- verified direct four-model Sandbox and exact Leaderboard build routes return 200 in production mode
- verified the running server connects only to Docker on `localhost:54327`

Closes #70

_(PR written by Codex)_
