### PR TITLE
(perf) serve arena snapshots from storage and drop legacy columns

### DIFF
--- a/app/api/arena/builds/[buildId]/route.ts
+++ b/app/api/arena/builds/[buildId]/route.ts
@@ -130,6 +130,13 @@ function pruneJsonResponseCache() {
   }
 }
 
+function dropCachedJsonResponse(key: string): void {
+  const cached = jsonResponseCache.get(key);
+  if (!cached) return;
+  jsonResponseCache.delete(key);
+  jsonResponseCacheWeight -= cached.byteWeight;
+}
+
 function getCachedJsonResponseByKey(key: string): CachedJsonResponse | null {
   const cached = jsonResponseCache.get(key);
   if (!cached) return null;
@@ -329,17 +336,23 @@ export async function GET(
   }
 
   const cachedJsonResponse = jsonCacheKey ? getCachedJsonResponseByKey(jsonCacheKey) : null;
-  if (cachedJsonResponse) {
-    // This body exists because the artifact was missing when it was built, and
-    // returning it short-circuits the heal in the after() hook below. Re-arm
-    // from the prepared cache so a previously failed upload still retries; the
-    // success set makes this a no-op once the artifact exists.
-    const cachedPrepared = getCachedPreparedArenaBuild(buildId, storedChecksum);
-    if (cachedPrepared) {
-      after(async () => {
-        await healArenaBuildSnapshotArtifactsOnce(cachedPrepared);
-      });
-    }
+  // This body exists because the artifact was missing when it was built, so
+  // returning it short-circuits the heal in the after() hook below. Re-arm from
+  // the prepared cache when possible; the success set makes that a no-op once
+  // the artifact exists. The two caches are sized independently, so when the
+  // prepared entry has been evicted the response entry is dropped instead and
+  // the request falls through to preparation, which heals. Otherwise a stale
+  // body could be served indefinitely with the snapshot still absent.
+  const cachedPreparedForHeal = cachedJsonResponse
+    ? getCachedPreparedArenaBuild(buildId, storedChecksum)
+    : null;
+  if (cachedJsonResponse && !cachedPreparedForHeal && jsonCacheKey) {
+    dropCachedJsonResponse(jsonCacheKey);
+  }
+  if (cachedJsonResponse && cachedPreparedForHeal) {
+    after(async () => {
+      await healArenaBuildSnapshotArtifactsOnce(cachedPreparedForHeal);
+    });
     timing.end("total", requestStartedAt);
     const headers = createJsonHeaders({
       byteLength: cachedJsonResponse.bytes.byteLength,

--- a/app/api/arena/builds/[buildId]/route.ts
+++ b/app/api/arena/builds/[buildId]/route.ts
@@ -330,6 +330,16 @@ export async function GET(
 
   const cachedJsonResponse = jsonCacheKey ? getCachedJsonResponseByKey(jsonCacheKey) : null;
   if (cachedJsonResponse) {
+    // This body exists because the artifact was missing when it was built, and
+    // returning it short-circuits the heal in the after() hook below. Re-arm
+    // from the prepared cache so a previously failed upload still retries; the
+    // success set makes this a no-op once the artifact exists.
+    const cachedPrepared = getCachedPreparedArenaBuild(buildId, storedChecksum);
+    if (cachedPrepared) {
+      after(async () => {
+        await healArenaBuildSnapshotArtifactsOnce(cachedPrepared);
+      });
+    }
     timing.end("total", requestStartedAt);
     const headers = createJsonHeaders({
       byteLength: cachedJsonResponse.bytes.byteLength,

--- a/app/api/arena/builds/[buildId]/route.ts
+++ b/app/api/arena/builds/[buildId]/route.ts
@@ -51,8 +51,9 @@ const JSON_RESPONSE_CACHE_MAX_WEIGHT = Number.parseInt(
 
 type CachedJsonResponse = {
   bytes: Uint8Array;
-  // which path produced this body, so a cached fallback still reports as one
-  source: "db-snapshot" | "live";
+  // which path produced this body; only live prepares are cached now that
+  // snapshots are served from storage
+  source: "live";
   byteWeight: number;
   touchedAt: number;
 };

--- a/app/api/arena/builds/[buildId]/route.ts
+++ b/app/api/arena/builds/[buildId]/route.ts
@@ -15,7 +15,6 @@ import {
 } from "@/lib/arena/buildSnapshotArtifacts";
 import {
   getArenaBuildMeta,
-  getArenaBuildSnapshotFields,
   invalidateArenaBuildMeta,
 } from "@/lib/arena/buildMetaCache";
 import { prisma } from "@/lib/prisma";
@@ -60,7 +59,6 @@ type CachedJsonResponse = {
 
 // short process cache avoids rebuilding the same snapshot json
 const jsonResponseCache = new Map<string, CachedJsonResponse>();
-const jsonResponseInflight = new Map<string, Promise<Uint8Array | null>>();
 let jsonResponseCacheWeight = 0;
 
 // shared build metadata cache lives in lib/arena/buildMetaCache so the build
@@ -68,42 +66,6 @@ let jsonResponseCacheWeight = 0;
 
 function parseVariant(value: string | null): ArenaBuildVariant {
   return value === "preview" ? "preview" : "full";
-}
-
-function isCurrentPersistedSnapshot(
-  snapshot: unknown | null | undefined,
-  snapshotChecksum: string | null | undefined,
-  storedChecksum: string | null,
-): boolean {
-  if (!snapshot) return false;
-  const normalizedSnapshotChecksum = snapshotChecksum?.trim();
-  // db snapshots need their own checksum marker
-  return Boolean(normalizedSnapshotChecksum && storedChecksum && normalizedSnapshotChecksum === storedChecksum);
-}
-
-function pickCurrentPersistedSnapshot(
-  row: {
-    arenaSnapshotPreview: unknown | null;
-    arenaSnapshotPreviewChecksum: string | null;
-    arenaSnapshotFull: unknown | null;
-    arenaSnapshotFullChecksum: string | null;
-  } | null,
-  variant: ArenaBuildVariant,
-  storedChecksum: string | null,
-): unknown | null {
-  if (!row) return null;
-  if (variant === "preview") {
-    return isCurrentPersistedSnapshot(
-      row.arenaSnapshotPreview,
-      row.arenaSnapshotPreviewChecksum,
-      storedChecksum,
-    )
-      ? row.arenaSnapshotPreview
-      : null;
-  }
-  return isCurrentPersistedSnapshot(row.arenaSnapshotFull, row.arenaSnapshotFullChecksum, storedChecksum)
-    ? row.arenaSnapshotFull
-    : null;
 }
 
 function acceptsGzip(request: Request): boolean {
@@ -209,33 +171,6 @@ function rememberJsonResponse(
   const key = buildJsonResponseCacheKey(buildId, variant, checksum, hints, gzip);
   if (!key) return;
   rememberJsonResponseByKey(key, bytes, source);
-}
-
-async function getOrCreateJsonResponse(
-  key: string,
-  source: CachedJsonResponse["source"],
-  create: () => Promise<Uint8Array | null>,
-): Promise<Uint8Array | null> {
-  const cached = getCachedJsonResponseByKey(key);
-  if (cached) return cached.bytes;
-
-  const existing = jsonResponseInflight.get(key);
-  // share db snapshot serialization across concurrent clients
-  if (existing) return existing;
-
-  const promise = (async () => {
-    const bytes = await create();
-    if (bytes) rememberJsonResponseByKey(key, bytes, source);
-    return bytes;
-  })();
-  jsonResponseInflight.set(key, promise);
-  try {
-    return await promise;
-  } finally {
-    if (jsonResponseInflight.get(key) === promise) {
-      jsonResponseInflight.delete(key);
-    }
-  }
 }
 
 async function withTimeout<T>(
@@ -394,11 +329,6 @@ export async function GET(
 
   const cachedJsonResponse = jsonCacheKey ? getCachedJsonResponseByKey(jsonCacheKey) : null;
   if (cachedJsonResponse) {
-    // a cached fallback body must still report as the fallback it is, or a
-    // soak measuring db-fallback traffic reads clean while serving it
-    if (cachedJsonResponse.source === "db-snapshot") {
-      console.log(`arena snapshot db fallback (build cached) build=${buildId} variant=${variant}`);
-    }
     timing.end("total", requestStartedAt);
     const headers = createJsonHeaders({
       byteLength: cachedJsonResponse.bytes.byteLength,
@@ -408,42 +338,6 @@ export async function GET(
     });
     timing.apply(headers);
     return new Response(Buffer.from(cachedJsonResponse.bytes), { headers });
-  }
-
-
-  const persistedResponseBytes = jsonCacheKey
-    ? await getOrCreateJsonResponse(jsonCacheKey, "db-snapshot", async () => {
-        // snapshot json bodies live outside the meta cache to avoid retaining
-        // multi-mb blobs across many buildIds. the response cache covers
-        // subsequent identical requests with its own byte-weight cap.
-        const snapshotFields = await getArenaBuildSnapshotFields(buildId);
-        const persistedSnapshot = pickCurrentPersistedSnapshot(snapshotFields, variant, storedChecksum);
-        if (!persistedSnapshot) return null;
-        return jsonBytes(
-          {
-            buildId,
-            variant,
-            checksum: storedChecksum,
-            serverValidated: true,
-            buildLoadHints: shellHints,
-            voxelBuild: persistedSnapshot,
-          },
-          shouldGzip,
-        );
-      })
-    : null;
-  if (persistedResponseBytes) {
-    // fallback hits must reach zero during the soak before columns can drop
-    console.log(`arena snapshot db fallback (build) build=${buildId} variant=${variant}`);
-    timing.end("total", requestStartedAt);
-    const headers = createJsonHeaders({
-      byteLength: persistedResponseBytes.byteLength,
-      deliveryClass: variant === "preview" ? shellHints.initialDeliveryClass : shellHints.deliveryClass,
-      source: "db-snapshot",
-      gzip: shouldGzip,
-    });
-    timing.apply(headers);
-    return new Response(Buffer.from(persistedResponseBytes), { headers });
   }
 
   if (shouldRequireStreamFallbackOnSnapshotMiss) {

--- a/app/api/arena/builds/[buildId]/route.ts
+++ b/app/api/arena/builds/[buildId]/route.ts
@@ -10,7 +10,7 @@ import {
 } from "@/lib/arena/buildArtifacts";
 import {
   createArenaBuildSnapshotArtifactSignedUrl,
-  ensureArenaBuildSnapshotArtifacts,
+  healArenaBuildSnapshotArtifactsOnce,
   fetchArenaBuildSnapshotArtifact,
 } from "@/lib/arena/buildSnapshotArtifacts";
 import {
@@ -436,7 +436,9 @@ export async function GET(
     if (!marked || marked.count === 0) return;
     // drop stale meta cache so the next request sees the freshly written checksum
     invalidateArenaBuildMeta(prepared.buildId);
-    await ensureArenaBuildSnapshotArtifacts(prepared);
+    // dedupes on success and retries after a failure, so warm cache hits do not
+    // re-upload and a transient failure is not permanent
+    await healArenaBuildSnapshotArtifactsOnce(prepared);
   });
 
   const responseBytes = jsonBytes(

--- a/app/api/arena/builds/[buildId]/stream/route.ts
+++ b/app/api/arena/builds/[buildId]/stream/route.ts
@@ -464,7 +464,12 @@ export async function GET(
           // so heal on every fallback rather than only the first prepare: the
           // prepared cache has no TTL, and gating on it meant a failed upload
           // was never retried. The success set makes repeat calls no-ops.
-          void healArenaBuildSnapshotArtifactsOnce(prepared);
+          // Registered with after() like the stream-artifact warmup above, so a
+          // short response or an early client disconnect cannot leave the
+          // invocation suspended mid-upload and lose the repair.
+          after(async () => {
+            await healArenaBuildSnapshotArtifactsOnce(prepared);
+          });
 
           if (expectedChecksum && expectedChecksum !== prepared.checksum) {
             send({

--- a/app/api/arena/builds/[buildId]/stream/route.ts
+++ b/app/api/arena/builds/[buildId]/stream/route.ts
@@ -457,17 +457,14 @@ export async function GET(
               safeClose();
               return;
             }
-            if (marked) {
-              invalidateArenaBuildMeta(buildId);
-              // A snapshot-class build reaches this route only after its snapshot
-              // artifact was missing. The matchup healer cannot cover that case:
-              // when only the full object is absent it still serves the preview
-              // artifact, so no live prepare happens there and the full snapshot
-              // would stay missing while every full hydration retried and fell
-              // back to this stream.
-              void healArenaBuildSnapshotArtifactsOnce(prepared);
-            }
+            if (marked) invalidateArenaBuildMeta(buildId);
           }
+
+          // Reaching this route at all means the snapshot artifact was missing,
+          // so heal on every fallback rather than only the first prepare: the
+          // prepared cache has no TTL, and gating on it meant a failed upload
+          // was never retried. The success set makes repeat calls no-ops.
+          void healArenaBuildSnapshotArtifactsOnce(prepared);
 
           if (expectedChecksum && expectedChecksum !== prepared.checksum) {
             send({

--- a/app/api/arena/builds/[buildId]/stream/route.ts
+++ b/app/api/arena/builds/[buildId]/stream/route.ts
@@ -18,6 +18,7 @@ import {
   pickBuildVariant,
   prepareArenaBuild,
 } from "@/lib/arena/buildArtifacts";
+import { ensureArenaBuildSnapshotArtifacts } from "@/lib/arena/buildSnapshotArtifacts";
 import { getArenaBuildMeta, invalidateArenaBuildMeta } from "@/lib/arena/buildMetaCache";
 import { prisma } from "@/lib/prisma";
 import { ServerTiming } from "@/lib/serverTiming";
@@ -456,7 +457,18 @@ export async function GET(
               safeClose();
               return;
             }
-            if (marked) invalidateArenaBuildMeta(buildId);
+            if (marked) {
+              invalidateArenaBuildMeta(buildId);
+              // A snapshot-class build reaches this route only after its snapshot
+              // artifact was missing. The matchup healer cannot cover that case:
+              // when only the full object is absent it still serves the preview
+              // artifact, so no live prepare happens there and the full snapshot
+              // would stay missing while every full hydration retried and fell
+              // back to this stream.
+              void ensureArenaBuildSnapshotArtifacts(prepared).catch((err) => {
+                console.warn("arena snapshot artifact heal (stream) failed", err);
+              });
+            }
           }
 
           if (expectedChecksum && expectedChecksum !== prepared.checksum) {

--- a/app/api/arena/builds/[buildId]/stream/route.ts
+++ b/app/api/arena/builds/[buildId]/stream/route.ts
@@ -18,7 +18,7 @@ import {
   pickBuildVariant,
   prepareArenaBuild,
 } from "@/lib/arena/buildArtifacts";
-import { ensureArenaBuildSnapshotArtifacts } from "@/lib/arena/buildSnapshotArtifacts";
+import { healArenaBuildSnapshotArtifactsOnce } from "@/lib/arena/buildSnapshotArtifacts";
 import { getArenaBuildMeta, invalidateArenaBuildMeta } from "@/lib/arena/buildMetaCache";
 import { prisma } from "@/lib/prisma";
 import { ServerTiming } from "@/lib/serverTiming";
@@ -465,9 +465,7 @@ export async function GET(
               // artifact, so no live prepare happens there and the full snapshot
               // would stay missing while every full hydration retried and fell
               // back to this stream.
-              void ensureArenaBuildSnapshotArtifacts(prepared).catch((err) => {
-                console.warn("arena snapshot artifact heal (stream) failed", err);
-              });
+              void healArenaBuildSnapshotArtifactsOnce(prepared);
             }
           }
 

--- a/app/api/arena/matchup/route.ts
+++ b/app/api/arena/matchup/route.ts
@@ -793,6 +793,10 @@ export async function GET(req: Request) {
   let preparedB: Awaited<ReturnType<typeof prepareArenaBuild>> | null = null;
   let persistedInitialBuildA: ArenaMatchup["a"]["build"] | null = null;
   let persistedInitialBuildB: ArenaMatchup["b"]["build"] | null = null;
+  // Only builds that actually reached a live prepare are missing an artifact.
+  // A warm cache hit proves nothing about storage, and healing it would
+  // re-upload multi-megabyte snapshots on ordinary matchup traffic.
+  const livePreparedBuildIds = new Set<string>();
   const prepareStartedAt = performance.now();
   if (shouldPrepareA || shouldPrepareB) {
     preparedA = shouldPrepareA && checksumA ? getCachedPreparedArenaBuild(buildA.id, checksumA) : null;
@@ -842,6 +846,13 @@ export async function GET(req: Request) {
           ? resolveInitialBuildSnapshot(buildB.id, shellHintsB, buildBForPrepare)
           : Promise.resolve(null),
       ]);
+
+      if (shouldPrepareA && !preparedA && !persistedInitialBuildA && buildAForPrepare) {
+        livePreparedBuildIds.add(buildA.id);
+      }
+      if (shouldPrepareB && !preparedB && !persistedInitialBuildB && buildBForPrepare) {
+        livePreparedBuildIds.add(buildB.id);
+      }
 
       [preparedA, preparedB] = await Promise.all([
 	        preparedA || persistedInitialBuildA
@@ -944,11 +955,14 @@ export async function GET(req: Request) {
           const persisted = await persistPreparedArenaBuildMetadata(prepared).catch(() => false);
           if (!persisted) return;
           // An inlined build is answered here, so the client never visits the
-          // build route that would upload the missing artifact. Without this,
-          // every cold matchup repeats the same miss and full payload parse.
-          await ensureArenaBuildSnapshotArtifacts(prepared).catch((err) => {
-            console.warn("arena snapshot artifact heal (matchup) failed", err);
-          });
+          // build route that would upload the missing artifact. Restricted to
+          // builds that live-prepared after an artifact miss, since ensure
+          // upserts unconditionally and warm traffic would re-upload snapshots.
+          if (livePreparedBuildIds.has(prepared.buildId)) {
+            await ensureArenaBuildSnapshotArtifacts(prepared).catch((err) => {
+              console.warn("arena snapshot artifact heal (matchup) failed", err);
+            });
+          }
         }),
       );
     });

--- a/app/api/arena/matchup/route.ts
+++ b/app/api/arena/matchup/route.ts
@@ -13,7 +13,7 @@ import {
 } from "@/lib/arena/buildArtifacts";
 import {
   createArenaBuildSnapshotArtifactSignedUrl,
-  ensureArenaBuildSnapshotArtifacts,
+  healArenaBuildSnapshotArtifactsOnce,
   fetchArenaBuildSnapshotArtifactPayload,
 } from "@/lib/arena/buildSnapshotArtifacts";
 import { createArenaBuildStreamArtifactSignedUrl } from "@/lib/arena/buildStream";
@@ -959,9 +959,7 @@ export async function GET(req: Request) {
           // builds that live-prepared after an artifact miss, since ensure
           // upserts unconditionally and warm traffic would re-upload snapshots.
           if (livePreparedBuildIds.has(prepared.buildId)) {
-            await ensureArenaBuildSnapshotArtifacts(prepared).catch((err) => {
-              console.warn("arena snapshot artifact heal (matchup) failed", err);
-            });
+            await healArenaBuildSnapshotArtifactsOnce(prepared);
           }
         }),
       );

--- a/app/api/arena/matchup/route.ts
+++ b/app/api/arena/matchup/route.ts
@@ -122,8 +122,6 @@ async function prepareArenaBuildById(buildId: string) {
       voxelByteSize: true,
       voxelCompressedByteSize: true,
       voxelSha256: true,
-      arenaSnapshotPreview: true,
-      arenaSnapshotFull: true,
       voxelData: true,
       voxelStorageBucket: true,
       voxelStoragePath: true,
@@ -145,39 +143,6 @@ async function persistPreparedArenaBuildMetadata(
   return result.count > 0;
 }
 
-function pickPersistedVariantBuild(
-  fullBuild: unknown | null | undefined,
-  fullChecksum: string | null | undefined,
-  previewBuild: unknown | null | undefined,
-  previewChecksum: string | null | undefined,
-  variant: "full" | "preview",
-  storedChecksum: string | null,
-): ArenaMatchup["a"]["build"] {
-  const snapshot = variant === "preview" ? previewBuild : fullBuild;
-  const snapshotChecksum = (variant === "preview" ? previewChecksum : fullChecksum)?.trim();
-  if (!snapshot || !snapshotChecksum || !storedChecksum || snapshotChecksum !== storedChecksum) return null;
-  // exact variant only, no partial-backfill promotion
-  return snapshot as ArenaMatchup["a"]["build"];
-}
-
-function pickPersistedInitialBuild(
-  hints: ArenaBuildLoadHints,
-  fullBuild: unknown | null | undefined,
-  fullChecksum: string | null | undefined,
-  previewBuild: unknown | null | undefined,
-  previewChecksum: string | null | undefined,
-  storedChecksum: string | null,
-): ArenaMatchup["a"]["build"] {
-  return pickPersistedVariantBuild(
-    fullBuild,
-    fullChecksum,
-    previewBuild,
-    previewChecksum,
-    hints.initialVariant,
-    storedChecksum,
-  );
-}
-
 const SNAPSHOT_ARTIFACT_FETCH_TIMEOUT_MS = Number.parseInt(
   process.env.ARENA_SNAPSHOT_ARTIFACT_FETCH_TIMEOUT_MS ?? "5000",
   10,
@@ -186,16 +151,11 @@ const SNAPSHOT_ARTIFACT_FETCH_TIMEOUT_MS = Number.parseInt(
 async function resolveInitialBuildSnapshot(
   buildId: string,
   hints: ArenaBuildLoadHints,
-  row: {
-    voxelSha256: string | null;
-    arenaSnapshotPreview: unknown | null;
-    arenaSnapshotPreviewChecksum: string | null;
-    arenaSnapshotFull: unknown | null;
-    arenaSnapshotFullChecksum: string | null;
-  },
+  row: { voxelSha256: string | null },
 ): Promise<ArenaMatchup["a"]["build"]> {
   const storedChecksum = row.voxelSha256?.trim() || null;
-  // storage-first: the checksum-addressed artifact is the canonical snapshot
+  // the checksum-addressed artifact is the canonical snapshot; a miss falls
+  // through to live prepare in the caller
   try {
     const artifact = await fetchArenaBuildSnapshotArtifactPayload(
       buildId,
@@ -205,21 +165,9 @@ async function resolveInitialBuildSnapshot(
     );
     if (artifact) return artifact.voxelBuild as ArenaMatchup["a"]["build"];
   } catch {
-    // storage failure still has the db snapshot columns below
+    // storage failure falls back to live prepare
   }
-  const persisted = pickPersistedInitialBuild(
-    hints,
-    row.arenaSnapshotFull,
-    row.arenaSnapshotFullChecksum,
-    row.arenaSnapshotPreview,
-    row.arenaSnapshotPreviewChecksum,
-    storedChecksum,
-  );
-  if (persisted) {
-    // fallback hits must reach zero during the soak before columns can drop
-    console.log(`arena snapshot db fallback (matchup) build=${buildId} variant=${hints.initialVariant}`);
-  }
-  return persisted;
+  return null;
 }
 
 async function warmFullBuildArtifactUrl(
@@ -862,10 +810,6 @@ export async function GET(req: Request) {
 	                voxelByteSize: true,
                   voxelCompressedByteSize: true,
                   voxelSha256: true,
-                  arenaSnapshotPreview: true,
-                  arenaSnapshotPreviewChecksum: true,
-                  arenaSnapshotFull: true,
-                  arenaSnapshotFullChecksum: true,
                 },
               })
           : Promise.resolve(null),
@@ -880,10 +824,6 @@ export async function GET(req: Request) {
 	                voxelByteSize: true,
                   voxelCompressedByteSize: true,
                   voxelSha256: true,
-                  arenaSnapshotPreview: true,
-                  arenaSnapshotPreviewChecksum: true,
-                  arenaSnapshotFull: true,
-                  arenaSnapshotFullChecksum: true,
                 },
               })
           : Promise.resolve(null),

--- a/app/api/arena/matchup/route.ts
+++ b/app/api/arena/matchup/route.ts
@@ -13,6 +13,7 @@ import {
 } from "@/lib/arena/buildArtifacts";
 import {
   createArenaBuildSnapshotArtifactSignedUrl,
+  ensureArenaBuildSnapshotArtifacts,
   fetchArenaBuildSnapshotArtifactPayload,
 } from "@/lib/arena/buildSnapshotArtifacts";
 import { createArenaBuildStreamArtifactSignedUrl } from "@/lib/arena/buildStream";
@@ -940,7 +941,14 @@ export async function GET(req: Request) {
     after(async () => {
       await Promise.all(
         preparedForPersistence.map(async (prepared) => {
-          await persistPreparedArenaBuildMetadata(prepared).catch(() => false);
+          const persisted = await persistPreparedArenaBuildMetadata(prepared).catch(() => false);
+          if (!persisted) return;
+          // An inlined build is answered here, so the client never visits the
+          // build route that would upload the missing artifact. Without this,
+          // every cold matchup repeats the same miss and full payload parse.
+          await ensureArenaBuildSnapshotArtifacts(prepared).catch((err) => {
+            console.warn("arena snapshot artifact heal (matchup) failed", err);
+          });
         }),
       );
     });

--- a/app/api/arena/matchup/route.ts
+++ b/app/api/arena/matchup/route.ts
@@ -793,10 +793,9 @@ export async function GET(req: Request) {
   let preparedB: Awaited<ReturnType<typeof prepareArenaBuild>> | null = null;
   let persistedInitialBuildA: ArenaMatchup["a"]["build"] | null = null;
   let persistedInitialBuildB: ArenaMatchup["b"]["build"] | null = null;
-  // Only builds that actually reached a live prepare are missing an artifact.
-  // A warm cache hit proves nothing about storage, and healing it would
-  // re-upload multi-megabyte snapshots on ordinary matchup traffic.
-  const livePreparedBuildIds = new Set<string>();
+  // Builds whose snapshot artifact was absent for this request; healing is
+  // deduped by the success set rather than by whether we prepared here.
+  const artifactMissBuildIds = new Set<string>();
   const prepareStartedAt = performance.now();
   if (shouldPrepareA || shouldPrepareB) {
     preparedA = shouldPrepareA && checksumA ? getCachedPreparedArenaBuild(buildA.id, checksumA) : null;
@@ -847,11 +846,15 @@ export async function GET(req: Request) {
           : Promise.resolve(null),
       ]);
 
-      if (shouldPrepareA && !preparedA && !persistedInitialBuildA && buildAForPrepare) {
-        livePreparedBuildIds.add(buildA.id);
+      // An absent initial snapshot means the artifact was missing, whether or
+      // not the prepare came from cache. Healing keys off the miss rather than
+      // the prepare so a failed upload is retried on the next matchup; the
+      // success set keeps warm traffic from re-uploading.
+      if (shouldPrepareA && !persistedInitialBuildA && (buildAForPrepare || preparedA)) {
+        artifactMissBuildIds.add(buildA.id);
       }
-      if (shouldPrepareB && !preparedB && !persistedInitialBuildB && buildBForPrepare) {
-        livePreparedBuildIds.add(buildB.id);
+      if (shouldPrepareB && !persistedInitialBuildB && (buildBForPrepare || preparedB)) {
+        artifactMissBuildIds.add(buildB.id);
       }
 
       [preparedA, preparedB] = await Promise.all([
@@ -958,7 +961,7 @@ export async function GET(req: Request) {
           // build route that would upload the missing artifact. Restricted to
           // builds that live-prepared after an artifact miss, since ensure
           // upserts unconditionally and warm traffic would re-upload snapshots.
-          if (livePreparedBuildIds.has(prepared.buildId)) {
+          if (artifactMissBuildIds.has(prepared.buildId)) {
             await healArenaBuildSnapshotArtifactsOnce(prepared);
           }
         }),

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -42,10 +42,6 @@ erDiagram
         string voxelStoragePath "canonical gzip payload in storage"
         string voxelSha256 "content checksum, addresses artifacts"
         json arenaBuildHints "delivery class, variants, sizes"
-        json arenaSnapshotPreview "LEGACY: leaving Postgres (Phase 2.2)"
-        string arenaSnapshotPreviewChecksum "LEGACY: leaving Postgres (Phase 2.2)"
-        json arenaSnapshotFull "LEGACY: leaving Postgres (Phase 2.2)"
-        string arenaSnapshotFullChecksum "LEGACY: leaving Postgres (Phase 2.2)"
     }
     Vote {
         string sessionId
@@ -99,19 +95,16 @@ flowchart TD
     SR -- yes --> S307["307 to immutable storage object<br/>(browser downloads directly)"]
     SR -- no --> AF{"snapshot artifact<br/>fetch (storage-first)"}
     AF -- hit --> ASRV["serve artifact bytes"]
-    AF -- miss --> DB{"legacy DB snapshot<br/>columns (fallback, instrumented)"}
-    DB -- hit --> DSRV["serve db snapshot<br/>(logged: must reach zero before columns drop)"]
-    DB -- miss --> LP["live prepare: parse canonical payload,<br/>validate, cache, heal core metadata"]
+    AF -- miss --> LP["live prepare: parse canonical payload,<br/>validate, cache, heal metadata<br/>and upload the missing artifact"]
     ST --> VOTE
     IN --> VOTE
     S307 --> VOTE
     ASRV --> VOTE
-    DSRV --> VOTE
     LP --> VOTE["voting unlocks only after<br/>the full build hydrates"]
 ```
 
 Artifacts are immutable and checksum-addressed, so every cache layer (CDN,
 signed-URL cache, in-process body caches, client IndexedDB mesh cache) can
-treat a hit as final. The DB snapshot columns are a compatibility fallback
-scheduled for removal once production logs show zero fallback hits
-(`arena snapshot db fallback` lines) through a full soak window.
+treat a hit as final. Snapshots live only in storage; a miss falls through to a
+live prepare, which serves the request and uploads the absent artifact so the
+next request hits storage.

--- a/lib/arena/artifactCoverage.ts
+++ b/lib/arena/artifactCoverage.ts
@@ -34,8 +34,6 @@ export type ArenaBuildArtifactStatusRow = {
   voxelCompressedByteSize: number | null;
   voxelSha256: string | null;
   arenaBuildHints: unknown;
-  arenaSnapshotPreviewChecksum: string | null;
-  arenaSnapshotFullChecksum: string | null;
 };
 
 export const ARTIFACT_STATUS_BUILD_SELECT = {
@@ -45,15 +43,13 @@ export const ARTIFACT_STATUS_BUILD_SELECT = {
   voxelCompressedByteSize: true,
   voxelSha256: true,
   arenaBuildHints: true,
-  arenaSnapshotPreviewChecksum: true,
-  arenaSnapshotFullChecksum: true,
 } as const;
 
 export type ArenaBuildArtifactStatus = {
   buildId: string;
   // valid voxelSha256 and load hints are required metadata
   missingCoreMetadata: boolean;
-  // snapshot-class build whose snapshot checksums are not recorded yet
+  // snapshot-class build whose artifact refs cannot be derived yet
   needsSnapshotCompute: boolean;
   required: ArtifactRequirement[];
   missing: ArtifactRequirement[];
@@ -116,27 +112,9 @@ export function expectedArtifactRequirements(
 
   const required: ArtifactRequirement[] = [];
 
-  // An overwrite import replaces voxelSha256 but can leave the snapshot
-  // checksum columns pointing at the previous payload. Probing those stale
-  // paths would find the old objects and report the build satisfied, so
-  // missing-only maintenance would skip it and verification could activate a
-  // model whose current payload has no snapshot at all. A marker that does not
-  // match the current checksum is treated as absent.
-  const fullSnapshotChecksum =
-    row.arenaSnapshotFullChecksum && row.arenaSnapshotFullChecksum === checksum
-      ? row.arenaSnapshotFullChecksum
-      : null;
-  const previewSnapshotChecksum =
-    row.arenaSnapshotPreviewChecksum && row.arenaSnapshotPreviewChecksum === checksum
-      ? row.arenaSnapshotPreviewChecksum
-      : null;
-  const snapshotChecksumStale =
-    (row.arenaSnapshotFullChecksum != null && fullSnapshotChecksum == null) ||
-    (row.arenaSnapshotPreviewChecksum != null && previewSnapshotChecksum == null);
-
-  const fullSnapshotRef = isSnapshotClass
-    ? getSnapshotArtifactRef(row.id, "full", fullSnapshotChecksum)
-    : null;
+  // snapshot artifacts are addressed by the build checksum; the persisted
+  // hints record whether a smaller preview variant exists for this build
+  const fullSnapshotRef = isSnapshotClass ? getSnapshotArtifactRef(row.id, "full", checksum) : null;
   if (fullSnapshotRef) {
     required.push({ kind: "snapshot", variant: "full", refs: [fullSnapshotRef] });
   }
@@ -168,8 +146,8 @@ export function expectedArtifactRequirements(
 
   return {
     missingCoreMetadata,
-    needsSnapshotCompute:
-      (isSnapshotClass && fullSnapshotChecksum == null) || snapshotChecksumStale,
+    // a snapshot-class build without core metadata cannot compute its refs yet
+    needsSnapshotCompute: isSnapshotClass && missingCoreMetadata,
     required,
   };
 }

--- a/lib/arena/artifactMaintenance.ts
+++ b/lib/arena/artifactMaintenance.ts
@@ -1,6 +1,6 @@
 import type { ArenaBuildSource } from "@/lib/arena/buildArtifacts";
 import {
-  getPreparedArenaBuildMetadataUpdate,
+  getPreparedArenaBuildCoreMetadataUpdate,
   pickBuildVariant,
   prepareArenaBuild,
 } from "@/lib/arena/buildArtifacts";
@@ -67,7 +67,7 @@ export async function maybePrecomputeArenaArtifactsForBuild(
   const prepared = await prepareArenaBuild(source);
   const marked = await prisma.build.updateMany({
     where: prepared.payloadIdentity,
-    data: getPreparedArenaBuildMetadataUpdate(prepared),
+    data: getPreparedArenaBuildCoreMetadataUpdate(prepared),
   });
   if (marked.count === 0) {
     throw new Error(`Build ${source.id} changed during artifact preparation`);

--- a/lib/arena/buildArtifacts.ts
+++ b/lib/arena/buildArtifacts.ts
@@ -49,10 +49,6 @@ export type ArenaBuildSource = {
 // Payload overwrites clear derived state until artifact preparation succeeds
 export const ARENA_BUILD_DERIVED_METADATA_RESET = {
   arenaBuildHints: Prisma.DbNull,
-  arenaSnapshotPreview: Prisma.DbNull,
-  arenaSnapshotPreviewChecksum: null,
-  arenaSnapshotFull: Prisma.DbNull,
-  arenaSnapshotFullChecksum: null,
 } as const;
 
 type ArenaBuildPayloadIdentitySource = Pick<
@@ -263,27 +259,10 @@ export function serializeArenaBuildLoadHints(hints: ArenaBuildLoadHints): Record
 export function getPreparedArenaBuildCoreMetadataUpdate(
   prepared: PreparedArenaBuild,
 ): Record<string, unknown> {
-  // hot-route self-healing repairs identity and hints only; snapshot JSON is maintenance-owned
+  // identity and hints only; snapshot payloads live in storage artifacts
   return {
     voxelSha256: prepared.checksum,
     arenaBuildHints: serializeArenaBuildLoadHints(prepared.hints),
-  };
-}
-
-export function getPreparedArenaBuildMetadataUpdate(prepared: PreparedArenaBuild): Record<string, unknown> {
-  // persisted snapshots cover inline and snapshot routes only
-  const shouldPersistPreparedPayload = prepared.hints.deliveryClass !== "stream-artifact";
-  const snapshotPreview =
-    shouldPersistPreparedPayload && prepared.previewBuild.blocks.length < prepared.fullBuild.blocks.length
-      ? prepared.previewBuild
-      : null;
-  const snapshotFull = shouldPersistPreparedPayload ? prepared.fullBuild : null;
-  return {
-    ...getPreparedArenaBuildCoreMetadataUpdate(prepared),
-    arenaSnapshotPreview: snapshotPreview,
-    arenaSnapshotPreviewChecksum: snapshotPreview ? prepared.checksum : null,
-    arenaSnapshotFull: snapshotFull,
-    arenaSnapshotFullChecksum: snapshotFull ? prepared.checksum : null,
   };
 }
 

--- a/lib/arena/buildMetaCache.ts
+++ b/lib/arena/buildMetaCache.ts
@@ -2,8 +2,8 @@ import { prisma } from "@/lib/prisma";
 
 // Lightweight build metadata. Immutable per (buildId, voxelSha256), so cold-warm
 // hits do not need a Postgres roundtrip every request. Heavy fields (voxelData,
-// storage pointers, arenaSnapshot* json) are intentionally excluded so this
-// cache stays tiny in memory under high cardinality.
+// storage pointers) are intentionally excluded so this cache stays tiny in
+// memory under high cardinality.
 export type ArenaBuildMetaRow = {
   id: string;
   gridSize: number;
@@ -13,13 +13,6 @@ export type ArenaBuildMetaRow = {
   voxelCompressedByteSize: number | null;
   voxelSha256: string | null;
   arenaBuildHints: unknown | null;
-};
-
-export type ArenaBuildSnapshotFields = {
-  arenaSnapshotPreview: unknown | null;
-  arenaSnapshotPreviewChecksum: string | null;
-  arenaSnapshotFull: unknown | null;
-  arenaSnapshotFullChecksum: string | null;
 };
 
 type CacheEntry = {
@@ -151,24 +144,6 @@ export async function getArenaBuildMeta(
       inflight.delete(buildId);
     }
   }
-}
-
-// Snapshot json fields are large and only needed when the artifact redirect
-// path missed and the response cache also missed, so they live outside the
-// metadata cache. Subsequent identical requests are served by the
-// jsonResponseCache in the build route, which has its own byte-weight cap.
-export async function getArenaBuildSnapshotFields(
-  buildId: string,
-): Promise<ArenaBuildSnapshotFields | null> {
-  return prisma.build.findUnique({
-    where: { id: buildId },
-    select: {
-      arenaSnapshotPreview: true,
-      arenaSnapshotPreviewChecksum: true,
-      arenaSnapshotFull: true,
-      arenaSnapshotFullChecksum: true,
-    },
-  });
 }
 
 export function invalidateArenaBuildMeta(buildId: string) {

--- a/lib/arena/buildSnapshotArtifacts.ts
+++ b/lib/arena/buildSnapshotArtifacts.ts
@@ -520,3 +520,27 @@ export async function createArenaBuildSnapshotArtifactSignedUrl(
     artifactSignedUrlInflight.delete(cacheKey);
   }
 }
+
+// Healing tracked separately from the prepared cache. The prepared cache has no
+// TTL, so gating repair on "did we just prepare this" means one failed upload
+// is never retried for the life of the process. Keyed by build and checksum so
+// a re-import re-arms it; recorded only on success, and also when the policy
+// says this build needs no snapshot at all.
+const healedSnapshotArtifacts = new Set<string>();
+
+export async function healArenaBuildSnapshotArtifactsOnce(
+  prepared: PreparedArenaBuild,
+): Promise<void> {
+  const checksum = prepared.checksum?.trim();
+  if (!checksum) return;
+  const key = `${prepared.buildId}:${checksum}`;
+  if (healedSnapshotArtifacts.has(key)) return;
+
+  try {
+    await ensureArenaBuildSnapshotArtifacts(prepared);
+    healedSnapshotArtifacts.add(key);
+  } catch (error) {
+    // leave the key unset so the next miss retries
+    console.warn("arena snapshot artifact heal failed", error);
+  }
+}

--- a/lib/arena/buildSnapshotArtifacts.ts
+++ b/lib/arena/buildSnapshotArtifacts.ts
@@ -31,9 +31,8 @@ const ARENA_SNAPSHOT_ARTIFACT_POLICY_KEY = normalizePrefix(
     getArenaPreviewTargetBlocks(),
   ].join("-"),
 );
-const ARENA_SNAPSHOT_ARTIFACT_BUCKET = (
-  process.env.ARENA_SNAPSHOT_ARTIFACT_BUCKET ?? getBuildStorageBucketFromEnv()
-).trim();
+const ARENA_SNAPSHOT_ARTIFACT_BUCKET =
+  process.env.ARENA_SNAPSHOT_ARTIFACT_BUCKET?.trim() || getBuildStorageBucketFromEnv();
 const ARENA_SNAPSHOT_ARTIFACT_MISS_TTL_MS = readIntEnv(
   "ARENA_SNAPSHOT_ARTIFACT_MISS_TTL_MS",
   1_000,

--- a/lib/arena/buildStream.ts
+++ b/lib/arena/buildStream.ts
@@ -50,9 +50,8 @@ const ARENA_STREAM_ARTIFACTS_ENABLED = readBoolEnv("ARENA_STREAM_ARTIFACTS_ENABL
 const ARENA_STREAM_ARTIFACT_PREFIX = normalizePrefix(
   process.env.ARENA_STREAM_ARTIFACT_PREFIX ?? "arena-stream/v3-gzip",
 );
-const ARENA_STREAM_ARTIFACT_BUCKET = (
-  process.env.ARENA_STREAM_ARTIFACT_BUCKET ?? getBuildStorageBucketFromEnv()
-).trim();
+const ARENA_STREAM_ARTIFACT_BUCKET =
+  process.env.ARENA_STREAM_ARTIFACT_BUCKET?.trim() || getBuildStorageBucketFromEnv();
 const ARENA_STREAM_ARTIFACT_MISS_TTL_MS = readIntEnv(
   "ARENA_STREAM_ARTIFACT_MISS_TTL_MS",
   1_000,

--- a/lib/storage/buildPayload.ts
+++ b/lib/storage/buildPayload.ts
@@ -100,7 +100,9 @@ export function hasSupabaseStorageConfig(): boolean {
 }
 
 export function getBuildStorageBucketFromEnv(): string {
-  return (process.env.SUPABASE_STORAGE_BUCKET ?? DEFAULT_BUILD_STORAGE_BUCKET).trim();
+  // an env var present but blank must fall back, not silently disable artifact
+  // delivery for every build
+  return process.env.SUPABASE_STORAGE_BUCKET?.trim() || DEFAULT_BUILD_STORAGE_BUCKET;
 }
 
 export async function getSupabaseStorageReadiness(): Promise<SupabaseStorageReadiness> {

--- a/prisma/migrations/20260813234500_drop_arena_snapshot_columns/migration.sql
+++ b/prisma/migrations/20260813234500_drop_arena_snapshot_columns/migration.sql
@@ -1,0 +1,10 @@
+-- Snapshot payloads are served from checksum-addressed storage artifacts;
+-- the legacy Build columns held redundant copies (~377MB of the relation).
+-- Deploy the code that stops selecting these columns BEFORE running this
+-- migration. Freed pages become reusable after autovacuum; physical shrink
+-- (VACUUM FULL / pg_repack) is a separately scheduled operation.
+
+ALTER TABLE "Build" DROP COLUMN IF EXISTS "arenaSnapshotPreview";
+ALTER TABLE "Build" DROP COLUMN IF EXISTS "arenaSnapshotPreviewChecksum";
+ALTER TABLE "Build" DROP COLUMN IF EXISTS "arenaSnapshotFull";
+ALTER TABLE "Build" DROP COLUMN IF EXISTS "arenaSnapshotFullChecksum";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -98,10 +98,6 @@ model Build {
   voxelCompressedByteSize Int?
   voxelSha256        String?
   arenaBuildHints    Json?
-  arenaSnapshotPreview Json?
-  arenaSnapshotPreviewChecksum String?
-  arenaSnapshotFull  Json?
-  arenaSnapshotFullChecksum String?
   blockCount        Int
   generationTimeMs  Int
 

--- a/scripts/backfill-arena-build-metadata.ts
+++ b/scripts/backfill-arena-build-metadata.ts
@@ -3,7 +3,7 @@
 import "dotenv/config";
 import { PrismaClient } from "@prisma/client";
 import {
-  getPreparedArenaBuildMetadataUpdate,
+  getPreparedArenaBuildCoreMetadataUpdate,
   parsePersistedArenaBuildMetadata,
   prepareArenaBuild,
 } from "../lib/arena/buildArtifacts";
@@ -126,7 +126,7 @@ async function main() {
       try {
         const payloadRow = await loadBuildPayloadRow(prisma, row);
         const prepared = await prepareArenaBuild(payloadRow);
-        const data = getPreparedArenaBuildMetadataUpdate(prepared);
+        const data = getPreparedArenaBuildCoreMetadataUpdate(prepared);
 
         if (opts.dryRun) {
           console.log(

--- a/scripts/precompute-arena-snapshot-artifacts.ts
+++ b/scripts/precompute-arena-snapshot-artifacts.ts
@@ -4,7 +4,7 @@ import "dotenv/config";
 import { PrismaClient } from "@prisma/client";
 import { gzipSync } from "node:zlib";
 import {
-  getPreparedArenaBuildMetadataUpdate,
+  getPreparedArenaBuildCoreMetadataUpdate,
   pickBuildVariant,
   prepareArenaBuild,
 } from "../lib/arena/buildArtifacts";
@@ -185,18 +185,10 @@ async function main() {
         }
 
         const result = await ensureArenaBuildSnapshotArtifacts(prepared);
-        // Record what now exists. Coverage treats a marker that disagrees with
-        // voxelSha256 as missing, and the missing-only metadata backfill skips
-        // rows whose checksum and hints are already set, so without this a
-        // stale marker survives its own recomputation and the build stays in
-        // missingBuildIds forever. Writing on the skipped path too clears a
-        // stale marker for builds that need no snapshot at all.
-        //
-        // Guarded on the payload identity observed when the row was loaded
-        // Storage identity protects rows that do not have a checksum yet
+        // Storage identity protects checksum-less rows from concurrent overwrites
         const marked = await prisma.build.updateMany({
           where: prepared.payloadIdentity,
-          data: getPreparedArenaBuildMetadataUpdate(prepared),
+          data: getPreparedArenaBuildCoreMetadataUpdate(prepared),
         });
         if (marked.count === 0) {
           skipped += 1;

--- a/tests/unit/arena/artifact-coverage-policy.test.ts
+++ b/tests/unit/arena/artifact-coverage-policy.test.ts
@@ -12,7 +12,7 @@ async function main() {
   const {
     ARENA_BUILD_DERIVED_METADATA_RESET,
     getArenaBuildPayloadIdentity,
-    getPreparedArenaBuildMetadataUpdate,
+    getPreparedArenaBuildCoreMetadataUpdate,
     parsePersistedArenaBuildMetadata,
     prepareArenaBuildFromBuild,
   } = await import("../../../lib/arena/buildArtifacts");
@@ -33,8 +33,6 @@ async function main() {
       initialEstimatedBytes: 1_700_000,
       fullEstimatedBytes: 20_000_000,
     },
-    arenaSnapshotPreviewChecksum: null,
-    arenaSnapshotFullChecksum: null,
   });
   const streamRequirements = expectations.required.filter(
     (requirement) => requirement.kind === "stream",
@@ -77,8 +75,6 @@ async function main() {
       initialEstimatedBytes: 3_000_000,
       fullEstimatedBytes: 3_000_000,
     },
-    arenaSnapshotPreviewChecksum: null,
-    arenaSnapshotFullChecksum: checksum,
   });
   const fullSnapshotRequirements = persistedSnapshotClass.required.filter(
     (requirement) => requirement.kind === "snapshot" && requirement.variant === "full",
@@ -106,8 +102,6 @@ async function main() {
       initialEstimatedBytes: 1_700_000,
       fullEstimatedBytes: 20_000_000,
     },
-    arenaSnapshotPreviewChecksum: null,
-    arenaSnapshotFullChecksum: null,
   });
   assert.equal(malformedChecksum.missingCoreMetadata, true);
   assert.equal(malformedChecksum.required.length, 0);
@@ -119,8 +113,6 @@ async function main() {
     voxelCompressedByteSize: 500,
     voxelSha256: checksum,
     arenaBuildHints: { deliveryClass: "snapshot" },
-    arenaSnapshotPreviewChecksum: null,
-    arenaSnapshotFullChecksum: null,
   });
   assert.equal(
     malformedHints.missingCoreMetadata,
@@ -171,11 +163,9 @@ async function main() {
     { id: "checksummed-storage-build", voxelSha256: checksum },
     "durable checksums should remain the complete payload identity",
   );
-  assert.equal(ARENA_BUILD_DERIVED_METADATA_RESET.arenaBuildHints, Prisma.DbNull);
-  assert.equal(ARENA_BUILD_DERIVED_METADATA_RESET.arenaSnapshotPreview, Prisma.DbNull);
-  assert.equal(ARENA_BUILD_DERIVED_METADATA_RESET.arenaSnapshotPreviewChecksum, null);
-  assert.equal(ARENA_BUILD_DERIVED_METADATA_RESET.arenaSnapshotFull, Prisma.DbNull);
-  assert.equal(ARENA_BUILD_DERIVED_METADATA_RESET.arenaSnapshotFullChecksum, null);
+  assert.deepEqual(ARENA_BUILD_DERIVED_METADATA_RESET, {
+    arenaBuildHints: Prisma.DbNull,
+  });
   assert.equal(
     parsePersistedArenaBuildMetadata({
       voxelSha256: checksum,
@@ -204,7 +194,7 @@ async function main() {
   );
   assert.match(repairedBuild.checksum ?? "", /^[0-9a-f]{64}$/);
   assert.equal(
-    getPreparedArenaBuildMetadataUpdate(repairedBuild).voxelSha256,
+    getPreparedArenaBuildCoreMetadataUpdate(repairedBuild).voxelSha256,
     repairedBuild.checksum,
     "checksum-less builds should receive durable metadata before token issuance",
   );

--- a/tests/unit/arena/build-metadata-updates.test.ts
+++ b/tests/unit/arena/build-metadata-updates.test.ts
@@ -1,7 +1,6 @@
 import assert from "node:assert/strict";
 import {
   getPreparedArenaBuildCoreMetadataUpdate,
-  getPreparedArenaBuildMetadataUpdate,
   prepareArenaBuildFromBuild,
   type ArenaBuildSource,
 } from "../../../lib/arena/buildArtifacts";
@@ -42,21 +41,14 @@ async function main() {
   assert.deepEqual(
     Object.keys(core).sort(),
     ["arenaBuildHints", "voxelSha256"],
-    "hot-route heals must write core metadata only",
+    "metadata updates must write core metadata only",
   );
   assert.equal(core.voxelSha256, prepared.checksum);
   for (const key of SNAPSHOT_KEYS) {
-    assert.ok(!(key in core), `core metadata update must not carry ${key}`);
+    assert.ok(!(key in core), `metadata update must not carry ${key}`);
   }
 
-  const full = getPreparedArenaBuildMetadataUpdate(prepared);
-  for (const key of ["voxelSha256", "arenaBuildHints", ...SNAPSHOT_KEYS]) {
-    assert.ok(key in full, `maintenance metadata update must carry ${key}`);
-  }
-  assert.equal(full.voxelSha256, core.voxelSha256);
-  assert.deepEqual(full.arenaBuildHints, core.arenaBuildHints);
-
-  console.log("build metadata update split checks passed");
+  console.log("build metadata update checks passed");
 }
 
 main().catch((err) => {


### PR DESCRIPTION
Completes the migration of arena snapshot payloads out of Postgres. The preceding work made storage the primary read path and left the database columns as an instrumented fallback; this removes the fallback and the columns.

**Do not merge before both gates pass.** Validate on the staging environment first (fresh production copy, migration applied, deep artifact audit green, delivery exercised), then confirm the deployed fallback instrumentation has logged zero hits through a full soak window. When promoting, deploy the code before running the migration — the second commit drops columns the previous deployment still selects.

**Reads**

The build route, the matchup route, and the metadata cache no longer read the snapshot columns. A storage miss now falls through to a live prepare, which is the same path that already handled builds whose snapshots were never persisted.

**Writes**

Every metadata writer is now the core writer: content checksum and load hints. Snapshot payloads are written only as storage artifacts.

**Artifact requirements**

Requirement derivation previously keyed on the snapshot checksum columns. It now derives from the build checksum and the persisted load hints, where a preview artifact is expected when the hints record a preview smaller than the full build. Checked against production data before removal: the new derivation finds 1,311 required snapshot artifacts against the old derivation's 1,282, with zero missing, and a deep audit sample verifies clean.

Physical space reclamation after the drop is a separately scheduled operation.

_(PR written by Codex)_
