### PR TITLE
(fix) improve GIF export framing and quality

### DIFF
--- a/components/sandbox/SandboxGifExportButton.tsx
+++ b/components/sandbox/SandboxGifExportButton.tsx
@@ -32,7 +32,7 @@ const MAX_IN_FLIGHT_FRAMES = 4;
 const YIELD_EVERY_FRAMES = 24;
 const COMPARISON_FRAME_COUNT = 108;
 const SINGLE_FRAME_COUNT = 135;
-const COMPARISON_FRAME_DELAY_MS = 50;
+const COMPARISON_FRAME_DELAY_MS = 40;
 const SINGLE_FRAME_DELAY_MS = 40;
 const COMPARISON_PALETTE_SAMPLE_COUNT = 12;
 const SINGLE_PALETTE_SAMPLE_COUNT = 16;
@@ -96,6 +96,7 @@ type ExportLayout = {
     urlText: string;
   };
 };
+type ExportRect = ExportLayout["panelRects"][number];
 
 type GifRenderProfile = (typeof EXPORT_RENDER_PROFILES)[GifExportLayoutFormat][number];
 type GifExportRuntime = {
@@ -457,13 +458,11 @@ function drawPanel(
     height: number;
     target: SandboxGifExportTarget;
     capture: HTMLCanvasElement;
+    captureRect: ExportRect;
   },
 ) {
-  const { x, y, width, height, target, capture } = opts;
-  const captureX = x + PANEL_PAD;
-  const captureY = y + PANEL_PAD + PANEL_META_HEIGHT;
-  const captureWidth = Math.max(1, width - PANEL_PAD * 2);
-  const captureHeight = Math.max(1, height - PANEL_PAD * 2 - PANEL_META_HEIGHT);
+  const { x, y, width, height, target, capture, captureRect } = opts;
+  const { x: captureX, y: captureY, width: captureWidth, height: captureHeight } = captureRect;
 
   ctx.save();
   roundedRectPath(ctx, x, y, width, height, PANEL_RADIUS);
@@ -527,13 +526,16 @@ function renderCompositeFrame(
     const target = targets[idx];
     const panel = layout.panelRects[idx];
     if (!panel) continue;
-    const captureWidth = Math.max(1, Math.round(panel.width - PANEL_PAD * 2));
-    const captureHeight = Math.max(1, Math.round(panel.height - PANEL_PAD * 2 - PANEL_META_HEIGHT));
+    const captureRect = {
+      x: Math.round(panel.x + PANEL_PAD),
+      y: Math.round(panel.y + PANEL_PAD + PANEL_META_HEIGHT),
+      width: Math.max(1, Math.round(panel.width - PANEL_PAD * 2)),
+      height: Math.max(1, Math.round(panel.height - PANEL_PAD * 2 - PANEL_META_HEIGHT)),
+    };
     const capture = target.viewerRef.current?.captureFrame({
       rotationY: (rotationBases[idx] ?? 0) + angle,
-      width: captureWidth,
-      height: captureHeight,
-      fit: "contain",
+      width: captureRect.width,
+      height: captureRect.height,
     });
     if (!capture) {
       throw new Error("One of the viewers is not ready for export");
@@ -546,6 +548,7 @@ function renderCompositeFrame(
       height: panel.height,
       target,
       capture,
+      captureRect,
     });
   }
 }

--- a/components/voxel/VoxelViewer.tsx
+++ b/components/voxel/VoxelViewer.tsx
@@ -12,6 +12,11 @@ import {
   type RenderableVoxelBuild,
 } from "@/lib/voxel/packedBlocks";
 import { VOXEL_VIEWER_WEBGL_ERROR } from "@/lib/voxel/errors";
