### PR TITLE
(feat) add GLM 5.3 + Z.ai provider harness

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,6 +28,7 @@ DEEPSEEK_API_KEY=
 MINIMAX_API_KEY=
 XAI_API_KEY=
 META_MODEL_API_KEY=
+ZAI_API_KEY=
 
 # OpenRouter (alternative/fallback for all providers)
 # If a direct provider key is missing or fails, OpenRouter will be used as fallback
@@ -57,6 +58,7 @@ ANTHROPIC_STREAM_RESPONSES=1
 # Batch generation uses non-streamed Responses JSON for reliability.
 OPENAI_STREAM_RESPONSES=1
 # DeepSeek V4 Pro defaults to thinking=max and uses up to 384000 output tokens unless MINEBENCH_MAX_OUTPUT_TOKENS lowers it.
+# GLM 5.3 always thinks and defaults to reasoning_effort=max; lower it with `pnpm batch:generate --reasoning high|low`.
 # Use OpenAI background mode for long-running Responses API models (default true for gpt-5* when not streaming deltas)
 OPENAI_USE_BACKGROUND_MODE=1
 # Poll interval (ms) while waiting on background Responses jobs
@@ -70,6 +72,7 @@ MOONSHOT_BASE_URL="https://api.moonshot.ai"
 DEEPSEEK_BASE_URL="https://api.deepseek.com"
 MINIMAX_BASE_URL="https://api.minimax.io/v1"
 XAI_BASE_URL="https://api.x.ai/v1"
+ZAI_BASE_URL="https://api.z.ai/api/paas/v4"
 META_MODEL_API_BASE_URL="https://api.meta.ai/v1"
 OPENROUTER_BASE_URL="https://openrouter.ai/api"
 

--- a/app/api/admin/seed/route.ts
+++ b/app/api/admin/seed/route.ts
@@ -67,6 +67,7 @@ function providerKeyStatus() {
     minimax: Boolean(process.env.MINIMAX_API_KEY),
     xai: Boolean(process.env.XAI_API_KEY),
     meta: Boolean(process.env.META_MODEL_API_KEY),
+    zai: Boolean(process.env.ZAI_API_KEY),
     openrouter: Boolean(process.env.OPENROUTER_API_KEY),
   };
 }
