### PR TITLE
(feat) add DeepSeek V4 Flash 0731 benchmark support

### DIFF
--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -124,6 +124,7 @@ Copy `.env.example` to `.env` and set what you need.
 - Grok 4.3 uses the native xAI API, reasons automatically, rejects `reasoning_effort`, and uses a `max_tokens` request of up to 1000000 unless `MINEBENCH_MAX_OUTPUT_TOKENS` lowers it; MineBench does not send a thinking override for this model.
 - Grok 4.5 uses the native xAI API with `reasoning_effort=high` and `max_completion_tokens=500000`. The token request is bounded by the model's 500000-token context window, so input and reasoning reduce the visible output available. OpenRouter fallback uses `x-ai/grok-4.5` with the same reasoning level and `max_tokens` request.
 - DeepSeek V4 Pro uses the native DeepSeek API with JSON Output mode, defaults to `thinking=max` and `max_tokens=384000`; use `pnpm batch:generate --reasoning high` only when intentionally lowering effort.
+- DeepSeek V4 Flash 0731 uses the native DeepSeek model ID `deepseek-v4-flash`, supports `reasoning_effort=low|high|max`, and MineBench defaults to `max` with a 384000-token output cap. Its OpenRouter fallback uses the exact `deepseek/deepseek-v4-flash-0731` route and requests `max` reasoning first, with `high` and `low` fallbacks.
 - `OPENROUTER_BASE_URL`, `MOONSHOT_BASE_URL`, `DEEPSEEK_BASE_URL`, `MINIMAX_BASE_URL`, `XAI_BASE_URL`
 - `AI_DEBUG=1` (logs raw model output on failures)
 - `MINEBENCH_TOOL_OUTPUT_DIR`, `MINEBENCH_TOOL_TIMEOUT_MS`, `MINEBENCH_TOOL_MAX_*` (advanced `voxel.exec` controls)

--- a/lib/ai/modelBenchmarkMetrics.generated.json
+++ b/lib/ai/modelBenchmarkMetrics.generated.json
@@ -445,6 +445,27 @@
       "failedAttemptCount": 31,
       "failedRunCount": 4,
       "interruptedRunCount": 1
+    },
+    "deepseek_v4_flash_0731": {
+      "inferenceSampleCount": 15,
+      "expectedBuildCount": 15,
+      "finalizedBuildCount": 15,
+      "averageJsonSizeBytes": 18416164,
+      "configurationSampleCount": 15,
+      "configurationIsConsistent": true,
+      "outputCapSampleCount": 15,
+      "outputCapIsConsistent": true,
+      "averageInferenceMs": 526265,
+      "finalizedAttemptCount": 25,
+      "outputCapTokens": 384000,
+      "providerCallCount": 25,
+      "completedAttemptCount": 24,
+      "rejectedResponseCount": 9,
+      "failedAttemptCount": 10,
+      "failedRunCount": 0,
+      "interruptedRunCount": 0,
+      "providerCallTrackingJobCount": 15,
+      "completedAttemptTrackingJobCount": 15
     }
   }
 }

--- a/lib/ai/modelBenchmarkProfiles.ts
+++ b/lib/ai/modelBenchmarkProfiles.ts
@@ -165,6 +165,10 @@ const MODEL_RUN_PARAMETERS = {
     { label: "Thinking", value: "Enabled" },
     { label: "Reasoning effort", value: "Max" },
   ],
+  deepseek_v4_flash_0731: [
+    { label: "Thinking", value: "Enabled" },
+    { label: "Reasoning effort", value: "Max" },
+  ],
   deepseek_v3_2: [
     { label: "Reasoning", value: "Provider default" },
   ],

--- a/lib/ai/modelBenchmarkProfiles.ts
+++ b/lib/ai/modelBenchmarkProfiles.ts
@@ -372,6 +372,10 @@ const MODEL_BENCHMARK_METADATA: Partial<
     sourceRelease: "3.3.2",
     totalCost: { usd: 3.92 },
   },
