### PR TITLE
(feat) add Qwen 3.8 Max benchmark support

### DIFF
--- a/app/api/local/voxel-exec/route.ts
+++ b/app/api/local/voxel-exec/route.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import { maxBlocksForGrid } from "@/lib/ai/limits";
 import { runVoxelExec } from "@/lib/ai/tools/voxelExec";
 import { getPalette } from "@/lib/blocks/palettes";
+import { getErrorMessage } from "@/lib/errorMessage";
 import { validateVoxelBuild } from "@/lib/voxel/validate";
 
 export const runtime = "nodejs";
@@ -94,7 +95,7 @@ export async function POST(req: Request) {
     });
   } catch (err) {
     return NextResponse.json(
-      { error: err instanceof Error ? err.message : "Tool execution failed" },
+      { error: getErrorMessage(err, "Tool execution failed") },
       { status: 400 },
     );
   }

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -125,6 +125,7 @@ Copy `.env.example` to `.env` and set what you need.
 - Grok 4.5 uses the native xAI API with `reasoning_effort=high` and `max_completion_tokens=500000`. The token request is bounded by the model's 500000-token context window, so input and reasoning reduce the visible output available. OpenRouter fallback uses `x-ai/grok-4.5` with the same reasoning level and `max_tokens` request.
 - DeepSeek V4 Pro uses the native DeepSeek API with JSON Output mode, defaults to `thinking=max` and `max_tokens=384000`; use `pnpm batch:generate --reasoning high` only when intentionally lowering effort.
 - DeepSeek V4 Flash 0731 uses the native DeepSeek model ID `deepseek-v4-flash`, supports `reasoning_effort=low|high|max`, and MineBench defaults to `max` with a 384000-token output cap. Its OpenRouter fallback uses the exact `deepseek/deepseek-v4-flash-0731` route and requests `max` reasoning first, with `high` and `low` fallbacks.
+- Qwen 3.8 Max is OpenRouter-only in MineBench and uses `qwen/qwen3.8-max`, with `xhigh|high|medium|low|minimal` reasoning efforts and `xhigh` by default. Its current OpenRouter output cap is 131072 tokens and its context window is 1M tokens.
 - `OPENROUTER_BASE_URL`, `MOONSHOT_BASE_URL`, `DEEPSEEK_BASE_URL`, `MINIMAX_BASE_URL`, `XAI_BASE_URL`
 - `AI_DEBUG=1` (logs raw model output on failures)
 - `MINEBENCH_TOOL_OUTPUT_DIR`, `MINEBENCH_TOOL_TIMEOUT_MS`, `MINEBENCH_TOOL_MAX_*` (advanced `voxel.exec` controls)

--- a/lib/ai/generateVoxelBuild.ts
+++ b/lib/ai/generateVoxelBuild.ts
@@ -44,6 +44,7 @@ import {
   voxelExecToolCallJsonSchema,
   voxelExecToolCallSchema,
 } from "@/lib/ai/tools/voxelExec";
+import { getErrorMessage } from "@/lib/errorMessage";
 
 const INT_ENV_MAX_OUTPUT_TOKENS = "MINEBENCH_MAX_OUTPUT_TOKENS";
 
