### PR TITLE
(feat) unify Sandbox workspaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,7 @@ MineBench, unlike other benchmarks, gives an easy way to visually determine (at 
 ## Features
 
 - **Arena** — blind head-to-head comparisons of pre-generated builds with confidence-aware ranking
-- **Sandbox** — compare existing builds or generate new ones live with your own API keys
-- **Local Lab** — copy the benchmark prompt, run it in any model, paste the JSON back to render
+- **Sandbox** — compare existing builds, generate new ones, or import output from any model
 - **Leaderboard** — live rankings with win/loss/draw stats across all models
 - **Exports** — save builds as GLB, STL, or WorldEdit `.schem` for Blender, 3D printing, and Minecraft
 

--- a/app/local/page.tsx
+++ b/app/local/page.tsx
@@ -1,34 +1,5 @@
-import type { Metadata } from "next";
-import { LocalLab } from "@/components/local/LocalLab";
-import { breadcrumbJsonLd } from "@/lib/seo";
-
-export const metadata: Metadata = {
-  title: "Local",
-  description:
-    "Run MineBench prompts with your own model setup and validate voxel JSON output locally.",
-  alternates: {
-    canonical: "/local",
-  },
-  robots: {
-    index: false,
-    follow: false,
-  },
-};
-
-const breadcrumbData = breadcrumbJsonLd([
-  { name: "Arena", path: "/" },
-  { name: "Local Lab", path: "/local" },
-]);
+import { redirect } from "next/navigation";
 
 export default function LocalLabPage() {
-  return (
-    <>
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbData) }}
-      />
-      <h1 className="sr-only">MineBench local lab</h1>
-      <LocalLab />
-    </>
-  );
+  redirect("/sandbox?mode=import");
 }

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -6,7 +6,7 @@ export default function robots(): MetadataRoute.Robots {
     rules: [
       {
         userAgent: "*",
-        allow: ["/", "/leaderboard", "/leaderboard/", "/sandbox", "/local"],
+        allow: ["/", "/leaderboard", "/leaderboard/", "/sandbox"],
         disallow: ["/api/"],
       },
     ],

--- a/app/sandbox/page.tsx
+++ b/app/sandbox/page.tsx
@@ -5,7 +5,7 @@ import { breadcrumbJsonLd, DEFAULT_OG_IMAGE } from "@/lib/seo";
 export const metadata: Metadata = {
   title: "Sandbox",
   description:
-    "Generate and compare AI voxel builds from custom prompts in the MineBench sandbox.",
+    "Compare, generate, and import AI voxel builds in the MineBench sandbox.",
   keywords: [
     "ai voxel generator",
     "voxel build generator",
@@ -18,14 +18,14 @@ export const metadata: Metadata = {
   openGraph: {
     title: "MineBench Sandbox | AI Voxel Generator",
     description:
-      "Generate and compare AI voxel builds from custom prompts in the MineBench sandbox.",
+      "Compare, generate, and import AI voxel builds in the MineBench sandbox.",
     url: "/sandbox",
     images: [{ url: DEFAULT_OG_IMAGE, alt: "MineBench sandbox voxel build generation" }],
   },
   twitter: {
     title: "MineBench Sandbox | AI Voxel Generator",
     description:
-      "Generate and compare AI voxel builds from custom prompts in the MineBench sandbox.",
+      "Compare, generate, and import AI voxel builds in the MineBench sandbox.",
     images: [DEFAULT_OG_IMAGE],
   },
 };

--- a/components/SiteHeader.tsx
+++ b/components/SiteHeader.tsx
@@ -234,7 +234,6 @@ export function SiteHeader() {
             <div className="flex items-center gap-1 overflow-x-auto [scrollbar-width:none] [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden">
               <NavLink href="/" label="Arena" />
               <NavLink href="/sandbox" label="Sandbox" />
-              <NavLink href="/local" label="Local" />
               <NavLink href="/leaderboard" label="Leaderboard" />
               <NavLink href="/faq" label="FAQ" />
               <div className="mx-0.5 h-5 w-px shrink-0 bg-border/50 sm:mx-1" aria-hidden="true" />

--- a/components/local/LocalLab.tsx
+++ b/components/local/LocalLab.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { ReactNode, useEffect, useMemo, useRef, useState } from "react";
+import { ReactNode, useEffect, useId, useMemo, useRef, useState } from "react";
 import { SandboxGifExportButton, type SandboxGifExportTarget } from "@/components/sandbox/SandboxGifExportButton";
-import { buildSystemPrompt, buildUserPrompt } from "@/lib/ai/prompts";
+import { buildSystemPrompt, buildUserPrompt, buildWebPrompt } from "@/lib/ai/prompts";
 import { MAX_BLOCKS_BY_GRID, MIN_BLOCKS_BY_GRID } from "@/lib/ai/limits";
 import { extractBestVoxelBuildJson } from "@/lib/ai/jsonExtract";
 import { getPalette } from "@/lib/blocks/palettes";
@@ -90,6 +90,7 @@ function CopyButton({
   tone = "ghost",
   icon,
   className,
+  description,
 }: {
   label: string;
   text: string;
@@ -97,8 +98,10 @@ function CopyButton({
   tone?: "ghost" | "primary";
   icon?: ReactNode;
   className?: string;
+  description?: string;
 }) {
   const [status, setStatus] = useState<"idle" | "copied" | "error">("idle");
+  const descriptionId = useId();
 
   async function copy() {
     try {
@@ -129,21 +132,33 @@ function CopyButton({
   }
 
   return (
-    <button
-      type="button"
-      className={cx(
-        "mb-btn h-8 rounded-full px-2.5 text-[11px] sm:h-9 sm:px-3 sm:text-xs",
-        tone === "primary" ? "mb-btn-primary" : "mb-btn-ghost",
-        className,
-      )}
-      disabled={disabled}
-      onClick={copy}
-    >
-      <span className="inline-flex items-center gap-1.5">
-        {icon}
-        <span>{status === "copied" ? "Copied" : status === "error" ? "Copy failed" : label}</span>
-      </span>
-    </button>
+    <span className="group relative z-20 inline-flex">
+      <button
+        type="button"
+        aria-describedby={description ? descriptionId : undefined}
+        className={cx(
+          "mb-btn h-8 rounded-full px-2.5 text-[11px] sm:h-9 sm:px-3 sm:text-xs",
+          tone === "primary" ? "mb-btn-primary" : "mb-btn-ghost",
+          className,
+        )}
+        disabled={disabled}
+        onClick={copy}
+      >
+        <span className="inline-flex items-center gap-1.5">
+          {icon}
+          <span>{status === "copied" ? "Copied" : status === "error" ? "Copy failed" : label}</span>
+        </span>
+      </button>
+      {description ? (
+        <span
+          id={descriptionId}
+          role="tooltip"
+          className="pointer-events-none invisible absolute bottom-[calc(100%+0.625rem)] right-0 z-50 w-64 rounded-xl bg-card px-3 py-2.5 text-left text-[11px] leading-relaxed text-fg/90 opacity-0 shadow-2xl ring-1 ring-border transition-opacity after:absolute after:-bottom-1 after:right-8 after:h-2 after:w-2 after:rotate-45 after:border-b after:border-r after:border-border after:bg-card group-hover:visible group-hover:opacity-100 group-focus-within:visible group-focus-within:opacity-100 sm:w-72"
+        >
+          {description}
+        </span>
+      ) : null}
+    </span>
   );
 }
 
@@ -251,9 +266,20 @@ export function LocalLab() {
   );
   const userPrompt = useMemo(() => buildUserPrompt(taskPrompt.trim()), [taskPrompt]);
 
-  const combinedPrompt = useMemo(() => {
+  const apiPrompt = useMemo(() => {
     return `SYSTEM:\n${systemPrompt}\n\nUSER:\n${userPrompt}`;
   }, [systemPrompt, userPrompt]);
+  const webPrompt = useMemo(
+    () =>
+      buildWebPrompt({
+        gridSize,
+        minBlocks: MIN_BLOCKS_BY_GRID[gridSize],
+        maxBlocks: MAX_BLOCKS_BY_GRID[gridSize],
+        palette,
+        prompt: taskPrompt,
+      }),
+    [gridSize, palette, taskPrompt],
+  );
 
   const modelOutputRef = useRef<HTMLTextAreaElement | null>(null);
   const bufferedOutputRef = useRef<string | null>(null);
@@ -262,6 +288,7 @@ export function LocalLab() {
     chars: 0,
   });
   const [statusNote, setStatusNote] = useState<string | null>(null);
+  const [isDraggingFile, setIsDraggingFile] = useState(false);
   const [rendered, setRendered] = useState<{
     kind: "idle" | "loading" | "ready" | "error";
     build: VoxelBuild | null;
@@ -399,6 +426,29 @@ export function LocalLab() {
     setStatusNote(null);
   }
 
+  async function loadJsonFile(file: File) {
+    if (!file.name.toLowerCase().endsWith(".json") && file.type !== "application/json") {
+      setStatusNote("Drop a JSON file.");
+      return;
+    }
+
+    try {
+      const text = await file.text();
+      if (!trimOuterWhitespace(text)) {
+        setStatusNote(`${file.name} is empty.`);
+        return;
+      }
+
+      const buffered = text.length >= LARGE_PASTE_CHAR_THRESHOLD;
+      bufferedOutputRef.current = buffered ? text : null;
+      if (modelOutputRef.current) modelOutputRef.current.value = buffered ? "" : text;
+      setInputStats({ mode: buffered ? "buffered" : "editor", chars: text.length });
+      setStatusNote(`${file.name} ready.`);
+    } catch {
+      setStatusNote(`Couldn't read ${file.name}.`);
+    }
+  }
+
   function renderFromText(text: string) {
     const trimmed = trimOuterWhitespace(text);
     if (!trimmed) {
@@ -510,10 +560,10 @@ export function LocalLab() {
         <div className="flex flex-col gap-5 lg:flex-row lg:items-start lg:justify-between">
           <div className="min-w-0">
             <div className="font-display text-[1.85rem] font-semibold tracking-tight text-fg sm:text-[2.1rem]">
-              Test models locally
+              Import a build
             </div>
             <div className="mt-1 text-sm text-muted">
-              Tweak the prompt, run it in your model, paste the JSON back here to see the build.
+              Run the prompt anywhere, then import the result here.
             </div>
           </div>
 
@@ -582,7 +632,7 @@ export function LocalLab() {
               <div className="min-w-0">
                 <div className="text-sm font-semibold text-fg">System prompt</div>
                 <div className="text-xs text-muted">
-                  This is what the benchmark uses. Edit freely — the default is one click away.
+                  Adjust it to see how models respond when different qualities are emphasized.
                 </div>
               </div>
               <div className="flex items-center gap-2">
@@ -613,7 +663,7 @@ export function LocalLab() {
 
             <textarea
               aria-label="System prompt"
-              className="mb-field mt-3 min-h-[178px] flex-1 font-mono text-[12px] leading-snug"
+              className="mb-field mb-prompt-scroll mt-3 min-h-[178px] flex-1 font-mono text-[12px] leading-snug"
               value={systemPrompt}
               spellCheck={false}
               onChange={(e) => {
@@ -631,18 +681,32 @@ export function LocalLab() {
                 <div className="text-sm font-semibold text-fg">User prompt</div>
                 <div className="text-xs text-muted">What you want the model to build.</div>
               </div>
-              <CopyButton
-                label="Copy both"
-                text={combinedPrompt}
-                disabled={!taskPrompt.trim()}
-                tone="primary"
-                icon={
-                  <svg aria-hidden="true" className="h-3.5 w-3.5" viewBox="0 0 24 24" fill="none">
-                    <rect x="8" y="8" width="11" height="11" rx="2" stroke="currentColor" strokeWidth="1.8" />
-                    <rect x="5" y="5" width="11" height="11" rx="2" stroke="currentColor" strokeWidth="1.8" />
-                  </svg>
-                }
-              />
+              <div className="flex flex-wrap items-center gap-2">
+                <CopyButton
+                  label="Copy for API"
+                  text={apiPrompt}
+                  disabled={!taskPrompt.trim()}
+                  icon={
+                    <svg aria-hidden="true" className="h-3.5 w-3.5" viewBox="0 0 24 24" fill="none">
+                      <rect x="8" y="8" width="11" height="11" rx="2" stroke="currentColor" strokeWidth="1.8" />
+                      <rect x="5" y="5" width="11" height="11" rx="2" stroke="currentColor" strokeWidth="1.8" />
+                    </svg>
+                  }
+                />
+                <CopyButton
+                  label="Copy for web"
+                  text={webPrompt}
+                  disabled={!taskPrompt.trim()}
+                  tone="primary"
+                  description="Optimized for the web harness. It asks the model to create a downloadable JSON file you can import here."
+                  icon={
+                    <svg aria-hidden="true" className="h-3.5 w-3.5" viewBox="0 0 24 24" fill="none">
+                      <path d="M12 21a9 9 0 1 0 0-18 9 9 0 0 0 0 18Z" stroke="currentColor" strokeWidth="1.8" />
+                      <path d="M3 12h18M12 3c2.4 2.45 3.6 5.45 3.6 9S14.4 18.55 12 21c-2.4-2.45-3.6-5.45-3.6-9S9.6 5.45 12 3Z" stroke="currentColor" strokeWidth="1.8" />
+                    </svg>
+                  }
+                />
+              </div>
             </div>
 
             <input
@@ -660,13 +724,6 @@ export function LocalLab() {
               )}
             </div>
 
-            <p className="mt-3 text-[11px] leading-relaxed text-muted">
-              Running this through a chat UI (chatgpt.com, claude.ai, etc.)? Ask for a JSON file or artifact
-              attachment — otherwise the model will hit its output limit on raw text.
-            </p>
-            <div className="mt-1.5 rounded-lg border border-border/70 bg-bg/45 p-2 font-mono text-[11px] leading-snug text-muted">
-              Return only the final voxel object as a JSON file/artifact attachment.
-            </div>
           </div>
         </div>
 
@@ -674,8 +731,8 @@ export function LocalLab() {
           <div className="mb-panel flex flex-col gap-3 p-4 sm:p-5">
             <div className="flex items-start justify-between gap-3">
               <div>
-                <div className="text-sm font-semibold text-fg">Paste JSON</div>
-                <div className="text-xs text-muted">Drop the model&apos;s JSON output here. Cmd/Ctrl+Enter to render.</div>
+                <div className="text-sm font-semibold text-fg">Import JSON</div>
+                <div className="text-xs text-muted">Paste or drop a JSON file.</div>
               </div>
               <div className="flex items-center gap-2">
                 <button
@@ -704,9 +761,30 @@ export function LocalLab() {
             <textarea
               ref={modelOutputRef}
               aria-label="Paste model JSON output"
-              className="mb-field min-h-[150px] flex-1 font-mono text-[12px] leading-snug"
+              className={cx(
+                "mb-field mb-prompt-scroll min-h-[150px] flex-1 font-mono text-[12px] leading-snug",
+                isDraggingFile ? "border-accent ring-2 ring-accent/20" : "",
+              )}
               placeholder='{"version":"1.0","boxes":[],"lines":[],"blocks":[{"x":0,"y":0,"z":0,"type":"stone"}]}'
               spellCheck={false}
+              onDragEnter={(e) => {
+                if (!e.dataTransfer.types.includes("Files")) return;
+                e.preventDefault();
+                setIsDraggingFile(true);
+              }}
+              onDragOver={(e) => {
+                if (!e.dataTransfer.types.includes("Files")) return;
+                e.preventDefault();
+                e.dataTransfer.dropEffect = "copy";
+                setIsDraggingFile(true);
+              }}
+              onDragLeave={() => setIsDraggingFile(false)}
+              onDrop={(e) => {
+                e.preventDefault();
+                setIsDraggingFile(false);
+                const file = e.dataTransfer.files[0];
+                if (file) void loadJsonFile(file);
+              }}
               onPaste={(e) => {
                 const pasted = e.clipboardData?.getData("text") ?? "";
                 if (!pasted || pasted.length < LARGE_PASTE_CHAR_THRESHOLD) return;

--- a/components/sandbox/Sandbox.tsx
+++ b/components/sandbox/Sandbox.tsx
@@ -1,66 +1,82 @@
 "use client";
 
+import dynamic from "next/dynamic";
 import { useEffect, useState } from "react";
 import { useSearchParams } from "next/navigation";
 import { SandboxBenchmark } from "@/components/sandbox/SandboxBenchmark";
 import { SandboxLive } from "@/components/sandbox/SandboxLive";
-import { buildSandboxModePath, readSandboxUrlMode } from "@/lib/deepLinks";
+import {
+  buildSandboxModePath,
+  readSandboxUrlMode,
+  type SandboxUrlMode,
+} from "@/lib/deepLinks";
 
-type SandboxMode = "benchmark" | "live";
+const LocalLab = dynamic(
+  () => import("@/components/local/LocalLab").then((module) => module.LocalLab),
+  { loading: () => <div aria-hidden="true" className="min-h-[24rem]" /> },
+);
 
-function ModeSegmentedControl({
+function SandboxModeTabs({
   value,
   onChange,
+  hrefFor,
   className,
 }: {
-  value: SandboxMode;
-  onChange: (value: SandboxMode) => void;
+  value: SandboxUrlMode;
+  onChange: (value: SandboxUrlMode) => void;
+  hrefFor: (value: SandboxUrlMode) => string;
   className?: string;
 }) {
-  const options: Array<{ value: SandboxMode; label: string }> = [
-    { value: "benchmark", label: "Model Comparison" },
-    { value: "live", label: "Live Generate" },
+  const options: Array<{ value: SandboxUrlMode; label: string }> = [
+    { value: "benchmark", label: "Compare" },
+    { value: "live", label: "Generate" },
+    { value: "import", label: "Import" },
   ];
 
-  const safeCount = Math.max(1, options.length);
   const activeIndex = Math.max(
     0,
     options.findIndex((option) => option.value === value),
   );
-  const segmentWidth = `${100 / safeCount}%`;
-  const segmentTranslate = `${activeIndex * 100}%`;
 
   return (
-    <div
-      className={`relative flex rounded-xl bg-bg/60 p-1 ring-1 ring-border ${className ?? ""}`}
+    <nav
+      aria-label="Sandbox modes"
+      className={`relative grid grid-cols-3 border-b border-border/70 ${className ?? ""}`}
     >
-      <div className="pointer-events-none absolute inset-1 rounded-lg">
-        <span
-          aria-hidden="true"
-          className="absolute inset-y-0 left-0 rounded-lg bg-accent/15 ring-1 ring-accent/40 transition-transform duration-200 ease-out"
-          style={{
-            width: segmentWidth,
-            transform: `translateX(${segmentTranslate})`,
-          }}
-        />
-      </div>
+      <span
+        aria-hidden="true"
+        className="pointer-events-none absolute -bottom-px left-0 h-0.5 w-1/3 bg-accent transition-transform duration-200 ease-[cubic-bezier(0.22,1,0.36,1)] motion-reduce:transition-none"
+        style={{ transform: `translateX(${activeIndex * 100}%)` }}
+      />
       {options.map((option) => {
         const active = option.value === value;
         return (
-          <button
+          <a
             key={option.value}
-            type="button"
-            aria-pressed={active}
-            className={`relative z-10 h-9 min-w-0 flex-1 rounded-lg px-3 text-xs font-semibold transition-colors duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60 sm:h-10 sm:px-4 sm:text-sm ${
+            aria-current={active ? "page" : undefined}
+            className={`grid min-h-11 min-w-0 place-items-center px-3 text-sm font-semibold transition-colors duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-accent/50 motion-reduce:transition-none ${
               active ? "text-fg" : "text-muted hover:text-fg"
             }`}
-            onClick={() => onChange(option.value)}
+            href={hrefFor(option.value)}
+            onClick={(event) => {
+              if (
+                event.button !== 0 ||
+                event.metaKey ||
+                event.ctrlKey ||
+                event.shiftKey ||
+                event.altKey
+              ) {
+                return;
+              }
+              event.preventDefault();
+              onChange(option.value);
+            }}
           >
             {option.label}
-          </button>
+          </a>
         );
       })}
-    </div>
+    </nav>
   );
 }
 
@@ -69,7 +85,7 @@ export function Sandbox({ initialPrompt }: { initialPrompt?: string }) {
   const searchKey = searchParams.toString();
   const livePrompt =
     searchParams.get("prompt") ?? (searchKey ? undefined : initialPrompt);
-  const [mode, setMode] = useState<SandboxMode>(() =>
+  const [mode, setMode] = useState<SandboxUrlMode>(() =>
     readSandboxUrlMode(new URLSearchParams(searchKey)),
   );
 
@@ -77,7 +93,7 @@ export function Sandbox({ initialPrompt }: { initialPrompt?: string }) {
     setMode(readSandboxUrlMode(new URLSearchParams(searchKey)));
   }, [searchKey]);
 
-  function handleModeChange(nextMode: SandboxMode) {
+  function handleModeChange(nextMode: SandboxUrlMode) {
     setMode(nextMode);
     const nextPath = buildSandboxModePath(
       new URLSearchParams(window.location.search),
@@ -93,17 +109,22 @@ export function Sandbox({ initialPrompt }: { initialPrompt?: string }) {
     <div className="flex flex-col gap-4">
       <div className="flex flex-col items-start gap-3 sm:flex-row sm:items-center sm:justify-between">
         <span className="mb-eyebrow">Sandbox</span>
-        <ModeSegmentedControl
+        <SandboxModeTabs
           value={mode}
           onChange={handleModeChange}
-          className="w-full sm:w-[360px]"
+          hrefFor={(nextMode) =>
+            buildSandboxModePath(new URLSearchParams(searchKey), nextMode)
+          }
+          className="w-full sm:w-[336px]"
         />
       </div>
 
       {mode === "benchmark" ? (
         <SandboxBenchmark />
-      ) : (
+      ) : mode === "live" ? (
         <SandboxLive key={livePrompt ?? "default"} initialPrompt={livePrompt} />
+      ) : (
+        <LocalLab />
       )}
     </div>
   );

--- a/components/sandbox/SandboxBenchmark.tsx
+++ b/components/sandbox/SandboxBenchmark.tsx
@@ -130,8 +130,8 @@ type CachedBuild = {
   variant: ArenaBuildVariant;
 };
 
-const DEFAULT_MODEL_A = "openai_gpt_5_5";
-const DEFAULT_MODEL_B = "openai_gpt_5_5_pro";
+const DEFAULT_MODEL_A = "openai_gpt_5_5_pro";
+const DEFAULT_MODEL_B = "openai_gpt_5_6_sol";
 const DEFAULT_MODEL_SELECTION: SandboxComparisonSelection<string> = {
   a: DEFAULT_MODEL_A,
   b: DEFAULT_MODEL_B,

--- a/components/sandbox/SandboxLive.tsx
+++ b/components/sandbox/SandboxLive.tsx
@@ -69,7 +69,7 @@ const DEFAULT_CUSTOM_MODEL: CustomSandboxModel = {
 const ENABLED_MODELS = MODEL_CATALOG.filter((model) => model.enabled);
 const FALLBACK_MODEL_A: ModelKey = ENABLED_MODELS[0]?.key ?? "openai_gpt_5_4_mini";
 const DEFAULT_MODEL_A: ModelKey =
-  ENABLED_MODELS.find((model) => model.key === "openai_gpt_5_4_mini")?.key ?? FALLBACK_MODEL_A;
+  ENABLED_MODELS.find((model) => model.key === "openai_gpt_5_6_luna")?.key ?? FALLBACK_MODEL_A;
 const DEFAULT_MODEL_B: ModelKey =
   ENABLED_MODELS.find(
     (model) => model.key === "openai_gpt_5_4_nano" && model.key !== DEFAULT_MODEL_A

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -61,7 +61,7 @@ pnpm dev
 To generate fresh builds in `/sandbox`:
 
 1. Open `http://localhost:3000/sandbox`
-2. Switch to `Live Generate`
+2. Switch to `Generate`
 3. Enter either:
    - an `OpenRouter` key, or
    - provider-specific keys (OpenAI, Anthropic, Gemini, Moonshot, DeepSeek, MiniMax, xAI)

--- a/lib/ai/prompts.ts
+++ b/lib/ai/prompts.ts
@@ -103,6 +103,69 @@ ${prompt}
 </build_request>`;
 }
 
+export function buildWebPrompt(opts: {
+  gridSize: number;
+  maxBlocks: number;
+  minBlocks: number;
+  palette: "simple" | "advanced";
+  prompt: string;
+}): string {
+  const center = Math.floor(opts.gridSize / 2);
+  const blockList = getPalette(opts.palette)
+    .map((block) => `- ${block.id}: ${block.name}`)
+    .join("\n");
+
+  return `You are a master 3D voxel architect. Create an immediately recognizable, structurally articulated build with true depth, strong proportions, and thoughtful detail.
+
+## Output format
+
+Return only valid JSON with no markdown or explanation. If the chat interface supports files or artifacts, return the JSON as a downloadable file instead of printing a very large object into the conversation.
+
+{
+  "version": "1.0",
+  "boxes": [{ "x1": 0, "y1": 0, "z1": 0, "x2": 10, "y2": 5, "z2": 10, "type": "block_id" }],
+  "lines": [{ "from": { "x": 0, "y": 0, "z": 0 }, "to": { "x": 0, "y": 10, "z": 0 }, "type": "block_id" }],
+  "blocks": [{ "x": 0, "y": 0, "z": 0, "type": "block_id" }]
+}
+
+- Always include boxes, lines, and blocks, using empty arrays when needed.
+- Use boxes for filled volumes and broad surfaces.
+- Use lines for beams, poles, rails, and other long thin elements.
+- Use individual blocks for details and irregular accents.
+
+## Spatial requirements
+
+- Build a true 3D object, not a flat image or decorated rectangle.
+- Decompose the subject into connected parts that protrude, recess, overlap, and read clearly from multiple angles.
+- Establish the primary silhouette and proportions before adding secondary structure and surface detail.
+- Use negative space for openings, gaps, windows, arches, and separation between parts.
+- Add environmental context only when it strengthens the requested subject and overall composition.
+
+## Quality criteria
+
+The build will be judged on recognizability, 3D structure, prompt fidelity, proportions, detail quality, composition, and overall impression. Concentrate detail around silhouette edges, focal features, joints, openings, and other areas that define the subject.
+
+## Constraints
+
+- Grid coordinates are integers in [0, ${opts.gridSize - 1}].
+- Y is vertical and Y=0 is ground.
+- Center the build around x=${center}, z=${center}.
+- Minimum ${opts.minBlocks.toLocaleString("en-US")} blocks.
+- Maximum ${opts.maxBlocks.toLocaleString("en-US")} blocks after boxes and lines are expanded.
+- Every block type must come from the selected ${opts.palette} palette below.
+- Do not use an air block. Leave coordinates empty to create open space.
+
+## Available blocks
+
+${blockList}
+
+## Build request
+
+${opts.prompt.trim()}
+
+Before producing the file, plan the complete structure, coordinate bounds, materials, scene composition, and construction order internally. Return only the final JSON object as a file or artifact when possible.`;
+}
+
 export function buildRepairPrompt(params: { error: string; previousOutput: string; originalPrompt: string }): string {
   return `Your previous output was invalid.
 Reason: ${params.error}

--- a/lib/deepLinks.ts
+++ b/lib/deepLinks.ts
@@ -5,7 +5,7 @@ export type SandboxComparisonDeepLink = {
   modelKeys: string[];
   promptId: string | null;
 };
-export type SandboxUrlMode = "benchmark" | "live";
+export type SandboxUrlMode = "benchmark" | "live" | "import";
 
 function buildPath(pathname: string, params: URLSearchParams): string {
   const query = params.toString();
@@ -63,6 +63,7 @@ export function buildSandboxComparisonPath(
 
 export function readSandboxUrlMode(params: URLSearchParams): SandboxUrlMode {
   if (params.has("models") || params.has("promptId")) return "benchmark";
+  if (params.get("mode") === "import") return "import";
   if (params.get("mode") === "live" || params.get("prompt")?.trim()) return "live";
   return "benchmark";
 }
@@ -77,6 +78,12 @@ export function buildSandboxModePath(
     params.delete("promptId");
     for (const param of SANDBOX_LEGACY_MODEL_PARAMS) params.delete(param);
     params.set("mode", "live");
+  } else if (mode === "import") {
+    params.delete("models");
+    params.delete("promptId");
+    params.delete("prompt");
+    for (const param of SANDBOX_LEGACY_MODEL_PARAMS) params.delete(param);
+    params.set("mode", "import");
   } else {
     params.delete("prompt");
     params.delete("mode");

--- a/lib/faq.ts
+++ b/lib/faq.ts
@@ -143,10 +143,10 @@ export const FAQ_SECTIONS: readonly FaqSection[] = [
         question: "Can models that are not on the official leaderboard be tested?",
         answer: [
           "Yes.",
-          "The Local Lab allows MineBench instructions to be used with models that are not directly integrated. The model can generate the expected output externally, and the result can then be loaded into MineBench and rendered.",
+          "The Sandbox Import workspace allows MineBench instructions to be used with models that are not directly integrated. The model can generate the expected output externally, and the result can then be loaded into MineBench and rendered.",
           "Those generations are useful for experimentation but should not be treated as official leaderboard results unless they were produced under the same controlled settings.",
         ],
-        links: [{ label: "Open Local Lab", href: "/local" }],
+        links: [{ label: "Open Import", href: "/sandbox?mode=import" }],
       },
       {
         id: "why-is-a-model-missing",

--- a/tests/ui/sandbox-workspaces.test.ts
+++ b/tests/ui/sandbox-workspaces.test.ts
@@ -1,0 +1,74 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const sandboxSource = readFileSync("components/sandbox/Sandbox.tsx", "utf8");
+const sandboxBenchmarkSource = readFileSync("components/sandbox/SandboxBenchmark.tsx", "utf8");
+const sandboxLiveSource = readFileSync("components/sandbox/SandboxLive.tsx", "utf8");
+const headerSource = readFileSync("components/SiteHeader.tsx", "utf8");
+const localRouteSource = readFileSync("app/local/page.tsx", "utf8");
+const localLabSource = readFileSync("components/local/LocalLab.tsx", "utf8");
+
+for (const label of ["Compare", "Generate", "Import"]) {
+  assert.ok(sandboxSource.includes(`label: "${label}"`), `missing ${label} mode`);
+}
+
+assert.ok(
+  sandboxLiveSource.includes('model.key === "openai_gpt_5_6_luna"'),
+  "Generate should default to GPT 5.6 Luna",
+);
+assert.ok(
+  sandboxBenchmarkSource.includes('const DEFAULT_MODEL_A = "openai_gpt_5_5_pro"') &&
+    sandboxBenchmarkSource.includes('const DEFAULT_MODEL_B = "openai_gpt_5_6_sol"'),
+  "Compare should default to GPT 5.5 Pro versus GPT 5.6 Sol Pro",
+);
+
+assert.ok(
+  sandboxSource.includes('aria-label="Sandbox modes"') &&
+    sandboxSource.includes("grid grid-cols-3 border-b border-border/70") &&
+    sandboxSource.includes("-bottom-px left-0 h-0.5 w-1/3") &&
+    sandboxSource.includes('aria-current={active ? "page" : undefined}'),
+  "Sandbox modes should use flat navigation with a shared underline",
+);
+assert.ok(
+  sandboxSource.includes("min-h-11") &&
+    sandboxSource.includes('className="w-full sm:w-[336px]"'),
+  "Sandbox modes should retain mobile-sized touch targets and a compact desktop width",
+);
+assert.ok(
+  sandboxSource.includes('import("@/components/local/LocalLab")') &&
+    sandboxSource.includes("<LocalLab />") &&
+    !sandboxSource.includes("Model Comparison") &&
+    !sandboxSource.includes("Live Generate"),
+  "Import should reuse the Local Lab inside the three-mode Sandbox",
+);
+assert.ok(
+  !headerSource.includes('<NavLink href="/local"') &&
+    localRouteSource.includes('redirect("/sandbox?mode=import")'),
+  "Local should leave the global header and remain as a compatibility redirect",
+);
+assert.ok(
+  localLabSource.includes("Import a build") &&
+    localLabSource.includes("Run the prompt anywhere, then import the result here.") &&
+    localLabSource.includes("Adjust it to see how models respond when different qualities are emphasized."),
+  "the imported workspace should use direct, location-independent copy",
+);
+assert.ok(
+  localLabSource.includes('label="Copy for API"') &&
+    localLabSource.includes('label="Copy for web"') &&
+    localLabSource.includes("buildWebPrompt") &&
+    localLabSource.includes("Optimized for the web harness") &&
+    !localLabSource.includes("Running this through a chat UI") &&
+    !localLabSource.includes("Return only the final voxel object as a JSON file/artifact attachment."),
+  "Import should provide complete API and web prompts without a separate instruction layer",
+);
+assert.ok(
+  localLabSource.includes("Import JSON") &&
+    localLabSource.includes("Paste or drop a JSON file.") &&
+    localLabSource.includes("async function loadJsonFile") &&
+    localLabSource.includes("onDrop={(e) =>") &&
+    localLabSource.includes("file.text()") &&
+    localLabSource.includes("mb-prompt-scroll"),
+  "Import should accept dropped JSON files through the existing input flow",
+);
+
+console.log("sandbox workspace UI checks passed");

--- a/tests/unit/ai/web-prompt.test.ts
+++ b/tests/unit/ai/web-prompt.test.ts
@@ -1,0 +1,34 @@
+import assert from "node:assert/strict";
+import { buildWebPrompt } from "../../../lib/ai/prompts";
+
+const prompt = buildWebPrompt({
+  gridSize: 64,
+  minBlocks: 200,
+  maxBlocks: 196_608,
+  palette: "simple",
+  prompt: "A medieval castle with four corner towers",
+});
+
+assert.ok(prompt.includes("Grid coordinates are integers in [0, 63]."));
+assert.ok(prompt.includes("Center the build around x=32, z=32."));
+assert.ok(prompt.includes("Minimum 200 blocks."));
+assert.ok(prompt.includes("Maximum 196,608 blocks"));
+assert.ok(prompt.includes("- stone: Stone"));
+assert.ok(!prompt.includes("mossy_stone_bricks"));
+assert.ok(prompt.includes("A medieval castle with four corner towers"));
+assert.ok(prompt.includes('"boxes"') && prompt.includes('"lines"') && prompt.includes('"blocks"'));
+assert.ok(!prompt.includes("voxel.exec"));
+assert.ok(prompt.includes("downloadable file"));
+
+const advancedPrompt = buildWebPrompt({
+  gridSize: 128,
+  minBlocks: 500,
+  maxBlocks: 500_000,
+  palette: "advanced",
+  prompt: "A locomotive",
+});
+
+assert.ok(advancedPrompt.includes("Grid coordinates are integers in [0, 127]."));
+assert.ok(advancedPrompt.includes("- mossy_stone_bricks: Mossy Stone Bricks"));
+
+console.log("web prompt checks passed");

--- a/tests/unit/deep-links.test.ts
+++ b/tests/unit/deep-links.test.ts
@@ -71,6 +71,14 @@ assert.equal(
   "benchmark",
 );
 assert.equal(
+  readSandboxUrlMode(new URLSearchParams("mode=import")),
+  "import",
+);
+assert.equal(
+  readSandboxUrlMode(new URLSearchParams("mode=import&prompt=build+a+castle")),
+  "import",
+);
+assert.equal(
   buildSandboxModePath(
     new URLSearchParams("models=model-a,model-b&promptId=prompt-1&utm_source=share"),
     "live",
@@ -83,6 +91,19 @@ assert.equal(
     "benchmark",
   ),
   "/sandbox",
+);
+assert.equal(
+  buildSandboxModePath(
+    new URLSearchParams(
+      "models=model-a,model-b&promptId=prompt-1&prompt=old+prompt&utm_source=share",
+    ),
+    "import",
+  ),
+  "/sandbox?utm_source=share&mode=import",
+);
+assert.equal(
+  buildSandboxModePath(new URLSearchParams("mode=import"), "live"),
+  "/sandbox?mode=live",
 );
 
 assert.equal(


### PR DESCRIPTION
## Summary

- organize Compare, Generate, and Import as lightweight workspaces within Sandbox
- move Local Lab into Import while preserving `/local` as a compatibility redirect
- add API and web-harness prompt copying plus pasted or dropped JSON imports
- default Generate to GPT 5.6 Luna Pro and Compare to GPT 5.5 Pro versus GPT 5.6 Sol Pro
- preserve shareable Sandbox URLs across all three workspaces

## Validation

- `pnpm exec tsc --noEmit`
- `pnpm lint`
- `pnpm test`
- `pnpm build`
- `git diff --check`
- `graphify update .`

*(PR written by Codex)*
