### PR TITLE
(feat) add graphics acceleration requirement error

### DIFF
--- a/app/error.tsx
+++ b/app/error.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link";
 import { useEffect } from "react";
+import { isVoxelViewerWebGLUnavailableError } from "@/lib/voxel/errors";
 
 export default function RouteError({ error, reset }: { error: Error & { digest?: string }; reset: () => void }) {
   useEffect(() => {
@@ -10,28 +11,29 @@ export default function RouteError({ error, reset }: { error: Error & { digest?:
     }
   }, [error]);
 
+  const webglUnavailable = isVoxelViewerWebGLUnavailableError(error);
+  const title = webglUnavailable ? "Enable graphics acceleration" : "We hit a snag loading this page";
+  const message = webglUnavailable
+    ? "MineBench uses WebGL to render model builds in 3D in your browser. Turn on graphics acceleration, then reload."
+    : "The site may be under heavy load. Try again in a moment.";
+
   return (
-    <div className="flex min-h-[60vh] items-center justify-center px-4 py-10">
-      <div className="mb-panel w-full max-w-md p-5 text-center sm:p-6">
-        <div className="mb-panel-inner space-y-3">
-          <div className="mx-auto inline-flex items-center gap-2 rounded-full bg-danger/10 px-3 py-1 text-xs font-medium text-danger ring-1 ring-danger/30">
-            <span className="h-1.5 w-1.5 rounded-full bg-danger" aria-hidden="true" />
-            <span>Something broke</span>
-          </div>
-          <h2 className="font-display text-xl font-semibold tracking-tight sm:text-2xl">
-            We hit a snag loading this page
-          </h2>
-          <p className="text-sm text-muted">
-            The site may be under heavy load. I am (probably) working to get it back up — try again in a moment.
-          </p>
+    <div className="flex min-h-[60vh] w-full items-center justify-center px-4 py-10">
+      <div className="mx-auto w-full max-w-sm rounded-xl border border-border bg-card p-6 shadow-soft">
+        <div className="space-y-3">
+          <h1 className="text-xl font-semibold leading-tight tracking-tight">{title}</h1>
+          <p className="max-w-[32ch] text-sm leading-6 text-muted">{message}</p>
           {error.digest ? (
             <p className="font-mono text-[11px] uppercase tracking-[0.12em] text-muted2">ref {error.digest}</p>
           ) : null}
-          <div className="flex items-center justify-center gap-2 pt-1">
-            <button type="button" onClick={reset} className="mb-btn mb-btn-primary h-9 px-4 text-sm">
+          <div className="flex items-center gap-4 pt-2">
+            <button type="button" onClick={reset} className="mb-btn mb-btn-primary min-h-11 px-4 text-sm">
               Try again
             </button>
-            <Link href="/" className="mb-btn mb-btn-ghost h-9 px-4 text-sm">
+            <Link
+              href="/"
+              className="inline-flex min-h-11 items-center text-sm font-medium text-muted underline-offset-4 hover:text-fg hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
+            >
               Back to arena
             </Link>
           </div>

--- a/components/voxel/VoxelViewer.tsx
+++ b/components/voxel/VoxelViewer.tsx
@@ -7,6 +7,7 @@ import type { BlockDefinition } from "@/lib/blocks/palettes";
 import { getPalette } from "@/lib/blocks/palettes";
 import { createVoxelGroupAsync, VoxelGroup } from "@/lib/voxel/mesh";
 import type { VoxelBuild } from "@/lib/voxel/types";
+import { VOXEL_VIEWER_WEBGL_ERROR } from "@/lib/voxel/errors";
 
 export type VoxelViewerBuildProgress = {
   processedBlocks: number;
@@ -951,11 +952,16 @@ export const VoxelViewer = forwardRef<VoxelViewerHandle, ViewerProps>(function V
     const camera = new THREE.PerspectiveCamera(45, 1, 0.1, 1000);
     camera.position.set(10, 8, 10);
 
-    const renderer = new THREE.WebGLRenderer({
-      antialias: false,
-      alpha: true,
-      powerPreference: "high-performance",
-    });
+    let renderer: THREE.WebGLRenderer;
+    try {
+      renderer = new THREE.WebGLRenderer({
+        antialias: false,
+        alpha: true,
+        powerPreference: "high-performance",
+      });
+    } catch {
+      throw new Error(VOXEL_VIEWER_WEBGL_ERROR);
+    }
     // mobile retina is much more fragment-shader bound; cap lower to keep memory + frame time down
     renderer.setPixelRatio(getViewerPixelRatio());
     // important: keep canvas css size in sync with the mount, otherwise we end up showing only a corner

--- a/lib/voxel/errors.ts
+++ b/lib/voxel/errors.ts
@@ -1,0 +1,5 @@
+export const VOXEL_VIEWER_WEBGL_ERROR = "__minebench_webgl_unavailable__";
+
+export function isVoxelViewerWebGLUnavailableError(error: unknown): boolean {
+  return error instanceof Error && error.message === VOXEL_VIEWER_WEBGL_ERROR;
+}


### PR DESCRIPTION
## Summary

- Catch WebGL renderer initialization failures and route them to the existing error boundary.
- Show a compact, centered message explaining why graphics acceleration is needed for MineBench’s 3D builds.
- Preserve the existing generic route-error behavior for unrelated failures.

## Verification

- `pnpm test:unit`
- `pnpm exec tsc --noEmit`
- `pnpm exec eslint app/error.tsx components/voxel/VoxelViewer.tsx lib/voxel/errors.ts`
- `git diff --check`

*(PR written by Codex)*