@@ -1081,7 +1082,7 @@ export async function generateVoxelBuild(
       try {
         invokeCallback(params.onRawResponse, attempt, text);
       } catch (err) {
-        const message = err instanceof Error ? err.message : String(err);
+        const message = getErrorMessage(err, String(err));
         invokeCallback(
           params.onProviderTrace,
           `Raw response callback failed for attempt ${attempt}: ${message}`,
@@ -1181,7 +1182,7 @@ export async function generateVoxelBuild(
         rawText: text,
       };
     } catch (err) {
-      lastError = err instanceof Error ? err.message : "Provider request failed";
+      lastError = getErrorMessage(err, "Provider request failed");
       // Retry transient work that failed safely before an outbound request
       if (
         !providerRequestStarted &&

--- a/lib/ai/modelBenchmarkProfiles.ts
+++ b/lib/ai/modelBenchmarkProfiles.ts
@@ -281,6 +281,10 @@ export const HISTORICAL_BENCHMARK_OUTPUT_CAPS: Partial<
 const MODEL_BENCHMARK_METADATA: Partial<
   Record<ModelKey, Omit<ModelBenchmarkProfile, "outputCap" | "parameters">>
 > = {
+  qwen_qwen3_8_max: {
+    sourceRelease: "3.12.0",
+    totalCost: { usd: 11.53 },
+  },
   openai_gpt_5_6_sol: {
     sourceRelease: "3.9.0",
     averageInference: { milliseconds: 1_516_200 },

--- a/lib/ai/modelBenchmarkProfiles.ts
+++ b/lib/ai/modelBenchmarkProfiles.ts
@@ -194,6 +194,7 @@ const MODEL_RUN_PARAMETERS = {
   zai_glm_4_7: PROVIDER_DEFAULT,
   qwen_qwen3_max_thinking: OPENROUTER_XHIGH,
   qwen_qwen3_5_397b_a17b: OPENROUTER_XHIGH,
+  qwen_qwen3_8_max: OPENROUTER_XHIGH,
   minimax_m2_7: [
     { label: "Reasoning effort", value: "XHigh" },
   ],

--- a/lib/ai/modelCatalog.ts
+++ b/lib/ai/modelCatalog.ts
@@ -63,6 +63,7 @@ export type ModelKey =
   | "zai_glm_4_7"
   | "qwen_qwen3_max_thinking"
   | "qwen_qwen3_5_397b_a17b"
+  | "qwen_qwen3_8_max"
   | "minimax_m2_7"
   | "minimax_m2_5"
   | "meta_llama_4_maverick";
@@ -503,6 +504,15 @@ export const MODEL_CATALOG: ModelCatalogEntry[] = [
     displayName: "Qwen 3.5 397B A17B",
     enabled: true,
     openRouterModelId: "qwen/qwen3.5-397b-a17b",
+    forceOpenRouter: true,
+  },
+  {
+    key: "qwen_qwen3_8_max",
+    provider: "qwen",
+    modelId: "qwen3.8-max",
+    displayName: "Qwen 3.8 Max",
+    enabled: true,
+    openRouterModelId: "qwen/qwen3.8-max",
     forceOpenRouter: true,
   },
   {

--- a/lib/ai/modelRequestProfiles.ts
+++ b/lib/ai/modelRequestProfiles.ts
@@ -22,6 +22,7 @@ const OUTPUT_CEILINGS: readonly { tokens: number; ids: readonly string[] }[] = [
       "deepseek/deepseek-v4-flash-0731",
     ],
   },
+  { tokens: 131_072, ids: ["qwen3.8-max", "qwen/qwen3.8-max"] },
   { tokens: 272_000, ids: ["gpt-5-pro"] },
   // MiniMax M2.7 rejects the larger MineBench default on its OpenAI-compatible route
   { tokens: 131_072, ids: ["glm-5.2", "glm-5.1", "glm-5", "minimax-m2.7"] },

--- a/lib/ai/modelRequestProfiles.ts
+++ b/lib/ai/modelRequestProfiles.ts
@@ -57,10 +57,13 @@ const OUTPUT_CEILING_PREFIXES: readonly { prefix: string; tokens: number }[] = [
   { prefix: "gpt-5", tokens: 128_000 },
 ];
 
-// Models rejecting a non-default temperature, top_p, or top_k
+// Models that should use provider-default sampling instead of MineBench's
+// shared temperature, including models that reject sampling overrides
 const DEFAULT_SAMPLING_IDS: readonly string[] = [
   "kimi-k3",
   "moonshotai/kimi-k3",
+  "qwen3.8-max",
+  "qwen/qwen3.8-max",
   "google/gemini-3.6-flash",
   "google/gemini-3.5-flash-lite",
 ];

--- a/lib/ai/reasoningProfiles.ts
+++ b/lib/ai/reasoningProfiles.ts
@@ -404,6 +404,9 @@ export function openRouterReasoningEffortAttempts(
   ) {
     return descendingAttempts(label, ["xhigh", "high", "medium", "low"], override);
   }
+  if (modelId === "qwen/qwen3.8-max") {
+    return descendingAttempts(label, ["xhigh", "high", "medium", "low", "minimal"], override);
+  }
   if (modelId === "openai/gpt-oss-120b") {
     return descendingAttempts(label, ["xhigh", "high", "medium", "low"], override);
   }

--- a/lib/errorMessage.ts
+++ b/lib/errorMessage.ts
@@ -1,0 +1,12 @@
+export function getErrorMessage(error: unknown, fallback: string): string {
+  if (error instanceof Error && error.message.trim()) return error.message;
+  if (typeof error === "string" && error.trim()) return error;
+  if (!error || (typeof error !== "object" && typeof error !== "function")) return fallback;
+
+  try {
+    const message = Reflect.get(error, "message");
+    return typeof message === "string" && message.trim() ? message : fallback;
+  } catch {
+    return fallback;
+  }
+}

--- a/scripts/uploadsCatalog.ts
+++ b/scripts/uploadsCatalog.ts
@@ -93,6 +93,7 @@ export const MODEL_SLUG: Record<ModelKey, string> = {
   zai_glm_4_7: "glm-4-7",
   qwen_qwen3_max_thinking: "qwen3-max-thinking",
   qwen_qwen3_5_397b_a17b: "qwen3-5-397b-a17b",
+  qwen_qwen3_8_max: "qwen3-8-max",
   minimax_m2_7: "minimax-m2-7",
   minimax_m2_5: "minimax-m2-5",
   meta_llama_4_maverick: "llama-4-maverick",

--- a/tests/ui/model-benchmark-details.test.ts
+++ b/tests/ui/model-benchmark-details.test.ts
@@ -232,6 +232,21 @@ assert.ok(
   "a fully tracked Gemini model should render every normalized statistic row",
 );
 
+const qwenMarkup = renderToStaticMarkup(
+  React.createElement(ModelBenchmarkDetailsInline, {
+    id: "qwen-details",
+    modelKey: "qwen_qwen3_8_max",
+    displayName: "Qwen 3.8 Max",
+    open: true,
+  }),
+);
+assert.ok(
+  qwenMarkup.includes("$11.53") &&
+    !qwenMarkup.includes("per build") &&
+    !qwenMarkup.includes("per attempt"),
+  "Qwen 3.8 Max should render its canonical benchmark total without an inferred denominator",
+);
+
 const gemini30Markup = renderToStaticMarkup(
   React.createElement(ModelBenchmarkDetailsInline, {
     id: "gemini-3-0-details",

--- a/tests/unit/ai/generate-voxel-build-vm-errors.test.ts
+++ b/tests/unit/ai/generate-voxel-build-vm-errors.test.ts
@@ -1,0 +1,79 @@
+import assert from "node:assert/strict";
+
+import { generateVoxelBuild } from "../../../lib/ai/generateVoxelBuild";
+
+type OpenRouterRequest = {
+  messages?: Array<{ role?: unknown; content?: unknown }>;
+};
+
+const originalFetch = globalThis.fetch;
+const originalOpenRouterBaseUrl = process.env.OPENROUTER_BASE_URL;
+const requests: OpenRouterRequest[] = [];
+
+const invalidToolCall = JSON.stringify({
+  tool: "voxel.exec",
+  input: {
+    code: "const R = rng(); R();",
+    gridSize: 64,
+    palette: "simple",
+    seed: 123,
+  },
+});
+
+globalThis.fetch = (async (_input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+  const body = init?.body;
+  if (typeof body !== "string") throw new Error("Expected a serialized OpenRouter request body");
+  requests.push(JSON.parse(body) as OpenRouterRequest);
+
+  return new Response(
+    JSON.stringify({
+      choices: [{ message: { content: invalidToolCall } }],
+    }),
+    {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    },
+  );
+}) as typeof fetch;
+
+async function main() {
+  process.env.OPENROUTER_BASE_URL = "https://openrouter.test/api";
+
+  const retries: Array<{ attempt: number; reason: string }> = [];
+  const result = await generateVoxelBuild({
+    modelKey: "qwen_qwen3_8_max",
+    prompt: "small tower",
+    gridSize: 64,
+    palette: "simple",
+    maxAttempts: 2,
+    enableTools: true,
+    providerKeys: { openrouter: "test-openrouter-key" },
+    allowServerKeys: false,
+    onRetry: (attempt, reason) => retries.push({ attempt, reason }),
+  });
+
+  assert.equal(requests.length, 2);
+  assert.deepEqual(retries, [{ attempt: 2, reason: "R is not a function" }]);
+  assert.equal(result.ok, false);
+  assert.equal(result.error, "R is not a function");
+
+  const retryPrompt = requests[1]?.messages?.find((message) => message.role === "user")?.content;
+  if (typeof retryPrompt !== "string") throw new Error("Expected a string retry prompt");
+  assert.match(retryPrompt, /R is not a function/);
+
+  console.log("voxel exec VM error propagation checks passed");
+}
+
+main()
+  .finally(() => {
+    globalThis.fetch = originalFetch;
+    if (originalOpenRouterBaseUrl === undefined) {
+      delete process.env.OPENROUTER_BASE_URL;
+    } else {
+      process.env.OPENROUTER_BASE_URL = originalOpenRouterBaseUrl;
+    }
+  })
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });

--- a/tests/unit/ai/model-benchmark-profiles.test.ts
+++ b/tests/unit/ai/model-benchmark-profiles.test.ts
@@ -210,6 +210,8 @@ const qwen38 = getModelBenchmarkProfile("qwen_qwen3_8_max");
 assert.deepEqual(qwen38?.parameters, [
   { label: "Reasoning effort", value: "XHigh" },
 ]);
+assert.equal(qwen38?.sourceRelease, "3.12.0");
+assert.deepEqual(qwen38?.totalCost, { usd: 11.53 });
 assert.deepEqual(
   qwen38?.outputCap,
   { kind: "unavailable", reason: "predates-tracking" },

--- a/tests/unit/ai/model-benchmark-profiles.test.ts
+++ b/tests/unit/ai/model-benchmark-profiles.test.ts
@@ -205,6 +205,17 @@ const reconstructedExactOutputCaps = {
   zai_glm_4_7: 65_536,
   minimax_m2_5: 131_072,
 } as const;
+
+const qwen38 = getModelBenchmarkProfile("qwen_qwen3_8_max");
+assert.deepEqual(qwen38?.parameters, [
+  { label: "Reasoning effort", value: "XHigh" },
+]);
+assert.deepEqual(
+  qwen38?.outputCap,
+  { kind: "unavailable", reason: "predates-tracking" },
+  "Qwen 3.8 Max should not publish an accepted benchmark cap before generation",
+);
+
 for (const [modelKey, tokens] of Object.entries(reconstructedExactOutputCaps)) {
   assert.deepEqual(
     HISTORICAL_BENCHMARK_OUTPUT_CAPS[

--- a/tests/unit/ai/model-request-profiles.test.ts
+++ b/tests/unit/ai/model-request-profiles.test.ts
@@ -11,6 +11,7 @@ for (const [direct, routed] of [
   ["kimi-k3", "moonshotai/kimi-k3"],
   ["grok-4.5", "x-ai/grok-4.5"],
   ["deepseek-v4-pro", "deepseek/deepseek-v4-pro"],
+  ["qwen3.8-max", "qwen/qwen3.8-max"],
   ["gemini-3.6-flash", "google/gemini-3.6-flash"],
 ] as const) {
   assert.equal(
@@ -23,6 +24,8 @@ for (const [direct, routed] of [
 assert.equal(modelOutputCeiling("kimi-k3"), 1_048_576);
 assert.equal(modelOutputCeiling("grok-4.3"), 1_000_000);
 assert.equal(modelOutputCeiling("claude-opus-5"), 128_000);
+assert.equal(modelOutputCeiling("qwen3.8-max"), 131_072);
+assert.equal(modelOutputCeiling("qwen/qwen3.8-max"), 131_072);
 assert.equal(modelOutputCeiling("MiniMax-M2.7"), 131_072);
 assert.equal(modelOutputCeiling("grok-4-1-fast"), 30_000);
 

--- a/tests/unit/ai/model-request-profiles.test.ts
+++ b/tests/unit/ai/model-request-profiles.test.ts
@@ -43,6 +43,8 @@ assert.equal(modelUsesDefaultSampling("kimi-k3"), true);
 assert.equal(modelUsesDefaultSampling("gpt-5.6-sol"), true);
 assert.equal(modelUsesDefaultSampling("claude-opus-5"), true);
 assert.equal(modelUsesDefaultSampling("anthropic/claude-opus-4.8"), true);
+assert.equal(modelUsesDefaultSampling("qwen3.8-max"), true);
+assert.equal(modelUsesDefaultSampling("qwen/qwen3.8-max"), true);
 assert.equal(modelUsesDefaultSampling("gpt-4o"), false);
 assert.equal(modelUsesDefaultSampling("claude-sonnet-4-6"), false);
 

--- a/tests/unit/api/local-voxel-exec-errors.test.ts
+++ b/tests/unit/api/local-voxel-exec-errors.test.ts
@@ -1,0 +1,29 @@
+import assert from "node:assert/strict";
+
+import { POST } from "../../../app/api/local/voxel-exec/route";
+
+async function main() {
+  const request = new Request("http://localhost:3000/api/local/voxel-exec", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      code: "const R = rng(); R();",
+      gridSize: 64,
+      palette: "simple",
+      seed: 123,
+    }),
+  });
+
+  const response = await POST(request);
+  const body = (await response.json()) as { error?: unknown };
+
+  assert.equal(response.status, 400);
+  assert.equal(body.error, "R is not a function");
+
+  console.log("local voxel exec error propagation checks passed");
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/tests/unit/providers/qwen3-8-max-config.test.ts
+++ b/tests/unit/providers/qwen3-8-max-config.test.ts
@@ -104,7 +104,7 @@ async function main() {
   assert.equal(request.model, "qwen/qwen3.8-max");
   assert.equal(request.max_tokens, 131072);
   assert.deepEqual(request.reasoning, { effort: "xhigh" });
-  assert.equal(request.temperature, 1);
+  assert.equal(Object.hasOwn(request, "temperature"), false);
   assert.deepEqual(request.provider, { require_parameters: true });
 
   const responseFormat = request.response_format as {
@@ -120,9 +120,9 @@ async function main() {
       trace.includes("Routing via OpenRouter (qwen/qwen3.8-max)") &&
       trace.includes("max_output_tokens=131072") &&
       trace.includes("effort_fallback=xhigh->high->medium->low->minimal->disabled") &&
-      trace.includes("temperature=1"),
+      trace.includes("temperature=default"),
     ),
-    "OpenRouter trace should report Qwen 3.8 Max's output cap and effort ladder",
+    "OpenRouter trace should report Qwen 3.8 Max's output cap, effort ladder, and provider-default sampling",
   );
 
   console.log("Qwen 3.8 Max config checks passed");

--- a/tests/unit/providers/qwen3-8-max-config.test.ts
+++ b/tests/unit/providers/qwen3-8-max-config.test.ts
@@ -1,0 +1,148 @@
+import assert from "node:assert/strict";
+import { generateVoxelBuild } from "../../../lib/ai/generateVoxelBuild";
+import { getModelBenchmarkProfile } from "../../../lib/ai/modelBenchmarkProfiles";
+import { getModelByKey } from "../../../lib/ai/modelCatalog";
+import { openRouterReasoningEffortAttempts } from "../../../lib/ai/reasoningProfiles";
+import { MODEL_SLUG } from "../../../scripts/uploadsCatalog";
+
+type CapturedRequest = {
+  url: string;
+  body: Record<string, unknown>;
+};
+
+const capturedRequests: CapturedRequest[] = [];
+const originalFetch = globalThis.fetch;
+const originalEnv = {
+  maxOutputTokens: process.env.MINEBENCH_MAX_OUTPUT_TOKENS,
+  openRouterBaseUrl: process.env.OPENROUTER_BASE_URL,
+};
+
+function validBuildJson(): string {
+  return JSON.stringify({
+    version: "1.0",
+    boxes: [],
+    lines: [],
+    blocks: [{ x: 0, y: 0, z: 0, type: "stone" }],
+  });
+}
+
+globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+  assert.ok(init?.body, "OpenRouter request should include a JSON body");
+  assert.equal(typeof init.body, "string", "OpenRouter request body should be serialized JSON");
+
+  capturedRequests.push({
+    url: String(input),
+    body: JSON.parse(init.body as string) as Record<string, unknown>,
+  });
+
+  return new Response(
+    JSON.stringify({
+      choices: [
+        {
+          message: {
+            content: validBuildJson(),
+          },
+        },
+      ],
+    }),
+    {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    },
+  );
+}) as typeof fetch;
+
+async function main() {
+  process.env.MINEBENCH_MAX_OUTPUT_TOKENS = "999999";
+  process.env.OPENROUTER_BASE_URL = "https://openrouter.test/api";
+
+  const model = getModelByKey("qwen_qwen3_8_max");
+  assert.equal(model.provider, "qwen");
+  assert.equal(model.modelId, "qwen3.8-max");
+  assert.equal(model.displayName, "Qwen 3.8 Max");
+  assert.equal(model.openRouterModelId, "qwen/qwen3.8-max");
+  assert.equal(model.forceOpenRouter, true);
+  assert.equal(MODEL_SLUG.qwen_qwen3_8_max, "qwen3-8-max");
+
+  assert.deepEqual(openRouterReasoningEffortAttempts(model.openRouterModelId), [
+    "xhigh",
+    "high",
+    "medium",
+    "low",
+    "minimal",
+  ]);
+  assert.deepEqual(openRouterReasoningEffortAttempts(model.openRouterModelId, "medium"), [
+    "medium",
+    "low",
+    "minimal",
+  ]);
+  assert.deepEqual(openRouterReasoningEffortAttempts(model.openRouterModelId, "minimal"), [
+    "minimal",
+  ]);
+
+  const profile = getModelBenchmarkProfile(model.key);
+  assert.deepEqual(profile?.parameters, [
+    { label: "Reasoning effort", value: "XHigh" },
+  ]);
+
+  const traces: string[] = [];
+  await generateVoxelBuild({
+    modelKey: model.key,
+    prompt: "small tower",
+    gridSize: 64,
+    palette: "simple",
+    enableTools: false,
+    providerKeys: { openrouter: "test-openrouter-key" },
+    allowServerKeys: false,
+    onProviderTrace: (message) => traces.push(message),
+  });
+
+  const request = capturedRequests.find((candidate) =>
+    candidate.url.includes("openrouter.test"),
+  )?.body;
+  assert.ok(request, "OpenRouter request should be captured");
+  assert.equal(request.model, "qwen/qwen3.8-max");
+  assert.equal(request.max_tokens, 131072);
+  assert.deepEqual(request.reasoning, { effort: "xhigh" });
+  assert.equal(request.temperature, 1);
+  assert.deepEqual(request.provider, { require_parameters: true });
+
+  const responseFormat = request.response_format as {
+    type?: unknown;
+    json_schema?: { name?: unknown; strict?: unknown; schema?: unknown };
+  };
+  assert.equal(responseFormat.type, "json_schema");
+  assert.equal(responseFormat.json_schema?.name, "voxel_build_response");
+  assert.equal(responseFormat.json_schema?.strict, true);
+  assert.ok(responseFormat.json_schema?.schema);
+  assert.ok(
+    traces.some((trace) =>
+      trace.includes("Routing via OpenRouter (qwen/qwen3.8-max)") &&
+      trace.includes("max_output_tokens=131072") &&
+      trace.includes("effort_fallback=xhigh->high->medium->low->minimal->disabled") &&
+      trace.includes("temperature=1"),
+    ),
+    "OpenRouter trace should report Qwen 3.8 Max's output cap and effort ladder",
+  );
+
+  console.log("Qwen 3.8 Max config checks passed");
+}
+
+main()
+  .finally(() => {
+    globalThis.fetch = originalFetch;
+    if (originalEnv.maxOutputTokens === undefined) {
+      delete process.env.MINEBENCH_MAX_OUTPUT_TOKENS;
+    } else {
+      process.env.MINEBENCH_MAX_OUTPUT_TOKENS = originalEnv.maxOutputTokens;
+    }
+    if (originalEnv.openRouterBaseUrl === undefined) {
+      delete process.env.OPENROUTER_BASE_URL;
+    } else {
+      process.env.OPENROUTER_BASE_URL = originalEnv.openRouterBaseUrl;
+    }
+  })
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });


### PR DESCRIPTION
## Summary

- Add Qwen 3.8 Max to MineBench through the OpenRouter-only `qwen/qwen3.8-max` route.
- Configure the 1M-token context window, 131,072-token completion ceiling, and `xhigh` default reasoning with `high`, `medium`, `low`, and `minimal` fallbacks.
- Use provider-default sampling for Qwen's native and OpenRouter IDs instead of MineBench's shared temperature override.
- Preserve cross-realm `voxel.exec` exceptions in batch retry messages and the local conversion API so model-program failures are not mislabeled as provider failures.
- Record `$11.53` as the canonical Qwen benchmark total shown in model details.
- Add exact request-shape, model-profile, batch VM-error, local VM-error, and benchmark-cost regression coverage.

Provider references: [QwenCloud model guide](https://docs.qwencloud.com/developer-guides/getting-started/text-generation-models) and [OpenRouter Qwen3.8 Max](https://openrouter.ai/qwen/qwen3.8-max).

## Verification

- `pnpm exec tsx tests/unit/ai/model-request-profiles.test.ts`
- `pnpm exec tsx tests/unit/providers/qwen3-8-max-config.test.ts`
- `pnpm exec tsx tests/unit/ai/generate-voxel-build-vm-errors.test.ts`
- `pnpm exec tsx tests/unit/api/local-voxel-exec-errors.test.ts`
- `pnpm test` — 36 test files passed
- `pnpm lint`
- `pnpm exec tsc --noEmit`
- `pnpm build`
- `graphify update .`
- `git diff --check`

## Release

- Draft release 3.12.0 includes the completed Qwen 3.8 Max benchmark row with the canonical `$11.53` total cost.
- Existing release Notes remain unchanged.

*(PR written by Codex)*