@@ -87,6 +88,7 @@ function isModelGeneratable(args: { modelKey: string; provider: string }) {
   if (args.provider === "deepseek") return status.deepseek;
   if (args.provider === "minimax") return status.minimax;
   if (args.provider === "meta") return status.meta;
+  if (args.provider === "zai") return status.zai;
 
   // Unknown provider: assume it's callable (or OpenRouter-gated via catalog entries).
   return true;
@@ -217,7 +219,7 @@ export async function POST(req: Request) {
       done: true,
       seeded: 0,
       error:
-        "No enabled models found. Set at least one API key (OPENROUTER_API_KEY, OPENAI_API_KEY, ANTHROPIC_API_KEY, GOOGLE_AI_API_KEY, MINIMAX_API_KEY, XAI_API_KEY, META_MODEL_API_KEY, etc.) or enable models for configured providers.",
+        "No enabled models found. Set at least one API key (OPENROUTER_API_KEY, OPENAI_API_KEY, ANTHROPIC_API_KEY, GOOGLE_AI_API_KEY, MINIMAX_API_KEY, XAI_API_KEY, META_MODEL_API_KEY, ZAI_API_KEY, etc.) or enable models for configured providers.",
       promptCount: prompts.length,
       modelCount: 0,
       settings: ARENA_SETTINGS,
@@ -280,7 +282,7 @@ export async function POST(req: Request) {
       done: true,
       seeded: 0,
       error:
-        "No API keys are configured, so no builds can be generated automatically. Use generateBuilds=0 to seed prompts/models only, or set OPENROUTER_API_KEY / provider API keys such as XAI_API_KEY or META_MODEL_API_KEY to generate builds.",
+        "No API keys are configured, so no builds can be generated automatically. Use generateBuilds=0 to seed prompts/models only, or set OPENROUTER_API_KEY or a direct provider key to generate builds.",
       promptCount: prompts.length,
       modelCount: modelsAll.length,
       modelCountGeneratable: 0,

--- a/app/api/generate/route.ts
+++ b/app/api/generate/route.ts
@@ -17,6 +17,7 @@ const providerKeysSchema = z
     minimax: z.string().trim().min(1).max(4000).optional(),
     xai: z.string().trim().min(1).max(4000).optional(),
     meta: z.string().trim().min(1).max(4000).optional(),
+    zai: z.string().trim().min(1).max(4000).optional(),
     openrouter: z.string().trim().min(1).max(4000).optional(),
     custom: z.string().trim().min(1).max(4000).optional(),
   })
@@ -118,7 +119,7 @@ export async function POST(req: Request) {
     return NextResponse.json(
       {
         error:
-          "No API keys provided. Add an OpenRouter key or a provider key (OpenAI/Anthropic/Gemini/Moonshot/DeepSeek/MiniMax/xAI/Meta/etc.) in Sandbox settings.",
+          "No API keys provided. Add an OpenRouter key or a provider key (OpenAI/Anthropic/Gemini/Moonshot/DeepSeek/MiniMax/xAI/Meta/Z.AI/etc.) in Sandbox settings.",
       },
       { status: 401 }
     );

--- a/components/sandbox/SandboxLive.tsx
+++ b/components/sandbox/SandboxLive.tsx
@@ -135,6 +135,7 @@ function loadProviderKeysFromStorage(): ProviderApiKeys {
     set("minimax");
     set("xai");
     set("meta");
+    set("zai");
     set("custom");
     return keys;
   } catch {
@@ -623,6 +624,7 @@ export function SandboxLive({ initialPrompt }: { initialPrompt?: string }) {
       setKey("minimax", providerKeys.minimax);
       setKey("xai", providerKeys.xai);
       setKey("meta", providerKeys.meta);
+      setKey("zai", providerKeys.zai);
       setKey("custom", providerKeys.custom);
 
       const res = await fetch("/api/generate", {
@@ -1279,6 +1281,19 @@ export function SandboxLive({ initialPrompt }: { initialPrompt?: string }) {
                       autoComplete="off"
                       spellCheck={false}
                       placeholder="Paste your Meta Model API key"
+                    />
+                  </label>
+
+                  <label className="flex flex-col gap-1">
+                    <div className="text-xs font-medium text-muted">Z.AI</div>
+                    <input
+                      className="mb-field h-10 w-full"
+                      type={showKeys ? "text" : "password"}
+                      value={providerKeys.zai ?? ""}
+                      onChange={(e) => setProviderKeys((prev) => ({ ...prev, zai: e.target.value }))}
+                      autoComplete="off"
+                      spellCheck={false}
+                      placeholder="Paste your Z.AI key"
                     />
                   </label>
                 </div>

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -95,6 +95,7 @@ Copy `.env.example` to `.env` and set what you need.
 - `MINIMAX_API_KEY`
 - `XAI_API_KEY`
 - `META_MODEL_API_KEY`
+- `ZAI_API_KEY`
 - `OPENROUTER_API_KEY`
 
 ### Optional Provider and Runtime Tuning
@@ -130,8 +131,9 @@ Copy `.env.example` to `.env` and set what you need.
 - DeepSeek V4 Pro uses the native DeepSeek API with JSON Output mode, defaults to `thinking=max` and `max_tokens=384000`; use `pnpm batch:generate --reasoning high` only when intentionally lowering effort.
 - DeepSeek V4 Flash 0731 uses the native DeepSeek model ID `deepseek-v4-flash`, supports `reasoning_effort=low|high|max`, and MineBench defaults to `max` with a 384000-token output cap. Its OpenRouter fallback uses the exact `deepseek/deepseek-v4-flash-0731` route and requests `max` reasoning first, with `high` and `low` fallbacks.
 - Qwen 3.8 Max is OpenRouter-only in MineBench and uses `qwen/qwen3.8-max`, with `xhigh|high|medium|low|minimal` reasoning efforts and `xhigh` by default. Its current OpenRouter output cap is 131072 tokens and its context window is 1M tokens.
+- GLM 5.3 uses the native Z.AI model ID `glm-5.3` on the OpenAI-compatible `/api/paas/v4` route, always thinks (`thinking.type=disabled` is rejected), supports `reasoning_effort=low|high|max`, and MineBench defaults it to `max` with a 131072-token output cap against its 1M-token context window. Its OpenRouter fallback uses `z-ai/glm-5.3` with the same cap and effort ladder, stepping down to `high` then `low`.
 - Muse Spark 1.2 uses the native Meta Model API model ID `muse-spark-1.2`, defaults to mandatory `reasoning_effort=xhigh`, and sends `max_completion_tokens=131072` with strict structured output. If no Meta key is available, or OpenRouter is explicitly preferred, MineBench uses `meta/muse-spark-1.2` without ever disabling reasoning.
-- `OPENROUTER_BASE_URL`, `MOONSHOT_BASE_URL`, `DEEPSEEK_BASE_URL`, `MINIMAX_BASE_URL`, `XAI_BASE_URL`, `META_MODEL_API_BASE_URL`
+- `OPENROUTER_BASE_URL`, `MOONSHOT_BASE_URL`, `DEEPSEEK_BASE_URL`, `MINIMAX_BASE_URL`, `XAI_BASE_URL`, `META_MODEL_API_BASE_URL`, `ZAI_BASE_URL`
 - `AI_DEBUG=1` (logs raw model output on failures)
 - `MINEBENCH_TOOL_OUTPUT_DIR`, `MINEBENCH_TOOL_TIMEOUT_MS`, `MINEBENCH_TOOL_MAX_*` (advanced `voxel.exec` controls)
 

--- a/lib/admin/seedModelCatalog.ts
+++ b/lib/admin/seedModelCatalog.ts
@@ -9,6 +9,7 @@ export type SeedProviderKeyStatus = {
   minimax: boolean;
   xai: boolean;
   meta: boolean;
+  zai: boolean;
   openrouter: boolean;
 };
 
@@ -70,6 +71,7 @@ export function isCatalogModelGeneratableForSeed(args: {
   if (model.provider === "deepseek") return providerKeys.deepseek || canUseOpenRouter;
   if (model.provider === "minimax") return providerKeys.minimax || canUseOpenRouter;
   if (model.provider === "meta") return providerKeys.meta || canUseOpenRouter;
+  if (model.provider === "zai") return providerKeys.zai || canUseOpenRouter;
 
   return true;
 }

--- a/lib/ai/generateVoxelBuild.ts
+++ b/lib/ai/generateVoxelBuild.ts
@@ -15,6 +15,7 @@ import { openAiCompatibleGenerateText } from "@/lib/ai/providers/openaiCompatibl
 import { openaiGenerateText } from "@/lib/ai/providers/openai";
 import { openrouterGenerateText } from "@/lib/ai/providers/openrouter";
 import { xaiGenerateText } from "@/lib/ai/providers/xai";
+import { zaiGenerateText } from "@/lib/ai/providers/zai";
 import {
   AnthropicAdaptiveEffort,
   anthropicAdaptiveEffortAttempts,
@@ -31,6 +32,7 @@ import {
   openRouterReasoningEffortAttempts as openRouterReasoningEffortAttemptsForModel,
   xaiAutomaticReasoningForModel,
   xaiReasoningEffortAttempts,
+  zaiReasoningEffortAttempts,
 } from "@/lib/ai/reasoningProfiles";
 import { parseVoxelBuildSpec, validateVoxelBuild } from "@/lib/voxel/validate";
 import type { VoxelBuild } from "@/lib/voxel/types";
@@ -163,7 +165,7 @@ function describeRequestedThinkingMode(opts: {
   if (opts.provider === "minimax") return "default";
   if (opts.provider === "custom") return "default";
 
-  if (opts.provider === "meta") {
+  if (opts.provider === "meta" || opts.provider === "zai") {
     if (opts.reasoningEffortAttempts && opts.reasoningEffortAttempts.length > 0) {
       return `reasoning_effort=${opts.reasoningEffortAttempts[0]}`;
     }
@@ -322,6 +324,7 @@ type ProviderKeyName =
   | "minimax"
   | "xai"
   | "meta"
+  | "zai"
   | "openrouter"
   | "custom";
 
@@ -343,6 +346,8 @@ function envVarForProviderKey(provider: ProviderKeyName): string {
       return "XAI_API_KEY";
     case "meta":
       return "META_MODEL_API_KEY";
+    case "zai":
+      return "ZAI_API_KEY";
     case "openrouter":
       return "OPENROUTER_API_KEY";
     case "custom":
@@ -368,6 +373,8 @@ function envVarForDirectProvider(provider: DirectProvider): string | null {
       return envVarForProviderKey("xai");
     case "meta":
       return envVarForProviderKey("meta");
+    case "zai":
+      return envVarForProviderKey("zai");
     case "custom":
       return envVarForProviderKey("custom");
     default:
@@ -386,7 +393,7 @@ function effectiveApiKey(opts: {
   allowServerKeys: boolean;
 }): string | null {
   const provider = opts.provider;
-  if (provider === "zai" || provider === "qwen") return null; // only supported via OpenRouter fallback
+  if (provider === "qwen") return null; // only supported via OpenRouter fallback
 
   const directKey = normalizeApiKey(
     provider === "openrouter"
@@ -407,9 +414,11 @@ function effectiveApiKey(opts: {
                     ? opts.providerKeys?.xai
                     : provider === "meta"
                       ? opts.providerKeys?.meta
-                      : provider === "custom"
-                        ? opts.providerKeys?.custom
-                        : undefined,
+                      : provider === "zai"
+                        ? opts.providerKeys?.zai
+                        : provider === "custom"
+                          ? opts.providerKeys?.custom
+                          : undefined,
   );
   if (directKey) return directKey;
 
@@ -424,6 +433,7 @@ function effectiveApiKey(opts: {
   if (provider === "minimax") return serverApiKey("minimax");
   if (provider === "xai") return serverApiKey("xai");
   if (provider === "meta") return serverApiKey("meta");
+  if (provider === "zai") return serverApiKey("zai");
   if (provider === "custom") return serverApiKey("custom");
 
   return null;
@@ -668,9 +678,23 @@ async function callDirectProvider(args: {
     });
   }
 
-  // Z.AI models are currently OpenRouter-only in MineBench
   if (args.provider === "zai") {
-    throw new Error("Z.AI direct API not supported; use OpenRouter fallback");
+    return zaiGenerateText({
+      modelId: args.modelId,
+      apiKey: args.apiKey,
+      system: args.system,
+      user: args.user,
+      maxOutputTokens: args.maxOutputTokens,
+      reasoningEffortAttempts: args.reasoningEffortAttempts,
+      temperature: DEFAULT_TEMPERATURE,
+      jsonSchema: args.jsonSchema,
+      signal: args.signal,
+      onDelta: args.onDelta,
+      onTrace: args.onTrace,
+      onAcceptedOutputTokens: args.onAcceptedOutputTokens,
+      onProviderRequest: args.onProviderRequest,
+      onAcceptedRequestConfiguration: args.onAcceptedRequestConfiguration,
+    });
   }
 
   // Qwen models are currently OpenRouter-only in MineBench
@@ -791,6 +815,10 @@ async function providerGenerateText(args: {
       model.provider === "meta"
         ? metaReasoningEffortAttempts(model.modelId, args.reasoning)
         : undefined;
+    const directZaiReasoningEffortAttempts =
+      model.provider === "zai"
+        ? zaiReasoningEffortAttempts(model.modelId, args.reasoning)
+        : undefined;
     const directAnthropicAdaptiveEffortAttempts =
       model.provider === "anthropic"
         ? anthropicAdaptiveEffortAttempts(model.modelId, args.reasoning)
@@ -819,7 +847,8 @@ async function providerGenerateText(args: {
       reasoningEffortAttempts:
         directOpenAiReasoningEffortAttempts ??
         directXaiReasoningEffortAttempts ??
-        directMetaReasoningEffortAttempts,
+        directMetaReasoningEffortAttempts ??
+        directZaiReasoningEffortAttempts,
       adaptiveEffortAttempts: directAnthropicAdaptiveEffortAttempts,
       geminiThinkingConfig: directGeminiThinkingConfig,
       moonshotThinkingConfig: directMoonshotThinkingConfig,
@@ -845,7 +874,8 @@ async function providerGenerateText(args: {
         reasoningEffortAttempts:
           directOpenAiReasoningEffortAttempts ??
           directXaiReasoningEffortAttempts ??
-          directMetaReasoningEffortAttempts,
+          directMetaReasoningEffortAttempts ??
+          directZaiReasoningEffortAttempts,
         adaptiveEffortAttempts: directAnthropicAdaptiveEffortAttempts,
         geminiThinkingConfig: directGeminiThinkingConfig,
         moonshotThinkingConfig: directMoonshotThinkingConfig,

--- a/lib/ai/modelBenchmarkMetrics.generated.json
+++ b/lib/ai/modelBenchmarkMetrics.generated.json
@@ -565,6 +565,28 @@
       "interruptedRunCount": 0,
       "providerCallTrackingJobCount": 15,
       "completedAttemptTrackingJobCount": 15
+    },
+    "zai_glm_5_3": {
+      "inferenceSampleCount": 15,
+      "expectedBuildCount": 15,
+      "finalizedBuildCount": 15,
+      "promptCohortId": "prompts-v1:bd8c28367f8a97f2",
+      "averageJsonSizeBytes": 29735133,
+      "configurationSampleCount": 15,
+      "configurationIsConsistent": true,
+      "outputCapSampleCount": 15,
+      "outputCapIsConsistent": true,
+      "averageInferenceMs": 2133473,
+      "finalizedAttemptCount": 25,
+      "outputCapTokens": 131072,
+      "providerCallCount": 25,
+      "completedAttemptCount": 24,
+      "rejectedResponseCount": 9,
+      "failedAttemptCount": 10,
+      "failedRunCount": 0,
+      "interruptedRunCount": 0,
+      "providerCallTrackingJobCount": 15,
+      "completedAttemptTrackingJobCount": 15
     }
   }
 }

--- a/lib/ai/modelBenchmarkProfiles.ts
+++ b/lib/ai/modelBenchmarkProfiles.ts
@@ -196,6 +196,7 @@ const MODEL_RUN_PARAMETERS = {
     { label: "Reasoning", value: "Automatic" },
   ],
   xai_grok_4_20: [{ label: "Reasoning", value: "Thinking enabled" }],
+  zai_glm_5_3: [{ label: "Reasoning effort", value: "Max" }],
   zai_glm_5_2: [
     { label: "Reasoning effort", value: "XHigh → High" },
   ],
@@ -280,6 +281,7 @@ export const HISTORICAL_BENCHMARK_OUTPUT_CAPS: Partial<
   xai_grok_4_5: exactOutputCap(262_144),
   xai_grok_4_3: exactOutputCap(983_040),
   xai_grok_4_1: exactOutputCap(30_000),
+  zai_glm_5_3: exactOutputCap(131_072),
   zai_glm_5_2: exactOutputCap(131_072),
   zai_glm_5_1: exactOutputCap(131_072),
   zai_glm_5: exactOutputCap(131_072),

--- a/lib/ai/modelBenchmarkProfiles.ts
+++ b/lib/ai/modelBenchmarkProfiles.ts
@@ -303,6 +303,9 @@ export const HISTORICAL_BENCHMARK_OUTPUT_CAPS: Partial<
 const MODEL_BENCHMARK_METADATA: Partial<
   Record<ModelKey, Omit<ModelBenchmarkProfile, "outputCap" | "parameters">>
 > = {
+  zai_glm_5_3: {
+    totalCost: { usd: 6.42 },
+  },
   gemini_3_7_flash: {
     totalCost: { usd: 1.46 },
   },

--- a/lib/ai/modelCatalog.ts
+++ b/lib/ai/modelCatalog.ts
@@ -471,6 +471,15 @@ const CATALOG = [
     openRouterModelId: "x-ai/grok-4.20",
   },
   {
+    key: "zai_glm_5_3",
+    slug: "glm-5-3",
+    provider: "zai",
+    modelId: "glm-5.3",
+    displayName: "Z.AI GLM 5.3",
+    enabled: true,
+    openRouterModelId: "z-ai/glm-5.3",
+  },
+  {
     key: "zai_glm_5_2",
     slug: "glm-5-2",
     provider: "zai",

--- a/lib/ai/modelRequestProfiles.ts
+++ b/lib/ai/modelRequestProfiles.ts
@@ -32,7 +32,7 @@ const OUTPUT_CEILINGS: readonly { tokens: number; ids: readonly string[] }[] = [
   // MiniMax M2.7 rejects the larger MineBench default on its OpenAI-compatible route
   {
     tokens: 131_072,
-    ids: ["glm-5.2", "glm-5.1", "glm-5", "minimax-m2.7", "muse-spark-1.2"],
+    ids: ["glm-5.3", "glm-5.2", "glm-5.1", "glm-5", "minimax-m2.7", "muse-spark-1.2"],
   },
   {
     tokens: 65_536,

--- a/lib/ai/providers/openrouter.ts
+++ b/lib/ai/providers/openrouter.ts
@@ -198,6 +198,18 @@ export async function openrouterGenerateText(params: {
 
   const baseUrl = process.env.OPENROUTER_BASE_URL ?? "https://openrouter.ai/api";
   const maxTokens = params.maxOutputTokens ?? 8192;
+  const responseFormat = !params.jsonSchema
+    ? undefined
+    : params.modelId === "z-ai/glm-5.3"
+      ? { type: "json_object" }
+      : {
+          type: "json_schema",
+          json_schema: {
+            name: VOXEL_BUILD_JSON_SCHEMA_NAME,
+            strict: true,
+            schema: params.jsonSchema,
+          },
+        };
   const reasoningAttempts = reasoningConfigFallbacks({
     automatic: params.automaticReasoning,
     enabled: params.enableReasoning,
@@ -273,18 +285,7 @@ export async function openrouterGenerateText(params: {
                 max_tokens: tok,
                 reasoning: reasoningConfig,
                 ...(textVerbosity ? { text: { verbosity: textVerbosity } } : {}),
-                ...(params.jsonSchema
-                  ? {
-                      response_format: {
-                        type: "json_schema",
-                        json_schema: {
-                          name: VOXEL_BUILD_JSON_SCHEMA_NAME,
-                          strict: true,
-                          schema: params.jsonSchema,
-                        },
-                      },
-                    }
-                  : {}),
+                ...(responseFormat ? { response_format: responseFormat } : {}),
               }),
             },
             {
@@ -367,7 +368,7 @@ export async function openrouterGenerateText(params: {
         textVerbosity:
           (useDefaultVerbosity ? defaultTextVerbosity(params.modelId) : undefined) ??
           "default",
-        responseFormat: params.jsonSchema ? "json_schema" : "text",
+        responseFormat: responseFormat?.type ?? "text",
       });
       params.onTrace?.(
         withMaxOutputTokens(

--- a/lib/ai/providers/shared.ts
+++ b/lib/ai/providers/shared.ts
@@ -2,7 +2,6 @@
 // Provider-specific variants (error vocabularies, content extraction, base URL
 // rules) stay in their own adapter files
 
-import { attachAbortSignal } from "@/lib/ai/providers/abort";
 import { tokenBudgetCandidates } from "@/lib/ai/tokenBudgets";
 
 const TRUE_VALUES = new Set(["1", "true", "yes", "on"]);
@@ -52,16 +51,14 @@ export async function postChatCompletionWithTokenBudgetRetry(params: {
   signal?: AbortSignal;
   onProviderRequest?: () => void;
 }): Promise<{ res: Response; acceptedTokenBudget: number }> {
-  const controller = new AbortController();
-  const detachAbort = attachAbortSignal(controller, params.signal);
-
   let res: Response | null = null;
   let lastBody = "";
   let selectedTokenBudget: number | null = null;
   try {
     for (const tok of tokenBudgetCandidates(params.maxOutputTokens)) {
-      controller.signal.throwIfAborted();
+      params.signal?.throwIfAborted();
       params.onProviderRequest?.();
+      // Fetch keeps this signal attached to the returned response body
       res = await fetch(params.url, {
         method: "POST",
         headers: {
@@ -69,7 +66,7 @@ export async function postChatCompletionWithTokenBudgetRetry(params: {
           "Content-Type": "application/json",
           ...(params.stream ? { Accept: "text/event-stream" } : {}),
         },
-        signal: controller.signal,
+        signal: params.signal,
         body: JSON.stringify(params.buildBody(tok)),
       });
       if (res.ok) {
@@ -89,8 +86,6 @@ export async function postChatCompletionWithTokenBudgetRetry(params: {
     throw new Error(
       `${params.serviceLabel} request failed: ${err instanceof Error ? err.message : String(err)}${cause}`,
     );
-  } finally {
-    detachAbort();
   }
 
   if (!res) {

--- a/lib/ai/providers/zai.ts
+++ b/lib/ai/providers/zai.ts
@@ -1,0 +1,114 @@
+import {
+  extractChatCompletionText,
+  postChatCompletionWithTokenBudgetRetry,
+  withMaxOutputTokens,
+} from "@/lib/ai/providers/shared";
+import { consumeSseStream } from "@/lib/ai/providers/sse";
+import type { ProviderTelemetryCallbacks } from "@/lib/ai/types";
+
+type ZaiChatResponse = {
+  choices?: { message?: { content?: unknown } }[];
+};
+
+type ZaiChatStreamChunk = {
+  choices?: { delta?: { content?: unknown } }[];
+};
+
+function looksLikeTokenLimitError(body: string): boolean {
+  const b = body.toLowerCase();
+  return (
+    b.includes("max_tokens") ||
+    (b.includes("maximum") && b.includes("tokens")) ||
+    b.includes("token limit")
+  );
+}
+
+export async function zaiGenerateText(params: {
+  modelId: string;
+  apiKey?: string;
+  system: string;
+  user: string;
+  maxOutputTokens?: number;
+  reasoningEffortAttempts?: string[];
+  temperature?: number;
+  jsonSchema?: Record<string, unknown>;
+  signal?: AbortSignal;
+  onDelta?: (delta: string) => void;
+  onTrace?: (message: string) => void;
+  onAcceptedOutputTokens?: (tokens: number) => void;
+} & ProviderTelemetryCallbacks): Promise<{ text: string }> {
+  const apiKey = params.apiKey ?? process.env.ZAI_API_KEY;
+  if (!apiKey) throw new Error("Missing ZAI_API_KEY");
+
+  const baseUrl = (process.env.ZAI_BASE_URL ?? "https://api.z.ai/api/paas/v4").replace(/\/+$/, "");
+  const url = `${baseUrl}/chat/completions`;
+  const maxTokens = params.maxOutputTokens ?? 65_536;
+  // GLM always thinks and rejects thinking.type=disabled, so effort alone selects the mode
+  const reasoningEffort = params.reasoningEffortAttempts?.[0];
+  const useJsonOutput = Boolean(params.jsonSchema);
+
+  const { res, acceptedTokenBudget: budget } = await postChatCompletionWithTokenBudgetRetry({
+    serviceLabel: "Z.AI",
+    url,
+    apiKey,
+    maxOutputTokens: maxTokens,
+    stream: Boolean(params.onDelta),
+    looksLikeTokenLimitError,
+    signal: params.signal,
+    onProviderRequest: params.onProviderRequest,
+    buildBody: (tok) => ({
+      model: params.modelId,
+      messages: [
+        { role: "system", content: params.system },
+        { role: "user", content: params.user },
+      ],
+      stream: Boolean(params.onDelta),
+      max_tokens: tok,
+      thinking: { type: "enabled" },
+      ...(params.temperature === undefined ? {} : { temperature: params.temperature }),
+      ...(reasoningEffort ? { reasoning_effort: reasoningEffort } : {}),
+      ...(useJsonOutput ? { response_format: { type: "json_object" } } : {}),
+    }),
+  });
+
+  const reasoningLabel = reasoningEffort ? `reasoning_effort=${reasoningEffort}` : "default";
+  const responseFormat = useJsonOutput ? "json_object" : "text";
+  params.onAcceptedOutputTokens?.(budget);
+  params.onAcceptedRequestConfiguration?.({
+    apiMode: "chat_completions",
+    maxOutputTokens: budget,
+    thinkingMode: reasoningLabel,
+    temperature: params.temperature ?? "default",
+    textVerbosity: "default",
+    responseFormat,
+  });
+  params.onTrace?.(
+    withMaxOutputTokens(
+      `Z.AI request config in use: ${reasoningLabel}, response_format=${responseFormat}.`,
+      budget,
+    ),
+  );
+
+  if (params.onDelta) {
+    let text = "";
+    await consumeSseStream(res, (evt) => {
+      if (evt.data === "[DONE]") return;
+      let parsed: ZaiChatStreamChunk | null = null;
+      try {
+        parsed = JSON.parse(evt.data) as ZaiChatStreamChunk;
+      } catch {
+        return;
+      }
+      const chunk = parsed?.choices?.[0]?.delta?.content;
+      if (typeof chunk === "string" && chunk) {
+        text += chunk;
+        params.onDelta?.(chunk);
+      }
+    });
+    return { text };
+  }
+
+  const data = (await res.json()) as ZaiChatResponse;
+  const text = extractChatCompletionText(data);
+  return { text };
+}

--- a/lib/ai/providers/zai.ts
+++ b/lib/ai/providers/zai.ts
@@ -23,6 +23,20 @@ function looksLikeTokenLimitError(body: string): boolean {
   );
 }
 
+function isReasoningEffortRejection(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  const message = error.message.toLowerCase();
+  return (
+    message.includes("z.ai error 400") &&
+    message.includes("reasoning") &&
+    message.includes("effort") &&
+    (message.includes("invalid") ||
+      message.includes("unsupported") ||
+      message.includes("enum") ||
+      message.includes("unknown"))
+  );
+}
+
 export async function zaiGenerateText(params: {
   modelId: string;
   apiKey?: string;
@@ -44,32 +58,50 @@ export async function zaiGenerateText(params: {
   const url = `${baseUrl}/chat/completions`;
   const maxTokens = params.maxOutputTokens ?? 65_536;
   // GLM always thinks and rejects thinking.type=disabled, so effort alone selects the mode
-  const reasoningEffort = params.reasoningEffortAttempts?.[0];
+  const effortAttempts: Array<string | undefined> = params.reasoningEffortAttempts?.length
+    ? params.reasoningEffortAttempts
+    : [undefined];
   const useJsonOutput = Boolean(params.jsonSchema);
 
-  const { res, acceptedTokenBudget: budget } = await postChatCompletionWithTokenBudgetRetry({
-    serviceLabel: "Z.AI",
-    url,
-    apiKey,
-    maxOutputTokens: maxTokens,
-    stream: Boolean(params.onDelta),
-    looksLikeTokenLimitError,
-    signal: params.signal,
-    onProviderRequest: params.onProviderRequest,
-    buildBody: (tok) => ({
-      model: params.modelId,
-      messages: [
-        { role: "system", content: params.system },
-        { role: "user", content: params.user },
-      ],
-      stream: Boolean(params.onDelta),
-      max_tokens: tok,
-      thinking: { type: "enabled" },
-      ...(params.temperature === undefined ? {} : { temperature: params.temperature }),
-      ...(reasoningEffort ? { reasoning_effort: reasoningEffort } : {}),
-      ...(useJsonOutput ? { response_format: { type: "json_object" } } : {}),
-    }),
-  });
+  let reasoningEffort: string | undefined;
+  let response: Awaited<ReturnType<typeof postChatCompletionWithTokenBudgetRetry>> | null = null;
+  for (const [index, effort] of effortAttempts.entries()) {
+    try {
+      response = await postChatCompletionWithTokenBudgetRetry({
+        serviceLabel: "Z.AI",
+        url,
+        apiKey,
+        maxOutputTokens: maxTokens,
+        stream: Boolean(params.onDelta),
+        looksLikeTokenLimitError,
+        signal: params.signal,
+        onProviderRequest: params.onProviderRequest,
+        buildBody: (tok) => ({
+          model: params.modelId,
+          messages: [
+            { role: "system", content: params.system },
+            { role: "user", content: params.user },
+          ],
+          stream: Boolean(params.onDelta),
+          max_tokens: tok,
+          thinking: { type: "enabled" },
+          ...(params.temperature === undefined ? {} : { temperature: params.temperature }),
+          ...(effort ? { reasoning_effort: effort } : {}),
+          ...(useJsonOutput ? { response_format: { type: "json_object" } } : {}),
+        }),
+      });
+      reasoningEffort = effort;
+      break;
+    } catch (error) {
+      const nextEffort = effortAttempts[index + 1];
+      if (nextEffort === undefined || !isReasoningEffortRejection(error)) throw error;
+      params.onTrace?.(
+        `Z.AI reasoning config '${effort}' rejected (HTTP 400); falling back to '${nextEffort}'.`,
+      );
+    }
+  }
+  if (!response) throw new Error("Z.AI request failed");
+  const { res, acceptedTokenBudget: budget } = response;
 
   const reasoningLabel = reasoningEffort ? `reasoning_effort=${reasoningEffort}` : "default";
   const responseFormat = useJsonOutput ? "json_object" : "text";

--- a/lib/ai/reasoningProfiles.ts
+++ b/lib/ai/reasoningProfiles.ts
@@ -126,6 +126,12 @@ const EFFORT_LADDER_RULES: readonly EffortLadderRule[] = [
   },
   { ids: ["moonshotai/kimi-k3"], ladder: ["max"] },
   {
+    ids: ["glm-5.3", "z-ai/glm-5.3"],
+    ladder: ["max", "high", "low"],
+    aliases: { xhigh: null },
+    supported: "max, xhigh, high, low",
+  },
+  {
     ids: ["z-ai/glm-5.2"],
     ladder: ["xhigh", "high"],
     aliases: { max: null },
@@ -202,11 +208,28 @@ export function metaReasoningEffortAttempts(
   return undefined;
 }
 
+export function zaiReasoningEffortAttempts(
+  modelId: string,
+  override?: string,
+): string[] | undefined {
+  const label = `Z.AI model ${modelId}`;
+  const rule = effortLadderRuleFor(modelId);
+  if (rule) return ladderAttempts(label, rule, override);
+
+  const normalized = normalizeReasoningOverride(override);
+  if (normalized) {
+    throw new Error(`${label} does not expose a reasoning-effort override.`);
+  }
+  return undefined;
+}
+
 export function modelRequiresReasoning(modelId: string): boolean {
   const normalized = modelId.trim().toLowerCase();
   return (
     normalized === "grok-4.6" ||
     normalized === "x-ai/grok-4.6" ||
+    normalized === "glm-5.3" ||
+    normalized === "z-ai/glm-5.3" ||
     normalized === "google/gemini-3.7-flash" ||
     normalized === "muse-spark-1.2" ||
     normalized === "meta/muse-spark-1.2"

--- a/lib/ai/types.ts
+++ b/lib/ai/types.ts
@@ -12,6 +12,7 @@ export type ProviderApiKeys = {
   minimax?: string;
   xai?: string;
   meta?: string;
+  zai?: string;
   openrouter?: string;
   custom?: string;
 };

--- a/tests/helpers/providerConfigHarness.ts
+++ b/tests/helpers/providerConfigHarness.ts
@@ -170,6 +170,7 @@ export async function runGeneration(
   options: {
     modelKey: ModelKey;
     providerKeys: Record<string, string>;
+    allowServerKeys?: boolean;
     gridSize?: 64 | 256 | 512;
     maxAttempts?: number;
     enableTools?: boolean;
@@ -188,7 +189,7 @@ export async function runGeneration(
     ...(options.maxAttempts !== undefined ? { maxAttempts: options.maxAttempts } : {}),
     enableTools: options.enableTools ?? false,
     providerKeys: options.providerKeys,
-    allowServerKeys: false,
+    allowServerKeys: options.allowServerKeys ?? false,
     ...(options.reasoning !== undefined ? { reasoning: options.reasoning } : {}),
     ...(options.preferOpenRouter !== undefined
       ? { preferOpenRouter: options.preferOpenRouter }

--- a/tests/helpers/providerConfigHarness.ts
+++ b/tests/helpers/providerConfigHarness.ts
@@ -8,6 +8,7 @@ export type CapturedRequest = {
   method: string;
   headers: Record<string, string>;
   body: Record<string, unknown>;
+  signal?: AbortSignal | null;
 };
 
 export type FetchResponder = (request: CapturedRequest) => Response | null;
@@ -81,6 +82,7 @@ export function installFetchCapture() {
       method: init.method ?? "GET",
       headers,
       body: JSON.parse(init.body as string) as Record<string, unknown>,
+      signal: init.signal,
     };
     requests.push(request);
 

--- a/tests/unit/admin/seed-model-catalog.test.ts
+++ b/tests/unit/admin/seed-model-catalog.test.ts
@@ -17,6 +17,7 @@ function providerKeyStatus(overrides: Partial<SeedProviderKeyStatus>): SeedProvi
     minimax: false,
     xai: false,
     meta: false,
+    zai: false,
     openrouter: false,
     ...overrides,
   };
@@ -135,6 +136,24 @@ assert.equal(
   }),
   false,
   "Muse Spark 1.2 should be skipped when neither route has a key",
+);
+
+const glm53 = getModelByKey("zai_glm_5_3");
+assert.equal(
+  isCatalogModelGeneratableForSeed({
+    model: glm53,
+    providerKeys: providerKeyStatus({ zai: true }),
+  }),
+  true,
+  "GLM 5.3 should be seed-generatable with a direct Z.AI key",
+);
+assert.equal(
+  isCatalogModelGeneratableForSeed({
+    model: glm53,
+    providerKeys: providerKeyStatus({}),
+  }),
+  false,
+  "GLM 5.3 should be skipped when neither route has a key",
 );
 
 console.log("seed model catalog checks passed");

--- a/tests/unit/providers/zai-family.test.ts
+++ b/tests/unit/providers/zai-family.test.ts
@@ -1,11 +1,98 @@
 import assert from "node:assert/strict";
-import { openRouterReasoningEffortAttempts } from "../../../lib/ai/reasoningProfiles";
+import { getModelBenchmarkProfile } from "../../../lib/ai/modelBenchmarkProfiles";
+import {
+  modelRequiresReasoning,
+  openRouterReasoningEffortAttempts,
+  zaiReasoningEffortAttempts,
+} from "../../../lib/ai/reasoningProfiles";
 import {
   assertCatalogEntry,
   assertTraceLine,
   runGeneration,
   runProviderConfigTest,
 } from "../../helpers/providerConfigHarness";
+
+runProviderConfigTest("zai glm 5.3", {
+  ZAI_API_KEY: "test-zai-key",
+  ZAI_BASE_URL: "https://zai.test/api/paas/v4",
+}, async (capture) => {
+  const model = assertCatalogEntry({
+    key: "zai_glm_5_3",
+    provider: "zai",
+    modelId: "glm-5.3",
+    displayName: "Z.AI GLM 5.3",
+    openRouterModelId: "z-ai/glm-5.3",
+    slug: "glm-5-3",
+  });
+  assert.equal(modelRequiresReasoning(model.modelId), true);
+  assert.equal(modelRequiresReasoning(model.openRouterModelId!), true);
+  assert.deepEqual(getModelBenchmarkProfile(model.key)?.parameters, [
+    { label: "Reasoning effort", value: "Max" },
+  ]);
+
+  // Z.AI documents low|high|max and rejects thinking.type=disabled, so max is
+  // both the default and the ladder head, and xhigh resolves onto it
+  assert.deepEqual(zaiReasoningEffortAttempts(model.modelId), ["max", "high", "low"]);
+  assert.deepEqual(zaiReasoningEffortAttempts(model.modelId, "max"), ["max", "high", "low"]);
+  assert.deepEqual(zaiReasoningEffortAttempts(model.modelId, "xhigh"), ["max", "high", "low"]);
+  assert.deepEqual(zaiReasoningEffortAttempts(model.modelId, "high"), ["high", "low"]);
+  assert.deepEqual(zaiReasoningEffortAttempts(model.modelId, "low"), ["low"]);
+  assert.throws(
+    () => zaiReasoningEffortAttempts(model.modelId, "medium"),
+    /Supported values: max, xhigh, high, low\./,
+  );
+  assert.deepEqual(openRouterReasoningEffortAttempts(model.openRouterModelId!), [
+    "max",
+    "high",
+    "low",
+  ]);
+  assert.deepEqual(openRouterReasoningEffortAttempts(model.openRouterModelId!, "high"), [
+    "high",
+    "low",
+  ]);
+
+  const direct = await runGeneration(capture, {
+    modelKey: model.key,
+    providerKeys: {},
+    allowServerKeys: true,
+  });
+  assert.equal(direct.result.providerRoute, "direct");
+  const directRequest = direct.requests.find((request) =>
+    request.url.includes("zai.test"),
+  );
+  assert.ok(directRequest, "Direct Z.AI request should be captured");
+  assert.equal(directRequest.url, "https://zai.test/api/paas/v4/chat/completions");
+  assert.equal(directRequest.body.model, "glm-5.3");
+  assert.equal(directRequest.body.max_tokens, 131_072);
+  assert.equal(directRequest.body.reasoning_effort, "max");
+  assert.deepEqual(directRequest.body.thinking, { type: "enabled" });
+  assert.deepEqual(directRequest.body.response_format, { type: "json_object" });
+  assertTraceLine(
+    direct.traces,
+    ["max_output_tokens=131072", "reasoning_effort=max"],
+    "Direct trace should report the 131072-token cap and max reasoning effort",
+  );
+
+  const openRouter = await runGeneration(capture, {
+    modelKey: model.key,
+    providerKeys: { openrouter: "test-openrouter-key" },
+    preferOpenRouter: true,
+  });
+  const openRouterRequest = openRouter.requests.find((request) =>
+    request.url.includes("openrouter.test"),
+  )?.body;
+  assert.ok(openRouterRequest, "OpenRouter request should be captured");
+  assert.equal(openRouterRequest.model, "z-ai/glm-5.3");
+  assert.equal(openRouterRequest.max_tokens, 131_072);
+  assert.deepEqual(openRouterRequest.reasoning, { effort: "max" });
+  assert.deepEqual(openRouterRequest.response_format, { type: "json_object" });
+  assertTraceLine(
+    openRouter.traces,
+    ["max_output_tokens=131072", "effort_fallback=max->high->low"],
+    "OpenRouter trace should report the 131072-token cap and the GLM 5.3 effort ladder",
+    ["disabled"],
+  );
+});
 
 runProviderConfigTest("zai family", {}, async (capture) => {
   const model = assertCatalogEntry({

--- a/tests/unit/providers/zai-family.test.ts
+++ b/tests/unit/providers/zai-family.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import { getModelBenchmarkProfile } from "../../../lib/ai/modelBenchmarkProfiles";
+import { zaiGenerateText } from "../../../lib/ai/providers/zai";
 import {
   modelRequiresReasoning,
   openRouterReasoningEffortAttempts,
@@ -12,7 +13,7 @@ import {
   runProviderConfigTest,
 } from "../../helpers/providerConfigHarness";
 
-runProviderConfigTest("zai glm 5.3", {
+runProviderConfigTest("zai family", {
   ZAI_API_KEY: "test-zai-key",
   ZAI_BASE_URL: "https://zai.test/api/paas/v4",
 }, async (capture) => {
@@ -74,6 +75,69 @@ runProviderConfigTest("zai glm 5.3", {
     "Direct trace should report the 131072-token cap and max reasoning effort",
   );
 
+  const fallbackTraces: string[] = [];
+  const fallbackStart = capture.requests.length;
+  capture.respondWith((request) => {
+    if (!request.url.includes("zai.test")) return null;
+    if (request.body.reasoning_effort === "max") {
+      return new Response(
+        JSON.stringify({ error: "Invalid reasoning_effort enum value: max" }),
+        { status: 400 },
+      );
+    }
+    return null;
+  });
+  await zaiGenerateText({
+    modelId: model.modelId,
+    apiKey: "test-zai-key",
+    system: "system",
+    user: "user",
+    reasoningEffortAttempts: ["max", "high", "low"],
+    onTrace: (message) => fallbackTraces.push(message),
+  });
+  assert.deepEqual(
+    capture.requests
+      .slice(fallbackStart)
+      .filter((request) => request.url.includes("zai.test"))
+      .map((request) => request.body.reasoning_effort),
+    ["max", "high"],
+  );
+  assertTraceLine(
+    fallbackTraces,
+    ["Z.AI reasoning config 'max' rejected", "falling back to 'high'"],
+    "Direct Z.AI should descend its reasoning-effort ladder on configuration rejections",
+  );
+  assertTraceLine(
+    fallbackTraces,
+    ["reasoning_effort=high"],
+    "Direct Z.AI should report the accepted fallback effort",
+  );
+
+  const caller = new AbortController();
+  let providerSignal: AbortSignal | null | undefined;
+  capture.respondWith((request) => {
+    if (!request.url.includes("zai.test")) return null;
+    providerSignal = request.signal;
+    return new Response(
+      'data: {"choices":[{"delta":{"content":"partial"}}]}\n\ndata: [DONE]\n\n',
+      {
+        status: 200,
+        headers: { "Content-Type": "text/event-stream" },
+      },
+    );
+  });
+  await zaiGenerateText({
+    modelId: model.modelId,
+    apiKey: "test-zai-key",
+    system: "system",
+    user: "user",
+    reasoningEffortAttempts: ["max", "high", "low"],
+    signal: caller.signal,
+    onDelta: () => caller.abort(),
+  });
+  assert.equal(providerSignal?.aborted, true, "Caller cancellation should reach the provider stream");
+  capture.respondWith(null);
+
   const openRouter = await runGeneration(capture, {
     modelKey: model.key,
     providerKeys: { openrouter: "test-openrouter-key" },
@@ -93,10 +157,8 @@ runProviderConfigTest("zai glm 5.3", {
     "OpenRouter trace should report the 131072-token cap and the GLM 5.3 effort ladder",
     ["disabled"],
   );
-});
 
-runProviderConfigTest("zai family", {}, async (capture) => {
-  const model = assertCatalogEntry({
+  const glm52 = assertCatalogEntry({
     key: "zai_glm_5_2",
     provider: "zai",
     modelId: "glm-5.2",
@@ -105,31 +167,31 @@ runProviderConfigTest("zai family", {}, async (capture) => {
     slug: "glm-5-2",
     forceOpenRouter: true,
   });
-  assert.deepEqual(openRouterReasoningEffortAttempts(model.openRouterModelId!), [
+  assert.deepEqual(openRouterReasoningEffortAttempts(glm52.openRouterModelId!), [
     "xhigh",
     "high",
   ]);
-  assert.deepEqual(openRouterReasoningEffortAttempts(model.openRouterModelId!, "max"), [
+  assert.deepEqual(openRouterReasoningEffortAttempts(glm52.openRouterModelId!, "max"), [
     "xhigh",
     "high",
   ]);
-  assert.deepEqual(openRouterReasoningEffortAttempts(model.openRouterModelId!, "high"), [
+  assert.deepEqual(openRouterReasoningEffortAttempts(glm52.openRouterModelId!, "high"), [
     "high",
   ]);
 
-  const openRouter = await runGeneration(capture, {
-    modelKey: model.key,
+  const glm52OpenRouter = await runGeneration(capture, {
+    modelKey: glm52.key,
     providerKeys: { openrouter: "test-openrouter-key" },
   });
-  const openRouterRequest = openRouter.requests.find((request) =>
+  const glm52Request = glm52OpenRouter.requests.find((request) =>
     request.url.includes("openrouter.test"),
   )?.body;
-  assert.ok(openRouterRequest, "OpenRouter request should be captured");
-  assert.equal(openRouterRequest.model, "z-ai/glm-5.2");
-  assert.equal(openRouterRequest.max_tokens, 131_072);
-  assert.deepEqual(openRouterRequest.reasoning, { effort: "xhigh" });
+  assert.ok(glm52Request, "OpenRouter request should be captured");
+  assert.equal(glm52Request.model, "z-ai/glm-5.2");
+  assert.equal(glm52Request.max_tokens, 131_072);
+  assert.deepEqual(glm52Request.reasoning, { effort: "xhigh" });
   assertTraceLine(
-    openRouter.traces,
+    glm52OpenRouter.traces,
     [
       "max_output_tokens=131072",
       "effort_fallback=xhigh->high->disabled",

--- a/tests/unit/providers/zai-family.test.ts
+++ b/tests/unit/providers/zai-family.test.ts
@@ -29,6 +29,7 @@ runProviderConfigTest("zai glm 5.3", {
   assert.deepEqual(getModelBenchmarkProfile(model.key)?.parameters, [
     { label: "Reasoning effort", value: "Max" },
   ]);
+  assert.deepEqual(getModelBenchmarkProfile(model.key)?.totalCost, { usd: 6.42 });
 
   // Z.AI documents low|high|max and rejects thinking.type=disabled, so max is
   // both the default and the ladder head, and xhigh resolves onto it


### PR DESCRIPTION
## Summary

- register GLM 5.3 with native Z.AI and OpenRouter routing
- add a focused Z.AI chat-completions adapter using the shared provider scaffold
- enforce the 131072-token output cap and mandatory max reasoning contract
- wire Z.AI keys through batch generation, Sandbox, and admin seeding
- add family-level request and routing coverage
- include finalized metrics for the 15-prompt Alpha benchmark cohort

## Why

GLM 5.2 remains OpenRouter-only, while GLM 5.3 supports a direct Z.AI route. The integration keeps the existing provider boundaries and uses Z.AI's native JSON output contract without expanding the generic custom-API client.

## Validation

- `pnpm lint`
- `pnpm test` — 47 test files passed
- `pnpm build`
- `pnpm exec tsx tests/run.ts tests/unit/providers/zai-family.test.ts tests/unit/admin/seed-model-catalog.test.ts`
- `pnpm staging:publish --model glm-5-3 --dry-run`
- Alpha deep audit — 15 builds and 82 required artifacts verified with zero failures
- `graphify update .`
- `git diff origin/master...HEAD --check`

## Alpha rollout

The complete 15-build cohort and benchmark metrics were published and validated on Alpha at `2a39b66`. Production publication remains a separate post-merge step and will start the model from the standard rating baseline.

*(PR written by Codex)*