+  deepseek_v4_flash_0731: {
+    sourceRelease: "3.12.0",
+    totalCost: { usd: 0.28, attemptCount: 24 },
+  },
   anthropic_claude_4_7_opus: {
     sourceRelease: "v3.0.0",
     averageInference: { milliseconds: 2_600_000 },

--- a/lib/ai/modelCatalog.ts
+++ b/lib/ai/modelCatalog.ts
@@ -51,6 +51,7 @@ export type ModelKey =
   | "moonshot_kimi_k2_6"
   | "moonshot_kimi_k2_5"
   | "deepseek_v4_pro"
+  | "deepseek_v4_flash_0731"
   | "deepseek_v3_2"
   | "xai_grok_4_5"
   | "xai_grok_4_3"
@@ -400,6 +401,14 @@ export const MODEL_CATALOG: ModelCatalogEntry[] = [
     modelId: "deepseek-v4-pro",
     displayName: "DeepSeek V4 Pro",
     enabled: true,
+  },
+  {
+    key: "deepseek_v4_flash_0731",
+    provider: "deepseek",
+    modelId: "deepseek-v4-flash",
+    displayName: "DeepSeek V4 Flash 0731",
+    enabled: true,
+    openRouterModelId: "deepseek/deepseek-v4-flash-0731",
   },
   {
     key: "deepseek_v3_2",

--- a/lib/ai/modelRequestProfiles.ts
+++ b/lib/ai/modelRequestProfiles.ts
@@ -19,6 +19,7 @@ const OUTPUT_CEILINGS: readonly { tokens: number; ids: readonly string[] }[] = [
       "deepseek-v4-flash",
       "deepseek/deepseek-v4-pro",
       "deepseek/deepseek-v4-flash",
+      "deepseek/deepseek-v4-flash-0731",
     ],
   },
   { tokens: 272_000, ids: ["gpt-5-pro"] },

--- a/lib/ai/reasoningProfiles.ts
+++ b/lib/ai/reasoningProfiles.ts
@@ -15,7 +15,7 @@ export type MoonshotThinkingConfig = {
 
 export type DeepSeekThinkingConfig = {
   type: "enabled" | "disabled";
-  reasoningEffort?: "high" | "max";
+  reasoningEffort?: "low" | "high" | "max";
 };
 
 function normalizeReasoningOverride(value?: string): string | undefined {
@@ -213,9 +213,10 @@ export function deepseekThinkingConfigForModel(
   override?: string,
 ): DeepSeekThinkingConfig | undefined {
   const normalized = normalizeReasoningOverride(override);
+  const isFlashModel = modelId === "deepseek-v4-flash";
   const supportsThinking =
     modelId === "deepseek-v4-pro" ||
-    modelId === "deepseek-v4-flash" ||
+    isFlashModel ||
     modelId === "deepseek-reasoner";
 
   if (!supportsThinking) {
@@ -232,12 +233,20 @@ export function deepseekThinkingConfigForModel(
     normalized === "on" ||
     normalized === "true" ||
     normalized === "max" ||
-    normalized === "xhigh"
+    (normalized === "xhigh" && !isFlashModel)
   ) {
     return { type: "enabled", reasoningEffort: "max" };
   }
 
   if (normalized === "high") {
+    return { type: "enabled", reasoningEffort: "high" };
+  }
+
+  if (normalized === "low") {
+    return { type: "enabled", reasoningEffort: "low" };
+  }
+
+  if (normalized === "xhigh" && isFlashModel) {
     return { type: "enabled", reasoningEffort: "high" };
   }
 
@@ -253,7 +262,7 @@ export function deepseekThinkingConfigForModel(
   }
 
   throw new Error(
-    `DeepSeek model ${modelId} does not support reasoning '${override}'. Supported values: max, high, disabled.`,
+    `DeepSeek model ${modelId} does not support reasoning '${override}'. Supported values: max, high, low, disabled.`,
   );
 }
 
@@ -358,6 +367,17 @@ export function openRouterReasoningEffortAttempts(
     if (normalized === "high") return ["high"];
     throw new Error(
       `${label} does not support reasoning '${override}'. Supported values: max, xhigh, high.`,
+    );
+  }
+  if (modelId === "deepseek/deepseek-v4-flash-0731") {
+    const normalized = normalizeReasoningOverride(override);
+    if (!normalized || normalized === "max" || normalized === "xhigh") {
+      return ["max", "high", "low"];
+    }
+    if (normalized === "high") return ["high", "low"];
+    if (normalized === "low") return ["low"];
+    throw new Error(
+      `${label} does not support reasoning '${override}'. Supported values: max, xhigh, high, low.`,
     );
   }
   if (

--- a/lib/ai/reasoningProfiles.ts
+++ b/lib/ai/reasoningProfiles.ts
@@ -242,7 +242,7 @@ export function deepseekThinkingConfigForModel(
     return { type: "enabled", reasoningEffort: "high" };
   }
 
-  if (normalized === "low") {
+  if (normalized === "low" && isFlashModel) {
     return { type: "enabled", reasoningEffort: "low" };
   }
 
@@ -262,7 +262,7 @@ export function deepseekThinkingConfigForModel(
   }
 
   throw new Error(
-    `DeepSeek model ${modelId} does not support reasoning '${override}'. Supported values: max, high, low, disabled.`,
+    `DeepSeek model ${modelId} does not support reasoning '${override}'. Supported values: max, high${isFlashModel ? ", low" : ""}, disabled.`,
   );
 }
 

--- a/scripts/uploadsCatalog.ts
+++ b/scripts/uploadsCatalog.ts
@@ -81,6 +81,7 @@ export const MODEL_SLUG: Record<ModelKey, string> = {
   moonshot_kimi_k2_6: "kimi-k2-6",
   moonshot_kimi_k2_5: "kimi-k2-5",
   deepseek_v4_pro: "deepseek-v4-pro",
+  deepseek_v4_flash_0731: "deepseek-v4-flash-0731",
   deepseek_v3_2: "deepseek-v3-2",
   xai_grok_4_5: "grok-4-5",
   xai_grok_4_3: "grok-4-3",

--- a/tests/unit/providers/deepseek-v4-flash-config.test.ts
+++ b/tests/unit/providers/deepseek-v4-flash-config.test.ts
@@ -1,0 +1,186 @@
+import assert from "node:assert/strict";
+import { generateVoxelBuild } from "../../../lib/ai/generateVoxelBuild";
+import { getModelByKey } from "../../../lib/ai/modelCatalog";
+import {
+  deepseekThinkingConfigForModel,
+  openRouterReasoningEffortAttempts,
+} from "../../../lib/ai/reasoningProfiles";
+import { getModelBenchmarkProfile } from "../../../lib/ai/modelBenchmarkProfiles";
+import { MODEL_SLUG } from "../../../scripts/uploadsCatalog";
+
+type CapturedRequest = {
+  url: string;
+  body: Record<string, unknown>;
+};
+
+const capturedRequests: CapturedRequest[] = [];
+const originalFetch = globalThis.fetch;
+const originalEnv = {
+  maxOutputTokens: process.env.MINEBENCH_MAX_OUTPUT_TOKENS,
+  deepseekBaseUrl: process.env.DEEPSEEK_BASE_URL,
+  openRouterBaseUrl: process.env.OPENROUTER_BASE_URL,
+};
+
+function validBuildJson(): string {
+  return JSON.stringify({
+    version: "1.0",
+    boxes: [],
+    lines: [],
+    blocks: [{ x: 0, y: 0, z: 0, type: "stone" }],
+  });
+}
+
+globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+  assert.ok(init?.body, "Provider request should include a JSON body");
+  assert.equal(typeof init.body, "string", "Provider request body should be serialized JSON");
+  capturedRequests.push({
+    url: String(input),
+    body: JSON.parse(init.body as string) as Record<string, unknown>,
+  });
+
+  return new Response(
+    JSON.stringify({ choices: [{ message: { content: validBuildJson() } }] }),
+    { status: 200, headers: { "Content-Type": "application/json" } },
+  );
+}) as typeof fetch;
+
+async function main() {
+  process.env.MINEBENCH_MAX_OUTPUT_TOKENS = "999999";
+  process.env.DEEPSEEK_BASE_URL = "https://deepseek.test";
+  process.env.OPENROUTER_BASE_URL = "https://openrouter.test/api";
+
+  const model = getModelByKey("deepseek_v4_flash_0731");
+  assert.equal(model.provider, "deepseek");
+  assert.equal(model.modelId, "deepseek-v4-flash");
+  assert.equal(model.displayName, "DeepSeek V4 Flash 0731");
+  assert.equal(model.openRouterModelId, "deepseek/deepseek-v4-flash-0731");
+  assert.equal(MODEL_SLUG.deepseek_v4_flash_0731, "deepseek-v4-flash-0731");
+
+  assert.deepEqual(deepseekThinkingConfigForModel(model.modelId), {
+    type: "enabled",
+    reasoningEffort: "max",
+  });
+  assert.deepEqual(deepseekThinkingConfigForModel(model.modelId, "low"), {
+    type: "enabled",
+    reasoningEffort: "low",
+  });
+  assert.deepEqual(deepseekThinkingConfigForModel(model.modelId, "xhigh"), {
+    type: "enabled",
+    reasoningEffort: "high",
+  });
+  assert.deepEqual(openRouterReasoningEffortAttempts(model.openRouterModelId), [
+    "max",
+    "high",
+    "low",
+  ]);
+  assert.deepEqual(openRouterReasoningEffortAttempts(model.openRouterModelId, "max"), [
+    "max",
+    "high",
+    "low",
+  ]);
+  assert.deepEqual(openRouterReasoningEffortAttempts(model.openRouterModelId, "xhigh"), [
+    "max",
+    "high",
+    "low",
+  ]);
+  assert.deepEqual(openRouterReasoningEffortAttempts(model.openRouterModelId, "high"), [
+    "high",
+    "low",
+  ]);
+
+  const profile = getModelBenchmarkProfile(model.key);
+  assert.deepEqual(profile?.parameters, [
+    { label: "Thinking", value: "Enabled" },
+    { label: "Reasoning effort", value: "Max" },
+  ]);
+
+  const directTraces: string[] = [];
+  await generateVoxelBuild({
+    modelKey: model.key,
+    prompt: "small tower",
+    gridSize: 64,
+    palette: "simple",
+    enableTools: false,
+    providerKeys: { deepseek: "test-deepseek-key" },
+    allowServerKeys: false,
+    onProviderTrace: (message) => directTraces.push(message),
+  });
+
+  const directRequest = capturedRequests.find((request) =>
+    request.url.includes("deepseek.test"),
+  )?.body;
+  assert.ok(directRequest, "Direct DeepSeek request should be captured");
+  assert.equal(directRequest.model, "deepseek-v4-flash");
+  assert.equal(directRequest.max_tokens, 384000);
+  assert.deepEqual(directRequest.thinking, { type: "enabled" });
+  assert.equal(directRequest.reasoning_effort, "max");
+  assert.equal("temperature" in directRequest, false);
+  assert.deepEqual(directRequest.response_format, { type: "json_object" });
+  assert.ok(
+    directTraces.some((trace) =>
+      trace.includes("Routing via direct deepseek provider (deepseek-v4-flash)") &&
+      trace.includes("max_output_tokens=384000") &&
+      trace.includes("thinking_mode=thinking=max") &&
+      trace.includes("temperature=n/a"),
+    ),
+    "Direct DeepSeek trace should report the maximum output and reasoning settings",
+  );
+
+  const openRouterTraces: string[] = [];
+  await generateVoxelBuild({
+    modelKey: model.key,
+    prompt: "small tower",
+    gridSize: 64,
+    palette: "simple",
+    enableTools: false,
+    providerKeys: { openrouter: "test-openrouter-key" },
+    allowServerKeys: false,
+    onProviderTrace: (message) => openRouterTraces.push(message),
+  });
+
+  const openRouterRequest = capturedRequests.find((request) =>
+    request.url.includes("openrouter.test"),
+  )?.body;
+  assert.ok(openRouterRequest, "OpenRouter request should be captured");
+  assert.equal(openRouterRequest.model, "deepseek/deepseek-v4-flash-0731");
+  assert.equal(openRouterRequest.max_tokens, 384000);
+  assert.deepEqual(openRouterRequest.reasoning, { effort: "max" });
+  assert.equal(openRouterRequest.temperature, 1);
+  assert.deepEqual(openRouterRequest.provider, { require_parameters: true });
+  const responseFormat = openRouterRequest.response_format as {
+    type?: unknown;
+    json_schema?: { name?: unknown; strict?: unknown; schema?: unknown };
+  };
+  assert.equal(responseFormat.type, "json_schema");
+  assert.equal(responseFormat.json_schema?.name, "voxel_build_response");
+  assert.equal(responseFormat.json_schema?.strict, true);
+  assert.ok(responseFormat.json_schema?.schema);
+  assert.ok(
+    openRouterTraces.some((trace) =>
+      trace.includes("Routing via OpenRouter (deepseek/deepseek-v4-flash-0731)") &&
+      trace.includes("max_output_tokens=384000") &&
+      trace.includes("effort_fallback=max->high->low->disabled") &&
+      trace.includes("temperature=1"),
+    ),
+    "OpenRouter trace should report maximum reasoning and output settings",
+  );
+
+  console.log("deepseek v4 flash config checks passed");
+}
+
+main()
+  .finally(() => {
+    globalThis.fetch = originalFetch;
+    for (const [name, value] of Object.entries({
+      MINEBENCH_MAX_OUTPUT_TOKENS: originalEnv.maxOutputTokens,
+      DEEPSEEK_BASE_URL: originalEnv.deepseekBaseUrl,
+      OPENROUTER_BASE_URL: originalEnv.openRouterBaseUrl,
+    })) {
+      if (value === undefined) delete process.env[name];
+      else process.env[name] = value;
+    }
+  })
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });

--- a/tests/unit/providers/deepseek-v4-flash-config.test.ts
+++ b/tests/unit/providers/deepseek-v4-flash-config.test.ts
@@ -93,6 +93,13 @@ async function main() {
     { label: "Thinking", value: "Enabled" },
     { label: "Reasoning effort", value: "Max" },
   ]);
+  assert.equal(profile?.sourceRelease, "3.12.0");
+  assert.deepEqual(profile?.outputCap, { kind: "exact", tokens: 384000 });
+  assert.deepEqual(profile?.averageInference, { milliseconds: 526265 });
+  assert.equal(profile?.averageJsonSizeBytes, 18416164);
+  assert.equal(profile?.totalAttempts, 24);
+  assert.equal(profile?.buildCount, 15);
+  assert.deepEqual(profile?.totalCost, { usd: 0.28, attemptCount: 24 });
 
   const directTraces: string[] = [];
   await generateVoxelBuild({

--- a/tests/unit/providers/deepseek-v4-flash-config.test.ts
+++ b/tests/unit/providers/deepseek-v4-flash-config.test.ts
@@ -68,6 +68,10 @@ async function main() {
     type: "enabled",
     reasoningEffort: "high",
   });
+  assert.throws(
+    () => deepseekThinkingConfigForModel("deepseek-v4-pro", "low"),
+    /Supported values: max, high, disabled\./,
+  );
   assert.deepEqual(openRouterReasoningEffortAttempts(model.openRouterModelId), [
     "max",
     "high",


### PR DESCRIPTION
## Summary

- register DeepSeek V4 Flash 0731 as a first-class MineBench model with native `deepseek-v4-flash` routing and the exact OpenRouter `deepseek/deepseek-v4-flash-0731` fallback
- request the native API's documented 384,000-token maximum output and maximum `reasoning_effort=max` by default
- support Flash's `low`, `high`, and `max` reasoning levels; normalize MineBench's `xhigh` alias to Flash's documented `high` level
- add the benchmark-ready upload slug, run-configuration profile, operator documentation, and focused direct/OpenRouter request-shape regression coverage
- publish the completed 15-build benchmark metrics and manually supplied `$0.28` cost while keeping production upload as a separate explicit step

## Research Notes

- DeepSeek identifies the API model as `deepseek-v4-flash` and the current model version as `DeepSeek-V4-Flash-0731`
- the native DeepSeek API documents a 1M-token context, a 384K maximum output, thinking and non-thinking modes, JSON output, and tool calls
- native thinking supports `low`, `high`, and `max`; thinking is enabled by default at `high`, while MineBench requests `max`
- DeepSeek maps a requested `xhigh` effort to actual `high` for Flash, so the direct route preserves that provider-defined mapping
- OpenRouter uses the exact versioned route and currently advertises `max`, `high`, and `low` reasoning efforts; MineBench requests `max` first, then falls back through `high` and `low`
- OpenRouter's live catalog currently reports a 65,536-token top-provider completion limit for this route; the existing token-budget fallback descends from the native 384K request to the accepted lower budget when required

Sources: [DeepSeek models and pricing](https://api-docs.deepseek.com/quick_start/pricing/?article_id=article_1779470751466_8), [DeepSeek thinking mode](https://api-docs.deepseek.com/guides/thinking_mode/), [DeepSeek changelog](https://api-docs.deepseek.com/updates/), [OpenRouter model page](https://openrouter.ai/deepseek/deepseek-v4-flash-0731), [OpenRouter live catalog](https://openrouter.ai/api/v1/models)

## Benchmark Results

- 15/15 benchmark builds finalized with the accepted 384,000-token output cap on every build
- Average inference time: `8m 46.3s` (`526,265 ms`, 15/15 samples)
- Average JSON size: `17.56 MiB` (`18,416,164` bytes)
- Total attempts: `24` completed provider responses across 15/15 jobs
- Provider calls: `25` across 15/15 jobs
- Rejected responses: `9`; failed attempts: `10` including one terminated response; failed runs: `0`; interrupted runs: `0`
- Total cost: `$0.28` across the 24 completed responses
- The cohort was generated locally; the separate production `--upload` step has not been invoked in this update

## Verification

- `pnpm test tests/unit/providers/deepseek-v4-flash-config.test.ts`
- `pnpm test tests/unit/providers`
- `pnpm test tests/unit/ai`
- `pnpm test` — 36 test files passed
- `pnpm exec tsc --noEmit`
- `pnpm lint`
- `pnpm build`
- `graphify update .`
- `git diff --check HEAD^ HEAD`

*(PR written by Codex)*
