### PR TITLE
(perf) streamline arena storage and client memory

### DIFF
--- a/app/api/arena/builds/[buildId]/route.ts
+++ b/app/api/arena/builds/[buildId]/route.ts
@@ -4,7 +4,7 @@ import type { ArenaBuildVariant } from "@/lib/arena/types";
 import {
   deriveArenaBuildLoadHints,
   getCachedPreparedArenaBuild,
-  getPreparedArenaBuildMetadataUpdate,
+  getPreparedArenaBuildCoreMetadataUpdate,
   pickBuildVariant,
   prepareArenaBuild,
 } from "@/lib/arena/buildArtifacts";
@@ -510,10 +510,11 @@ export async function GET(
   const voxelBuild = pickBuildVariant(prepared, variant);
   after(async () => {
     // write metadata and artifacts off the response path
+    console.log(`arena metadata heal (build) build=${prepared.buildId}`);
     const marked = await prisma.build
       .updateMany({
         where: prepared.payloadIdentity,
-        data: getPreparedArenaBuildMetadataUpdate(prepared),
+        data: getPreparedArenaBuildCoreMetadataUpdate(prepared),
       })
       .catch(() => null);
     if (!marked || marked.count === 0) return;

--- a/app/api/arena/builds/[buildId]/route.ts
+++ b/app/api/arena/builds/[buildId]/route.ts
@@ -52,6 +52,8 @@ const JSON_RESPONSE_CACHE_MAX_WEIGHT = Number.parseInt(
 
 type CachedJsonResponse = {
   bytes: Uint8Array;
+  // which path produced this body, so a cached fallback still reports as one
+  source: "db-snapshot" | "live";
   byteWeight: number;
   touchedAt: number;
 };
@@ -165,18 +167,19 @@ function pruneJsonResponseCache() {
   }
 }
 
-function getCachedJsonResponseByKey(key: string): Uint8Array | null {
+function getCachedJsonResponseByKey(key: string): CachedJsonResponse | null {
   const cached = jsonResponseCache.get(key);
   if (!cached) return null;
   cached.touchedAt = Date.now();
   jsonResponseCache.delete(key);
   jsonResponseCache.set(key, cached);
-  return cached.bytes;
+  return cached;
 }
 
 function rememberJsonResponseByKey(
   key: string,
   bytes: Uint8Array,
+  source: CachedJsonResponse["source"],
 ) {
   if (bytes.byteLength > JSON_RESPONSE_CACHE_MAX_WEIGHT) return;
   const previous = jsonResponseCache.get(key);
@@ -186,6 +189,7 @@ function rememberJsonResponseByKey(
   }
   jsonResponseCache.set(key, {
     bytes,
+    source,
     byteWeight: bytes.byteLength,
     touchedAt: Date.now(),
   });
@@ -200,18 +204,20 @@ function rememberJsonResponse(
   hints: unknown,
   gzip: boolean,
   bytes: Uint8Array,
+  source: CachedJsonResponse["source"],
 ) {
   const key = buildJsonResponseCacheKey(buildId, variant, checksum, hints, gzip);
   if (!key) return;
-  rememberJsonResponseByKey(key, bytes);
+  rememberJsonResponseByKey(key, bytes, source);
 }
 
 async function getOrCreateJsonResponse(
   key: string,
+  source: CachedJsonResponse["source"],
   create: () => Promise<Uint8Array | null>,
 ): Promise<Uint8Array | null> {
   const cached = getCachedJsonResponseByKey(key);
-  if (cached) return cached;
+  if (cached) return cached.bytes;
 
   const existing = jsonResponseInflight.get(key);
   // share db snapshot serialization across concurrent clients
@@ -219,7 +225,7 @@ async function getOrCreateJsonResponse(
 
   const promise = (async () => {
     const bytes = await create();
-    if (bytes) rememberJsonResponseByKey(key, bytes);
+    if (bytes) rememberJsonResponseByKey(key, bytes, source);
     return bytes;
   })();
   jsonResponseInflight.set(key, promise);
@@ -350,19 +356,6 @@ export async function GET(
     shellHints,
     shouldGzip,
   );
-  const cachedJsonResponse = jsonCacheKey ? getCachedJsonResponseByKey(jsonCacheKey) : null;
-  if (cachedJsonResponse) {
-    timing.end("total", requestStartedAt);
-    const headers = createJsonHeaders({
-      byteLength: cachedJsonResponse.byteLength,
-      deliveryClass: variant === "preview" ? shellHints.initialDeliveryClass : shellHints.deliveryClass,
-      source: "response-cache",
-      gzip: shouldGzip,
-    });
-    timing.apply(headers);
-    return new Response(Buffer.from(cachedJsonResponse), { headers });
-  }
-
   // storage-first: the checksum-addressed artifact is the canonical snapshot
   try {
     if (artifactAllowed && canServeSnapshotArtifact) {
@@ -399,8 +392,27 @@ export async function GET(
     console.warn("arena snapshot artifact fetch failed", error);
   }
 
+  const cachedJsonResponse = jsonCacheKey ? getCachedJsonResponseByKey(jsonCacheKey) : null;
+  if (cachedJsonResponse) {
+    // a cached fallback body must still report as the fallback it is, or a
+    // soak measuring db-fallback traffic reads clean while serving it
+    if (cachedJsonResponse.source === "db-snapshot") {
+      console.log(`arena snapshot db fallback (build cached) build=${buildId} variant=${variant}`);
+    }
+    timing.end("total", requestStartedAt);
+    const headers = createJsonHeaders({
+      byteLength: cachedJsonResponse.bytes.byteLength,
+      deliveryClass: variant === "preview" ? shellHints.initialDeliveryClass : shellHints.deliveryClass,
+      source: `response-cache:${cachedJsonResponse.source}`,
+      gzip: shouldGzip,
+    });
+    timing.apply(headers);
+    return new Response(Buffer.from(cachedJsonResponse.bytes), { headers });
+  }
+
+
   const persistedResponseBytes = jsonCacheKey
-    ? await getOrCreateJsonResponse(jsonCacheKey, async () => {
+    ? await getOrCreateJsonResponse(jsonCacheKey, "db-snapshot", async () => {
         // snapshot json bodies live outside the meta cache to avoid retaining
         // multi-mb blobs across many buildIds. the response cache covers
         // subsequent identical requests with its own byte-weight cap.
@@ -543,7 +555,15 @@ export async function GET(
     },
     shouldGzip,
   );
-  rememberJsonResponse(prepared.buildId, variant, prepared.checksum, prepared.hints, shouldGzip, responseBytes);
+  rememberJsonResponse(
+    prepared.buildId,
+    variant,
+    prepared.checksum,
+    prepared.hints,
+    shouldGzip,
+    responseBytes,
+    "live",
+  );
   timing.end("total", requestStartedAt);
   const headers = createJsonHeaders({
     byteLength: responseBytes.byteLength,

--- a/app/api/arena/builds/[buildId]/route.ts
+++ b/app/api/arena/builds/[buildId]/route.ts
@@ -376,15 +376,22 @@ export async function GET(
       if (artifactBytes) {
         timing.end("artifact_hit", artifactStartedAt);
         timing.end("total", requestStartedAt);
+        // the stored object is gzip; proxying it verbatim to a gzip-capable
+        // client keeps snapshot-class fallbacks off the uncompressed path
+        const body = shouldGzip ? gzipSync(Buffer.from(artifactBytes)) : artifactBytes;
         const headers = new Headers({
           "Cache-Control": "public, max-age=0, s-maxage=300, stale-while-revalidate=86400, no-transform",
           "Content-Type": "application/json; charset=utf-8",
-          "Content-Length": String(artifactBytes.byteLength),
+          "Content-Length": String(body.byteLength),
           "x-build-delivery-class": deliveryClass,
           "x-build-source": "artifact",
         });
+        if (shouldGzip) {
+          headers.set("Content-Encoding", "gzip");
+          headers.set("Vary", "Accept-Encoding");
+        }
         timing.apply(headers);
-        return new Response(Buffer.from(artifactBytes), { headers });
+        return new Response(Buffer.from(body), { headers });
       }
       timing.end("artifact_miss", artifactStartedAt);
     }

--- a/app/api/arena/builds/[buildId]/route.ts
+++ b/app/api/arena/builds/[buildId]/route.ts
@@ -28,7 +28,7 @@ const SNAPSHOT_ARTIFACT_FETCH_TIMEOUT_MS = Number.parseInt(
   10,
 );
 const SNAPSHOT_ARTIFACT_FETCH_ENABLED =
-  (process.env.ARENA_SNAPSHOT_ARTIFACT_FETCH_ENABLED ?? "0").trim() === "1";
+  (process.env.ARENA_SNAPSHOT_ARTIFACT_FETCH_ENABLED ?? "1").trim() === "1";
 const SNAPSHOT_ARTIFACT_REDIRECT_ENABLED =
   (process.env.ARENA_SNAPSHOT_ARTIFACT_REDIRECT_ENABLED ?? "1").trim() !== "0";
 const SNAPSHOT_PREVIEW_ARTIFACT_REDIRECT_ENABLED =
@@ -281,7 +281,6 @@ export async function GET(
   const artifactAllowed =
     SNAPSHOT_ARTIFACT_FETCH_ENABLED &&
     url.searchParams.get("artifact") !== "0" &&
-    Boolean(expectedChecksum) &&
     Boolean(storedChecksum);
   const shellHints = deriveArenaBuildLoadHints({
     blockCount: buildMeta.blockCount,
@@ -364,6 +363,35 @@ export async function GET(
     return new Response(Buffer.from(cachedJsonResponse), { headers });
   }
 
+  // storage-first: the checksum-addressed artifact is the canonical snapshot
+  try {
+    if (artifactAllowed && canServeSnapshotArtifact) {
+      const artifactStartedAt = timing.start();
+      const artifactBytes = await withTimeout(
+        (signal) =>
+          fetchArenaBuildSnapshotArtifact(buildId, variant, storedChecksum, { signal }),
+        SNAPSHOT_ARTIFACT_FETCH_TIMEOUT_MS,
+        "snapshot artifact fetch",
+      );
+      if (artifactBytes) {
+        timing.end("artifact_hit", artifactStartedAt);
+        timing.end("total", requestStartedAt);
+        const headers = new Headers({
+          "Cache-Control": "public, max-age=0, s-maxage=300, stale-while-revalidate=86400, no-transform",
+          "Content-Type": "application/json; charset=utf-8",
+          "Content-Length": String(artifactBytes.byteLength),
+          "x-build-delivery-class": deliveryClass,
+          "x-build-source": "artifact",
+        });
+        timing.apply(headers);
+        return new Response(Buffer.from(artifactBytes), { headers });
+      }
+      timing.end("artifact_miss", artifactStartedAt);
+    }
+  } catch (error) {
+    console.warn("arena snapshot artifact fetch failed", error);
+  }
+
   const persistedResponseBytes = jsonCacheKey
     ? await getOrCreateJsonResponse(jsonCacheKey, async () => {
         // snapshot json bodies live outside the meta cache to avoid retaining
@@ -386,6 +414,8 @@ export async function GET(
       })
     : null;
   if (persistedResponseBytes) {
+    // fallback hits must reach zero during the soak before columns can drop
+    console.log(`arena snapshot db fallback (build) build=${buildId} variant=${variant}`);
     timing.end("total", requestStartedAt);
     const headers = createJsonHeaders({
       byteLength: persistedResponseBytes.byteLength,
@@ -414,34 +444,6 @@ export async function GET(
       },
       { status: 503, headers },
     );
-  }
-
-  try {
-    if (artifactAllowed && canServeSnapshotArtifact) {
-      const artifactStartedAt = timing.start();
-      const artifactBytes = await withTimeout(
-        (signal) =>
-          fetchArenaBuildSnapshotArtifact(buildId, variant, storedChecksum, { signal }),
-        SNAPSHOT_ARTIFACT_FETCH_TIMEOUT_MS,
-        "snapshot artifact fetch",
-      );
-      if (artifactBytes) {
-        timing.end("artifact_hit", artifactStartedAt);
-        timing.end("total", requestStartedAt);
-        const headers = new Headers({
-          "Cache-Control": "public, max-age=0, s-maxage=300, stale-while-revalidate=86400, no-transform",
-          "Content-Type": "application/json; charset=utf-8",
-          "Content-Length": String(artifactBytes.byteLength),
-          "x-build-delivery-class": deliveryClass,
-          "x-build-source": "artifact",
-        });
-        timing.apply(headers);
-        return new Response(Buffer.from(artifactBytes), { headers });
-      }
-      timing.end("artifact_miss", artifactStartedAt);
-    }
-  } catch (error) {
-    console.warn("arena snapshot artifact fetch failed", error);
   }
 
   if (variant === "full" && shellHints.deliveryClass === "stream-artifact") {

--- a/app/api/arena/builds/[buildId]/stream/route.ts
+++ b/app/api/arena/builds/[buildId]/stream/route.ts
@@ -14,7 +14,7 @@ import {
 import {
   deriveArenaBuildLoadHints,
   getCachedPreparedArenaBuild,
-  getPreparedArenaBuildMetadataUpdate,
+  getPreparedArenaBuildCoreMetadataUpdate,
   pickBuildVariant,
   prepareArenaBuild,
 } from "@/lib/arena/buildArtifacts";
@@ -441,10 +441,11 @@ export async function GET(
           if (closed || request.signal.aborted) return;
 
           if (!cachedPrepared) {
+            console.log(`arena metadata heal (stream) build=${buildId}`);
             const marked = await prisma.build
               .updateMany({
                 where: prepared.payloadIdentity,
-                data: getPreparedArenaBuildMetadataUpdate(prepared),
+                data: getPreparedArenaBuildCoreMetadataUpdate(prepared),
               })
               .catch((err) => {
                 console.warn("arena stream metadata update failed", err);

--- a/app/api/arena/matchup/route.ts
+++ b/app/api/arena/matchup/route.ts
@@ -11,7 +11,10 @@ import {
   prepareArenaBuild,
   type PreparedArenaBuild,
 } from "@/lib/arena/buildArtifacts";
-import { createArenaBuildSnapshotArtifactSignedUrl } from "@/lib/arena/buildSnapshotArtifacts";
+import {
+  createArenaBuildSnapshotArtifactSignedUrl,
+  fetchArenaBuildSnapshotArtifactPayload,
+} from "@/lib/arena/buildSnapshotArtifacts";
 import { createArenaBuildStreamArtifactSignedUrl } from "@/lib/arena/buildStream";
 import { invalidateArenaBuildMeta } from "@/lib/arena/buildMetaCache";
 import { normalizeArenaBuildChecksum } from "@/lib/arena/buildChecksum";
@@ -173,6 +176,50 @@ function pickPersistedInitialBuild(
     hints.initialVariant,
     storedChecksum,
   );
+}
+
+const SNAPSHOT_ARTIFACT_FETCH_TIMEOUT_MS = Number.parseInt(
+  process.env.ARENA_SNAPSHOT_ARTIFACT_FETCH_TIMEOUT_MS ?? "5000",
+  10,
+);
+
+async function resolveInitialBuildSnapshot(
+  buildId: string,
+  hints: ArenaBuildLoadHints,
+  row: {
+    voxelSha256: string | null;
+    arenaSnapshotPreview: unknown | null;
+    arenaSnapshotPreviewChecksum: string | null;
+    arenaSnapshotFull: unknown | null;
+    arenaSnapshotFullChecksum: string | null;
+  },
+): Promise<ArenaMatchup["a"]["build"]> {
+  const storedChecksum = row.voxelSha256?.trim() || null;
+  // storage-first: the checksum-addressed artifact is the canonical snapshot
+  try {
+    const artifact = await fetchArenaBuildSnapshotArtifactPayload(
+      buildId,
+      hints.initialVariant,
+      storedChecksum,
+      { signal: AbortSignal.timeout(SNAPSHOT_ARTIFACT_FETCH_TIMEOUT_MS) },
+    );
+    if (artifact) return artifact.voxelBuild as ArenaMatchup["a"]["build"];
+  } catch {
+    // storage failure still has the db snapshot columns below
+  }
+  const persisted = pickPersistedInitialBuild(
+    hints,
+    row.arenaSnapshotFull,
+    row.arenaSnapshotFullChecksum,
+    row.arenaSnapshotPreview,
+    row.arenaSnapshotPreviewChecksum,
+    storedChecksum,
+  );
+  if (persisted) {
+    // fallback hits must reach zero during the soak before columns can drop
+    console.log(`arena snapshot db fallback (matchup) build=${buildId} variant=${hints.initialVariant}`);
+  }
+  return persisted;
 }
 
 async function warmFullBuildArtifactUrl(
@@ -846,26 +893,14 @@ export async function GET(req: Request) {
         return respondJson({ error: "Missing seeded build payload" }, { status: 500 });
       }
 
-      if (checksumA && shouldPrepareA && !preparedA && buildAForPrepare) {
-        persistedInitialBuildA = pickPersistedInitialBuild(
-          shellHintsA,
-          buildAForPrepare.arenaSnapshotFull,
-          buildAForPrepare.arenaSnapshotFullChecksum,
-          buildAForPrepare.arenaSnapshotPreview,
-          buildAForPrepare.arenaSnapshotPreviewChecksum,
-          buildAForPrepare.voxelSha256?.trim() || null,
-        );
-      }
-      if (checksumB && shouldPrepareB && !preparedB && buildBForPrepare) {
-        persistedInitialBuildB = pickPersistedInitialBuild(
-          shellHintsB,
-          buildBForPrepare.arenaSnapshotFull,
-          buildBForPrepare.arenaSnapshotFullChecksum,
-          buildBForPrepare.arenaSnapshotPreview,
-          buildBForPrepare.arenaSnapshotPreviewChecksum,
-          buildBForPrepare.voxelSha256?.trim() || null,
-        );
-      }
+      [persistedInitialBuildA, persistedInitialBuildB] = await Promise.all([
+        checksumA && shouldPrepareA && !preparedA && buildAForPrepare
+          ? resolveInitialBuildSnapshot(buildA.id, shellHintsA, buildAForPrepare)
+          : Promise.resolve(null),
+        checksumB && shouldPrepareB && !preparedB && buildBForPrepare
+          ? resolveInitialBuildSnapshot(buildB.id, shellHintsB, buildBForPrepare)
+          : Promise.resolve(null),
+      ]);
 
       [preparedA, preparedB] = await Promise.all([
 	        preparedA || persistedInitialBuildA

--- a/app/api/arena/matchup/route.ts
+++ b/app/api/arena/matchup/route.ts
@@ -6,7 +6,7 @@ import { expectedScore } from "@/lib/arena/rating";
 import {
   deriveArenaBuildLoadHints,
   getCachedPreparedArenaBuild,
-  getPreparedArenaBuildMetadataUpdate,
+  getPreparedArenaBuildCoreMetadataUpdate,
   pickInitialBuild,
   prepareArenaBuild,
   type PreparedArenaBuild,
@@ -133,9 +133,10 @@ async function prepareArenaBuildById(buildId: string) {
 async function persistPreparedArenaBuildMetadata(
   prepared: PreparedArenaBuild,
 ): Promise<boolean> {
+  console.log(`arena metadata heal (matchup) build=${prepared.buildId}`);
   const result = await prisma.build.updateMany({
     where: prepared.payloadIdentity,
-    data: getPreparedArenaBuildMetadataUpdate(prepared),
+    data: getPreparedArenaBuildCoreMetadataUpdate(prepared),
   });
   invalidateArenaBuildMeta(prepared.buildId);
   return result.count > 0;

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,116 @@
+# Architecture: Data Model and Build Delivery
+
+Three views of how MineBench stores and serves arena builds: the database
+entities, the lifecycle of a build from generation to a rendered mesh, and the
+decision flow that picks a delivery route per request.
+
+## Database entities
+
+```mermaid
+erDiagram
+    Model ||--o{ Build : "generates"
+    Model ||--o{ ModelRankSnapshot : "rank history"
+    Model ||--o{ ArenaShownJob : "impression queue"
+    Prompt ||--o{ Build : "answered by"
+    Prompt ||--o{ Matchup : "compared on"
+    Model ||--o{ Matchup : "as A or B"
+    Build ||--o{ Matchup : "as A or B"
+    Matchup ||--o{ Vote : "receives"
+    Vote ||--|| ArenaVoteJob : "queues"
+    Model ||--o{ ArenaCoverageModelPrompt : "decisive votes"
+    Prompt ||--o{ ArenaCoverageModelPrompt : ""
+    Model ||--o{ ArenaCoveragePair : "as low or high"
+    Model ||--o{ ArenaCoveragePairPrompt : "as low or high"
+
+    Model {
+        string key UK
+        string slug "derived from catalog"
+        boolean enabled "activation boundary"
+        float eloRating
+        float glickoRd
+        float conservativeRating
+        int shownCount
+    }
+    Prompt {
+        string text
+        boolean active "benchmark cohort or imported custom"
+    }
+    Build {
+        int gridSize
+        string palette
+        string mode
+        json voxelData "inline payload, small builds only"
+        string voxelStoragePath "canonical gzip payload in storage"
+        string voxelSha256 "content checksum, addresses artifacts"
+        json arenaBuildHints "delivery class, variants, sizes"
+        json arenaSnapshotPreview "LEGACY: leaving Postgres (Phase 2.2)"
+        json arenaSnapshotFull "LEGACY: leaving Postgres (Phase 2.2)"
+    }
+    Vote {
+        string sessionId
+        string choice "A / B / TIE / BOTH_BAD"
+    }
+    ArenaVoteJob {
+        datetime processedAt "drained by SKIP LOCKED batches"
+    }
+    ArenaShownJob {
+        datetime processedAt "drained by SKIP LOCKED batches"
+        int count
+    }
+```
+
+Rating state lives on `Model` and is updated only by the vote-job drain (one
+advisory-locked writer). Coverage tables hold decisive-vote tallies for
+matchup sampling. Both job tables are append-then-drain queues; processed rows
+older than 30 days are pruned by `pnpm arena:jobs:prune`.
+
+## Build lifecycle
+
+```mermaid
+flowchart TD
+    G["pnpm batch:generate --generate<br/>provider adapters, validation"] --> U["uploads/&lt;prompt&gt;/&lt;prompt&gt;-&lt;slug&gt;.json<br/>box/block spec + raw artifacts"]
+    U --> P["pnpm model:publish --model &lt;slug&gt;"]
+    P --> I["POST /api/admin/import-build<br/>expands spec, stores gzip payload,<br/>upserts Build (staged: enabled=false)"]
+    I --> S[("Supabase Storage<br/>canonical build payloads")]
+    P --> M["maintenance, missing-only:<br/>metadata backfill, snapshot artifacts,<br/>stream artifacts"]
+    M --> A[("checksum-addressed artifacts<br/>arena-snapshot/v2-gzip<br/>arena-stream/v3-gzip")]
+    P --> V{"policy-aware verification<br/>getArenaArtifactCoverage"}
+    V -- incomplete --> X["hard fail, model stays disabled"]
+    V -- complete --> R["metrics refresh<br/>(records promptCohortId)"]
+    R --> E["activation: enabled=true<br/>arena + leaderboard caches invalidated"]
+    E --> D["delivery: matchup / build / stream routes"]
+    D --> W["client: gzip JSON to blocks<br/>transferable typed arrays to mesh worker<br/>meshed geometry back via transfer"]
+```
+
+A model can never reach public surfaces with a partial cohort: imports stage it
+disabled and only publish verification activates it. `arena:artifacts:audit
+--deep` re-validates everything end to end (fetch, decompress, parse, checksum,
+signed-URL delivery).
+
+## Delivery decision flow
+
+```mermaid
+flowchart TD
+    Q["request for build variant<br/>(preview or full)"] --> C{"delivery class<br/>from arenaBuildHints"}
+    C -- "inline ≤2MiB" --> IN["inlined in matchup response<br/>(adaptive mode, prepared cache or snapshot)"]
+    C -- "snapshot ≤15MiB" --> SR{"signed-URL redirect<br/>available?"}
+    C -- "stream-artifact" --> ST["stream route: 307 to ndjson artifact,<br/>else live-parsed ndjson stream"]
+    SR -- yes --> S307["307 to immutable storage object<br/>(browser downloads directly)"]
+    SR -- no --> AF{"snapshot artifact<br/>fetch (storage-first)"}
+    AF -- hit --> ASRV["serve artifact bytes"]
+    AF -- miss --> DB{"legacy DB snapshot<br/>columns (fallback, instrumented)"}
+    DB -- hit --> DSRV["serve db snapshot<br/>(logged: must reach zero before columns drop)"]
+    DB -- miss --> LP["live prepare: parse canonical payload,<br/>validate, cache, heal core metadata"]
+    ST --> VOTE
+    IN --> VOTE
+    S307 --> VOTE
+    ASRV --> VOTE
+    DSRV --> VOTE
+    LP --> VOTE["voting unlocks only after<br/>the full build hydrates"]
+```
+
+Artifacts are immutable and checksum-addressed, so every cache layer (CDN,
+signed-URL cache, in-process body caches, client IndexedDB mesh cache) can
+treat a hit as final. The DB snapshot columns are a compatibility fallback
+scheduled for removal once production logs show zero fallback hits
+(`arena snapshot db fallback` lines) through a full soak window.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -16,7 +16,7 @@ erDiagram
     Model ||--o{ Matchup : "as A or B"
     Build ||--o{ Matchup : "as A or B"
     Matchup ||--o{ Vote : "receives"
-    Vote ||--|| ArenaVoteJob : "queues"
+    Vote ||--o| ArenaVoteJob : "queues"
     Model ||--o{ ArenaCoverageModelPrompt : "decisive votes"
     Prompt ||--o{ ArenaCoverageModelPrompt : ""
     Model ||--o{ ArenaCoveragePair : "as low or high"
@@ -24,7 +24,6 @@ erDiagram
 
     Model {
         string key UK
-        string slug "derived from catalog"
         boolean enabled "activation boundary"
         float eloRating
         float glickoRd
@@ -44,7 +43,9 @@ erDiagram
         string voxelSha256 "content checksum, addresses artifacts"
         json arenaBuildHints "delivery class, variants, sizes"
         json arenaSnapshotPreview "LEGACY: leaving Postgres (Phase 2.2)"
+        string arenaSnapshotPreviewChecksum "LEGACY: leaving Postgres (Phase 2.2)"
         json arenaSnapshotFull "LEGACY: leaving Postgres (Phase 2.2)"
+        string arenaSnapshotFullChecksum "LEGACY: leaving Postgres (Phase 2.2)"
     }
     Vote {
         string sessionId

--- a/lib/arena/buildArtifacts.ts
+++ b/lib/arena/buildArtifacts.ts
@@ -260,6 +260,16 @@ export function serializeArenaBuildLoadHints(hints: ArenaBuildLoadHints): Record
   };
 }
 
+export function getPreparedArenaBuildCoreMetadataUpdate(
+  prepared: PreparedArenaBuild,
+): Record<string, unknown> {
+  // hot-route self-healing repairs identity and hints only; snapshot JSON is maintenance-owned
+  return {
+    voxelSha256: prepared.checksum,
+    arenaBuildHints: serializeArenaBuildLoadHints(prepared.hints),
+  };
+}
+
 export function getPreparedArenaBuildMetadataUpdate(prepared: PreparedArenaBuild): Record<string, unknown> {
   // persisted snapshots cover inline and snapshot routes only
   const shouldPersistPreparedPayload = prepared.hints.deliveryClass !== "stream-artifact";
@@ -269,8 +279,7 @@ export function getPreparedArenaBuildMetadataUpdate(prepared: PreparedArenaBuild
       : null;
   const snapshotFull = shouldPersistPreparedPayload ? prepared.fullBuild : null;
   return {
-    voxelSha256: prepared.checksum,
-    arenaBuildHints: serializeArenaBuildLoadHints(prepared.hints),
+    ...getPreparedArenaBuildCoreMetadataUpdate(prepared),
     arenaSnapshotPreview: snapshotPreview,
     arenaSnapshotPreviewChecksum: snapshotPreview ? prepared.checksum : null,
     arenaSnapshotFull: snapshotFull,

--- a/lib/arena/buildSnapshotArtifacts.ts
+++ b/lib/arena/buildSnapshotArtifacts.ts
@@ -411,6 +411,25 @@ export async function fetchArenaBuildSnapshotArtifact(
   }
 }
 
+export async function fetchArenaBuildSnapshotArtifactPayload(
+  buildId: string,
+  variant: ArenaBuildVariant,
+  checksum: string | null,
+  opts?: { signal?: AbortSignal },
+): Promise<SnapshotArtifactPayload | null> {
+  const bytes = await fetchArenaBuildSnapshotArtifact(buildId, variant, checksum, opts);
+  if (!bytes) return null;
+  try {
+    const payload = JSON.parse(Buffer.from(bytes).toString("utf8")) as SnapshotArtifactPayload;
+    if (payload?.buildId !== buildId || payload.variant !== variant) return null;
+    const normalizedChecksum = checksum?.trim() || null;
+    if (normalizedChecksum && payload.checksum !== normalizedChecksum) return null;
+    return payload;
+  } catch {
+    return null;
+  }
+}
+
 export async function createArenaBuildSnapshotArtifactSignedUrl(
   buildId: string,
   variant: ArenaBuildVariant,

--- a/lib/arena/shownJobs.ts
+++ b/lib/arena/shownJobs.ts
@@ -1,7 +1,7 @@
 import { Prisma } from "@prisma/client";
 import { ARENA_SHOWN_JOB_DRAIN_LOCK_KEY } from "@/lib/arena/advisoryLocks";
 import { settleArenaMatchupShown } from "@/lib/arena/coverage";
-import { invalidateArenaStatsCache } from "@/lib/arena/stats";
+import { invalidateArenaModelDetailStatsCache } from "@/lib/arena/stats";
 import { ARENA_WRITE_RETRY_MAX_ATTEMPTS, withArenaWriteRetry } from "@/lib/arena/writeRetry";
 import { prisma } from "@/lib/prisma";
 
@@ -156,7 +156,6 @@ async function processArenaShownJobBatch(limit = JOB_BATCH_LIMIT): Promise<Shown
   if (result.processedCount <= 0) return result;
 
   settleArenaMatchupShown(result.increments);
-  invalidateArenaStatsCache();
   return result;
 }
 
@@ -172,20 +171,25 @@ export async function drainArenaShownJobs(opts?: {
   const maxMs = Math.max(250, opts?.maxMs ?? JOB_DRAIN_MAX_MS);
   const deadlineAt = Date.now() + maxMs;
 
-  while (processedCount < maxJobs) {
-    const remainingMs = deadlineAt - Date.now();
-    if (remainingMs < JOB_DRAIN_MIN_BATCH_BUDGET_MS && processedCount > 0) break;
-    const remainingJobs = maxJobs - processedCount;
-    const result = await processArenaShownJobBatch(remainingJobs);
-    if (result.lockSkipped) {
-      lockSkipped = true;
-      break;
+  try {
+    while (processedCount < maxJobs) {
+      const remainingMs = deadlineAt - Date.now();
+      if (remainingMs < JOB_DRAIN_MIN_BATCH_BUDGET_MS && processedCount > 0) break;
+      const remainingJobs = maxJobs - processedCount;
+      const result = await processArenaShownJobBatch(remainingJobs);
+      if (result.lockSkipped) {
+        lockSkipped = true;
+        break;
+      }
+      const processed = result.processedCount;
+      if (processed <= 0) break;
+      processedCount += processed;
+      batches += 1;
+      if (processed < Math.max(1, JOB_BATCH_LIMIT)) break;
     }
-    const processed = result.processedCount;
-    if (processed <= 0) break;
-    processedCount += processed;
-    batches += 1;
-    if (processed < Math.max(1, JOB_BATCH_LIMIT)) break;
+  } finally {
+    // once per drain, and even on a late-batch failure committed counts stay visible
+    if (processedCount > 0) invalidateArenaModelDetailStatsCache();
   }
 
   return { processedCount, batches, lockSkipped };

--- a/lib/arena/stats.ts
+++ b/lib/arena/stats.ts
@@ -677,6 +677,11 @@ export function invalidateArenaStatsCache() {
   modelDetailCache.clear();
 }
 
+export function invalidateArenaModelDetailStatsCache() {
+  // shown counts surface only in model detail stats, so shown drains scope here
+  modelDetailCache.clear();
+}
+
 function promptFilterSql(promptIds: string[]): Prisma.Sql {
   return sqlInColumn(Prisma.sql`matchup."promptId"`, promptIds);
 }

--- a/lib/arena/voteJobs.ts
+++ b/lib/arena/voteJobs.ts
@@ -45,9 +45,13 @@ type MutableModelState = LockedModelRow & {
   conservativeRating: number;
 };
 
-type ModelUpdatePlan = {
+type ModelUpdateRow = {
   id: string;
-  data: Prisma.ModelUpdateInput;
+  eloRating: number;
+  glickoRd: number;
+  glickoVolatility: number;
+  conservativeRating: number;
+  counters: CounterIncrements;
 };
 
 type VoteCacheUpdate = {
@@ -117,20 +121,45 @@ function emptyCounterIncrements(): CounterIncrements {
   };
 }
 
-function orderModelUpdatePlans(plans: ModelUpdatePlan[]): ModelUpdatePlan[] {
-  return [...plans].sort((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0));
-}
-
-async function applyOrderedModelUpdates(
+async function applyBatchedModelUpdates(
   tx: Prisma.TransactionClient,
-  plans: ModelUpdatePlan[],
+  rows: ModelUpdateRow[],
 ) {
-  for (const plan of orderModelUpdatePlans(plans)) {
-    await tx.model.update({
-      where: { id: plan.id },
-      data: plan.data,
-    });
-  }
+  if (rows.length === 0) return;
+  const ordered = [...rows].sort((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0));
+  // one grouped statement replaces up to batch-limit serial updates in the drain tx
+  await tx.$executeRaw(Prisma.sql`
+    UPDATE "Model" AS model
+    SET
+      "eloRating" = updated."eloRating",
+      "glickoRd" = updated."glickoRd",
+      "glickoVolatility" = updated."glickoVolatility",
+      "conservativeRating" = updated."conservativeRating",
+      "winCount" = model."winCount" + updated."winDelta",
+      "lossCount" = model."lossCount" + updated."lossDelta",
+      "drawCount" = model."drawCount" + updated."drawDelta",
+      "bothBadCount" = model."bothBadCount" + updated."bothBadDelta",
+      "updatedAt" = CURRENT_TIMESTAMP
+    FROM (
+      VALUES ${Prisma.join(
+        ordered.map(
+          (row) =>
+            Prisma.sql`(${row.id}::text, ${row.eloRating}::double precision, ${row.glickoRd}::double precision, ${row.glickoVolatility}::double precision, ${row.conservativeRating}::double precision, ${row.counters.winCount}::int, ${row.counters.lossCount}::int, ${row.counters.drawCount}::int, ${row.counters.bothBadCount}::int)`,
+        ),
+      )}
+    ) AS updated(
+      "id",
+      "eloRating",
+      "glickoRd",
+      "glickoVolatility",
+      "conservativeRating",
+      "winDelta",
+      "lossDelta",
+      "drawDelta",
+      "bothBadDelta"
+    )
+    WHERE model."id" = updated."id"
+  `);
 }
 
 async function loadModelsForVoteJobs(
@@ -424,22 +453,18 @@ async function processArenaVoteJobBatch(limit = JOB_BATCH_LIMIT): Promise<VoteJo
           });
         }
 
-        const modelUpdatePlans = Array.from(modelStates.values()).map((model) => {
-          const counters = counterIncrements.get(model.id) ?? emptyCounterIncrements();
-          const data: Prisma.ModelUpdateInput = {
+        const modelUpdateRows: ModelUpdateRow[] = Array.from(modelStates.values()).map(
+          (model) => ({
+            id: model.id,
             eloRating: model.eloRating,
             glickoRd: model.glickoRd,
             glickoVolatility: model.glickoVolatility,
             conservativeRating: model.conservativeRating,
-          };
-          if (counters.winCount > 0) data.winCount = { increment: counters.winCount };
-          if (counters.lossCount > 0) data.lossCount = { increment: counters.lossCount };
-          if (counters.drawCount > 0) data.drawCount = { increment: counters.drawCount };
-          if (counters.bothBadCount > 0) data.bothBadCount = { increment: counters.bothBadCount };
-          return { id: model.id, data };
-        });
+            counters: counterIncrements.get(model.id) ?? emptyCounterIncrements(),
+          }),
+        );
 
-        await applyOrderedModelUpdates(tx, modelUpdatePlans);
+        await applyBatchedModelUpdates(tx, modelUpdateRows);
         // coverage rows update in the same tx as processedAt
         await applyCoveragePersistUpdates(tx, Array.from(coveragePersistUpdates.values()));
         await tx.$executeRaw(Prisma.sql`

--- a/lib/arena/voteJobs.ts
+++ b/lib/arena/voteJobs.ts
@@ -460,7 +460,6 @@ async function processArenaVoteJobBatch(limit = JOB_BATCH_LIMIT): Promise<VoteJo
 
   if (result.processedCount <= 0) return result;
 
-  invalidateArenaStatsCache();
   for (const cacheUpdate of result.cacheUpdates) {
     recordArenaVoteInSamplingCache(cacheUpdate);
   }
@@ -479,21 +478,27 @@ export async function drainArenaVoteJobs(opts?: {
   const maxMs = Math.max(250, opts?.maxMs ?? JOB_DRAIN_MAX_MS);
   const deadlineAt = Date.now() + maxMs;
 
-  while (processedCount < maxJobs) {
-    const remainingMs = deadlineAt - Date.now();
-    // always let a fresh drain try one batch
-    if (remainingMs < JOB_DRAIN_MIN_BATCH_BUDGET_MS && processedCount > 0) break;
-    const remainingJobs = maxJobs - processedCount;
-    const result = await processArenaVoteJobBatch(remainingJobs);
-    if (result.lockSkipped) {
-      lockSkipped = true;
-      break;
+  try {
+    while (processedCount < maxJobs) {
+      const remainingMs = deadlineAt - Date.now();
+      // always let a fresh drain try one batch
+      if (remainingMs < JOB_DRAIN_MIN_BATCH_BUDGET_MS && processedCount > 0) break;
+      const remainingJobs = maxJobs - processedCount;
+      const result = await processArenaVoteJobBatch(remainingJobs);
+      if (result.lockSkipped) {
+        lockSkipped = true;
+        break;
+      }
+      const processed = result.processedCount;
+      if (processed <= 0) break;
+      processedCount += processed;
+      batches += 1;
+      if (processed < Math.max(1, JOB_BATCH_LIMIT)) break;
     }
-    const processed = result.processedCount;
-    if (processed <= 0) break;
-    processedCount += processed;
-    batches += 1;
-    if (processed < Math.max(1, JOB_BATCH_LIMIT)) break;
+  } finally {
+    // ratings moved: leaderboard, prompt signals, and model detail are all stale.
+    // once per drain, and even on a late-batch failure committed data stays visible
+    if (processedCount > 0) invalidateArenaStatsCache();
   }
 
   return { processedCount, batches, lockSkipped };

--- a/lib/voxel/mesh.ts
+++ b/lib/voxel/mesh.ts
@@ -1031,9 +1031,41 @@ export function createVoxelGroup(build: VoxelBuild, palette: BlockDefinition[], 
   };
 }
 
+// blocks cross the worker boundary as transferable typed arrays so the main
+// thread never structured-clones millions of block objects
+export type TransferableVoxelBlocks = {
+  positions: Int16Array;
+  typeIds: Uint16Array;
+  typeNames: string[];
+};
+
+export function encodeTransferableVoxelBlocks(
+  blocks: VoxelBuild["blocks"],
+): TransferableVoxelBlocks {
+  const positions = new Int16Array(blocks.length * 3);
+  const typeIds = new Uint16Array(blocks.length);
+  const typeNames: string[] = [];
+  const typeIdByName = new Map<string, number>();
+  for (let i = 0; i < blocks.length; i += 1) {
+    const block = blocks[i];
+    if (!block) continue;
+    positions[i * 3] = block.x;
+    positions[i * 3 + 1] = block.y;
+    positions[i * 3 + 2] = block.z;
+    let typeId = typeIdByName.get(block.type);
+    if (typeId === undefined) {
+      typeId = typeNames.length;
+      typeNames.push(block.type);
+      typeIdByName.set(block.type, typeId);
+    }
+    typeIds[i] = typeId;
+  }
+  return { positions, typeIds, typeNames };
+}
+
 type MeshWorkerRequest = {
   type: "build";
-  build: VoxelBuild;
+  blocks: TransferableVoxelBlocks;
   allowedBlockIds: string[];
   blockLimit?: number;
 };
@@ -1191,13 +1223,14 @@ async function createVoxelMeshPayloadInWorker(
     }
     opts?.signal?.addEventListener("abort", onAbort, { once: true });
 
+    const blocks = encodeTransferableVoxelBlocks(build.blocks);
     const request: MeshWorkerRequest = {
       type: "build",
-      build,
+      blocks,
       allowedBlockIds: palette.map((entry) => entry.id),
       blockLimit: opts?.blockLimit,
     };
-    worker.postMessage(request);
+    worker.postMessage(request, [blocks.positions.buffer, blocks.typeIds.buffer]);
   });
 }
 

--- a/lib/voxel/mesh.worker.ts
+++ b/lib/voxel/mesh.worker.ts
@@ -341,7 +341,7 @@ function prepareMeshData(
     }
   }
 
-  // only visible blocks are materialized as objects; hidden volume stays in the typed arrays
+  // materialize one temporary block at a time and retain only visible blocks
   for (let i = 0; i < maxInputBlocks; i += 1) {
     const type = typeNames[typeIds[i]];
     if (!type || !allowed.has(type)) continue;

--- a/lib/voxel/mesh.worker.ts
+++ b/lib/voxel/mesh.worker.ts
@@ -3,7 +3,12 @@ import { getAtlasUv, hasAtlasKey } from "@/lib/blocks/atlas";
 import { Face, getTextureKey } from "@/lib/blocks/textures";
 import { canVoxelBlockEmitAnyFace, isVoxelOccluder } from "@/lib/voxel/renderVisibility";
 import type { VoxelBuild } from "@/lib/voxel/types";
-import type { SerializedBuildBounds, SerializedMeshBucket, VoxelMeshPayload } from "@/lib/voxel/mesh";
+import type {
+  SerializedBuildBounds,
+  SerializedMeshBucket,
+  TransferableVoxelBlocks,
+  VoxelMeshPayload,
+} from "@/lib/voxel/mesh";
 
 type BuildProgress = {
   processedBlocks: number;
@@ -13,7 +18,7 @@ type BuildProgress = {
 
 type WorkerRequest = {
   type: "build";
-  build: VoxelBuild;
+  blocks: TransferableVoxelBlocks;
   allowedBlockIds: string[];
   blockLimit?: number;
 };
@@ -295,7 +300,7 @@ function postProgress(processedBlocks: number, totalBlocks: number, stageLabel: 
 }
 
 function prepareMeshData(
-  build: VoxelBuild,
+  blocks: TransferableVoxelBlocks,
   allowedBlockIds: string[],
   blockLimit?: number,
 ): PreparedMeshData {
@@ -303,6 +308,7 @@ function prepareMeshData(
   const nonWaterBlocks: VoxelBuild["blocks"] = [];
   const waterBlocks: VoxelBuild["blocks"] = [];
   const blocksByPos = new Map<number, string>();
+  const { positions, typeIds, typeNames } = blocks;
 
   let minX = Infinity;
   let minY = Infinity;
@@ -314,27 +320,37 @@ function prepareMeshData(
   const inputLimit =
     typeof blockLimit === "number" && Number.isFinite(blockLimit)
       ? Math.max(0, Math.floor(blockLimit))
-      : build.blocks.length;
-  const maxInputBlocks = Math.min(build.blocks.length, inputLimit);
+      : typeIds.length;
+  const maxInputBlocks = Math.min(typeIds.length, inputLimit);
 
   for (let i = 0; i < maxInputBlocks; i += 1) {
-    const b = build.blocks[i];
-    if (!b || !allowed.has(b.type)) continue;
-    blocksByPos.set(encodePosition(b.x, b.y, b.z), b.type);
-    minX = Math.min(minX, b.x);
-    minY = Math.min(minY, b.y);
-    minZ = Math.min(minZ, b.z);
-    maxX = Math.max(maxX, b.x);
-    maxY = Math.max(maxY, b.y);
-    maxZ = Math.max(maxZ, b.z);
+    const type = typeNames[typeIds[i]];
+    if (!type || !allowed.has(type)) continue;
+    const x = positions[i * 3];
+    const y = positions[i * 3 + 1];
+    const z = positions[i * 3 + 2];
+    blocksByPos.set(encodePosition(x, y, z), type);
+    minX = Math.min(minX, x);
+    minY = Math.min(minY, y);
+    minZ = Math.min(minZ, z);
+    maxX = Math.max(maxX, x);
+    maxY = Math.max(maxY, y);
+    maxZ = Math.max(maxZ, z);
     if ((i & (PROGRESS_EVERY - 1)) === 0) {
       postProgress(i, maxInputBlocks, "Indexing blocks");
     }
   }
 
+  // only visible blocks are materialized as objects; hidden volume stays in the typed arrays
   for (let i = 0; i < maxInputBlocks; i += 1) {
-    const b = build.blocks[i];
-    if (!b || !allowed.has(b.type)) continue;
+    const type = typeNames[typeIds[i]];
+    if (!type || !allowed.has(type)) continue;
+    const b = {
+      x: positions[i * 3],
+      y: positions[i * 3 + 1],
+      z: positions[i * 3 + 2],
+      type,
+    };
     if (b.type === WATER_BLOCK_ID) {
       if (!canVoxelBlockEmitAnyFace(b, blocksByPos)) continue;
       waterBlocks.push(b);
@@ -622,8 +638,12 @@ function buildWaterSurfaceBucket(prepared: PreparedMeshData): MeshBucket {
   return bucket;
 }
 
-function buildMeshPayload(build: VoxelBuild, allowedBlockIds: string[], blockLimit?: number): VoxelMeshPayload {
-  const prepared = prepareMeshData(build, allowedBlockIds, blockLimit);
+function buildMeshPayload(
+  blocks: TransferableVoxelBlocks,
+  allowedBlockIds: string[],
+  blockLimit?: number,
+): VoxelMeshPayload {
+  const prepared = prepareMeshData(blocks, allowedBlockIds, blockLimit);
   const opaque = makeBucket();
   const cutout = makeBucket();
   const transparent = makeBucket();
@@ -677,7 +697,7 @@ workerScope.onmessage = (event: MessageEvent<WorkerRequest>) => {
   if (!message || message.type !== "build") return;
 
   try {
-    const payload = buildMeshPayload(message.build, message.allowedBlockIds, message.blockLimit);
+    const payload = buildMeshPayload(message.blocks, message.allowedBlockIds, message.blockLimit);
     const response: WorkerResponse = { type: "complete", payload };
     workerScope.postMessage(response, collectTransferables(payload));
   } catch (err) {

--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
     "arena:snapshot:precompute": "tsx scripts/precompute-arena-snapshot-artifacts.ts",
     "arena:stream:precompute": "tsx scripts/precompute-arena-stream-artifacts.ts",
     "arena:stream:clear": "tsx scripts/clear-arena-stream-artifacts.ts",
-    "arena:jobs:prune": "tsx scripts/prune-arena-job-history.ts"
+    "arena:jobs:prune": "tsx scripts/prune-arena-job-history.ts",
+    "arena:artifacts:audit": "tsx scripts/audit-arena-artifacts.ts"
   },
   "dependencies": {
     "@prisma/client": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
     "arena:metadata:backfill": "tsx scripts/backfill-arena-build-metadata.ts",
     "arena:snapshot:precompute": "tsx scripts/precompute-arena-snapshot-artifacts.ts",
     "arena:stream:precompute": "tsx scripts/precompute-arena-stream-artifacts.ts",
-    "arena:stream:clear": "tsx scripts/clear-arena-stream-artifacts.ts"
+    "arena:stream:clear": "tsx scripts/clear-arena-stream-artifacts.ts",
+    "arena:jobs:prune": "tsx scripts/prune-arena-job-history.ts"
   },
   "dependencies": {
     "@prisma/client": "^6.0.0",

--- a/scripts/audit-arena-artifacts.ts
+++ b/scripts/audit-arena-artifacts.ts
@@ -123,21 +123,72 @@ function verifyStreamPayload(
   const lines = Buffer.from(bytes).toString("utf8").split("\n").filter(Boolean);
   if (lines.length === 0) return "stream artifact is empty";
 
-  let hello: { type?: unknown; buildId?: unknown; variant?: unknown; checksum?: unknown };
-  let last: { type?: unknown };
-  try {
-    hello = JSON.parse(lines[0]);
-    last = JSON.parse(lines[lines.length - 1]);
-  } catch {
-    return "stream artifact contains invalid ndjson";
+  // Every event is parsed, not just the first and last: a truncated or
+  // malformed middle chunk still leaves a valid hello and complete pair, and
+  // clients reject the artifact on the block total. Checking the ends only
+  // would let this audit pass artifacts production falls back on.
+  let hello: {
+    type?: unknown;
+    buildId?: unknown;
+    variant?: unknown;
+    checksum?: unknown;
+    totalBlocks?: unknown;
+    chunkCount?: unknown;
+  } | null = null;
+  let complete: { type?: unknown; totalBlocks?: unknown } | null = null;
+  let seenBlocks = 0;
+  let seenChunks = 0;
+
+  for (const [index, line] of lines.entries()) {
+    let event: Record<string, unknown>;
+    try {
+      event = JSON.parse(line) as Record<string, unknown>;
+    } catch {
+      return `stream artifact has invalid ndjson at line ${index + 1}`;
+    }
+
+    if (index === 0) {
+      if (event.type !== "hello") return "stream artifact does not start with a hello event";
+      hello = event;
+      continue;
+    }
+    if (event.type === "chunk") {
+      if (complete) return `stream artifact has a chunk after complete at line ${index + 1}`;
+      const blocks = event.blocks;
+      if (!Array.isArray(blocks)) return `stream chunk at line ${index + 1} has no blocks array`;
+      // chunk indexes are 1-based (iterateArenaBuildChunks yields index + 1)
+      if (typeof event.index === "number" && event.index !== seenChunks + 1) {
+        return `stream chunk out of order at line ${index + 1} (index ${event.index}, expected ${seenChunks + 1})`;
+      }
+      seenBlocks += blocks.length;
+      seenChunks += 1;
+      continue;
+    }
+    if (event.type === "complete") {
+      complete = event;
+      continue;
+    }
   }
-  if (hello.type !== "hello") return "stream artifact does not start with a hello event";
+
+  if (!hello) return "stream artifact has no hello event";
   if (hello.buildId !== buildId) return `stream hello buildId mismatch (${String(hello.buildId)})`;
   if (hello.variant !== variant) return `stream hello variant mismatch (${String(hello.variant)})`;
   if (expectedChecksum && hello.checksum !== expectedChecksum) {
     return `stream hello checksum mismatch (${String(hello.checksum)})`;
   }
-  if (last.type !== "complete") return "stream artifact does not end with a complete event";
+  if (!complete) return "stream artifact does not end with a complete event";
+
+  const announced = typeof hello.totalBlocks === "number" ? hello.totalBlocks : null;
+  if (announced != null && announced !== seenBlocks) {
+    return `stream block total mismatch (hello ${announced}, chunks ${seenBlocks})`;
+  }
+  const completed = typeof complete.totalBlocks === "number" ? complete.totalBlocks : null;
+  if (completed != null && completed !== seenBlocks) {
+    return `stream complete total mismatch (complete ${completed}, chunks ${seenBlocks})`;
+  }
+  if (typeof hello.chunkCount === "number" && hello.chunkCount !== seenChunks) {
+    return `stream chunk count mismatch (hello ${hello.chunkCount}, seen ${seenChunks})`;
+  }
   return null;
 }
 

--- a/scripts/audit-arena-artifacts.ts
+++ b/scripts/audit-arena-artifacts.ts
@@ -168,6 +168,13 @@ function verifyStreamPayload(
       complete = event;
       continue;
     }
+    // the client throws on an error event and ignores pings, so anything else
+    // makes the artifact undeliverable no matter how well-formed the rest is
+    if (event.type === "ping") continue;
+    if (event.type === "error") {
+      return `stream artifact carries an error event at line ${index + 1}: ${String(event.message ?? "")}`;
+    }
+    return `stream artifact has an unsupported event type at line ${index + 1}: ${String(event.type)}`;
   }
 
   if (!hello) return "stream artifact has no hello event";

--- a/scripts/audit-arena-artifacts.ts
+++ b/scripts/audit-arena-artifacts.ts
@@ -98,6 +98,7 @@ function verifySnapshotPayload(
     buildId?: unknown;
     variant?: unknown;
     checksum?: unknown;
+    buildLoadHints?: { previewBlockCount?: unknown; fullBlockCount?: unknown } | null;
     voxelBuild?: { blocks?: unknown } | null;
   };
   try {
@@ -110,7 +111,36 @@ function verifySnapshotPayload(
   if (expectedChecksum && payload.checksum !== expectedChecksum) {
     return `snapshot checksum mismatch (${String(payload.checksum)})`;
   }
-  if (!Array.isArray(payload.voxelBuild?.blocks)) return "snapshot voxelBuild.blocks missing";
+  const blocks = payload.voxelBuild?.blocks;
+  if (!Array.isArray(blocks)) return "snapshot voxelBuild.blocks missing";
+
+  // The client trusts serverValidated and skips voxel validation, comparing the
+  // received length against the count in buildLoadHints. A truncated blocks
+  // array therefore leaves the viewer unready and voting blocked while still
+  // carrying a valid envelope, so the audit has to check the same total.
+  const hints = payload.buildLoadHints;
+  const announced =
+    variant === "preview" ? hints?.previewBlockCount : hints?.fullBlockCount;
+  if (typeof announced === "number" && Number.isFinite(announced) && announced > 0) {
+    if (blocks.length !== Math.floor(announced)) {
+      return `snapshot block count mismatch (hints ${Math.floor(announced)}, blocks ${blocks.length})`;
+    }
+  }
+
+  // spot-check entries rather than every block: a truncation or corruption that
+  // survives the count check still shows up at the boundaries
+  for (const index of [0, Math.floor(blocks.length / 2), blocks.length - 1]) {
+    const block = blocks[index] as { x?: unknown; y?: unknown; z?: unknown; type?: unknown };
+    if (!block || typeof block !== "object") return `snapshot block ${index} is not an object`;
+    if (
+      typeof block.x !== "number" ||
+      typeof block.y !== "number" ||
+      typeof block.z !== "number" ||
+      typeof block.type !== "string"
+    ) {
+      return `snapshot block ${index} is malformed`;
+    }
+  }
   return null;
 }
 

--- a/scripts/audit-arena-artifacts.ts
+++ b/scripts/audit-arena-artifacts.ts
@@ -186,6 +186,25 @@ function verifyStreamPayload(
       if (complete) return `stream artifact has a chunk after complete at line ${index + 1}`;
       const blocks = event.blocks;
       if (!Array.isArray(blocks)) return `stream chunk at line ${index + 1} has no blocks array`;
+      // Production trusts the stream's serverValidated flag and skips voxel
+      // validation, gating readiness on array length alone, so malformed or
+      // null entries render as missing or phantom geometry while still
+      // enabling voting. Spot-check entries in every chunk.
+      for (const at of [0, Math.floor(blocks.length / 2), blocks.length - 1]) {
+        if (blocks.length === 0) break;
+        const block = blocks[at] as { x?: unknown; y?: unknown; z?: unknown; type?: unknown } | null;
+        if (!block || typeof block !== "object") {
+          return `stream chunk at line ${index + 1} has a non-object block at ${at}`;
+        }
+        if (
+          typeof block.x !== "number" ||
+          typeof block.y !== "number" ||
+          typeof block.z !== "number" ||
+          typeof block.type !== "string"
+        ) {
+          return `stream chunk at line ${index + 1} has a malformed block at ${at}`;
+        }
+      }
       // chunk indexes are 1-based (iterateArenaBuildChunks yields index + 1)
       if (typeof event.index === "number" && event.index !== seenChunks + 1) {
         return `stream chunk out of order at line ${index + 1} (index ${event.index}, expected ${seenChunks + 1})`;

--- a/scripts/audit-arena-artifacts.ts
+++ b/scripts/audit-arena-artifacts.ts
@@ -1,0 +1,294 @@
+#!/usr/bin/env -S tsx
+
+import "dotenv/config";
+import { gunzipSync } from "node:zlib";
+import { findCatalogEntryBySlugOrKey } from "../lib/ai/modelCatalog";
+import {
+  ARTIFACT_STATUS_BUILD_SELECT,
+  expectedArtifactRequirements,
+  getArenaArtifactCoverage,
+  type ArtifactRef,
+  type ArtifactRequirement,
+} from "../lib/arena/artifactCoverage";
+import { createArenaBuildSnapshotArtifactSignedUrl } from "../lib/arena/buildSnapshotArtifacts";
+import { createArenaBuildStreamArtifactSignedUrl } from "../lib/arena/buildStream";
+import { arenaCohortBuildWhere } from "../lib/arena/eligibility";
+import { getSupabaseStorageConfig } from "../lib/storage/buildPayload";
+import { prisma } from "../lib/prisma";
+
+type Args = {
+  deep: boolean;
+  modelKeys: string[] | undefined;
+  limit: number | undefined;
+};
+
+type AuditFailure = {
+  buildId: string;
+  requirement: string;
+  reason: string;
+};
+
+function parseArgs(argv: string[]): Args {
+  const args = argv.slice(2);
+  const deep = args.includes("--deep");
+
+  let modelKeys: string[] | undefined;
+  const modelIndex = args.indexOf("--model");
+  if (modelIndex >= 0) {
+    const raw = args[modelIndex + 1]?.trim();
+    if (!raw) throw new Error("--model expects a model slug or key");
+    const entry = findCatalogEntryBySlugOrKey(raw);
+    if (!entry) throw new Error(`Unknown model: ${raw}`);
+    modelKeys = [entry.key];
+  }
+
+  let limit: number | undefined;
+  const limitIndex = args.indexOf("--limit");
+  if (limitIndex >= 0) {
+    const parsed = Number.parseInt(args[limitIndex + 1] ?? "", 10);
+    if (!Number.isFinite(parsed) || parsed <= 0) throw new Error("--limit expects a positive integer");
+    limit = parsed;
+  }
+
+  return { deep, modelKeys, limit };
+}
+
+function describeRequirement(requirement: ArtifactRequirement): string {
+  return `${requirement.kind}/${requirement.variant}`;
+}
+
+function maybeGunzip(bytes: Uint8Array): Uint8Array {
+  if (bytes.length < 2 || bytes[0] !== 0x1f || bytes[1] !== 0x8b) return bytes;
+  return gunzipSync(Buffer.from(bytes.buffer as ArrayBuffer, bytes.byteOffset, bytes.byteLength));
+}
+
+async function fetchArtifactBytes(ref: ArtifactRef): Promise<Uint8Array | null> {
+  const config = getSupabaseStorageConfig();
+  const encodedPath = ref.path
+    .split("/")
+    .filter(Boolean)
+    .map((segment) => encodeURIComponent(segment))
+    .join("/");
+  const resp = await fetch(
+    `${config.url}/storage/v1/object/${encodeURIComponent(ref.bucket)}/${encodedPath}`,
+    {
+      method: "GET",
+      headers: {
+        Authorization: `Bearer ${config.serviceRoleKey}`,
+        apikey: config.serviceRoleKey,
+      },
+      cache: "no-store",
+    },
+  );
+  if (resp.status === 404) return null;
+  if (!resp.ok) {
+    const text = await resp.text().catch(() => "");
+    throw new Error(`fetch failed (${resp.status}): ${text || "empty response"}`);
+  }
+  return maybeGunzip(new Uint8Array(await resp.arrayBuffer()));
+}
+
+function verifySnapshotPayload(
+  bytes: Uint8Array,
+  buildId: string,
+  variant: ArtifactRequirement["variant"],
+  expectedChecksum: string | null,
+): string | null {
+  let payload: {
+    buildId?: unknown;
+    variant?: unknown;
+    checksum?: unknown;
+    voxelBuild?: { blocks?: unknown } | null;
+  };
+  try {
+    payload = JSON.parse(Buffer.from(bytes).toString("utf8"));
+  } catch {
+    return "snapshot payload is not valid json";
+  }
+  if (payload.buildId !== buildId) return `snapshot buildId mismatch (${String(payload.buildId)})`;
+  if (payload.variant !== variant) return `snapshot variant mismatch (${String(payload.variant)})`;
+  if (expectedChecksum && payload.checksum !== expectedChecksum) {
+    return `snapshot checksum mismatch (${String(payload.checksum)})`;
+  }
+  if (!Array.isArray(payload.voxelBuild?.blocks)) return "snapshot voxelBuild.blocks missing";
+  return null;
+}
+
+function verifyStreamPayload(
+  bytes: Uint8Array,
+  buildId: string,
+  variant: ArtifactRequirement["variant"],
+  expectedChecksum: string | null,
+): string | null {
+  const lines = Buffer.from(bytes).toString("utf8").split("\n").filter(Boolean);
+  if (lines.length === 0) return "stream artifact is empty";
+
+  let hello: { type?: unknown; buildId?: unknown; variant?: unknown; checksum?: unknown };
+  let last: { type?: unknown };
+  try {
+    hello = JSON.parse(lines[0]);
+    last = JSON.parse(lines[lines.length - 1]);
+  } catch {
+    return "stream artifact contains invalid ndjson";
+  }
+  if (hello.type !== "hello") return "stream artifact does not start with a hello event";
+  if (hello.buildId !== buildId) return `stream hello buildId mismatch (${String(hello.buildId)})`;
+  if (hello.variant !== variant) return `stream hello variant mismatch (${String(hello.variant)})`;
+  if (expectedChecksum && hello.checksum !== expectedChecksum) {
+    return `stream hello checksum mismatch (${String(hello.checksum)})`;
+  }
+  if (last.type !== "complete") return "stream artifact does not end with a complete event";
+  return null;
+}
+
+async function checkSignedUrlDelivery(
+  kind: ArtifactRequirement["kind"],
+  buildId: string,
+  variant: ArtifactRequirement["variant"],
+  checksum: string | null,
+): Promise<string | null> {
+  const signedUrl =
+    kind === "snapshot"
+      ? await createArenaBuildSnapshotArtifactSignedUrl(buildId, variant, checksum)
+      : await createArenaBuildStreamArtifactSignedUrl(buildId, variant, checksum);
+  if (!signedUrl) return "signed url unavailable (signing disabled or object missing)";
+  // a ranged read proves anonymous delivery without re-downloading the body
+  const resp = await fetch(signedUrl, {
+    method: "GET",
+    headers: { Range: "bytes=0-0" },
+    cache: "no-store",
+  });
+  if (resp.status !== 200 && resp.status !== 206) {
+    return `signed url fetch failed (${resp.status})`;
+  }
+  await resp.arrayBuffer().catch(() => undefined);
+  return null;
+}
+
+// the requirement checksum is the one embedded in the artifact path
+function requirementChecksum(requirement: ArtifactRequirement): string | null {
+  const path = requirement.refs[0]?.path ?? "";
+  if (requirement.kind === "snapshot") {
+    const match = path.match(/-([0-9a-f]{64})\.json$/);
+    return match?.[1] ?? null;
+  }
+  const match = path.match(/\/checksum\/([0-9a-f]{64})\//) ?? path.match(/-([0-9a-f]{64})\.ndjson$/);
+  return match?.[1] ?? null;
+}
+
+async function runDeepAudit(args: Args): Promise<number> {
+  const rows = await prisma.build.findMany({
+    where: arenaCohortBuildWhere(args.modelKeys),
+    select: ARTIFACT_STATUS_BUILD_SELECT,
+    orderBy: { id: "asc" },
+    ...(args.limit ? { take: args.limit } : {}),
+  });
+  console.log(`Deep-auditing ${rows.length} builds`);
+
+  const failures: AuditFailure[] = [];
+  let checkedArtifacts = 0;
+
+  for (const [index, row] of rows.entries()) {
+    const { missingCoreMetadata, needsSnapshotCompute, required } = expectedArtifactRequirements(row);
+    if (missingCoreMetadata) {
+      failures.push({ buildId: row.id, requirement: "core-metadata", reason: "voxelSha256 or hints missing" });
+    }
+    if (needsSnapshotCompute) {
+      failures.push({ buildId: row.id, requirement: "snapshot-compute", reason: "snapshot checksums not recorded" });
+    }
+
+    for (const requirement of required) {
+      const label = describeRequirement(requirement);
+      const checksum = requirementChecksum(requirement);
+      let bytes: Uint8Array | null = null;
+      let fetchError: string | null = null;
+      for (const ref of requirement.refs) {
+        try {
+          bytes = await fetchArtifactBytes(ref);
+        } catch (err) {
+          fetchError = err instanceof Error ? err.message : String(err);
+        }
+        if (bytes) break;
+      }
+      if (!bytes) {
+        failures.push({
+          buildId: row.id,
+          requirement: label,
+          reason: fetchError ?? "object missing in storage",
+        });
+        continue;
+      }
+
+      const contentError =
+        requirement.kind === "snapshot"
+          ? verifySnapshotPayload(bytes, row.id, requirement.variant, checksum)
+          : verifyStreamPayload(bytes, row.id, requirement.variant, checksum);
+      if (contentError) {
+        failures.push({ buildId: row.id, requirement: label, reason: contentError });
+        continue;
+      }
+
+      const deliveryError = await checkSignedUrlDelivery(
+        requirement.kind,
+        row.id,
+        requirement.variant,
+        checksum,
+      );
+      if (deliveryError) {
+        failures.push({ buildId: row.id, requirement: label, reason: deliveryError });
+        continue;
+      }
+      checkedArtifacts += 1;
+    }
+
+    if ((index + 1) % 50 === 0) {
+      console.log(`- audited ${index + 1}/${rows.length} builds`);
+    }
+  }
+
+  console.log(`Deep audit complete: ${checkedArtifacts} artifacts verified, ${failures.length} failures.`);
+  for (const failure of failures.slice(0, 50)) {
+    console.log(`- FAIL build=${failure.buildId} ${failure.requirement}: ${failure.reason}`);
+  }
+  if (failures.length > 50) {
+    console.log(`- ... (${failures.length - 50} more failures)`);
+  }
+  return failures.length === 0 ? 0 : 1;
+}
+
+async function runFastAudit(args: Args): Promise<number> {
+  const coverage = await getArenaArtifactCoverage(args.modelKeys);
+  if (coverage.error) {
+    console.error(`Coverage lookup failed: ${coverage.error}`);
+    return 1;
+  }
+  console.log("Arena artifact coverage");
+  console.log(`- eligible stream builds: ${coverage.eligibleBuilds}`);
+  console.log(`- stream builds complete: ${coverage.buildsWithBothVariants}`);
+  console.log(`- snapshot requirements: ${coverage.snapshotRequirements} (missing ${coverage.snapshotMissing})`);
+  console.log(`- builds missing core metadata: ${coverage.buildsMissingCoreMetadata}`);
+  console.log(`- builds needing snapshot compute: ${coverage.buildsNeedingSnapshotCompute}`);
+  const missing = coverage.missingBuildIds ?? [];
+  if (missing.length > 0) {
+    console.log(`- builds needing work: ${missing.length}`);
+    for (const buildId of missing.slice(0, 20)) console.log(`  - ${buildId}`);
+    if (missing.length > 20) console.log(`  - ... (${missing.length - 20} more)`);
+    return 1;
+  }
+  console.log("All policy-required artifacts are present.");
+  return 0;
+}
+
+async function main() {
+  const args = parseArgs(process.argv);
+  const exitCode = args.deep ? await runDeepAudit(args) : await runFastAudit(args);
+  process.exitCode = exitCode;
+}
+
+void main()
+  .catch((err) => {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error(`Fatal: ${message}`);
+    process.exitCode = 1;
+  })
+  .finally(() => prisma.$disconnect());

--- a/scripts/prototype-binary-v4.ts
+++ b/scripts/prototype-binary-v4.ts
@@ -2,7 +2,6 @@
 
 // Measures the proposed binary v4 build encoding against the current
 // gzip-JSON v3 shape on real cohort builds. Read-only; writes nothing.
-// See .agents/binary-v4-rfc-2026-08-13.md for the format spec and results.
 
 import { readFileSync } from "node:fs";
 import { performance } from "node:perf_hooks";

--- a/scripts/prototype-binary-v4.ts
+++ b/scripts/prototype-binary-v4.ts
@@ -6,7 +6,8 @@
 import { readFileSync } from "node:fs";
 import { performance } from "node:perf_hooks";
 import { gzipSync, gunzipSync } from "node:zlib";
-import { parseVoxelBuildSpec } from "../lib/voxel/validate";
+import { validateVoxelBuild } from "../lib/voxel/validate";
+import { getPalette } from "../lib/blocks/palettes";
 
 type VoxelBlock = { x: number; y: number; z: number; type: string };
 type VoxelBuild = { version: string; blocks: VoxelBlock[] };
@@ -104,13 +105,22 @@ function main() {
   );
   for (const file of files) {
     const raw = readFileSync(file);
-    // uploads hold the model's box/block spec; delivery serves expanded blocks
-    const parsed = parseVoxelBuildSpec(JSON.parse(raw.toString("utf8")));
-    if (!parsed.ok) {
-      console.error(`- ${file}: ${parsed.error}, skipping`);
+    // uploads hold the model's box/line/block spec; delivery serves the fully
+    // expanded blocks, so benchmark the same expansion production performs
+    const validated = validateVoxelBuild(JSON.parse(raw.toString("utf8")), {
+      gridSize: 256,
+      palette: getPalette("simple"),
+      maxBlocks: Number.MAX_SAFE_INTEGER,
+    });
+    if (!validated.ok) {
+      console.error(`- ${file}: ${validated.error}, skipping`);
       continue;
     }
-    const build = parsed.value as VoxelBuild;
+    const build = validated.value.build as VoxelBuild;
+    if (build.blocks.length === 0) {
+      console.error(`- ${file}: expanded to zero blocks, skipping`);
+      continue;
+    }
 
     const jsonBytes = Buffer.from(JSON.stringify(build));
     const gzipJson = timed(() => gzipSync(jsonBytes));

--- a/scripts/prototype-binary-v4.ts
+++ b/scripts/prototype-binary-v4.ts
@@ -1,0 +1,151 @@
+#!/usr/bin/env -S tsx
+
+// Measures the proposed binary v4 build encoding against the current
+// gzip-JSON v3 shape on real cohort builds. Read-only; writes nothing.
+// See .agents/binary-v4-rfc-2026-08-13.md for the format spec and results.
+
+import { readFileSync } from "node:fs";
+import { performance } from "node:perf_hooks";
+import { gzipSync, gunzipSync } from "node:zlib";
+import { parseVoxelBuildSpec } from "../lib/voxel/validate";
+
+type VoxelBlock = { x: number; y: number; z: number; type: string };
+type VoxelBuild = { version: string; blocks: VoxelBlock[] };
+
+const MAGIC = 0x4d425634; // "MBV4"
+
+function encodeV4(build: VoxelBuild): Uint8Array {
+  const blocks = build.blocks;
+  const typeNames: string[] = [];
+  const typeIdByName = new Map<string, number>();
+  const typeIds = new Uint16Array(blocks.length);
+  const positions = new Uint16Array(blocks.length * 3);
+
+  for (let i = 0; i < blocks.length; i += 1) {
+    const block = blocks[i];
+    positions[i * 3] = block.x;
+    positions[i * 3 + 1] = block.y;
+    positions[i * 3 + 2] = block.z;
+    let typeId = typeIdByName.get(block.type);
+    if (typeId === undefined) {
+      typeId = typeNames.length;
+      typeNames.push(block.type);
+      typeIdByName.set(block.type, typeId);
+    }
+    typeIds[i] = typeId;
+  }
+
+  const paletteBytes = Buffer.from(JSON.stringify(typeNames), "utf8");
+  const header = Buffer.alloc(16);
+  header.writeUInt32BE(MAGIC, 0);
+  header.writeUInt8(4, 4); // format version
+  header.writeUInt8(0, 5); // flags
+  header.writeUInt16BE(paletteBytes.byteLength, 6);
+  header.writeUInt32BE(blocks.length, 8);
+  header.writeUInt32BE(0, 12); // reserved (source checksum prefix in the real format)
+
+  return Buffer.concat([
+    header,
+    paletteBytes,
+    Buffer.from(positions.buffer, positions.byteOffset, positions.byteLength),
+    Buffer.from(typeIds.buffer, typeIds.byteOffset, typeIds.byteLength),
+  ]);
+}
+
+function decodeV4(bytes: Uint8Array): VoxelBuild {
+  const buf = Buffer.from(bytes.buffer as ArrayBuffer, bytes.byteOffset, bytes.byteLength);
+  if (buf.readUInt32BE(0) !== MAGIC) throw new Error("bad magic");
+  const paletteLength = buf.readUInt16BE(6);
+  const blockCount = buf.readUInt32BE(8);
+  const typeNames = JSON.parse(buf.subarray(16, 16 + paletteLength).toString("utf8")) as string[];
+  const positionsOffset = 16 + paletteLength;
+  const typeIdsOffset = positionsOffset + blockCount * 6;
+  // array payloads are little-endian, matching typed-array memory layout
+  const positions = new Uint16Array(blockCount * 3);
+  const typeIds = new Uint16Array(blockCount);
+  for (let i = 0; i < blockCount * 3; i += 1) {
+    positions[i] = buf.readUInt16LE(positionsOffset + i * 2);
+  }
+  for (let i = 0; i < blockCount; i += 1) {
+    typeIds[i] = buf.readUInt16LE(typeIdsOffset + i * 2);
+  }
+  const blocks: VoxelBlock[] = new Array(blockCount);
+  for (let i = 0; i < blockCount; i += 1) {
+    blocks[i] = {
+      x: positions[i * 3],
+      y: positions[i * 3 + 1],
+      z: positions[i * 3 + 2],
+      type: typeNames[typeIds[i]],
+    };
+  }
+  return { version: "1.0", blocks };
+}
+
+function timed<T>(fn: () => T): { value: T; ms: number } {
+  const start = performance.now();
+  const value = fn();
+  return { value, ms: performance.now() - start };
+}
+
+function fmtBytes(bytes: number): string {
+  if (bytes >= 1_048_576) return `${(bytes / 1_048_576).toFixed(2)}MiB`;
+  return `${(bytes / 1024).toFixed(1)}KiB`;
+}
+
+function main() {
+  const files = process.argv.slice(2);
+  if (files.length === 0) {
+    console.error("Usage: tsx scripts/prototype-binary-v4.ts <build.json> [more.json ...]");
+    process.exitCode = 1;
+    return;
+  }
+
+  console.log(
+    "file | blocks | raw json | gzip json (v3) | gzip v4 | transfer delta | json decode | v4 decode",
+  );
+  for (const file of files) {
+    const raw = readFileSync(file);
+    // uploads hold the model's box/block spec; delivery serves expanded blocks
+    const parsed = parseVoxelBuildSpec(JSON.parse(raw.toString("utf8")));
+    if (!parsed.ok) {
+      console.error(`- ${file}: ${parsed.error}, skipping`);
+      continue;
+    }
+    const build = parsed.value as VoxelBuild;
+
+    const jsonBytes = Buffer.from(JSON.stringify(build));
+    const gzipJson = timed(() => gzipSync(jsonBytes));
+    const v4 = encodeV4(build);
+    const gzipV4 = timed(() => gzipSync(v4));
+
+    const jsonDecode = timed(() => JSON.parse(gunzipSync(gzipJson.value).toString("utf8")) as VoxelBuild);
+    const v4Decode = timed(() => decodeV4(gunzipSync(gzipV4.value)));
+
+    if (v4Decode.value.blocks.length !== build.blocks.length) {
+      throw new Error(`v4 roundtrip lost blocks in ${file}`);
+    }
+    for (const i of [0, Math.floor(build.blocks.length / 2), build.blocks.length - 1]) {
+      const a = build.blocks[i];
+      const b = v4Decode.value.blocks[i];
+      if (a.x !== b.x || a.y !== b.y || a.z !== b.z || a.type !== b.type) {
+        throw new Error(`v4 roundtrip mismatch at index ${i} in ${file}`);
+      }
+    }
+
+    const delta = 1 - gzipV4.value.byteLength / gzipJson.value.byteLength;
+    console.log(
+      [
+        file.split("/").pop(),
+        build.blocks.length.toLocaleString(),
+        fmtBytes(jsonBytes.byteLength),
+        fmtBytes(gzipJson.value.byteLength),
+        fmtBytes(gzipV4.value.byteLength),
+        `${(delta * 100).toFixed(1)}%`,
+        `${jsonDecode.ms.toFixed(0)}ms`,
+        `${v4Decode.ms.toFixed(0)}ms`,
+      ].join(" | "),
+    );
+  }
+}
+
+main();

--- a/scripts/prune-arena-job-history.ts
+++ b/scripts/prune-arena-job-history.ts
@@ -1,0 +1,126 @@
+#!/usr/bin/env -S tsx
+
+import "dotenv/config";
+import { Prisma } from "@prisma/client";
+import { prisma } from "../lib/prisma";
+
+type Args = {
+  dryRun: boolean;
+  days: number;
+  batchSize: number;
+};
+
+const DEFAULT_RETENTION_DAYS = 30;
+const MIN_RETENTION_DAYS = 7;
+const DEFAULT_BATCH_SIZE = 5000;
+const MAX_BATCH_SIZE = 20000;
+
+const JOB_TABLES = ["ArenaVoteJob", "ArenaShownJob"] as const;
+
+type JobTable = (typeof JOB_TABLES)[number];
+
+function parsePositiveIntArg(args: string[], flag: string, fallback: number): number {
+  const index = args.indexOf(flag);
+  if (index < 0) return fallback;
+  const parsed = Number.parseInt(args[index + 1] ?? "", 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    throw new Error(`${flag} expects a positive integer`);
+  }
+  return parsed;
+}
+
+function parseArgs(argv: string[]): Args {
+  const args = argv.slice(2);
+  const days = parsePositiveIntArg(args, "--days", DEFAULT_RETENTION_DAYS);
+  if (days < MIN_RETENTION_DAYS) {
+    throw new Error(`--days must be at least ${MIN_RETENTION_DAYS}`);
+  }
+  return {
+    dryRun: args.includes("--dry-run"),
+    days,
+    batchSize: Math.min(parsePositiveIntArg(args, "--batch", DEFAULT_BATCH_SIZE), MAX_BATCH_SIZE),
+  };
+}
+
+async function countPrunable(table: JobTable, cutoff: Date): Promise<number> {
+  const rows = await prisma.$queryRaw<Array<{ count: bigint | number }>>(Prisma.sql`
+    SELECT COUNT(*) AS "count"
+    FROM ${Prisma.raw(`"${table}"`)}
+    WHERE "processedAt" IS NOT NULL AND "processedAt" < ${cutoff}
+  `);
+  return Number(rows[0]?.count ?? 0);
+}
+
+async function deleteBatch(table: JobTable, cutoff: Date, batchSize: number): Promise<number> {
+  // each batch is its own statement so drains never wait on a long delete
+  return prisma.$executeRaw(Prisma.sql`
+    DELETE FROM ${Prisma.raw(`"${table}"`)}
+    WHERE "id" IN (
+      SELECT "id"
+      FROM ${Prisma.raw(`"${table}"`)}
+      WHERE "processedAt" IS NOT NULL AND "processedAt" < ${cutoff}
+      ORDER BY "processedAt" ASC
+      LIMIT ${batchSize}
+    )
+  `);
+}
+
+async function reportRetained(table: JobTable): Promise<void> {
+  const rows = await prisma.$queryRaw<
+    Array<{ pending: bigint | number; processed: bigint | number; oldestProcessed: Date | null }>
+  >(Prisma.sql`
+    SELECT
+      COUNT(*) FILTER (WHERE "processedAt" IS NULL) AS "pending",
+      COUNT(*) FILTER (WHERE "processedAt" IS NOT NULL) AS "processed",
+      MIN("processedAt") AS "oldestProcessed"
+    FROM ${Prisma.raw(`"${table}"`)}
+  `);
+  const row = rows[0];
+  const oldest = row?.oldestProcessed ? row.oldestProcessed.toISOString() : "none";
+  console.log(
+    `- ${table}: retained pending=${Number(row?.pending ?? 0)} processed=${Number(
+      row?.processed ?? 0,
+    )} oldestProcessed=${oldest}`,
+  );
+}
+
+async function main() {
+  const args = parseArgs(process.argv);
+  const cutoff = new Date(Date.now() - args.days * 24 * 60 * 60 * 1000);
+
+  console.log("Pruning processed arena job history");
+  console.log(`- cutoff: ${cutoff.toISOString()} (${args.days} days)`);
+  console.log(`- batch size: ${args.batchSize}`);
+  console.log(`- dry run: ${args.dryRun ? "yes" : "no"}`);
+
+  for (const table of JOB_TABLES) {
+    const prunable = await countPrunable(table, cutoff);
+    if (args.dryRun) {
+      console.log(`- ${table}: would delete ${prunable}`);
+      continue;
+    }
+
+    let deleted = 0;
+    while (deleted < prunable) {
+      const batchDeleted = await deleteBatch(table, cutoff, args.batchSize);
+      if (batchDeleted <= 0) break;
+      deleted += batchDeleted;
+      console.log(`- ${table}: deleted ${deleted}/${prunable}`);
+    }
+    if (deleted === 0) console.log(`- ${table}: nothing to delete`);
+  }
+
+  if (!args.dryRun) {
+    for (const table of JOB_TABLES) {
+      await reportRetained(table);
+    }
+  }
+}
+
+void main()
+  .catch((err) => {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error(`Fatal: ${message}`);
+    process.exitCode = 1;
+  })
+  .finally(() => prisma.$disconnect());

--- a/tests/unit/arena/build-metadata-updates.test.ts
+++ b/tests/unit/arena/build-metadata-updates.test.ts
@@ -1,0 +1,65 @@
+import assert from "node:assert/strict";
+import {
+  getPreparedArenaBuildCoreMetadataUpdate,
+  getPreparedArenaBuildMetadataUpdate,
+  prepareArenaBuildFromBuild,
+  type ArenaBuildSource,
+} from "../../../lib/arena/buildArtifacts";
+
+const SNAPSHOT_KEYS = [
+  "arenaSnapshotPreview",
+  "arenaSnapshotPreviewChecksum",
+  "arenaSnapshotFull",
+  "arenaSnapshotFullChecksum",
+];
+
+function makeSource(): ArenaBuildSource {
+  return {
+    id: "test-build",
+    gridSize: 64,
+    palette: "simple",
+    blockCount: 2,
+    voxelByteSize: null,
+    voxelCompressedByteSize: null,
+    voxelSha256: "abc123",
+    voxelData: null,
+    voxelStorageBucket: null,
+    voxelStoragePath: null,
+    voxelStorageEncoding: null,
+  };
+}
+
+async function main() {
+  const prepared = prepareArenaBuildFromBuild(makeSource(), {
+    version: "1.0",
+    blocks: [
+      { x: 0, y: 0, z: 0, type: "stone" },
+      { x: 1, y: 0, z: 0, type: "stone" },
+    ],
+  });
+
+  const core = getPreparedArenaBuildCoreMetadataUpdate(prepared);
+  assert.deepEqual(
+    Object.keys(core).sort(),
+    ["arenaBuildHints", "voxelSha256"],
+    "hot-route heals must write core metadata only",
+  );
+  assert.equal(core.voxelSha256, prepared.checksum);
+  for (const key of SNAPSHOT_KEYS) {
+    assert.ok(!(key in core), `core metadata update must not carry ${key}`);
+  }
+
+  const full = getPreparedArenaBuildMetadataUpdate(prepared);
+  for (const key of ["voxelSha256", "arenaBuildHints", ...SNAPSHOT_KEYS]) {
+    assert.ok(key in full, `maintenance metadata update must carry ${key}`);
+  }
+  assert.equal(full.voxelSha256, core.voxelSha256);
+  assert.deepEqual(full.arenaBuildHints, core.arenaBuildHints);
+
+  console.log("build metadata update split checks passed");
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/tests/unit/arena/pending-vote-coverage.test.ts
+++ b/tests/unit/arena/pending-vote-coverage.test.ts
@@ -40,9 +40,9 @@ assert.ok(
 assert.ok(
   metadataPersistenceIndex >= 0 &&
     matchupSource.slice(metadataPersistenceIndex, checksumRepairIndex).includes(
-      "data: getPreparedArenaBuildMetadataUpdate(prepared)",
+      "data: getPreparedArenaBuildCoreMetadataUpdate(prepared)",
     ),
-  "checksum repair should persist the same prepared metadata used by maintenance",
+  "checksum repair should persist core metadata from the prepared payload",
 );
 assert.ok(
   matchupSource

--- a/tests/unit/voxel/transferable-blocks.test.ts
+++ b/tests/unit/voxel/transferable-blocks.test.ts
@@ -1,0 +1,30 @@
+import assert from "node:assert/strict";
+import { encodeTransferableVoxelBlocks } from "../../../lib/voxel/mesh";
+
+async function main() {
+  const blocks = [
+    { x: 0, y: 0, z: 0, type: "stone" },
+    { x: 511, y: 255, z: 511, type: "oak_leaves" },
+    { x: 3, y: 7, z: 9, type: "stone" },
+    { x: 1, y: 2, z: 3, type: "water" },
+  ];
+
+  const encoded = encodeTransferableVoxelBlocks(blocks);
+  assert.equal(encoded.typeIds.length, blocks.length);
+  assert.equal(encoded.positions.length, blocks.length * 3);
+  assert.deepEqual(encoded.typeNames, ["stone", "oak_leaves", "water"]);
+
+  for (let i = 0; i < blocks.length; i += 1) {
+    assert.equal(encoded.positions[i * 3], blocks[i].x, `x roundtrip at ${i}`);
+    assert.equal(encoded.positions[i * 3 + 1], blocks[i].y, `y roundtrip at ${i}`);
+    assert.equal(encoded.positions[i * 3 + 2], blocks[i].z, `z roundtrip at ${i}`);
+    assert.equal(encoded.typeNames[encoded.typeIds[i]], blocks[i].type, `type roundtrip at ${i}`);
+  }
+
+  console.log("transferable voxel block encoding checks passed");
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
Depends on #85.

## Summary

- Scope arena stats-cache invalidation to the data changed by each drain and batch vote-rating model updates into one grouped statement.
- Add bounded, operator-invoked retention pruning for processed vote and shown jobs.
- Move snapshot delivery to storage-first reads while retaining instrumented database-column fallbacks for the expand/contract compatibility window.
- Add policy-aware fast and deep artifact audits, including content-envelope checks and signed-URL delivery verification.
- Send mesh-worker input through transferable typed arrays to remove the structured clone of the full block-object array.
- Add the measured binary v4 prototype and architecture documentation without changing the production artifact format.

## Verification

- `pnpm lint`
- 39 tracked test files via `tests/run.ts`
- `pnpm build`
- `pnpm arena:jobs:prune --dry-run`: 57,574 vote jobs and 160,484 shown jobs currently eligible; no rows deleted
- `pnpm arena:artifacts:audit`: 312/312 stream builds complete and 1,282 snapshot requirements present with zero missing metadata or artifacts
- `pnpm arena:artifacts:audit --deep --limit 3`: 6 artifacts fetched, decompressed, validated, and delivered through signed URLs with zero failures

## Rollout gates

- The snapshot columns remain in Postgres and continue to serve as logged fallbacks. Column removal requires a production soak with zero fallback hits plus a full deep audit.
- The retention prune remains manual and has not been executed.
- Binary v4 remains a prototype only; no writer or client rollout is included.
- Real-device iPhone Safari profiling remains required after deployment.
- No index changes, partial visual rendering, or worker-pool changes are included.

*(PR written by Codex)*