+import {
+  fitDistanceToRotatingBounds,
+  retargetDistanceForAspect,
+  type RotatingBoundsFraming,
+} from "@/lib/voxel/framing";
 
 export type VoxelViewerBuildProgress = {
   processedBlocks: number;
@@ -37,15 +42,13 @@ export type VoxelViewerHandle = {
   getRotationY: () => number | null;
   captureFrame: (opts?: {
     rotationY?: number;
-    rotationOffsetY?: number;
     width?: number;
     height?: number;
-    fit?: "cover" | "contain";
   }) => HTMLCanvasElement | null;
 };
 
 let atlasPromise: Promise<THREE.Texture> | null = null;
-const EXPORT_RENDER_OVERSCAN = 1;
+const EXPORT_CAPTURE_PIXEL_RATIO = 2;
 let viewerSpinPreference = true;
 const viewerSpinPreferenceListeners = new Set<(enabled: boolean) => void>();
 const MOBILE_DOUBLE_TAP_MS = 330;
@@ -255,6 +258,21 @@ function computeBuildYieldAfterMs(blockCount: number): number {
   return 8;
 }
 
+function getRotatingBoundsFraming(
+  camera: THREE.PerspectiveCamera,
+  bounds: BuildBounds,
+  cameraDirectionY: number,
+): RotatingBoundsFraming {
+  const size = bounds.box.getSize(new THREE.Vector3());
+  return {
+    width: size.x,
+    height: size.y,
+    depth: size.z,
+    verticalFovDegrees: camera.fov,
+    cameraDirectionY,
+  };
+}
+
 function frameBounds(
   camera: THREE.PerspectiveCamera,
   controls: OrbitControls,
@@ -276,13 +294,11 @@ function frameBounds(
   }
   controls.target.copy(target);
 
-  const vFov = THREE.MathUtils.degToRad(camera.fov);
-  const hFov = 2 * Math.atan(Math.tan(vFov / 2) * camera.aspect);
-  const fitHeight = radius / Math.sin(vFov / 2);
-  const fitWidth = radius / Math.sin(hFov / 2);
-  const distance = Math.max(fitHeight, fitWidth);
-
   const dir = new THREE.Vector3(1, yBias, 1).normalize();
+  const distance = fitDistanceToRotatingBounds(
+    getRotatingBoundsFraming(camera, bounds, dir.y),
+    camera.aspect,
+  );
   // slightly closer default framing
   camera.position.copy(target).addScaledVector(dir, distance * (reserveMobileBottomChrome ? 1.22 : 1.1));
   camera.near = Math.max(0.05, distance / 250);
@@ -392,8 +408,6 @@ export const VoxelViewer = forwardRef<VoxelViewerHandle, ViewerProps>(function V
   const onBuildErrorChangeRef = useRef<((message: string | null) => void) | undefined>(undefined);
   const requestRenderRef = useRef<(() => void) | null>(null);
   const exportRendererRef = useRef<THREE.WebGLRenderer | null>(null);
-  const exportCanvasRef = useRef<HTMLCanvasElement | null>(null);
-  const captureCanvasRef = useRef<HTMLCanvasElement | null>(null);
   const tapStartRef = useRef<{ x: number; y: number; at: number } | null>(null);
   const lastTapRef = useRef<{ x: number; y: number; at: number } | null>(null);
   const threeRef = useRef<{
@@ -456,14 +470,6 @@ export const VoxelViewer = forwardRef<VoxelViewerHandle, ViewerProps>(function V
     onBuildReadyChangeRef.current?.(ready);
   }, []);
 
-  const getCaptureCanvas = useCallback((width: number, height: number) => {
-    const canvas = captureCanvasRef.current ?? document.createElement("canvas");
-    captureCanvasRef.current = canvas;
-    if (canvas.width !== width) canvas.width = width;
-    if (canvas.height !== height) canvas.height = height;
-    return canvas;
-  }, []);
-
   const getExportRenderer = useCallback(() => {
     const existing = exportRendererRef.current;
     if (existing) return existing;
@@ -475,9 +481,8 @@ export const VoxelViewer = forwardRef<VoxelViewerHandle, ViewerProps>(function V
       alpha: true,
       powerPreference: "high-performance",
     });
-    renderer.setPixelRatio(1);
+    renderer.setPixelRatio(EXPORT_CAPTURE_PIXEL_RATIO);
     renderer.outputColorSpace = THREE.SRGBColorSpace;
-    exportCanvasRef.current = canvas;
     exportRendererRef.current = renderer;
     return renderer;
   }, []);
@@ -802,137 +807,49 @@ export const VoxelViewer = forwardRef<VoxelViewerHandle, ViewerProps>(function V
       captureFrame(opts) {
         const three = threeRef.current;
         const vg = voxelGroupRef.current;
-        if (!three || !vg) return null;
+        const bounds = boundsRef.current;
+        if (!three || !vg || !bounds) return null;
 
         const { scene, camera, renderer, controls } = three;
         const previousY = vg.group.rotation.y;
-        const absoluteRotationY =
+        const previousAspect = camera.aspect;
+        const previousPosition = camera.position.clone();
+        const rotationY =
           typeof opts?.rotationY === "number" && Number.isFinite(opts.rotationY) ? opts.rotationY : null;
-        const rotationOffsetY =
-          typeof opts?.rotationOffsetY === "number" && Number.isFinite(opts.rotationOffsetY)
-            ? opts.rotationOffsetY
-            : null;
-        const hasExportRotation = absoluteRotationY !== null || rotationOffsetY !== null;
-        if (absoluteRotationY !== null) {
-          vg.group.rotation.y = absoluteRotationY;
-        } else if (rotationOffsetY !== null) {
-          vg.group.rotation.y = previousY + rotationOffsetY;
-        }
-
-        controls.update();
         const source = renderer.domElement;
         const width = Math.max(1, Math.floor(opts?.width ?? source.width));
         const height = Math.max(1, Math.floor(opts?.height ?? source.height));
-        const frame = getCaptureCanvas(width, height);
-        frame.width = width;
-        frame.height = height;
-        const ctx = frame.getContext("2d");
-        if (!ctx) {
-          if (hasExportRotation) {
-            vg.group.rotation.y = previousY;
-            controls.update();
-            renderer.render(scene, camera);
+        const targetAspect = width / height;
+        const cameraOffset = camera.position.clone().sub(controls.target);
+        const distance = cameraOffset.length();
+        const exportRenderer = getExportRenderer();
+
+        try {
+          if (rotationY !== null) vg.group.rotation.y = rotationY;
+
+          if (distance > 0 && targetAspect !== previousAspect) {
+            const targetDistance = retargetDistanceForAspect({
+              ...getRotatingBoundsFraming(camera, bounds, cameraOffset.y / distance),
+              distance,
+              sourceAspect: previousAspect,
+              targetAspect,
+            });
+            camera.position.copy(controls.target).addScaledVector(cameraOffset, targetDistance / distance);
           }
-          return null;
-        }
-        ctx.imageSmoothingEnabled = true;
-        ctx.imageSmoothingQuality = "high";
-
-        const srcW = source.width;
-        const srcH = source.height;
-        const dstW = width;
-        const dstH = height;
-        const srcAspect = srcW > 0 && srcH > 0 ? srcW / srcH : camera.aspect || 1;
-        const dstAspect = dstW > 0 && dstH > 0 ? dstW / dstH : 1;
-        const fitMode = opts?.fit ?? "cover";
-
-        if (fitMode === "contain") {
-          const drawWidth =
-            dstAspect > srcAspect ? Math.max(1, Math.round(dstH * srcAspect)) : dstW;
-          const drawHeight =
-            dstAspect > srcAspect ? dstH : Math.max(1, Math.round(dstW / srcAspect));
-          const needsHighResSource = srcW < drawWidth || srcH < drawHeight;
-          let sourceCanvas: HTMLCanvasElement = source;
-          if (needsHighResSource) {
-            const exportRenderer = getExportRenderer();
-            exportRenderer.setSize(drawWidth, drawHeight, false);
-            exportRenderer.render(scene, camera);
-            sourceCanvas = exportRenderer.domElement;
-          } else {
-            renderer.render(scene, camera);
-          }
-
-          ctx.clearRect(0, 0, dstW, dstH);
-          ctx.drawImage(
-            sourceCanvas,
-            0,
-            0,
-            sourceCanvas.width,
-            sourceCanvas.height,
-            Math.round((dstW - drawWidth) / 2),
-            Math.round((dstH - drawHeight) / 2),
-            drawWidth,
-            drawHeight,
-          );
-        } else {
-          let cropWidth = srcW;
-          let cropHeight = srcH;
-          if (srcAspect > dstAspect) {
-            cropWidth = Math.max(1, Math.round(srcH * dstAspect));
-          } else if (srcAspect < dstAspect) {
-            cropHeight = Math.max(1, Math.round(srcW / dstAspect));
-          }
-
-          const needsHighResSource = cropWidth < dstW || cropHeight < dstH;
-          let sourceCanvas: HTMLCanvasElement = source;
-          if (needsHighResSource) {
-            const exportRenderer = getExportRenderer();
-            let renderWidth = dstW;
-            let renderHeight = dstH;
-            if (srcAspect > dstAspect) {
-              renderHeight = Math.max(1, Math.round(dstH * EXPORT_RENDER_OVERSCAN));
-              renderWidth = Math.max(dstW, Math.ceil(renderHeight * srcAspect));
-            } else {
-              renderWidth = Math.max(1, Math.round(dstW * EXPORT_RENDER_OVERSCAN));
-              renderHeight = Math.max(dstH, Math.ceil(renderWidth / srcAspect));
-            }
-            exportRenderer.setSize(renderWidth, renderHeight, false);
-            exportRenderer.render(scene, camera);
-            sourceCanvas = exportRenderer.domElement;
-          } else {
-            renderer.render(scene, camera);
-          }
-
-          const exportSrcW = sourceCanvas.width;
-          const exportSrcH = sourceCanvas.height;
-          let sx = 0;
-          let sy = 0;
-          let sw = exportSrcW;
-          let sh = exportSrcH;
-          const exportAspect = exportSrcW > 0 && exportSrcH > 0 ? exportSrcW / exportSrcH : srcAspect;
-          if (exportAspect > dstAspect) {
-            // Too wide: crop left/right.
-            sw = Math.max(1, Math.round(exportSrcH * dstAspect));
-            sx = Math.round((exportSrcW - sw) / 2);
-          } else if (exportAspect < dstAspect) {
-            // Too tall: crop top/bottom.
-            sh = Math.max(1, Math.round(exportSrcW / dstAspect));
-            sy = Math.round((exportSrcH - sh) / 2);
-          }
-          ctx.clearRect(0, 0, dstW, dstH);
-          ctx.drawImage(sourceCanvas, sx, sy, sw, sh, 0, 0, dstW, dstH);
-        }
-
-        if (hasExportRotation) {
+          camera.aspect = targetAspect;
+          camera.updateProjectionMatrix();
+          exportRenderer.setSize(width, height, false);
+          exportRenderer.render(scene, camera);
+          return exportRenderer.domElement;
+        } finally {
           vg.group.rotation.y = previousY;
-          controls.update();
-          renderer.render(scene, camera);
+          camera.position.copy(previousPosition);
+          camera.aspect = previousAspect;
+          camera.updateProjectionMatrix();
         }
-
-        return frame;
       },
     }),
-    [getCaptureCanvas, getExportRenderer]
+    [getExportRenderer]
   );
 
   async function toggleFullscreen() {
@@ -1206,8 +1123,6 @@ export const VoxelViewer = forwardRef<VoxelViewerHandle, ViewerProps>(function V
         exportRendererRef.current.dispose();
         exportRendererRef.current = null;
       }
-      exportCanvasRef.current = null;
-      captureCanvasRef.current = null;
       tapStartRef.current = null;
       lastTapRef.current = null;
       renderer.domElement.removeEventListener("pointerdown", onPointerDownForTap);

--- a/lib/voxel/framing.ts
+++ b/lib/voxel/framing.ts
@@ -1,0 +1,48 @@
+const MIN_FIT_DISTANCE = 0.001;
+
+export type RotatingBoundsFraming = {
+  width: number;
+  height: number;
+  depth: number;
+  verticalFovDegrees: number;
+  cameraDirectionY: number;
+};
+
+export function fitDistanceToRotatingBounds(
+  framing: RotatingBoundsFraming,
+  aspect: number,
+): number {
+  const radius = Math.hypot(framing.width, framing.depth) / 2;
+  const halfHeight = framing.height / 2;
+  const verticalFov = (framing.verticalFovDegrees * Math.PI) / 180;
+  const cotVerticalFov = 1 / Math.tan(verticalFov / 2);
+  const cotHorizontalFov = cotVerticalFov / Math.max(MIN_FIT_DISTANCE, aspect);
+  const sinElevation = Math.min(1, Math.abs(framing.cameraDirectionY));
+  const cosElevation = Math.sqrt(Math.max(0, 1 - sinElevation * sinElevation));
+
+  // A Y-axis spin sweeps the build through this cylinder
+  const horizontalFit =
+    radius * Math.hypot(cosElevation, cotHorizontalFov) + halfHeight * sinElevation;
+  const upperVerticalFit =
+    radius * Math.abs(cosElevation - sinElevation * cotVerticalFov) +
+    halfHeight * Math.abs(sinElevation + cosElevation * cotVerticalFov);
+  const lowerVerticalFit =
+    radius * Math.abs(cosElevation + sinElevation * cotVerticalFov) +
+    halfHeight * Math.abs(sinElevation - cosElevation * cotVerticalFov);
+
+  return Math.max(MIN_FIT_DISTANCE, horizontalFit, upperVerticalFit, lowerVerticalFit);
+}
+
+export function retargetDistanceForAspect(
+  framing: RotatingBoundsFraming & {
+    distance: number;
+    sourceAspect: number;
+    targetAspect: number;
+  },
+): number {
+  if (framing.sourceAspect === framing.targetAspect) return framing.distance;
+
+  const sourceFit = fitDistanceToRotatingBounds(framing, framing.sourceAspect);
+  const targetFit = fitDistanceToRotatingBounds(framing, framing.targetAspect);
+  return framing.distance * (targetFit / sourceFit);
+}

--- a/tests/ui/gif-export-config.test.ts
+++ b/tests/ui/gif-export-config.test.ts
@@ -6,6 +6,7 @@ import { getSandboxGifExportPanelGrid } from "../../lib/sandbox/gifExportLayout"
 const SOURCE_PATH = "components/sandbox/SandboxGifExportButton.tsx";
 const sourceText = readFileSync(SOURCE_PATH, "utf8");
 const benchmarkSourceText = readFileSync("components/sandbox/SandboxBenchmark.tsx", "utf8");
+const viewerSourceText = readFileSync("components/voxel/VoxelViewer.tsx", "utf8");
 const sourceFile = ts.createSourceFile(SOURCE_PATH, sourceText, ts.ScriptTarget.Latest, true, ts.ScriptKind.TSX);
 
 function readNumericConst(name: string): number {
@@ -135,9 +136,9 @@ const singleFrameDelayMs = readNumericConst("SINGLE_FRAME_DELAY_MS");
 
 assert.equal(comparisonFrameCount, 108);
 assert.equal(singleFrameCount, 135);
-assert.equal(comparisonFrameDelayMs, 50);
+assert.equal(comparisonFrameDelayMs, 40);
 assert.equal(singleFrameDelayMs, 40);
-assert.equal(comparisonFrameCount * comparisonFrameDelayMs, 5400);
+assert.equal(comparisonFrameCount * comparisonFrameDelayMs, 4320);
 assert.equal(singleFrameCount * singleFrameDelayMs, 5400);
 assert.equal(readNumericConst("COMPARISON_PALETTE_SAMPLE_COUNT"), 12);
 assert.equal(readNumericConst("COMPARISON_PALETTE_SAMPLE_LONG_EDGE"), 640);
@@ -197,6 +198,18 @@ assert.ok(
 assert.ok(
   !benchmarkSourceText.includes("autoRotate="),
   "comparison cards should use the shared viewer spin control",
+);
+assert.ok(
+  !sourceText.includes('fit: "contain"'),
+  "GIF panels should render at their own aspect instead of containing a viewer screenshot",
+);
+assert.ok(
+  viewerSourceText.includes("retargetDistanceForAspect"),
+  "GIF capture should preserve relative camera zoom when the export aspect changes",
+);
+assert.ok(
+  viewerSourceText.includes("renderer.setPixelRatio(EXPORT_CAPTURE_PIXEL_RATIO)"),
+  "GIF capture should supersample before compositing at the export size",
 );
 
 console.log("gif export config checks passed");

--- a/tests/unit/voxel/framing.test.ts
+++ b/tests/unit/voxel/framing.test.ts
@@ -1,0 +1,50 @@
+import assert from "node:assert/strict";
+import {
+  fitDistanceToRotatingBounds,
+  retargetDistanceForAspect,
+  type RotatingBoundsFraming,
+} from "../../../lib/voxel/framing";
+
+const framing: RotatingBoundsFraming = {
+  width: 40,
+  height: 8,
+  depth: 40,
+  verticalFovDegrees: 45,
+  cameraDirectionY: 0.313,
+};
+
+const liveAspect = 1.6;
+const verticalAspect = 351 / 550;
+const liveFit = fitDistanceToRotatingBounds(framing, liveAspect);
+const verticalFit = fitDistanceToRotatingBounds(framing, verticalAspect);
+
+assert.ok(verticalFit > liveFit, "a narrower frame should move a wide build farther back");
+
+const liveDistance = liveFit * 0.82;
+assert.equal(
+  retargetDistanceForAspect({
+    ...framing,
+    distance: liveDistance,
+    sourceAspect: liveAspect,
+    targetAspect: liveAspect,
+  }),
+  liveDistance,
+  "matching aspects should preserve the camera exactly",
+);
+
+const verticalDistance = retargetDistanceForAspect({
+  ...framing,
+  distance: liveDistance,
+  sourceAspect: liveAspect,
+  targetAspect: verticalAspect,
+});
+assert.ok(
+  Math.abs(verticalDistance / verticalFit - liveDistance / liveFit) < 1e-12,
+  "aspect retargeting should preserve the user's zoom ratio",
+);
+
+const sphereRadius = Math.hypot(framing.width / 2, framing.height / 2, framing.depth / 2);
+const sphereFit = sphereRadius / Math.sin((framing.verticalFovDegrees * Math.PI) / 360);
+assert.ok(liveFit < sphereFit, "a rotating cylinder should frame flat builds more tightly than a sphere");
+
+console.log("voxel framing checks passed");


### PR DESCRIPTION
## Summary

- render each voxel scene directly for the GIF panel instead of containing a flattened viewer screenshot
- preserve the viewer's relative camera zoom when export and viewer aspect ratios differ
- frame rotating builds against their swept cylinder instead of an oversized bounding sphere
- supersample captures at 2x before compositing for cleaner texture detail and edges
- standardize comparison and single-build exports at 25 FPS while retaining seamless loop sampling

## Root cause

GIF capture retained the live viewer aspect ratio, then scaled that flattened image into differently shaped export panels with `contain`. This introduced a second fit that shrank builds and left avoidable space above and below them. Simply changing the camera aspect would crop narrow panels because it preserved raw camera distance rather than the user's zoom relative to a fitted view.

The export renderer also captured at 1x pixel density while the desktop viewer renders at up to 2x. With the nearest-filtered voxel texture atlas, this made distant textures and diagonal edges shimmer during rotation.

## Implementation

A shared framing helper now calculates the perspective distance required for the cylinder swept by a full Y-axis rotation. Live fitting and export capture use the same calculation, and aspect changes retarget camera distance while preserving the user's relative zoom.

Capture now renders once through the offscreen WebGL renderer at the panel aspect, restores camera and build state in `finally`, and removes the old contain/cover branches, crop math, overscan, and intermediate screenshot canvas. The compositor uses one integer capture rectangle for rendering and drawing.

The encoded dimensions, frame counts, palette size, and 15 MB limit remain unchanged. Supersampling increases render work, and highly detailed scenes may use the existing lower-resolution fallback when necessary to stay under the limit.

## Validation

- `pnpm lint`
- `pnpm test` — 48 test files passed
- production build and manual alpha export
- vertical two-build export verified at 108 frames, 25 FPS, and a seamless loop
- `graphify update .`
- `git diff --check origin/master...HEAD`

*(PR written by Codex)*