### PR TITLE
feat(arena): add private stealth evaluations

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,9 +8,24 @@ DIRECT_URL="postgresql://minebench:minebench@localhost:54327/minebench?schema=pu
 
 # Admin
 ADMIN_TOKEN=
-# Optional dedicated HMAC secret for arena matchup/vote tokens.
+# Optional dedicated secret for encrypted arena matchup/vote tokens.
 # If unset, ADMIN_TOKEN or NEXTAUTH_SECRET is required.
 ARENA_MATCHUP_SIGNING_SECRET=
+# Matchup envelopes expire after two hours by default.
+ARENA_MATCHUP_TOKEN_MAX_AGE_MS=7200000
+
+# Invite-only lab authentication
+NEXT_PUBLIC_SUPABASE_URL=
+NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY=
+SUPABASE_SECRET_KEY=
+
+# Private checkpoint evaluations
+# Generate with: pnpm stealth:eval keygen
+STEALTH_CONFIG_ENCRYPTION_KEY=
+# Fraction of ordinary Arena matchups eligible for one stealth checkpoint.
+STEALTH_ARENA_SHARE=0.25
+# One-time operator input for `stealth:eval configure`; do not deploy this value.
+STEALTH_ENDPOINT_API_KEY=
 
 # Supabase Storage (recommended for large build uploads, e.g. 50-100MB+)
 # Used by scripts/batch-generate.ts and storage-backed build reads in API routes.
@@ -145,5 +160,7 @@ NEXT_PUBLIC_VOXEL_MESH_WORKER_TIMEOUT_MS=45000
 # - STAGING_SUPABASE_URL / STAGING_SUPABASE_SERVICE_ROLE_KEY: alpha branch API
 # - STAGING_SUPABASE_STORAGE_BUCKET: defaults to SUPABASE_STORAGE_BUCKET
 # - STAGING_SITE_URL: alpha deployment URL, used as the import target
+# - STAGING_SUPABASE_PUBLISHABLE_KEY: alpha branch publishable key
+# - STAGING_STEALTH_CONFIG_ENCRYPTION_KEY: alpha-only checkpoint configuration key
 # - STAGING_VERCEL_BYPASS_SECRET: Vercel protection bypass, required for staging publishes
 # MINEBENCH_SITE_URL overrides the publish/import target (defaults to production)

--- a/app/api/admin/rank-snapshots/capture/route.ts
+++ b/app/api/admin/rank-snapshots/capture/route.ts
@@ -46,7 +46,7 @@ async function capture(req: Request) {
   const capturedAt = floorToUtcHour(anchor);
 
   const models = await prisma.model.findMany({
-    where: { enabled: true, isBaseline: false },
+    where: { enabled: true, isBaseline: false, stealthVariant: null },
     orderBy: [{ conservativeRating: "desc" }, { displayName: "asc" }],
     select: {
       id: true,

--- a/app/api/admin/seed/route.ts
+++ b/app/api/admin/seed/route.ts
@@ -163,7 +163,7 @@ export async function POST(req: Request) {
   if (!generateBuilds) {
     const [promptCount, modelCount] = await Promise.all([
       prisma.prompt.count({ where: { active: true } }),
-      prisma.model.count({ where: { enabled: true, isBaseline: false } }),
+      prisma.model.count({ where: { enabled: true, isBaseline: false, stealthVariant: null } }),
     ]);
 
     return NextResponse.json({

--- a/app/api/admin/status/route.ts
+++ b/app/api/admin/status/route.ts
@@ -105,7 +105,7 @@ export async function GET(req: Request) {
       prisma.prompt.count(),
       prisma.prompt.count({ where: { active: true } }),
       prisma.model.count(),
-      prisma.model.count({ where: { enabled: true, isBaseline: false } }),
+      prisma.model.count({ where: { enabled: true, isBaseline: false, stealthVariant: null } }),
       prisma.build.count(),
       prisma.matchup.count(),
       prisma.vote.count(),

--- a/app/api/arena/builds/[buildId]/route.ts
+++ b/app/api/arena/builds/[buildId]/route.ts
@@ -19,6 +19,8 @@ import {
   getArenaBuildMeta,
   invalidateArenaBuildMeta,
 } from "@/lib/arena/buildMetaCache";
+import { parseArenaBuildAccessToken } from "@/lib/arena/matchupToken";
+import { isLoopbackDatabaseUrl } from "@/lib/db/identity";
 import { prisma } from "@/lib/prisma";
 import { ServerTiming } from "@/lib/serverTiming";
 
@@ -80,6 +82,11 @@ function jsonBytes(value: unknown, gzip: boolean): Uint8Array {
   return gzip ? gzipSync(bytes) : bytes;
 }
 
+function rewriteBlindSnapshotIdentity(bytes: Uint8Array, buildId: string): Uint8Array {
+  const payload = JSON.parse(Buffer.from(bytes).toString("utf8")) as Record<string, unknown>;
+  return Buffer.from(JSON.stringify({ ...payload, buildId, checksum: null }));
+}
+
 function buildJsonResponseCacheKey(
   buildId: string,
   variant: ArenaBuildVariant,
@@ -97,9 +104,12 @@ function createJsonHeaders(opts: {
   deliveryClass: string;
   source: string;
   gzip: boolean;
+  privateAccess?: boolean;
 }): Headers {
   const headers = new Headers({
-    "Cache-Control": "public, max-age=0, s-maxage=300, stale-while-revalidate=86400",
+    "Cache-Control": opts.privateAccess
+      ? "private, no-store"
+      : "public, max-age=0, s-maxage=300, stale-while-revalidate=86400",
     "Content-Type": "application/json; charset=utf-8",
     "Content-Length": String(opts.byteLength),
     "x-build-delivery-class": opts.deliveryClass,
@@ -215,10 +225,24 @@ export async function GET(
 ) {
   const timing = new ServerTiming();
   const requestStartedAt = timing.start();
-  const { buildId } = await params;
+  const { buildId: requestedBuildId } = await params;
+  const buildAccess = parseArenaBuildAccessToken(requestedBuildId);
+  if (requestedBuildId.startsWith("b1.") && !buildAccess) {
+    return NextResponse.json({ error: "Build not found" }, { status: 404 });
+  }
+  const buildId = buildAccess?.buildId ?? requestedBuildId;
+  const clientBuildId = buildAccess ? requestedBuildId : buildId;
+  const privateLoopbackAccess = Boolean(
+    buildAccess &&
+      isLoopbackDatabaseUrl(process.env.DATABASE_URL ?? process.env.DIRECT_URL ?? ""),
+  );
   const url = new URL(request.url);
   const variant = parseVariant(url.searchParams.get("variant"));
-  const expectedChecksum = url.searchParams.get("checksum")?.trim() || null;
+  const requestedChecksum = url.searchParams.get("checksum")?.trim() || null;
+  if (buildAccess && requestedChecksum && requestedChecksum !== buildAccess.checksum) {
+    return NextResponse.json({ error: "Build checksum mismatch" }, { status: 409 });
+  }
+  const expectedChecksum = buildAccess?.checksum ?? requestedChecksum;
   const shouldGzip = acceptsGzip(request);
   // pass the client-supplied checksum so the meta cache can detect stale
   // entries left behind by an overwrite import that landed on another lambda
@@ -230,6 +254,7 @@ export async function GET(
 
   const storedChecksum = buildMeta.voxelSha256?.trim() || null;
   const artifactAllowed =
+    !privateLoopbackAccess &&
     SNAPSHOT_ARTIFACT_FETCH_ENABLED &&
     url.searchParams.get("artifact") !== "0" &&
     Boolean(storedChecksum);
@@ -240,7 +265,7 @@ export async function GET(
     arenaBuildHints: buildMeta.arenaBuildHints,
   });
   const deliveryClass = variant === "preview" ? shellHints.initialDeliveryClass : shellHints.deliveryClass;
-  const binaryFormatRequested = url.searchParams.get("format") === "v4";
+  const binaryFormatRequested = !buildAccess && url.searchParams.get("format") === "v4";
   const binaryArtifactRequested =
     binaryFormatRequested && isBinarySnapshotArtifactEnabled();
   const fullUsesStreamDelivery =
@@ -261,11 +286,13 @@ export async function GET(
   let shouldRequireStreamFallbackOnSnapshotMiss = avoidWholeBodyJsonFallback;
   if (expectedChecksum && storedChecksum && expectedChecksum !== storedChecksum) {
     return NextResponse.json(
-      {
-        error: "Build checksum mismatch",
-        expectedChecksum,
-        actualChecksum: storedChecksum,
-      },
+      buildAccess
+        ? { error: "Build changed" }
+        : {
+            error: "Build checksum mismatch",
+            expectedChecksum,
+            actualChecksum: storedChecksum,
+          },
       { status: 409 },
     );
   }
@@ -284,6 +311,7 @@ export async function GET(
   let servedArtifactFormat: ArenaSnapshotArtifactFormat = "json";
 
   if (
+    !buildAccess &&
     SNAPSHOT_ARTIFACT_REDIRECT_ENABLED &&
     url.searchParams.get("redirect") !== "0" &&
     canServeSnapshotArtifact
@@ -333,13 +361,15 @@ export async function GET(
     }
   }
 
-  const jsonCacheKey = buildJsonResponseCacheKey(
-    buildId,
-    variant,
-    storedChecksum,
-    shellHints,
-    shouldGzip,
-  );
+  const jsonCacheKey = buildAccess
+    ? null
+    : buildJsonResponseCacheKey(
+        buildId,
+        variant,
+        storedChecksum,
+        shellHints,
+        shouldGzip,
+      );
   // storage-first: the checksum-addressed artifact is the canonical snapshot
   try {
     if (artifactAllowed && canServeSnapshotArtifact) {
@@ -366,11 +396,18 @@ export async function GET(
       if (artifactBytes) {
         timing.end("artifact_hit", artifactStartedAt);
         timing.end("total", requestStartedAt);
+        const responseArtifactBytes = buildAccess
+          ? rewriteBlindSnapshotIdentity(artifactBytes, clientBuildId)
+          : artifactBytes;
         // the stored object is gzip; proxying it verbatim to a gzip-capable
         // client keeps snapshot-class fallbacks off the uncompressed path
-        const body = shouldGzip ? gzipSync(Buffer.from(artifactBytes)) : artifactBytes;
+        const body = shouldGzip
+          ? gzipSync(Buffer.from(responseArtifactBytes))
+          : responseArtifactBytes;
         const headers = new Headers({
-          "Cache-Control": "public, max-age=0, s-maxage=300, stale-while-revalidate=86400, no-transform",
+          "Cache-Control": buildAccess
+            ? "private, no-store"
+            : "public, max-age=0, s-maxage=300, stale-while-revalidate=86400, no-transform",
           "Content-Type":
             servedArtifactFormat === "binary"
               ? "application/octet-stream"
@@ -393,7 +430,7 @@ export async function GET(
   }
 
   const cachedJsonResponse =
-    !avoidWholeBodyJsonFallback && jsonCacheKey
+    !buildAccess && !avoidWholeBodyJsonFallback && jsonCacheKey
       ? getCachedJsonResponseByKey(jsonCacheKey)
       : null;
   // This body exists because the artifact was missing when it was built, so
@@ -489,7 +526,8 @@ export async function GET(
       }
       prepared = await prepareArenaBuild(build, { signal: request.signal });
     } catch (err) {
-      const message = err instanceof Error ? err.message : "Failed to load build payload";
+      const message =
+        !buildAccess && err instanceof Error ? err.message : "Failed to load build payload";
       return NextResponse.json({ error: message }, { status: 422 });
     }
     timing.end("prepare", prepareStartedAt);
@@ -497,11 +535,13 @@ export async function GET(
 
   if (expectedChecksum && expectedChecksum !== prepared.checksum) {
     return NextResponse.json(
-      {
-        error: "Build checksum mismatch",
-        expectedChecksum,
-        actualChecksum: prepared.checksum,
-      },
+      buildAccess
+        ? { error: "Build changed" }
+        : {
+            error: "Build checksum mismatch",
+            expectedChecksum,
+            actualChecksum: prepared.checksum,
+          },
       { status: 409 },
     );
   }
@@ -521,35 +561,38 @@ export async function GET(
     invalidateArenaBuildMeta(prepared.buildId);
     // dedupes on success and retries after a failure, so warm cache hits do not
     // re-upload and a transient failure is not permanent
-    await healArenaBuildSnapshotArtifactsOnce(prepared);
+    if (!privateLoopbackAccess) await healArenaBuildSnapshotArtifactsOnce(prepared);
   });
 
   const responseBytes = jsonBytes(
     {
-      buildId: prepared.buildId,
+      buildId: clientBuildId,
       variant,
-      checksum: prepared.checksum,
+      checksum: buildAccess ? null : prepared.checksum,
       serverValidated: true,
       buildLoadHints: prepared.hints,
       voxelBuild,
     },
     shouldGzip,
   );
-  rememberJsonResponse(
-    prepared.buildId,
-    variant,
-    prepared.checksum,
-    prepared.hints,
-    shouldGzip,
-    responseBytes,
-    "live",
-  );
+  if (!buildAccess) {
+    rememberJsonResponse(
+      prepared.buildId,
+      variant,
+      prepared.checksum,
+      prepared.hints,
+      shouldGzip,
+      responseBytes,
+      "live",
+    );
+  }
   timing.end("total", requestStartedAt);
   const headers = createJsonHeaders({
     byteLength: responseBytes.byteLength,
     deliveryClass: variant === "preview" ? prepared.hints.initialDeliveryClass : prepared.hints.deliveryClass,
     source: "live",
     gzip: shouldGzip,
+    privateAccess: Boolean(buildAccess),
   });
   timing.apply(headers);
 

--- a/app/api/arena/builds/[buildId]/stream/route.ts
+++ b/app/api/arena/builds/[buildId]/stream/route.ts
@@ -6,6 +6,7 @@ import {
   createArenaBuildStreamArtifactSignedUrl,
   estimateArenaBuildVariantBytes,
   encodeArenaBuildStreamEvent,
+  fetchArenaBuildStreamArtifact,
   iterateArenaBuildChunks,
   iterateArenaBuildStreamEvents,
   planArenaBuildStream,
@@ -20,6 +21,8 @@ import {
 } from "@/lib/arena/buildArtifacts";
 import { healArenaBuildSnapshotArtifactsOnce } from "@/lib/arena/buildSnapshotArtifacts";
 import { getArenaBuildMeta, invalidateArenaBuildMeta } from "@/lib/arena/buildMetaCache";
+import { parseArenaBuildAccessToken } from "@/lib/arena/matchupToken";
+import { isLoopbackDatabaseUrl } from "@/lib/db/identity";
 import { prisma } from "@/lib/prisma";
 import { ServerTiming } from "@/lib/serverTiming";
 import { trackServerEventInBackground } from "@/lib/analytics.server";
@@ -56,12 +59,14 @@ function toErrorMessage(err: unknown, fallback: string): string {
 
 function createStreamHeaders(
   source: "live" | "artifact",
-  opts?: { deliveryClass?: string; estimatedBytes?: number | null },
+  opts?: { deliveryClass?: string; estimatedBytes?: number | null; privateAccess?: boolean },
 ): Headers {
   const headers = new Headers({
     "Content-Type": "application/x-ndjson; charset=utf-8",
     "Cache-Control":
-      source === "artifact"
+      opts?.privateAccess
+        ? "private, no-store, no-transform"
+        : source === "artifact"
         ? createSignedRedirectCacheControl(ARTIFACT_SIGN_URL_TTL_SEC)
         : "no-store, no-transform",
     Connection: "keep-alive",
@@ -134,6 +139,40 @@ function chunkStreamArtifactBytes(events: Iterable<ArenaBuildStreamEvent>) {
   return out;
 }
 
+function rewriteBlindStreamIdentity(
+  body: ReadableStream<Uint8Array>,
+  buildId: string,
+): ReadableStream<Uint8Array> {
+  const decoder = new TextDecoder();
+  const encoder = new TextEncoder();
+  let pending = "";
+  const rewriteLine = (line: string) => {
+    if (!line.trim()) return line;
+    try {
+      const event = JSON.parse(line) as ArenaBuildStreamEvent;
+      return event.type === "hello"
+        ? JSON.stringify({ ...event, buildId, checksum: null })
+        : line;
+    } catch {
+      return line;
+    }
+  };
+  return body.pipeThrough(
+    new TransformStream<Uint8Array, Uint8Array>({
+      transform(chunk, controller) {
+        pending += decoder.decode(chunk, { stream: true });
+        const lines = pending.split("\n");
+        pending = lines.pop() ?? "";
+        for (const line of lines) controller.enqueue(encoder.encode(`${rewriteLine(line)}\n`));
+      },
+      flush(controller) {
+        pending += decoder.decode();
+        if (pending) controller.enqueue(encoder.encode(rewriteLine(pending)));
+      },
+    }),
+  );
+}
+
 function warmStreamArtifactInBackground(opts: {
   buildId: string;
   variant: ArenaBuildVariant;
@@ -198,10 +237,24 @@ export async function GET(
 ) {
   const timing = new ServerTiming();
   const requestStartedAt = timing.start();
-  const { buildId } = await params;
+  const { buildId: requestedBuildId } = await params;
+  const buildAccess = parseArenaBuildAccessToken(requestedBuildId);
+  if (requestedBuildId.startsWith("b1.") && !buildAccess) {
+    return NextResponse.json({ error: "Build not found" }, { status: 404 });
+  }
+  const buildId = buildAccess?.buildId ?? requestedBuildId;
+  const clientBuildId = buildAccess ? requestedBuildId : buildId;
+  const privateLoopbackAccess = Boolean(
+    buildAccess &&
+      isLoopbackDatabaseUrl(process.env.DATABASE_URL ?? process.env.DIRECT_URL ?? ""),
+  );
   const url = new URL(request.url);
   const variant = parseVariant(url.searchParams.get("variant"));
-  const expectedChecksum = url.searchParams.get("checksum")?.trim() || null;
+  const requestedChecksum = url.searchParams.get("checksum")?.trim() || null;
+  if (buildAccess && requestedChecksum && requestedChecksum !== buildAccess.checksum) {
+    return NextResponse.json({ error: "Build checksum mismatch" }, { status: 409 });
+  }
+  const expectedChecksum = buildAccess?.checksum ?? requestedChecksum;
 
   // pass expected checksum so the meta cache can detect cross-lambda staleness
   const meta = await getArenaBuildMeta(buildId, expectedChecksum);
@@ -213,11 +266,13 @@ export async function GET(
   const storedChecksum = meta.voxelSha256?.trim() || null;
   if (expectedChecksum && storedChecksum && expectedChecksum !== storedChecksum) {
     return NextResponse.json(
-      {
-        error: "Build checksum mismatch",
-        expectedChecksum,
-        actualChecksum: storedChecksum,
-      },
+      buildAccess
+        ? { error: "Build changed" }
+        : {
+            error: "Build checksum mismatch",
+            expectedChecksum,
+            actualChecksum: storedChecksum,
+          },
       { status: 409 },
     );
   }
@@ -234,6 +289,7 @@ export async function GET(
     isArtifactEligibleBuild(shellHints.fullEstimatedBytes) ||
     isArtifactEligibleBuild(rawFullEstimatedBytes);
   const fullRequiresArtifact =
+    !privateLoopbackAccess &&
     variant === "full" &&
     (shellHints.deliveryClass === "stream-artifact" || fullArtifactEligible);
   const artifactRequested = url.searchParams.get("artifact") !== "0";
@@ -243,41 +299,63 @@ export async function GET(
   try {
     if (artifactFetchAllowed) {
       const artifactStartedAt = timing.start();
-      const artifactSignedUrl = await withTimeout(
-        (signal) =>
-          createArenaBuildStreamArtifactSignedUrl(buildId, variant, storedChecksum, {
-            signal,
-            expiresInSec: ARTIFACT_SIGN_URL_TTL_SEC,
-          }),
-        ARTIFACT_FETCH_TIMEOUT_MS,
-        "artifact sign",
-      );
-      if (artifactSignedUrl) {
-        timing.end("artifact_hit", artifactStartedAt);
-        timing.end("total", requestStartedAt);
-        const shellEstimatedBytes =
-          variant === "full"
-            ? fullEstimatedBytes
-            : (estimateArenaBuildVariantBytes(
-                shellHints,
-                variant,
-                shellHints.previewBlockCount,
-              ) ?? shellHints.fullEstimatedBytes);
-        const headers = createStreamHeaders("artifact", {
-          deliveryClass:
-            variant === "full" && fullRequiresArtifact
-              ? "stream-artifact"
-              : variant === "preview"
-                ? shellHints.initialDeliveryClass
-                : shellHints.deliveryClass,
-          estimatedBytes: shellEstimatedBytes,
-        });
-        headers.set("Location", artifactSignedUrl);
-        timing.apply(headers);
-        return new Response(null, {
-          status: 307,
-          headers,
-        });
+      const shellEstimatedBytes =
+        variant === "full"
+          ? fullEstimatedBytes
+          : (estimateArenaBuildVariantBytes(
+              shellHints,
+              variant,
+              shellHints.previewBlockCount,
+            ) ?? shellHints.fullEstimatedBytes);
+      const artifactDeliveryClass =
+        variant === "full" && fullRequiresArtifact
+          ? "stream-artifact"
+          : variant === "preview"
+            ? shellHints.initialDeliveryClass
+            : shellHints.deliveryClass;
+      if (buildAccess) {
+        const artifactResponse = await withTimeout(
+          (signal) => fetchArenaBuildStreamArtifact(buildId, variant, storedChecksum, { signal }),
+          ARTIFACT_FETCH_TIMEOUT_MS,
+          "artifact fetch",
+        );
+        if (artifactResponse?.body) {
+          timing.end("artifact_hit", artifactStartedAt);
+          timing.end("total", requestStartedAt);
+          const headers = createStreamHeaders("artifact", {
+            deliveryClass: artifactDeliveryClass,
+            estimatedBytes: shellEstimatedBytes,
+            privateAccess: true,
+          });
+          timing.apply(headers);
+          return new Response(rewriteBlindStreamIdentity(artifactResponse.body, clientBuildId), {
+            headers,
+          });
+        }
+      } else {
+        const artifactSignedUrl = await withTimeout(
+          (signal) =>
+            createArenaBuildStreamArtifactSignedUrl(buildId, variant, storedChecksum, {
+              signal,
+              expiresInSec: ARTIFACT_SIGN_URL_TTL_SEC,
+            }),
+          ARTIFACT_FETCH_TIMEOUT_MS,
+          "artifact sign",
+        );
+        if (artifactSignedUrl) {
+          timing.end("artifact_hit", artifactStartedAt);
+          timing.end("total", requestStartedAt);
+          const headers = createStreamHeaders("artifact", {
+            deliveryClass: artifactDeliveryClass,
+            estimatedBytes: shellEstimatedBytes,
+          });
+          headers.set("Location", artifactSignedUrl);
+          timing.apply(headers);
+          return new Response(null, {
+            status: 307,
+            headers,
+          });
+        }
       }
       timing.end("artifact_miss", artifactStartedAt);
       trackServerEventInBackground("arena_artifact_miss", {
@@ -371,6 +449,7 @@ export async function GET(
   const responseHeaders = createStreamHeaders("live", {
     deliveryClass: variant === "preview" ? initialHints.initialDeliveryClass : initialHints.deliveryClass,
     estimatedBytes: estimateArenaBuildVariantBytes(initialHints, variant, initialBlockCount),
+    privateAccess: Boolean(buildAccess),
   });
   timing.apply(responseHeaders);
 
@@ -417,9 +496,9 @@ export async function GET(
       send({
         // early hello lets the client show progress before prepare finishes
         type: "hello",
-        buildId,
+        buildId: clientBuildId,
         variant,
-        checksum: storedChecksum,
+        checksum: buildAccess ? null : storedChecksum,
         serverValidated: false,
         buildLoadHints: initialHints,
         totalBlocks: initialPlan.totalBlocks,
@@ -467,9 +546,11 @@ export async function GET(
           // Registered with after() like the stream-artifact warmup above, so a
           // short response or an early client disconnect cannot leave the
           // invocation suspended mid-upload and lose the repair.
-          after(async () => {
-            await healArenaBuildSnapshotArtifactsOnce(prepared);
-          });
+          if (!privateLoopbackAccess) {
+            after(async () => {
+              await healArenaBuildSnapshotArtifactsOnce(prepared);
+            });
+          }
 
           if (expectedChecksum && expectedChecksum !== prepared.checksum) {
             send({
@@ -482,6 +563,7 @@ export async function GET(
 
           const voxelBuild = pickBuildVariant(prepared, variant);
           if (
+            !privateLoopbackAccess &&
             variant === "full" &&
             prepared.hints.deliveryClass === "stream-artifact" &&
             prepared.checksum
@@ -502,9 +584,9 @@ export async function GET(
 
           send({
             type: "hello",
-            buildId,
+            buildId: clientBuildId,
             variant,
-            checksum: prepared.checksum,
+            checksum: buildAccess ? null : prepared.checksum,
             serverValidated: true,
             buildLoadHints: prepared.hints,
             totalBlocks: plan.totalBlocks,
@@ -548,7 +630,9 @@ export async function GET(
         } catch (err) {
           send({
             type: "error",
-            message: toErrorMessage(err, "Failed to stream build"),
+            message: buildAccess
+              ? "Failed to stream build"
+              : toErrorMessage(err, "Failed to stream build"),
           });
         } finally {
           safeClose();

--- a/app/api/arena/matchup/route.ts
+++ b/app/api/arena/matchup/route.ts
@@ -19,7 +19,11 @@ import {
 import { createArenaBuildStreamArtifactSignedUrl } from "@/lib/arena/buildStream";
 import { invalidateArenaBuildMeta } from "@/lib/arena/buildMetaCache";
 import { normalizeArenaBuildChecksum } from "@/lib/arena/buildChecksum";
-import { createArenaMatchupToken, hasArenaMatchupSigningSecret } from "@/lib/arena/matchupToken";
+import {
+  createArenaBuildAccessToken,
+  createArenaMatchupToken,
+  hasArenaMatchupSigningSecret,
+} from "@/lib/arena/matchupToken";
 import { isArenaCapacityError } from "@/lib/arena/writeRetry";
 import {
   databaseUnavailableBody,
@@ -27,18 +31,21 @@ import {
   getErrorMessage,
   isDatabaseUnavailableError,
 } from "@/lib/db/errors";
+import { isLoopbackDatabaseUrl } from "@/lib/db/identity";
 import {
   getArenaMatchupSamplingStateWithMeta,
   invalidateArenaCoverageCache,
   recordArenaMatchupShown,
   type CoverageState,
+  type EligibleBuildMeta,
   type EligibleModel,
   type EligiblePrompt,
 } from "@/lib/arena/coverage";
 import { enqueueArenaMatchupShownDurably } from "@/lib/arena/shownJobs";
 import { ServerTiming } from "@/lib/serverTiming";
 import { trackServerEventInBackground } from "@/lib/analytics.server";
-import { resolveModelDisplayName } from "@/lib/ai/modelCatalog";
+import { readStealthArenaShare } from "@/lib/stealth/policy";
+import { pickStealthMatchup } from "@/lib/stealth/sampling";
 
 export const runtime = "nodejs";
 
@@ -73,6 +80,9 @@ type MatchupChoice = {
   prompt: EligiblePrompt;
   modelA: EligibleModel;
   modelB: EligibleModel;
+  stealthVariantId?: string;
+  stealthModelId?: string;
+  stealthBuild?: EligibleBuildMeta;
 };
 
 function getOrSetSessionId(res: NextResponse, req: Request) {
@@ -743,7 +753,27 @@ export async function GET(req: Request) {
   const forcedPromptId = prompts.some((prompt) => prompt.id === requestedPromptId)
     ? requestedPromptId
     : undefined;
-  const picked = pickMatchup({
+  let picked: MatchupChoice | null = null;
+  if (Math.random() < readStealthArenaShare()) {
+    try {
+      const stealth = await pickStealthMatchup({ publicState: sampling.state, forcedPromptId });
+      if (stealth) {
+        picked = {
+          lane: chooseLane(),
+          reason: `stealth:${stealth.stealthVariantId}`,
+          prompt: stealth.prompt,
+          modelA: stealth.stealthModel,
+          modelB: stealth.publicModel,
+          stealthVariantId: stealth.stealthVariantId,
+          stealthModelId: stealth.stealthModel.id,
+          stealthBuild: stealth.stealthBuild,
+        };
+      }
+    } catch (error) {
+      console.warn("stealth matchup sampling failed", getErrorMessage(error, "unknown error"));
+    }
+  }
+  picked ??= pickMatchup({
     prompts,
     modelsById,
     promptIdsByModelId,
@@ -763,9 +793,12 @@ export async function GET(req: Request) {
   const rightModel = swapSides ? picked.modelA : picked.modelB;
 
   const buildMetaStartedAt = performance.now();
-  const buildA = buildsByModelPromptKey.get(modelPromptKey(leftModel.id, picked.prompt.id)) ?? null;
-  const buildB =
-    buildsByModelPromptKey.get(modelPromptKey(rightModel.id, picked.prompt.id)) ?? null;
+  const selectedBuild = (modelId: string) =>
+    picked.stealthModelId === modelId
+      ? picked.stealthBuild ?? null
+      : buildsByModelPromptKey.get(modelPromptKey(modelId, picked.prompt.id)) ?? null;
+  const buildA = selectedBuild(leftModel.id);
+  const buildB = selectedBuild(rightModel.id);
   const buildMetaMs = performance.now() - buildMetaStartedAt;
   timing.add("build_meta", buildMetaMs);
 
@@ -944,9 +977,25 @@ export async function GET(req: Request) {
     buildBChecksum: tokenBuildBChecksum,
     samplingLane: picked.lane,
     samplingReason: picked.reason,
+    stealthVariantId: picked.stealthVariantId,
   });
+  const blindBuildAccess = picked.stealthVariantId
+    ? {
+        a: createArenaBuildAccessToken({
+          buildId: buildA.id,
+          checksum: tokenBuildAChecksum,
+        }),
+        b: createArenaBuildAccessToken({
+          buildId: buildB.id,
+          checksum: tokenBuildBChecksum,
+        }),
+      }
+    : null;
   const txMs = 0;
   timing.add("tx", txMs);
+  const allowArtifactHealing =
+    !picked.stealthVariantId ||
+    !isLoopbackDatabaseUrl(process.env.DATABASE_URL ?? process.env.DIRECT_URL ?? "");
   const preparedForPersistence = [preparedA, preparedB].filter(
     (value): value is NonNullable<typeof value> =>
       Boolean(value) && !repairedBuildIds.has(value?.buildId ?? ""),
@@ -961,7 +1010,7 @@ export async function GET(req: Request) {
           // build route that would upload the missing artifact. Restricted to
           // builds that live-prepared after an artifact miss, since ensure
           // upserts unconditionally and warm traffic would re-upload snapshots.
-          if (artifactMissBuildIds.has(prepared.buildId)) {
+          if (allowArtifactHealing && artifactMissBuildIds.has(prepared.buildId)) {
             await healArenaBuildSnapshotArtifactsOnce(prepared);
           }
         }),
@@ -969,7 +1018,7 @@ export async function GET(req: Request) {
     });
   }
 
-  if (MATCHUP_ARTIFACT_URL_WARMING_ENABLED) {
+  if (MATCHUP_ARTIFACT_URL_WARMING_ENABLED && !blindBuildAccess) {
     // warm signing caches after the matchup is already ready
     after(async () => {
       await Promise.allSettled([
@@ -984,64 +1033,76 @@ export async function GET(req: Request) {
     samplingLane: picked.lane,
     prompt: { id: picked.prompt.id, text: picked.prompt.text },
     a: {
-      model: {
-        key: leftModel.key,
-        provider: leftModel.provider,
-        displayName: resolveModelDisplayName(leftModel.key, leftModel.displayName),
-        eloRating: leftModel.eloRating,
-      },
+      model: null,
       build:
         (preparedA && shouldInlineA
           ? pickInitialBuild(preparedA)
           : shouldInlineA
             ? persistedInitialBuildA
             : null) as ArenaMatchup["a"]["build"],
-      buildRef: preparedA?.buildRef ?? {
-        buildId: buildA.id,
-        variant: "full",
-        checksum: tokenBuildAChecksum,
-      },
-      previewRef: preparedA?.previewRef ?? {
-        buildId: buildA.id,
-        variant: "preview",
-        checksum: tokenBuildAChecksum,
-      },
+      buildRef: blindBuildAccess
+        ? { buildId: blindBuildAccess.a, variant: "full", checksum: null }
+        : preparedA?.buildRef ?? {
+            buildId: buildA.id,
+            variant: "full",
+            checksum: tokenBuildAChecksum,
+          },
+      previewRef: blindBuildAccess
+        ? { buildId: blindBuildAccess.a, variant: "preview", checksum: null }
+        : preparedA?.previewRef ?? {
+            buildId: buildA.id,
+            variant: "preview",
+            checksum: tokenBuildAChecksum,
+          },
       serverValidated: Boolean(preparedA || (shouldInlineA && persistedInitialBuildA)),
       buildLoadHints: preparedA?.hints ?? shellHintsA,
     },
     b: {
-      model: {
-        key: rightModel.key,
-        provider: rightModel.provider,
-        displayName: resolveModelDisplayName(rightModel.key, rightModel.displayName),
-        eloRating: rightModel.eloRating,
-      },
+      model: null,
       build:
         (preparedB && shouldInlineB
           ? pickInitialBuild(preparedB)
           : shouldInlineB
             ? persistedInitialBuildB
             : null) as ArenaMatchup["b"]["build"],
-      buildRef: preparedB?.buildRef ?? {
-        buildId: buildB.id,
-        variant: "full",
-        checksum: tokenBuildBChecksum,
-      },
-      previewRef: preparedB?.previewRef ?? {
-        buildId: buildB.id,
-        variant: "preview",
-        checksum: tokenBuildBChecksum,
-      },
+      buildRef: blindBuildAccess
+        ? { buildId: blindBuildAccess.b, variant: "full", checksum: null }
+        : preparedB?.buildRef ?? {
+            buildId: buildB.id,
+            variant: "full",
+            checksum: tokenBuildBChecksum,
+          },
+      previewRef: blindBuildAccess
+        ? { buildId: blindBuildAccess.b, variant: "preview", checksum: null }
+        : preparedB?.previewRef ?? {
+            buildId: buildB.id,
+            variant: "preview",
+            checksum: tokenBuildBChecksum,
+          },
       serverValidated: Boolean(preparedB || (shouldInlineB && persistedInitialBuildB)),
       buildLoadHints: preparedB?.hints ?? shellHintsB,
     },
   };
-  recordArenaMatchupShown([leftModel.id, rightModel.id]);
-  after(() => {
-    return enqueueArenaMatchupShownDurably([leftModel.id, rightModel.id]).catch((error) => {
-      console.warn("arena shown-count enqueue failed", error);
+  if (!picked.stealthVariantId) {
+    recordArenaMatchupShown([leftModel.id, rightModel.id]);
+    after(() => {
+      return enqueueArenaMatchupShownDurably([leftModel.id, rightModel.id]).catch((error) => {
+        console.warn("arena shown-count enqueue failed", error);
+      });
     });
-  });
+  }
+  if (picked.stealthVariantId) {
+    after(() =>
+      prisma.stealthVariant
+        .updateMany({
+          where: { id: picked.stealthVariantId, status: "ACTIVE" },
+          data: { shownCount: { increment: 1 } },
+        })
+        .catch((error) => {
+          console.warn("stealth shown-count update failed", error);
+        }),
+    );
+  }
 
   const totalMs = performance.now() - requestStartedAt;
   if (Number.isFinite(totalMs) && totalMs >= MATCHUP_SLOW_EVENT_MS) {

--- a/app/api/arena/vote/route.ts
+++ b/app/api/arena/vote/route.ts
@@ -2,13 +2,14 @@ import { Prisma } from "@prisma/client";
 import { z } from "zod";
 import { after, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
-import type { VoteChoice } from "@/lib/arena/types";
+import type { ArenaModelReveal, ArenaVoteResponse, VoteChoice } from "@/lib/arena/types";
 import { hasArenaMatchupSigningSecret, parseArenaMatchupToken } from "@/lib/arena/matchupToken";
 import { recordArenaVoteQueuedForSampling } from "@/lib/arena/coverage";
 import { shouldScheduleArenaVoteJobDrainAfterResponse } from "@/lib/arena/drainConfig";
 import { scheduleArenaVoteJobDrain } from "@/lib/arena/voteJobs";
 import { isArenaCapacityError, withArenaWriteRetry } from "@/lib/arena/writeRetry";
 import { ServerTiming } from "@/lib/serverTiming";
+import { resolveModelDisplayName } from "@/lib/ai/modelCatalog";
 
 export const runtime = "nodejs";
 
@@ -19,28 +20,38 @@ const reqSchema = z.object({
   choice: z.union([z.literal("A"), z.literal("B"), z.literal("TIE"), z.literal("BOTH_BAD")]),
 });
 
-function getOrSetSessionId(res: NextResponse, req: Request) {
+function getOrCreateSessionId(req: Request): { id: string; cookieValue: string | null } {
   const cookieHeader = req.headers.get("cookie") ?? "";
   const match = cookieHeader.match(new RegExp(`${SESSION_COOKIE}=([^;]+)`));
   const existing = match?.[1];
-  if (existing) return existing;
+  if (existing) return { id: existing, cookieValue: null };
 
   const id = crypto.randomUUID();
-  res.cookies.set(SESSION_COOKIE, id, {
-    httpOnly: true,
-    sameSite: "lax",
-    path: "/",
-    maxAge: 60 * 60 * 24 * 365,
-  });
-  return id;
+  return { id, cookieValue: id };
 }
 
 function isCapacityVoteError(error: unknown): boolean {
   return isArenaCapacityError(error);
 }
 
-function isDuplicateVoteError(error: unknown): boolean {
-  return error instanceof Prisma.PrismaClientKnownRequestError && error.code === "P2002";
+async function loadModelReveal(modelId: string): Promise<ArenaModelReveal | null> {
+  const model = await prisma.model.findUnique({
+    where: { id: modelId },
+    select: {
+      key: true,
+      provider: true,
+      displayName: true,
+      stealthVariant: { select: { codename: true } },
+    },
+  });
+  if (!model) return null;
+  if (model.stealthVariant) {
+    return { provider: "Stealth", displayName: model.stealthVariant.codename };
+  }
+  return {
+    provider: model.provider,
+    displayName: resolveModelDisplayName(model.key, model.displayName),
+  };
 }
 
 export async function POST(req: Request) {
@@ -79,6 +90,7 @@ export async function POST(req: Request) {
         modelAId: string;
         modelBId: string;
         choice: VoteChoice;
+        stealthVariantId?: string;
       }
     | null = null;
 
@@ -102,9 +114,10 @@ export async function POST(req: Request) {
       buildBId: tokenMatchup.buildBId,
       samplingLane: tokenMatchup.samplingLane ?? null,
       samplingReason: tokenMatchup.samplingReason ?? null,
+      stealthVariantId: tokenMatchup.stealthVariantId ?? null,
     };
-    res = NextResponse.json({ ok: true }, { headers: { "Cache-Control": "no-store" } });
-    const sessionId = getOrSetSessionId(res, req);
+    const session = getOrCreateSessionId(req);
+    const sessionId = session.id;
     const txStartedAt = timing.start();
     const voteId = crypto.randomUUID();
     const jobId = crypto.randomUUID();
@@ -124,6 +137,32 @@ export async function POST(req: Request) {
         AND build_b."modelId" = ${tokenMatchup.modelBId}
         AND BTRIM(build_b."voxelSha256") = ${tokenMatchup.buildBChecksum}
         AND model_b."enabled" = true
+        AND ${
+          tokenMatchup.stealthVariantId
+            ? Prisma.sql`EXISTS (
+                SELECT 1
+                FROM "StealthVariant" variant
+                INNER JOIN "StealthExperiment" experiment ON experiment.id = variant."experimentId"
+                WHERE variant.id = ${tokenMatchup.stealthVariantId}
+                  AND variant.status = 'ACTIVE'
+                  AND experiment.status IN ('ACTIVE', 'STABLE')
+                  AND (
+                    (variant."modelId" = ${tokenMatchup.modelAId} AND variant."modelId" <> ${tokenMatchup.modelBId}) OR
+                    (variant."modelId" = ${tokenMatchup.modelBId} AND variant."modelId" <> ${tokenMatchup.modelAId})
+                  )
+                  AND NOT EXISTS (
+                    SELECT 1
+                    FROM "StealthVariant" other_variant
+                    WHERE other_variant.id <> variant.id
+                      AND other_variant."modelId" IN (${tokenMatchup.modelAId}, ${tokenMatchup.modelBId})
+                  )
+              )`
+            : Prisma.sql`NOT EXISTS (
+                SELECT 1
+                FROM "StealthVariant" variant
+                WHERE variant."modelId" IN (${tokenMatchup.modelAId}, ${tokenMatchup.modelBId})
+              )`
+        }
       FOR SHARE OF build_a, build_b, model_a, model_b
     `;
     const [voteWrite] = await withArenaWriteRetry(async () => {
@@ -140,7 +179,8 @@ export async function POST(req: Request) {
             "buildAId",
             "buildBId",
             "samplingLane",
-            "samplingReason"
+            "samplingReason",
+            "stealthVariantId"
           )
           SELECT
             ${dbMatchupId},
@@ -150,7 +190,8 @@ export async function POST(req: Request) {
             ${matchup.buildAId},
             ${matchup.buildBId},
             ${matchup.samplingLane},
-            ${matchup.samplingReason}
+            ${matchup.samplingReason},
+            ${matchup.stealthVariantId}
           FROM valid_matchup
           ON CONFLICT ("id") DO NOTHING
         ),
@@ -174,7 +215,8 @@ export async function POST(req: Request) {
             "promptId",
             "modelAId",
             "modelBId",
-            "choice"
+            "choice",
+            "stealthVariantId"
           )
           SELECT
             ${jobId},
@@ -183,7 +225,8 @@ export async function POST(req: Request) {
             ${matchup.promptId},
             ${matchup.modelAId},
             ${matchup.modelBId},
-            ${choice}
+            ${choice},
+            ${matchup.stealthVariantId}
           FROM inserted_vote
           RETURNING "voteId"
         )
@@ -205,17 +248,31 @@ export async function POST(req: Request) {
         modelAId: matchup.modelAId,
         modelBId: matchup.modelBId,
         choice,
+        ...(matchup.stealthVariantId ? { stealthVariantId: matchup.stealthVariantId } : {}),
       };
     }
-  } catch (err) {
-    if (res && isDuplicateVoteError(err)) {
-      if (!finalized) {
-        timing.end("total", requestStartedAt);
-        finalized = true;
-      }
-      timing.apply(res.headers);
-      return res;
+
+    const [revealA, revealB] = await Promise.all([
+      loadModelReveal(matchup.modelAId),
+      loadModelReveal(matchup.modelBId),
+    ]);
+    if (!revealA || !revealB) {
+      return respondJson({ error: "Matchup reveal is unavailable" }, { status: 409 });
     }
+    const responseBody: ArenaVoteResponse = {
+      ok: true,
+      reveal: { a: revealA, b: revealB },
+    };
+    res = NextResponse.json(responseBody, { headers: { "Cache-Control": "no-store" } });
+    if (session.cookieValue) {
+      res.cookies.set(SESSION_COOKIE, session.cookieValue, {
+        httpOnly: true,
+        sameSite: "lax",
+        path: "/",
+        maxAge: 60 * 60 * 24 * 365,
+      });
+    }
+  } catch (err) {
     const capacityError = isCapacityVoteError(err);
     const msg = err instanceof Error ? err.message : "Vote failed";
     return respondJson(
@@ -234,7 +291,7 @@ export async function POST(req: Request) {
   if (!res) {
     return respondJson({ error: "Vote failed" }, { status: 409 });
   }
-  if (queuedVoteJobInput) {
+  if (queuedVoteJobInput && !queuedVoteJobInput.stealthVariantId) {
     recordArenaVoteQueuedForSampling(queuedVoteJobInput);
   }
   if (shouldScheduleArenaVoteJobDrainAfterResponse(queuedVoteJobs)) {

--- a/app/api/lab/organizations/[orgSlug]/experiments/[experimentId]/export/route.ts
+++ b/app/api/lab/organizations/[orgSlug]/experiments/[experimentId]/export/route.ts
@@ -1,0 +1,43 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { getLabOrganizationContext } from "@/lib/stealth/auth";
+import { canExportStealthVotes, normalizeStealthSlug } from "@/lib/stealth/policy";
+import {
+  getDeidentifiedStealthVotes,
+  serializeDeidentifiedStealthVotes,
+} from "@/lib/stealth/report";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ orgSlug: string; experimentId: string }> },
+) {
+  const { orgSlug, experimentId } = await params;
+  const context = await getLabOrganizationContext(orgSlug).catch(() => null);
+  if (!context) return NextResponse.json({ error: "Authentication required" }, { status: 401 });
+  const experiment = await prisma.stealthExperiment.findUnique({
+    where: { id: experimentId },
+    select: { organizationId: true, slug: true, exportPolicy: true },
+  });
+  if (!experiment || experiment.organizationId !== context.membership.organization.id) {
+    return NextResponse.json({ error: "Evaluation not found" }, { status: 404 });
+  }
+  if (
+    experiment.exportPolicy !== "DEIDENTIFIED_VOTES" ||
+    !canExportStealthVotes(context.membership.role)
+  ) {
+    return NextResponse.json({ error: "Vote export is not enabled" }, { status: 403 });
+  }
+  const rows = await getDeidentifiedStealthVotes(experimentId);
+  const filename = `${normalizeStealthSlug(experiment.slug)}-votes.csv`;
+  return new NextResponse(serializeDeidentifiedStealthVotes(rows), {
+    headers: {
+      "Cache-Control": "private, no-store",
+      "Content-Disposition": `attachment; filename="${filename}"`,
+      "Content-Type": "text/csv; charset=utf-8",
+      "X-Content-Type-Options": "nosniff",
+    },
+  });
+}

--- a/app/api/leaderboard/route.ts
+++ b/app/api/leaderboard/route.ts
@@ -70,7 +70,7 @@ export async function GET() {
   try {
     [models, dispersionByModelId, eligiblePromptIds, baselineAnchor] = await Promise.all([
       prisma.model.findMany({
-        where: { isBaseline: false, enabled: true },
+        where: { isBaseline: false, enabled: true, stealthVariant: null },
         orderBy: [{ conservativeRating: "desc" }, { displayName: "asc" }],
         select: LEADERBOARD_MODEL_SELECT,
       }),

--- a/app/api/sandbox/benchmark/route.ts
+++ b/app/api/sandbox/benchmark/route.ts
@@ -101,7 +101,7 @@ export async function GET(req: Request) {
         gridSize: ARENA_GRID_SIZE,
         palette: ARENA_PALETTE,
         mode: ARENA_MODE,
-        model: { enabled: true, isBaseline: false },
+        model: { enabled: true, isBaseline: false, stealthVariant: null },
         prompt: { active: true },
       },
     });
@@ -147,6 +147,7 @@ export async function GET(req: Request) {
       where: {
         enabled: true,
         isBaseline: false,
+        stealthVariant: null,
         builds: {
           some: {
             promptId: { in: eligiblePromptIds },

--- a/app/lab/[orgSlug]/experiments/[experimentId]/page.tsx
+++ b/app/lab/[orgSlug]/experiments/[experimentId]/page.tsx
@@ -11,7 +11,7 @@ import {
 export const dynamic = "force-dynamic";
 
 export const metadata: Metadata = {
-  title: "Evaluation report",
+  title: "Evaluation",
   robots: { index: false, follow: false },
 };
 
@@ -24,31 +24,41 @@ function date(value: Date | null): string {
 }
 
 function statusClass(status: string): string {
-  if (status === "ACTIVE" || status === "STABLE") return "bg-success/10 text-success ring-success/25";
-  if (status === "DEGRADED" || status === "WITHDRAWN") return "bg-warn/10 text-warn ring-warn/25";
-  return "bg-bg/45 text-muted ring-border/65";
+  if (status === "ACTIVE" || status === "STABLE") return "text-success";
+  if (status === "DEGRADED" || status === "WITHDRAWN") return "text-warn";
+  return "text-muted";
 }
 
-function BreakdownTable({ title, rows }: { title: string; rows: StealthBreakdown[] }) {
+function statusLabel(status: string): string {
+  return status.charAt(0) + status.slice(1).toLowerCase();
+}
+
+function BreakdownTable({
+  title,
+  label,
+  rows,
+}: {
+  title: string;
+  label: string;
+  rows: StealthBreakdown[];
+}) {
   return (
-    <section className="mb-panel overflow-hidden before:hidden">
-      <div className="border-b border-border/55 px-4 py-3 sm:px-5">
-        <h3 className="font-display text-sm font-semibold tracking-tight text-fg">{title}</h3>
-      </div>
+    <section className="space-y-3">
+      <h3 className="text-lg font-medium tracking-tight text-fg">{title}</h3>
       <div className="overflow-x-auto">
-        <table className="w-full min-w-[34rem] text-left text-sm">
+        <table className="w-full min-w-[34rem] border-y border-border/70 text-left text-sm">
           <thead className="font-mono text-[10px] uppercase tracking-[0.1em] text-muted">
             <tr className="border-b border-border/45">
-              <th className="px-4 py-2.5 font-medium sm:px-5">Name</th>
+              <th className="py-2.5 pr-4 font-medium">{label}</th>
               <th className="px-3 py-2.5 text-right font-medium">Votes</th>
-              <th className="px-3 py-2.5 text-right font-medium">W–L–T</th>
-              <th className="px-4 py-2.5 text-right font-medium sm:px-5">Score</th>
+              <th className="px-3 py-2.5 text-right font-medium">Record</th>
+              <th className="py-2.5 pl-4 text-right font-medium">Score</th>
             </tr>
           </thead>
           <tbody>
             {rows.map((row) => (
               <tr key={row.id} className="border-b border-border/35 last:border-0">
-                <td className="max-w-[30rem] px-4 py-3 text-fg sm:px-5">
+                <td className="max-w-[30rem] py-3 pr-4 text-fg">
                   <span className="line-clamp-2">{row.label}</span>
                 </td>
                 <td className="px-3 py-3 text-right font-mono text-xs tabular-nums text-muted">
@@ -57,14 +67,14 @@ function BreakdownTable({ title, rows }: { title: string; rows: StealthBreakdown
                 <td className="px-3 py-3 text-right font-mono text-xs tabular-nums text-muted">
                   {row.wins}–{row.losses}–{row.draws}
                 </td>
-                <td className="px-4 py-3 text-right font-mono text-xs tabular-nums text-fg sm:px-5">
+                <td className="py-3 pl-4 text-right font-mono text-xs tabular-nums text-fg">
                   {percent(row.averageScore)}
                 </td>
               </tr>
             ))}
             {rows.length === 0 ? (
               <tr>
-                <td colSpan={4} className="px-5 py-8 text-center text-sm text-muted">
+                <td colSpan={4} className="py-8 text-center text-sm text-muted">
                   No votes yet
                 </td>
               </tr>
@@ -88,123 +98,111 @@ export default async function LabExperimentPage({
   if (!report || report.organization.id !== context.membership.organization.id) notFound();
   const exportAvailable =
     report.exportPolicy === "DEIDENTIFIED_VOTES" && canExportStealthVotes(context.membership.role);
+  const period = [
+    report.startsAt ? `Started ${date(report.startsAt)}` : null,
+    report.endedAt ? `Ended ${date(report.endedAt)}` : null,
+  ]
+    .filter(Boolean)
+    .join(" · ");
 
   return (
-    <div className="mx-auto w-full max-w-7xl space-y-7 py-6 sm:py-10">
-      <header className="space-y-5">
+    <div className="mx-auto w-full max-w-6xl space-y-10 py-6 sm:py-12">
+      <header className="space-y-6 border-b border-border/70 pb-7">
         <Link
           href={`/lab/${orgSlug}`}
-          className="inline-flex font-mono text-xs text-muted transition hover:text-fg"
+          className="inline-flex text-sm text-muted transition hover:text-fg"
         >
           ← {report.organization.name}
         </Link>
-        <div className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
-          <div className="space-y-3">
-            <div className="flex flex-wrap items-center gap-2">
-              <span className="mb-eyebrow">Evaluation report</span>
+        <div className="flex flex-col gap-5 sm:flex-row sm:items-end sm:justify-between">
+          <div className="space-y-2">
+            <div className="flex flex-wrap items-center gap-3">
+              <h1 className="text-3xl font-semibold tracking-tight text-fg sm:text-4xl">
+                {report.name}
+              </h1>
               <span
-                className={`inline-flex rounded-full px-2.5 py-1 font-mono text-[10px] uppercase tracking-[0.1em] ring-1 ${statusClass(report.status)}`}
+                className={`inline-flex items-center gap-2 text-xs font-medium ${statusClass(report.status)}`}
               >
-                {report.status.toLowerCase()}
+                <span aria-hidden="true" className="h-1.5 w-1.5 rounded-full bg-current" />
+                {statusLabel(report.status)}
               </span>
             </div>
-            <h1 className="font-display text-3xl font-semibold tracking-tight text-fg sm:text-4xl">
-              {report.name}
-            </h1>
-            <p className="text-sm text-muted">
-              Started {date(report.startsAt)}{report.endedAt ? ` · Ended ${date(report.endedAt)}` : ""}
-            </p>
+            {period ? <p className="text-sm text-muted">{period}</p> : null}
           </div>
           {exportAvailable ? (
             <a
               href={`/api/lab/organizations/${orgSlug}/experiments/${report.id}/export`}
               className="mb-btn mb-btn-ghost h-10 px-4 text-xs"
             >
-              Export votes
+              Export
             </a>
           ) : null}
         </div>
       </header>
 
       {report.variants.map((variant) => (
-        <article key={variant.id} className="space-y-4">
-          <section className="mb-panel overflow-hidden p-5 before:hidden sm:p-6">
-            <div className="mb-panel-inner space-y-6">
-              <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-                <div className="space-y-2">
-                  <span className="font-mono text-[10px] uppercase tracking-[0.12em] text-muted">Stealth checkpoint</span>
-                  <h2 className="font-display text-2xl font-semibold tracking-tight text-fg">
-                    {variant.codename}
-                  </h2>
-                  <p className="text-sm text-muted">
-                    {variant.releasedModelKey ? `Released as ${variant.releasedModelKey}` : variant.stability}
-                  </p>
-                </div>
-                <span
-                  className={`inline-flex w-fit rounded-full px-2.5 py-1 font-mono text-[10px] uppercase tracking-[0.1em] ring-1 ${statusClass(variant.status)}`}
-                >
-                  {variant.status.toLowerCase()}
-                </span>
-              </div>
-
-              <div className="grid grid-cols-2 gap-px overflow-hidden rounded-xl bg-border/55 ring-1 ring-border/55 sm:grid-cols-3 lg:grid-cols-6">
-                {[
-                  ["Record", `${variant.outcomes.wins}–${variant.outcomes.losses}–${variant.outcomes.draws}`],
-                  ["Score", percent(variant.outcomes.averageScore)],
-                  ["Field estimate", `#${variant.estimatedFieldRank} / ${variant.estimatedFieldSize}`],
-                  ["Confidence", `${variant.confidence}%`],
-                  ["Rating deviation", Math.round(variant.ratingDeviation).toString()],
-                  ["Side split", `${variant.sideA} / ${variant.sideB}`],
-                ].map(([label, metric]) => (
-                  <div key={label} className="bg-card/80 px-3 py-4 sm:px-4">
-                    <div className="font-mono text-[9px] uppercase tracking-[0.1em] text-muted">{label}</div>
-                    <div className="mt-1.5 text-lg font-semibold tabular-nums text-fg">{metric}</div>
-                  </div>
-                ))}
-              </div>
-
-              <div className="space-y-2">
-                <div className="flex items-center justify-between gap-4 text-xs">
-                  <span className="text-muted">Decisive vote target</span>
-                  <span className="font-mono tabular-nums text-fg">
-                    {variant.outcomes.decisiveVotes.toLocaleString()} / {variant.targetDecisiveVotes.toLocaleString()}
-                  </span>
-                </div>
-                <div className="h-1.5 overflow-hidden rounded-full bg-border/50">
-                  <div className="h-full rounded-full bg-accent" style={{ width: `${variant.progress * 100}%` }} />
-                </div>
-              </div>
-
-              <div className="flex flex-wrap gap-x-6 gap-y-2 border-t border-border/55 pt-4 text-xs text-muted">
-                <span>Cohort {variant.generatedBuildCount}/{variant.expectedBuildCount}</span>
-                <span>Both bad {variant.outcomes.bothBad}</span>
-                <span>Prompt spread {percent(variant.promptScoreSpread)}</span>
-                {variant.pendingVotes > 0 ? <span>{variant.pendingVotes} votes processing</span> : null}
-                {variant.latestGenerationRun ? (
-                  <span>Last generation {variant.latestGenerationRun.status.toLowerCase()}</span>
-                ) : null}
-              </div>
+        <article key={variant.id} className="space-y-8 border-b border-border/70 pb-10 last:border-0">
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+            <div className="space-y-1">
+              <h2 className="text-2xl font-semibold tracking-tight text-fg">{variant.codename}</h2>
+              <p className="text-sm text-muted">
+                {variant.releasedModelKey ? `Released as ${variant.releasedModelKey}` : variant.stability}
+              </p>
             </div>
-          </section>
+            <span
+              className={`inline-flex w-fit items-center gap-2 text-xs font-medium ${statusClass(variant.status)}`}
+            >
+              <span aria-hidden="true" className="h-1.5 w-1.5 rounded-full bg-current" />
+              {statusLabel(variant.status)}
+            </span>
+          </div>
 
-          <div className="grid gap-4 xl:grid-cols-2">
-            <BreakdownTable title="Prompt performance" rows={variant.prompts} />
-            <BreakdownTable title="Public opponents" rows={variant.opponents} />
+          <dl className="grid grid-cols-2 gap-x-8 gap-y-6 border-y border-border/70 py-5 lg:grid-cols-4">
+            {[
+              ["Score", percent(variant.outcomes.averageScore)],
+              [
+                "Record",
+                `${variant.outcomes.wins}–${variant.outcomes.losses}–${variant.outcomes.draws}`,
+              ],
+              ["Estimated rank", `#${variant.estimatedFieldRank} of ${variant.estimatedFieldSize}`],
+              [
+                "Decisive votes",
+                `${variant.outcomes.decisiveVotes.toLocaleString()} / ${variant.targetDecisiveVotes.toLocaleString()}`,
+              ],
+            ].map(([label, metric]) => (
+              <div key={label}>
+                <dt className="text-xs text-muted">{label}</dt>
+                <dd className="mt-1.5 text-xl font-semibold tabular-nums text-fg">{metric}</dd>
+              </div>
+            ))}
+          </dl>
+
+          <div
+            className="h-1 overflow-hidden rounded-full bg-border/50"
+            role="progressbar"
+            aria-label="Evaluation progress"
+            aria-valuemin={0}
+            aria-valuemax={100}
+            aria-valuenow={Math.round(variant.progress * 100)}
+          >
+            <div
+              className="h-full rounded-full bg-accent"
+              style={{ width: `${variant.progress * 100}%` }}
+            />
+          </div>
+
+          <div className="space-y-8">
+            <BreakdownTable title="By prompt" label="Prompt" rows={variant.prompts} />
+            <BreakdownTable title="By model" label="Model" rows={variant.opponents} />
           </div>
         </article>
       ))}
 
       {report.variants.length === 0 ? (
-        <section className="mb-panel p-7 text-center before:hidden">
-          <p className="text-sm text-muted">This evaluation has no configured variants.</p>
+        <section className="border-y border-border/70 py-8">
+          <p className="text-sm text-muted">No checkpoints</p>
         </section>
       ) : null}
-
-      <footer className="flex flex-wrap gap-x-6 gap-y-2 border-t border-border/50 pt-5 text-xs text-muted">
-        <span>{report.exportPolicy === "DEIDENTIFIED_VOTES" ? "Deidentified export enabled" : "Aggregate reporting"}</span>
-        {report.agreementReference ? <span>Agreement {report.agreementReference}</span> : null}
-        {report.retentionDeleteAt ? <span>Retention through {date(report.retentionDeleteAt)}</span> : null}
-      </footer>
     </div>
   );
 }

--- a/app/lab/[orgSlug]/experiments/[experimentId]/page.tsx
+++ b/app/lab/[orgSlug]/experiments/[experimentId]/page.tsx
@@ -1,0 +1,210 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound, redirect } from "next/navigation";
+import { getLabOrganizationContext } from "@/lib/stealth/auth";
+import { canExportStealthVotes } from "@/lib/stealth/policy";
+import {
+  getStealthExperimentReport,
+  type StealthBreakdown,
+} from "@/lib/stealth/report";
+
+export const dynamic = "force-dynamic";
+
+export const metadata: Metadata = {
+  title: "Evaluation report",
+  robots: { index: false, follow: false },
+};
+
+function percent(value: number | null): string {
+  return value == null ? "—" : `${Math.round(value * 100)}%`;
+}
+
+function date(value: Date | null): string {
+  return value ? value.toLocaleDateString("en-US", { dateStyle: "medium", timeZone: "UTC" }) : "—";
+}
+
+function statusClass(status: string): string {
+  if (status === "ACTIVE" || status === "STABLE") return "bg-success/10 text-success ring-success/25";
+  if (status === "DEGRADED" || status === "WITHDRAWN") return "bg-warn/10 text-warn ring-warn/25";
+  return "bg-bg/45 text-muted ring-border/65";
+}
+
+function BreakdownTable({ title, rows }: { title: string; rows: StealthBreakdown[] }) {
+  return (
+    <section className="mb-panel overflow-hidden before:hidden">
+      <div className="border-b border-border/55 px-4 py-3 sm:px-5">
+        <h3 className="font-display text-sm font-semibold tracking-tight text-fg">{title}</h3>
+      </div>
+      <div className="overflow-x-auto">
+        <table className="w-full min-w-[34rem] text-left text-sm">
+          <thead className="font-mono text-[10px] uppercase tracking-[0.1em] text-muted">
+            <tr className="border-b border-border/45">
+              <th className="px-4 py-2.5 font-medium sm:px-5">Name</th>
+              <th className="px-3 py-2.5 text-right font-medium">Votes</th>
+              <th className="px-3 py-2.5 text-right font-medium">W–L–T</th>
+              <th className="px-4 py-2.5 text-right font-medium sm:px-5">Score</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((row) => (
+              <tr key={row.id} className="border-b border-border/35 last:border-0">
+                <td className="max-w-[30rem] px-4 py-3 text-fg sm:px-5">
+                  <span className="line-clamp-2">{row.label}</span>
+                </td>
+                <td className="px-3 py-3 text-right font-mono text-xs tabular-nums text-muted">
+                  {row.votes}
+                </td>
+                <td className="px-3 py-3 text-right font-mono text-xs tabular-nums text-muted">
+                  {row.wins}–{row.losses}–{row.draws}
+                </td>
+                <td className="px-4 py-3 text-right font-mono text-xs tabular-nums text-fg sm:px-5">
+                  {percent(row.averageScore)}
+                </td>
+              </tr>
+            ))}
+            {rows.length === 0 ? (
+              <tr>
+                <td colSpan={4} className="px-5 py-8 text-center text-sm text-muted">
+                  No votes yet
+                </td>
+              </tr>
+            ) : null}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  );
+}
+
+export default async function LabExperimentPage({
+  params,
+}: {
+  params: Promise<{ orgSlug: string; experimentId: string }>;
+}) {
+  const { orgSlug, experimentId } = await params;
+  const context = await getLabOrganizationContext(orgSlug).catch(() => null);
+  if (!context) redirect("/lab/sign-in");
+  const report = await getStealthExperimentReport(experimentId);
+  if (!report || report.organization.id !== context.membership.organization.id) notFound();
+  const exportAvailable =
+    report.exportPolicy === "DEIDENTIFIED_VOTES" && canExportStealthVotes(context.membership.role);
+
+  return (
+    <div className="mx-auto w-full max-w-7xl space-y-7 py-6 sm:py-10">
+      <header className="space-y-5">
+        <Link
+          href={`/lab/${orgSlug}`}
+          className="inline-flex font-mono text-xs text-muted transition hover:text-fg"
+        >
+          ← {report.organization.name}
+        </Link>
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+          <div className="space-y-3">
+            <div className="flex flex-wrap items-center gap-2">
+              <span className="mb-eyebrow">Evaluation report</span>
+              <span
+                className={`inline-flex rounded-full px-2.5 py-1 font-mono text-[10px] uppercase tracking-[0.1em] ring-1 ${statusClass(report.status)}`}
+              >
+                {report.status.toLowerCase()}
+              </span>
+            </div>
+            <h1 className="font-display text-3xl font-semibold tracking-tight text-fg sm:text-4xl">
+              {report.name}
+            </h1>
+            <p className="text-sm text-muted">
+              Started {date(report.startsAt)}{report.endedAt ? ` · Ended ${date(report.endedAt)}` : ""}
+            </p>
+          </div>
+          {exportAvailable ? (
+            <a
+              href={`/api/lab/organizations/${orgSlug}/experiments/${report.id}/export`}
+              className="mb-btn mb-btn-ghost h-10 px-4 text-xs"
+            >
+              Export votes
+            </a>
+          ) : null}
+        </div>
+      </header>
+
+      {report.variants.map((variant) => (
+        <article key={variant.id} className="space-y-4">
+          <section className="mb-panel overflow-hidden p-5 before:hidden sm:p-6">
+            <div className="mb-panel-inner space-y-6">
+              <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                <div className="space-y-2">
+                  <span className="font-mono text-[10px] uppercase tracking-[0.12em] text-muted">Stealth checkpoint</span>
+                  <h2 className="font-display text-2xl font-semibold tracking-tight text-fg">
+                    {variant.codename}
+                  </h2>
+                  <p className="text-sm text-muted">
+                    {variant.releasedModelKey ? `Released as ${variant.releasedModelKey}` : variant.stability}
+                  </p>
+                </div>
+                <span
+                  className={`inline-flex w-fit rounded-full px-2.5 py-1 font-mono text-[10px] uppercase tracking-[0.1em] ring-1 ${statusClass(variant.status)}`}
+                >
+                  {variant.status.toLowerCase()}
+                </span>
+              </div>
+
+              <div className="grid grid-cols-2 gap-px overflow-hidden rounded-xl bg-border/55 ring-1 ring-border/55 sm:grid-cols-3 lg:grid-cols-6">
+                {[
+                  ["Record", `${variant.outcomes.wins}–${variant.outcomes.losses}–${variant.outcomes.draws}`],
+                  ["Score", percent(variant.outcomes.averageScore)],
+                  ["Field estimate", `#${variant.estimatedFieldRank} / ${variant.estimatedFieldSize}`],
+                  ["Confidence", `${variant.confidence}%`],
+                  ["Rating deviation", Math.round(variant.ratingDeviation).toString()],
+                  ["Side split", `${variant.sideA} / ${variant.sideB}`],
+                ].map(([label, metric]) => (
+                  <div key={label} className="bg-card/80 px-3 py-4 sm:px-4">
+                    <div className="font-mono text-[9px] uppercase tracking-[0.1em] text-muted">{label}</div>
+                    <div className="mt-1.5 text-lg font-semibold tabular-nums text-fg">{metric}</div>
+                  </div>
+                ))}
+              </div>
+
+              <div className="space-y-2">
+                <div className="flex items-center justify-between gap-4 text-xs">
+                  <span className="text-muted">Decisive vote target</span>
+                  <span className="font-mono tabular-nums text-fg">
+                    {variant.outcomes.decisiveVotes.toLocaleString()} / {variant.targetDecisiveVotes.toLocaleString()}
+                  </span>
+                </div>
+                <div className="h-1.5 overflow-hidden rounded-full bg-border/50">
+                  <div className="h-full rounded-full bg-accent" style={{ width: `${variant.progress * 100}%` }} />
+                </div>
+              </div>
+
+              <div className="flex flex-wrap gap-x-6 gap-y-2 border-t border-border/55 pt-4 text-xs text-muted">
+                <span>Cohort {variant.generatedBuildCount}/{variant.expectedBuildCount}</span>
+                <span>Both bad {variant.outcomes.bothBad}</span>
+                <span>Prompt spread {percent(variant.promptScoreSpread)}</span>
+                {variant.pendingVotes > 0 ? <span>{variant.pendingVotes} votes processing</span> : null}
+                {variant.latestGenerationRun ? (
+                  <span>Last generation {variant.latestGenerationRun.status.toLowerCase()}</span>
+                ) : null}
+              </div>
+            </div>
+          </section>
+
+          <div className="grid gap-4 xl:grid-cols-2">
+            <BreakdownTable title="Prompt performance" rows={variant.prompts} />
+            <BreakdownTable title="Public opponents" rows={variant.opponents} />
+          </div>
+        </article>
+      ))}
+
+      {report.variants.length === 0 ? (
+        <section className="mb-panel p-7 text-center before:hidden">
+          <p className="text-sm text-muted">This evaluation has no configured variants.</p>
+        </section>
+      ) : null}
+
+      <footer className="flex flex-wrap gap-x-6 gap-y-2 border-t border-border/50 pt-5 text-xs text-muted">
+        <span>{report.exportPolicy === "DEIDENTIFIED_VOTES" ? "Deidentified export enabled" : "Aggregate reporting"}</span>
+        {report.agreementReference ? <span>Agreement {report.agreementReference}</span> : null}
+        {report.retentionDeleteAt ? <span>Retention through {date(report.retentionDeleteAt)}</span> : null}
+      </footer>
+    </div>
+  );
+}

--- a/app/lab/[orgSlug]/page.tsx
+++ b/app/lab/[orgSlug]/page.tsx
@@ -1,0 +1,133 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { redirect } from "next/navigation";
+import { prisma } from "@/lib/prisma";
+import { getLabOrganizationContext } from "@/lib/stealth/auth";
+import { signOutLab } from "../sign-in/actions";
+
+export const dynamic = "force-dynamic";
+
+export const metadata: Metadata = {
+  title: "Private evaluations",
+  robots: { index: false, follow: false },
+};
+
+function statusClass(status: string): string {
+  if (status === "ACTIVE" || status === "STABLE") return "bg-success/10 text-success ring-success/25";
+  if (status === "DEGRADED" || status === "WITHDRAWN") return "bg-warn/10 text-warn ring-warn/25";
+  return "bg-bg/45 text-muted ring-border/65";
+}
+
+export default async function LabOrganizationPage({
+  params,
+}: {
+  params: Promise<{ orgSlug: string }>;
+}) {
+  const { orgSlug } = await params;
+  const context = await getLabOrganizationContext(orgSlug).catch(() => null);
+  if (!context) redirect("/lab/sign-in");
+  const experiments = await prisma.stealthExperiment.findMany({
+    where: { organizationId: context.membership.organization.id },
+    orderBy: { updatedAt: "desc" },
+    include: {
+      variants: {
+        orderBy: { codename: "asc" },
+        select: {
+          id: true,
+          codename: true,
+          status: true,
+          winCount: true,
+          lossCount: true,
+          drawCount: true,
+        },
+      },
+    },
+  });
+
+  return (
+    <div className="mx-auto w-full max-w-6xl space-y-7 py-6 sm:py-10">
+      <header className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+        <div className="space-y-2">
+          <span className="mb-eyebrow">Private evaluations</span>
+          <h1 className="font-display text-3xl font-semibold tracking-tight text-fg sm:text-4xl">
+            {context.membership.organization.name}
+          </h1>
+          <p className="font-mono text-xs uppercase tracking-[0.12em] text-muted">
+            {context.membership.role.toLowerCase()} access
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          {context.memberships.length > 1 ? (
+            <Link href="/lab" className="mb-btn mb-btn-ghost h-9 px-4 text-xs">
+              Organizations
+            </Link>
+          ) : null}
+          <form action={signOutLab}>
+            <button type="submit" className="mb-btn mb-btn-ghost h-9 px-4 text-xs">
+              Sign out
+            </button>
+          </form>
+        </div>
+      </header>
+
+      {experiments.length > 0 ? (
+        <div className="grid gap-4 md:grid-cols-2">
+          {experiments.map((experiment) => {
+            const decisiveVotes = experiment.variants.reduce(
+              (total, variant) => total + variant.winCount + variant.lossCount,
+              0,
+            );
+            return (
+              <Link
+                key={experiment.id}
+                href={`/lab/${orgSlug}/experiments/${experiment.id}`}
+                className="mb-panel overflow-hidden p-5 before:hidden transition hover:border-accent/35 sm:p-6"
+              >
+                <div className="mb-panel-inner space-y-5">
+                  <div className="flex items-start justify-between gap-4">
+                    <div className="space-y-2">
+                      <h2 className="font-display text-xl font-semibold tracking-tight text-fg">
+                        {experiment.name}
+                      </h2>
+                      <p className="text-sm text-muted">
+                        {experiment.variants.map((variant) => variant.codename).join(" · ") || "No variants"}
+                      </p>
+                    </div>
+                    <span
+                      className={`inline-flex rounded-full px-2.5 py-1 font-mono text-[10px] uppercase tracking-[0.1em] ring-1 ${statusClass(experiment.status)}`}
+                    >
+                      {experiment.status.toLowerCase()}
+                    </span>
+                  </div>
+                  <div className="grid grid-cols-2 gap-3 border-t border-border/55 pt-4 text-sm">
+                    <div>
+                      <div className="font-mono text-[10px] uppercase tracking-[0.12em] text-muted">Variants</div>
+                      <div className="mt-1 text-lg font-semibold tabular-nums text-fg">
+                        {experiment.variants.length}
+                      </div>
+                    </div>
+                    <div>
+                      <div className="font-mono text-[10px] uppercase tracking-[0.12em] text-muted">Decisive votes</div>
+                      <div className="mt-1 text-lg font-semibold tabular-nums text-fg">
+                        {decisiveVotes.toLocaleString()}
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </Link>
+            );
+          })}
+        </div>
+      ) : (
+        <section className="mb-panel p-5 before:hidden sm:p-7">
+          <div className="mb-panel-inner space-y-3">
+            <h2 className="font-display text-xl font-semibold tracking-tight text-fg">No evaluations yet</h2>
+            <p className="max-w-[55ch] text-sm leading-relaxed text-muted">
+              New evaluations appear here after MineBench finishes checkpoint onboarding.
+            </p>
+          </div>
+        </section>
+      )}
+    </div>
+  );
+}

--- a/app/lab/[orgSlug]/page.tsx
+++ b/app/lab/[orgSlug]/page.tsx
@@ -8,14 +8,18 @@ import { signOutLab } from "../sign-in/actions";
 export const dynamic = "force-dynamic";
 
 export const metadata: Metadata = {
-  title: "Private evaluations",
+  title: "Evaluations",
   robots: { index: false, follow: false },
 };
 
 function statusClass(status: string): string {
-  if (status === "ACTIVE" || status === "STABLE") return "bg-success/10 text-success ring-success/25";
-  if (status === "DEGRADED" || status === "WITHDRAWN") return "bg-warn/10 text-warn ring-warn/25";
-  return "bg-bg/45 text-muted ring-border/65";
+  if (status === "ACTIVE" || status === "STABLE") return "text-success";
+  if (status === "DEGRADED" || status === "WITHDRAWN") return "text-warn";
+  return "text-muted";
+}
+
+function statusLabel(status: string): string {
+  return status.charAt(0) + status.slice(1).toLowerCase();
 }
 
 export default async function LabOrganizationPage({
@@ -39,23 +43,18 @@ export default async function LabOrganizationPage({
           winCount: true,
           lossCount: true,
           drawCount: true,
+          bothBadCount: true,
         },
       },
     },
   });
 
   return (
-    <div className="mx-auto w-full max-w-6xl space-y-7 py-6 sm:py-10">
-      <header className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
-        <div className="space-y-2">
-          <span className="mb-eyebrow">Private evaluations</span>
-          <h1 className="font-display text-3xl font-semibold tracking-tight text-fg sm:text-4xl">
-            {context.membership.organization.name}
-          </h1>
-          <p className="font-mono text-xs uppercase tracking-[0.12em] text-muted">
-            {context.membership.role.toLowerCase()} access
-          </p>
-        </div>
+    <div className="mx-auto w-full max-w-5xl space-y-9 py-6 sm:py-12">
+      <header className="flex flex-col gap-5 border-b border-border/70 pb-6 sm:flex-row sm:items-end sm:justify-between">
+        <h1 className="text-3xl font-semibold tracking-tight text-fg sm:text-4xl">
+          {context.membership.organization.name}
+        </h1>
         <div className="flex items-center gap-2">
           {context.memberships.length > 1 ? (
             <Link href="/lab" className="mb-btn mb-btn-ghost h-9 px-4 text-xs">
@@ -71,61 +70,56 @@ export default async function LabOrganizationPage({
       </header>
 
       {experiments.length > 0 ? (
-        <div className="grid gap-4 md:grid-cols-2">
-          {experiments.map((experiment) => {
-            const decisiveVotes = experiment.variants.reduce(
-              (total, variant) => total + variant.winCount + variant.lossCount,
-              0,
-            );
-            return (
-              <Link
-                key={experiment.id}
-                href={`/lab/${orgSlug}/experiments/${experiment.id}`}
-                className="mb-panel overflow-hidden p-5 before:hidden transition hover:border-accent/35 sm:p-6"
-              >
-                <div className="mb-panel-inner space-y-5">
-                  <div className="flex items-start justify-between gap-4">
-                    <div className="space-y-2">
-                      <h2 className="font-display text-xl font-semibold tracking-tight text-fg">
-                        {experiment.name}
-                      </h2>
-                      <p className="text-sm text-muted">
-                        {experiment.variants.map((variant) => variant.codename).join(" · ") || "No variants"}
-                      </p>
-                    </div>
+        <section className="space-y-3">
+          <h2 className="text-sm font-medium text-muted">Evaluations</h2>
+          <div className="divide-y divide-border/60 border-y border-border/70">
+            {experiments.map((experiment) => {
+              const votes = experiment.variants.reduce(
+                (total, variant) =>
+                  total +
+                  variant.winCount +
+                  variant.lossCount +
+                  variant.drawCount +
+                  variant.bothBadCount,
+                0,
+              );
+              return (
+                <Link
+                  key={experiment.id}
+                  href={`/lab/${orgSlug}/experiments/${experiment.id}`}
+                  className="group grid gap-4 py-5 transition-colors sm:grid-cols-[minmax(0,1fr)_auto] sm:items-center"
+                >
+                  <div className="min-w-0 space-y-1.5">
+                    <h3 className="text-xl font-medium tracking-tight text-fg transition-colors group-hover:text-accent">
+                      {experiment.name}
+                    </h3>
+                    <p className="truncate text-sm text-muted">
+                      {experiment.variants.map((variant) => variant.codename).join(" · ") ||
+                        "No checkpoints"}
+                    </p>
+                  </div>
+                  <div className="flex flex-wrap items-center gap-x-5 gap-y-2 text-sm sm:justify-end">
+                    <span className="font-mono text-xs tabular-nums text-muted">
+                      {votes.toLocaleString()} votes
+                    </span>
                     <span
-                      className={`inline-flex rounded-full px-2.5 py-1 font-mono text-[10px] uppercase tracking-[0.1em] ring-1 ${statusClass(experiment.status)}`}
+                      className={`inline-flex items-center gap-2 text-xs font-medium ${statusClass(experiment.status)}`}
                     >
-                      {experiment.status.toLowerCase()}
+                      <span aria-hidden="true" className="h-1.5 w-1.5 rounded-full bg-current" />
+                      {statusLabel(experiment.status)}
+                    </span>
+                    <span aria-hidden="true" className="text-muted">
+                      →
                     </span>
                   </div>
-                  <div className="grid grid-cols-2 gap-3 border-t border-border/55 pt-4 text-sm">
-                    <div>
-                      <div className="font-mono text-[10px] uppercase tracking-[0.12em] text-muted">Variants</div>
-                      <div className="mt-1 text-lg font-semibold tabular-nums text-fg">
-                        {experiment.variants.length}
-                      </div>
-                    </div>
-                    <div>
-                      <div className="font-mono text-[10px] uppercase tracking-[0.12em] text-muted">Decisive votes</div>
-                      <div className="mt-1 text-lg font-semibold tabular-nums text-fg">
-                        {decisiveVotes.toLocaleString()}
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </Link>
-            );
-          })}
-        </div>
-      ) : (
-        <section className="mb-panel p-5 before:hidden sm:p-7">
-          <div className="mb-panel-inner space-y-3">
-            <h2 className="font-display text-xl font-semibold tracking-tight text-fg">No evaluations yet</h2>
-            <p className="max-w-[55ch] text-sm leading-relaxed text-muted">
-              New evaluations appear here after MineBench finishes checkpoint onboarding.
-            </p>
+                </Link>
+              );
+            })}
           </div>
+        </section>
+      ) : (
+        <section className="border-y border-border/70 py-8">
+          <h2 className="text-lg font-medium tracking-tight text-fg">No evaluations</h2>
         </section>
       )}
     </div>

--- a/app/lab/auth/confirm/route.ts
+++ b/app/lab/auth/confirm/route.ts
@@ -1,0 +1,36 @@
+import type { EmailOtpType } from "@supabase/supabase-js";
+import { NextRequest, NextResponse } from "next/server";
+import { createSupabaseServerClient } from "@/lib/supabase/server";
+
+function safeNextPath(value: string | null): string {
+  return value?.startsWith("/lab") && !value.startsWith("//") ? value : "/lab";
+}
+
+export async function GET(request: NextRequest) {
+  const redirectTo = request.nextUrl.clone();
+  redirectTo.pathname = safeNextPath(request.nextUrl.searchParams.get("next"));
+  redirectTo.search = "";
+
+  const supabase = await createSupabaseServerClient();
+  const code = request.nextUrl.searchParams.get("code");
+  const tokenHash = request.nextUrl.searchParams.get("token_hash");
+  const type = request.nextUrl.searchParams.get("type") as EmailOtpType | null;
+
+  const result = code
+    ? await supabase.auth.exchangeCodeForSession(code)
+    : tokenHash && type
+      ? await supabase.auth.verifyOtp({ token_hash: tokenHash, type })
+      : { error: new Error("Missing sign-in token") };
+
+  if (!result.error) {
+    return NextResponse.redirect(redirectTo, {
+      headers: { "Cache-Control": "private, no-store" },
+    });
+  }
+
+  redirectTo.pathname = "/lab/sign-in";
+  redirectTo.searchParams.set("error", "link");
+  return NextResponse.redirect(redirectTo, {
+    headers: { "Cache-Control": "private, no-store" },
+  });
+}

--- a/app/lab/page.tsx
+++ b/app/lab/page.tsx
@@ -7,7 +7,7 @@ import { signOutLab } from "./sign-in/actions";
 export const dynamic = "force-dynamic";
 
 export const metadata: Metadata = {
-  title: "Private evaluations",
+  title: "Evaluations",
   robots: { index: false, follow: false },
 };
 
@@ -19,40 +19,35 @@ export default async function LabHomePage() {
   }
 
   return (
-    <div className="mx-auto w-full max-w-4xl space-y-6 py-6 sm:py-10">
-      <header className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
-        <div className="space-y-2">
-          <span className="mb-eyebrow">Private evaluations</span>
-          <h1 className="font-display text-3xl font-semibold tracking-tight text-fg">Organizations</h1>
-        </div>
+    <div className="mx-auto w-full max-w-3xl space-y-8 py-6 sm:py-12">
+      <header className="flex items-center justify-between gap-4 border-b border-border/70 pb-5">
+        <h1 className="text-3xl font-semibold tracking-tight text-fg">Evaluations</h1>
         <form action={signOutLab}>
           <button type="submit" className="mb-btn mb-btn-ghost h-9 px-4 text-xs">Sign out</button>
         </form>
       </header>
 
       {identity.memberships.length > 0 ? (
-        <div className="grid gap-3 sm:grid-cols-2">
-          {identity.memberships.map(({ organization, role }) => (
+        <div className="divide-y divide-border/60 border-y border-border/70">
+          {identity.memberships.map(({ organization }) => (
             <Link
               key={organization.id}
               href={`/lab/${organization.slug}`}
-              className="mb-panel overflow-hidden p-5 before:hidden transition hover:border-accent/35"
+              className="group flex items-center justify-between gap-6 py-5 transition-colors hover:text-accent"
             >
-              <div className="mb-panel-inner space-y-2">
-                <h2 className="font-display text-lg font-semibold tracking-tight text-fg">{organization.name}</h2>
-                <p className="font-mono text-xs uppercase tracking-[0.12em] text-muted">{role.toLowerCase()}</p>
-              </div>
+              <h2 className="text-lg font-medium tracking-tight text-fg transition-colors group-hover:text-accent">
+                {organization.name}
+              </h2>
+              <span aria-hidden="true" className="text-muted">
+                →
+              </span>
             </Link>
           ))}
         </div>
       ) : (
-        <section className="mb-panel p-5 before:hidden sm:p-7">
-          <div className="mb-panel-inner space-y-3">
-            <h2 className="font-display text-xl font-semibold tracking-tight">Access pending</h2>
-            <p className="max-w-[55ch] text-sm leading-relaxed text-muted">
-              This account is signed in but has not been added to an evaluation organization.
-            </p>
-          </div>
+        <section className="border-y border-border/70 py-8">
+          <h2 className="text-lg font-medium tracking-tight text-fg">No evaluations</h2>
+          <p className="mt-2 text-sm text-muted">This account is not linked to an evaluation.</p>
         </section>
       )}
     </div>

--- a/app/lab/page.tsx
+++ b/app/lab/page.tsx
@@ -1,0 +1,60 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { redirect } from "next/navigation";
+import { getLabIdentity } from "@/lib/stealth/auth";
+import { signOutLab } from "./sign-in/actions";
+
+export const dynamic = "force-dynamic";
+
+export const metadata: Metadata = {
+  title: "Private evaluations",
+  robots: { index: false, follow: false },
+};
+
+export default async function LabHomePage() {
+  const identity = await getLabIdentity().catch(() => null);
+  if (!identity) redirect("/lab/sign-in");
+  if (identity.memberships.length === 1) {
+    redirect(`/lab/${identity.memberships[0].organization.slug}`);
+  }
+
+  return (
+    <div className="mx-auto w-full max-w-4xl space-y-6 py-6 sm:py-10">
+      <header className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+        <div className="space-y-2">
+          <span className="mb-eyebrow">Private evaluations</span>
+          <h1 className="font-display text-3xl font-semibold tracking-tight text-fg">Organizations</h1>
+        </div>
+        <form action={signOutLab}>
+          <button type="submit" className="mb-btn mb-btn-ghost h-9 px-4 text-xs">Sign out</button>
+        </form>
+      </header>
+
+      {identity.memberships.length > 0 ? (
+        <div className="grid gap-3 sm:grid-cols-2">
+          {identity.memberships.map(({ organization, role }) => (
+            <Link
+              key={organization.id}
+              href={`/lab/${organization.slug}`}
+              className="mb-panel overflow-hidden p-5 before:hidden transition hover:border-accent/35"
+            >
+              <div className="mb-panel-inner space-y-2">
+                <h2 className="font-display text-lg font-semibold tracking-tight text-fg">{organization.name}</h2>
+                <p className="font-mono text-xs uppercase tracking-[0.12em] text-muted">{role.toLowerCase()}</p>
+              </div>
+            </Link>
+          ))}
+        </div>
+      ) : (
+        <section className="mb-panel p-5 before:hidden sm:p-7">
+          <div className="mb-panel-inner space-y-3">
+            <h2 className="font-display text-xl font-semibold tracking-tight">Access pending</h2>
+            <p className="max-w-[55ch] text-sm leading-relaxed text-muted">
+              This account is signed in but has not been added to an evaluation organization.
+            </p>
+          </div>
+        </section>
+      )}
+    </div>
+  );
+}

--- a/app/lab/sign-in/actions.ts
+++ b/app/lab/sign-in/actions.ts
@@ -1,0 +1,47 @@
+"use server";
+
+import { headers } from "next/headers";
+import { redirect } from "next/navigation";
+import { z } from "zod";
+import { SITE_URL } from "@/lib/seo";
+import { createSupabaseServerClient } from "@/lib/supabase/server";
+
+const emailSchema = z.string().trim().email().max(320);
+
+async function requestOrigin(): Promise<string> {
+  const configured = process.env.MINEBENCH_SITE_URL?.trim();
+  if (configured) return new URL(configured).origin;
+  if (process.env.NODE_ENV === "production") return SITE_URL;
+
+  const requestHeaders = await headers();
+  const host = requestHeaders.get("x-forwarded-host") ?? requestHeaders.get("host");
+  if (!host) throw new Error("Could not determine the sign-in origin");
+  const protocol = requestHeaders.get("x-forwarded-proto") ?? (host.startsWith("localhost") ? "http" : "https");
+  return `${protocol}://${host}`;
+}
+
+export async function requestLabMagicLink(formData: FormData) {
+  const parsed = emailSchema.safeParse(formData.get("email"));
+  if (!parsed.success) redirect("/lab/sign-in?error=email");
+
+  try {
+    const supabase = await createSupabaseServerClient();
+    await supabase.auth.signInWithOtp({
+      email: parsed.data.toLowerCase(),
+      options: {
+        shouldCreateUser: false,
+        emailRedirectTo: `${await requestOrigin()}/lab/auth/confirm?next=/lab`,
+      },
+    });
+  } catch {
+    // Keep invited and unknown addresses indistinguishable
+  }
+
+  redirect("/lab/sign-in?sent=1");
+}
+
+export async function signOutLab() {
+  const supabase = await createSupabaseServerClient();
+  await supabase.auth.signOut();
+  redirect("/lab/sign-in");
+}

--- a/app/lab/sign-in/page.tsx
+++ b/app/lab/sign-in/page.tsx
@@ -1,0 +1,66 @@
+import type { Metadata } from "next";
+import { redirect } from "next/navigation";
+import { getLabIdentity } from "@/lib/stealth/auth";
+import { requestLabMagicLink } from "./actions";
+
+export const dynamic = "force-dynamic";
+
+export const metadata: Metadata = {
+  title: "Evaluation access",
+  robots: { index: false, follow: false },
+};
+
+export default async function LabSignInPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ sent?: string; error?: string }>;
+}) {
+  const identity = await getLabIdentity().catch(() => null);
+  if (identity?.memberships[0]) redirect(`/lab/${identity.memberships[0].organization.slug}`);
+  const params = await searchParams;
+
+  return (
+    <div className="mx-auto flex min-h-[62vh] w-full max-w-lg items-center py-8 sm:py-14">
+      <section className="mb-panel w-full overflow-hidden p-5 before:hidden sm:p-7">
+        <div className="mb-panel-inner space-y-6">
+          <div className="space-y-3">
+            <span className="mb-eyebrow">Private evaluations</span>
+            <h1 className="font-display text-2xl font-semibold tracking-tight text-fg sm:text-3xl">
+              Lab access
+            </h1>
+            <p className="max-w-[42ch] text-sm leading-relaxed text-muted sm:text-base">
+              Sign in with an invited email to view active evaluations and results.
+            </p>
+          </div>
+
+          {params.sent === "1" ? (
+            <div className="rounded-xl border border-accent/25 bg-accent/8 px-4 py-3 text-sm leading-relaxed text-fg">
+              If that address has access, a sign-in link is on its way.
+            </div>
+          ) : null}
+          {params.error ? (
+            <div className="rounded-xl border border-danger/25 bg-danger/8 px-4 py-3 text-sm leading-relaxed text-fg">
+              That sign-in link is invalid or expired. Request a new one.
+            </div>
+          ) : null}
+
+          <form action={requestLabMagicLink} className="space-y-3">
+            <label className="block space-y-2 text-sm font-medium text-fg">
+              <span>Email</span>
+              <input
+                name="email"
+                type="email"
+                autoComplete="email"
+                required
+                className="h-12 w-full rounded-xl border border-border/75 bg-bg/55 px-4 text-base text-fg outline-none transition focus:border-accent/60 focus:ring-2 focus:ring-accent/20"
+              />
+            </label>
+            <button type="submit" className="mb-btn mb-btn-primary h-11 w-full text-sm">
+              Send link
+            </button>
+          </form>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/app/lab/sign-in/page.tsx
+++ b/app/lab/sign-in/page.tsx
@@ -6,7 +6,7 @@ import { requestLabMagicLink } from "./actions";
 export const dynamic = "force-dynamic";
 
 export const metadata: Metadata = {
-  title: "Evaluation access",
+  title: "Sign in",
   robots: { index: false, follow: false },
 };
 
@@ -20,46 +20,39 @@ export default async function LabSignInPage({
   const params = await searchParams;
 
   return (
-    <div className="mx-auto flex min-h-[62vh] w-full max-w-lg items-center py-8 sm:py-14">
-      <section className="mb-panel w-full overflow-hidden p-5 before:hidden sm:p-7">
-        <div className="mb-panel-inner space-y-6">
-          <div className="space-y-3">
-            <span className="mb-eyebrow">Private evaluations</span>
-            <h1 className="font-display text-2xl font-semibold tracking-tight text-fg sm:text-3xl">
-              Lab access
-            </h1>
-            <p className="max-w-[42ch] text-sm leading-relaxed text-muted sm:text-base">
-              Sign in with an invited email to view active evaluations and results.
-            </p>
-          </div>
+    <div className="mx-auto flex min-h-[62vh] w-full max-w-sm items-center py-10 sm:py-16">
+      <section className="w-full space-y-7">
+        <header className="space-y-2 border-b border-border/70 pb-6">
+          <h1 className="text-3xl font-semibold tracking-tight text-fg">Sign in</h1>
+          <p className="text-sm text-muted">Use your invited email.</p>
+        </header>
 
-          {params.sent === "1" ? (
-            <div className="rounded-xl border border-accent/25 bg-accent/8 px-4 py-3 text-sm leading-relaxed text-fg">
-              If that address has access, a sign-in link is on its way.
-            </div>
-          ) : null}
-          {params.error ? (
-            <div className="rounded-xl border border-danger/25 bg-danger/8 px-4 py-3 text-sm leading-relaxed text-fg">
-              That sign-in link is invalid or expired. Request a new one.
-            </div>
-          ) : null}
+        {params.sent === "1" ? (
+          <p role="status" className="border-y border-accent/30 py-3 text-sm text-fg">
+            Check your email for a sign-in link.
+          </p>
+        ) : null}
+        {params.error ? (
+          <p role="alert" className="border-y border-danger/30 py-3 text-sm text-fg">
+            That link has expired. Request another.
+          </p>
+        ) : null}
 
-          <form action={requestLabMagicLink} className="space-y-3">
-            <label className="block space-y-2 text-sm font-medium text-fg">
-              <span>Email</span>
-              <input
-                name="email"
-                type="email"
-                autoComplete="email"
-                required
-                className="h-12 w-full rounded-xl border border-border/75 bg-bg/55 px-4 text-base text-fg outline-none transition focus:border-accent/60 focus:ring-2 focus:ring-accent/20"
-              />
-            </label>
-            <button type="submit" className="mb-btn mb-btn-primary h-11 w-full text-sm">
-              Send link
-            </button>
-          </form>
-        </div>
+        <form action={requestLabMagicLink} className="space-y-4">
+          <label className="block space-y-2 text-sm font-medium text-fg">
+            <span>Email</span>
+            <input
+              name="email"
+              type="email"
+              autoComplete="email"
+              required
+              className="h-12 w-full rounded-lg border border-border bg-card px-4 text-base text-fg outline-none transition focus:border-accent/70 focus:ring-2 focus:ring-accent/20"
+            />
+          </label>
+          <button type="submit" className="mb-btn mb-btn-primary h-11 w-full text-sm">
+            Send link
+          </button>
+        </form>
       </section>
     </div>
   );

--- a/components/arena/Arena.tsx
+++ b/components/arena/Arena.tsx
@@ -6,7 +6,9 @@ import {
   ArenaBuildRef,
   ArenaBuildVariant,
   ArenaMatchup,
+  ArenaModelReveal,
   ArenaBuildStreamEvent,
+  ArenaVoteResponse,
   VoteChoice,
 } from "@/lib/arena/types";
 import { readBuildVariantArtifact } from "@/lib/arena/clientBuildResponse";
@@ -30,6 +32,11 @@ type ArenaState =
   | { kind: "loading" }
   | { kind: "ready"; matchup: ArenaMatchup }
   | { kind: "error"; message: string };
+
+function modelRevealLabel(model: ArenaModelReveal | null | undefined): string | null {
+  if (!model) return null;
+  return model.provider === "Stealth" ? `Stealth • ${model.displayName}` : model.displayName;
+}
 
 // Reading the binary artifact is opt-in per request, so turning this off is a
 // client deploy and needs no coordination with what storage holds.
@@ -198,7 +205,7 @@ const VOTE_REQUEST_TIMEOUT_MS = Number.parseInt(
   10,
 );
 
-async function submitVote(matchupId: string, choice: VoteChoice) {
+async function submitVote(matchupId: string, choice: VoteChoice): Promise<ArenaVoteResponse> {
   // hard timeout so a stalled /api/arena/vote call can't hang the reveal state
   const timed = makeTimeoutSignal(undefined, VOTE_REQUEST_TIMEOUT_MS);
   try {
@@ -210,6 +217,11 @@ async function submitVote(matchupId: string, choice: VoteChoice) {
       signal: timed.signal,
     });
     if (!res.ok) throw new Error(await readErrorResponse(res, "Couldn't record your vote."));
+    const response = (await res.json()) as ArenaVoteResponse;
+    if (!response?.reveal?.a?.displayName || !response.reveal.b?.displayName) {
+      throw new Error("The vote saved, but the model reveal was unavailable. Refresh to continue.");
+    }
+    return response;
   } catch (err) {
     if (err instanceof Error && err.name === "AbortError") {
       throw new Error("Vote timed out — the site may be under heavy load. Please try again.");
@@ -1082,7 +1094,7 @@ function formatBuildLoadingMessage(
   return formatVoxelLoadingMessage(fullLoading ? "Retrieving full build" : "Retrieving build", progress);
 }
 
-type RevealAction = VoteChoice | "SKIP";
+type RevealAction = VoteChoice;
 
 type RevealState =
   | { kind: "none" }
@@ -1096,7 +1108,6 @@ type RevealState =
     };
 
 const REVEAL_MS_AFTER_VOTE = 2600;
-const REVEAL_MS_AFTER_SKIP = 1600;
 const TRANSITION_OUT_MS = 220;
 const BUILD_STUCK_AUTOSKIP_MS = Number.parseInt(
   process.env.NEXT_PUBLIC_ARENA_BUILD_STUCK_AUTOSKIP_MS ?? "45000",
@@ -2277,9 +2288,6 @@ export function Arena() {
     setSubmitting(true);
     clearAutoAdvance();
     advanceNowRequestedAtRef.current = null;
-    const startedAt = Date.now();
-    const advanceAt = startedAt + REVEAL_MS_AFTER_VOTE;
-    setReveal({ kind: "reveal", matchupId: matchup.id, action: choice, startedAt, advanceAt, next: null });
 
     // Submit the vote first. If it fails, stay on the current matchup so
     // the user can retry — advancing anyway would silently convert a
@@ -2287,7 +2295,19 @@ export function Arena() {
     // also don't fetch the next matchup because matchup creation is still
     // a server-side side effect.
     try {
-      await submitVote(matchup.id, choice);
+      const response = await submitVote(matchup.id, choice);
+      setState((prev) =>
+        prev.kind === "ready" && prev.matchup.id === matchup.id
+          ? {
+              kind: "ready",
+              matchup: {
+                ...prev.matchup,
+                a: { ...prev.matchup.a, model: response.reveal.a },
+                b: { ...prev.matchup.b, model: response.reveal.b },
+              },
+            }
+          : prev,
+      );
     } catch (err) {
       const msg = err instanceof Error ? err.message : "Couldn't record your vote.";
       flashVoteWarning(msg);
@@ -2295,6 +2315,10 @@ export function Arena() {
       setSubmitting(false);
       return;
     }
+
+    const startedAt = Date.now();
+    const advanceAt = startedAt + REVEAL_MS_AFTER_VOTE;
+    setReveal({ kind: "reveal", matchupId: matchup.id, action: choice, startedAt, advanceAt, next: null });
 
     try {
       const next = applyCachedBuildsToMatchup(await fetchMatchup(undefined));
@@ -2342,30 +2366,17 @@ export function Arena() {
       abortFullHydrations(matchup.id);
       abortFullPrefetches(matchup.id);
       advanceNowRequestedAtRef.current = null;
-      const startedAt = Date.now();
-      const advanceAt = startedAt + REVEAL_MS_AFTER_SKIP;
-      setReveal({ kind: "reveal", matchupId: matchup.id, action: "SKIP", startedAt, advanceAt, next: null });
       const next = applyCachedBuildsToMatchup(await fetchMatchup(undefined));
       prefetchMatchupBuilds(next);
-      const stillRevealing = revealRef.current.kind === "reveal" && revealRef.current.matchupId === matchup.id;
-      if (stillRevealing) {
-        const requestedAt = advanceNowRequestedAtRef.current;
-        const effectiveAdvanceAt =
-          typeof requestedAt === "number" && Number.isFinite(requestedAt) ? Math.min(advanceAt, requestedAt) : advanceAt;
-        setReveal((prev) =>
-          prev.kind === "reveal" && prev.matchupId === matchup.id
-            ? { ...prev, next, advanceAt: effectiveAdvanceAt }
-            : prev,
-        );
-        scheduleAutoAdvance(matchup.id, effectiveAdvanceAt, next);
-      } else {
-        setState((prev) => {
-          if (prev.kind === "ready" && prev.matchup.id !== matchup.id) return prev;
-          if (prev.kind === "error") return prev;
-          return { kind: "ready", matchup: next };
-        });
-        setSubmitting(false);
-      }
+      transitionRef.current = true;
+      setTransitioning(true);
+      await sleepMs(TRANSITION_OUT_MS);
+      setState({ kind: "ready", matchup: next });
+      setSubmitting(false);
+      requestAnimationFrame(() => {
+        transitionRef.current = false;
+        setTransitioning(false);
+      });
     } catch (err) {
       clearAutoAdvance();
       setState({
@@ -2374,8 +2385,6 @@ export function Arena() {
       });
       setReveal({ kind: "none" });
       setSubmitting(false);
-    } finally {
-      // `submitting` stays true through the reveal so users can see the model names.
     }
   }
 
@@ -2680,8 +2689,8 @@ export function Arena() {
                 subtitle={
                   <ModelReveal
                     revealed={revealModels}
-                    provider={matchup?.a.model.provider}
-                    modelName={matchup?.a.model.displayName}
+                    provider={matchup?.a.model?.provider}
+                    modelName={matchup?.a.model?.displayName}
                   />
                 }
                 voxelBuild={matchup?.a.build ?? null}
@@ -2708,7 +2717,7 @@ export function Arena() {
                 autoRotate={!isCoarsePointer || mobileBuildView === "a"}
                 viewerSize="arena"
                 enableBuildExport={Boolean(matchup?.a.build && !laneNeedsFullA)}
-                exportLabel={matchup?.a.model.displayName ?? "build-a"}
+                exportLabel={matchup?.a.model?.displayName ?? "build-a"}
                 exportPrompt={promptText}
                 actions={
                   laneNeedsFullA ? (
@@ -2733,8 +2742,8 @@ export function Arena() {
                 subtitle={
                   <ModelReveal
                     revealed={revealModels}
-                    provider={matchup?.b.model.provider}
-                    modelName={matchup?.b.model.displayName}
+                    provider={matchup?.b.model?.provider}
+                    modelName={matchup?.b.model?.displayName}
                   />
                 }
                 voxelBuild={matchup?.b.build ?? null}
@@ -2761,7 +2770,7 @@ export function Arena() {
                 autoRotate={!isCoarsePointer || mobileBuildView === "b"}
                 viewerSize="arena"
                 enableBuildExport={Boolean(matchup?.b.build && !laneNeedsFullB)}
-                exportLabel={matchup?.b.model.displayName ?? "build-b"}
+                exportLabel={matchup?.b.model?.displayName ?? "build-b"}
                 exportPrompt={promptText}
                 actions={
                   laneNeedsFullB ? (
@@ -2866,9 +2875,7 @@ export function Arena() {
                         <div className="flex min-w-0 flex-col items-stretch gap-2 sm:flex-row sm:items-center sm:justify-between">
                           <div className="flex min-w-0 items-center gap-2">
                             <span className="mb-badge bg-bg/40 text-muted ring-border/60">
-                              {revealAction === "SKIP"
-                                ? "Skipped"
-                                : revealAction === "TIE"
+                              {revealAction === "TIE"
                                   ? "You voted: Tie"
                                   : revealAction === "BOTH_BAD"
                                     ? "You voted: Both bad"
@@ -2884,14 +2891,14 @@ export function Arena() {
                                 A
                               </span>
                               <span className="min-w-0 max-w-[10rem] truncate font-medium text-fg md:max-w-[16rem]">
-                                {matchup?.a.model.displayName}
+                                {modelRevealLabel(matchup?.a.model)}
                               </span>
                               <span className="text-muted">vs</span>
                               <span className="inline-flex h-5 items-center rounded-full bg-accent2/10 px-2 font-mono text-[11px] font-semibold text-accent2 ring-1 ring-accent2/20">
                                 B
                               </span>
                               <span className="min-w-0 max-w-[10rem] truncate font-medium text-fg md:max-w-[16rem]">
-                                {matchup?.b.model.displayName}
+                                {modelRevealLabel(matchup?.b.model)}
                               </span>
                             </div>
                           </div>
@@ -2948,7 +2955,7 @@ export function Arena() {
                               A
                             </span>
                             <span className="min-w-0 flex-1 truncate font-medium text-fg/95">
-                              {matchup?.a.model.displayName ?? "—"}
+                              {modelRevealLabel(matchup?.a.model) ?? "—"}
                             </span>
                           </div>
                           <div
@@ -2960,7 +2967,7 @@ export function Arena() {
                               B
                             </span>
                             <span className="min-w-0 flex-1 truncate font-medium text-fg/95">
-                              {matchup?.b.model.displayName ?? "—"}
+                              {modelRevealLabel(matchup?.b.model) ?? "—"}
                             </span>
                           </div>
                         </div>

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,6 +14,7 @@ Documentation for running, extending, and understanding MineBench.
 - [Arena Ranking System](./arena-ranking-system.md)
 - [Arena Ranking Policy](./arena-ranking-validity-policy-v2.md)
 - [Consistency Metric](./consistency-metric-percentile-band.md)
+- [Private Checkpoint Evaluations](./private-evaluations.md)
 
 ## Builds & Generation
 

--- a/docs/privacy-policy.md
+++ b/docs/privacy-policy.md
@@ -1,6 +1,6 @@
 # MineBench Privacy Policy
 
-Effective and last updated: August 19, 2026
+Effective and last updated: August 21, 2026
 
 MineBench is an independent service operated by Ammaar Alam in the United States. This Privacy Policy explains how MineBench handles information when you use [minebench.ai](https://minebench.ai), participate in model evaluations, use MineBench's generation tools, or communicate with MineBench.
 
@@ -78,6 +78,8 @@ Unless the participating organization authorizes it in writing, MineBench does n
 MineBench shows evaluators model outputs and confidential codenames only as necessary to conduct an evaluation. Evaluators are informed that their votes and feedback are provided to the sponsoring organization. The organization controls whether and when its identity, model identity, results, or evaluation materials are made public.
 
 Access is limited to authorized personnel, evaluators, and service providers that need the information to perform the evaluation. Credentials and secrets are excluded from evaluator-facing and public results.
+
+For pre-generated private evaluations, MineBench encrypts a checkpoint endpoint credential while building the evaluation cohort, disables the endpoint after generation, and deletes the stored credential when the cohort completes. Arena voters receive stored MineBench build artifacts; their browsers do not connect to the private checkpoint endpoint.
 
 Evaluation agreements and data processing addenda set additional protections, retention terms, and instructions. If an agreement conflicts with this Privacy Policy regarding private evaluation data, the agreement controls.
 

--- a/docs/private-evaluations.md
+++ b/docs/private-evaluations.md
@@ -1,0 +1,192 @@
+# Private Checkpoint Evaluations
+
+MineBench can run blind, LM Arena-style A/B evaluations for unreleased model
+checkpoints. An evaluation is administered by MineBench, appears inside the
+ordinary public Arena, and reports only to invited members of the sponsoring
+organization.
+
+Each private matchup contains exactly one codenamed checkpoint and one public
+MineBench model. The voter sees neither identity before voting. After a vote,
+the public model is named normally and the private model is revealed as
+`Stealth • Codename`. Private checkpoints never appear on the public
+leaderboard.
+
+## Provider contract
+
+A lab supplies MineBench through a confidential channel with:
+
+- an HTTPS endpoint implementing OpenAI-compatible `POST /chat/completions`;
+- a bearer API key;
+- the endpoint's private model or checkpoint ID;
+- one codename per checkpoint or configuration under test;
+- supported output settings, reasoning mode, and request-rate constraints;
+- the decisive-vote target and authorized report recipients;
+- raw-export, retention, disclosure, and publication terms; and
+- an agreement reference used to bind the operational record to those terms.
+
+Structured JSON output is required by default. MineBench sends a strict JSON
+schema, validates every response, and retries invalid outputs within the
+configured attempt limit. A provider that does not implement strict structured
+output can be onboarded only when the lab explicitly accepts the unstructured
+fallback. Tool mode does not grant the checkpoint network or shell access: the
+model returns a JSON description of a local voxel operation, and MineBench
+executes that operation in its existing restricted runtime.
+
+The initial provider contract deliberately supports one common protocol. A lab
+with different authentication, request, or response semantics needs a reviewed
+provider adapter before onboarding.
+
+## Request and data flow
+
+```mermaid
+sequenceDiagram
+    participant Lab
+    participant Operator as MineBench operator
+    participant Endpoint as Private checkpoint endpoint
+    participant Storage as MineBench database and storage
+    participant Voter as Arena voter
+    participant Portal as Lab portal
+
+    Lab->>Operator: Endpoint, key, checkpoint ID, codenames, terms
+    Operator->>Storage: Encrypted configuration and organization access
+    Operator->>Endpoint: Fixed benchmark prompts during cohort generation
+    Endpoint-->>Operator: Structured candidate builds
+    Operator->>Storage: Validated builds and delivery artifacts
+    Operator->>Storage: Delete endpoint credential after complete cohort
+    Storage-->>Voter: Anonymous checkpoint build vs public build
+    Voter->>Storage: Vote
+    Storage-->>Voter: Stealth codename and public model reveal
+    Storage-->>Portal: Organization-scoped aggregate report
+```
+
+The lab endpoint is a generation-time dependency only. It is never called from
+an Arena request, never exposed to a browser, and never placed on the voting
+latency path. Generation uses the fixed `BENCHMARK_PROMPT_MAP` cohort at grid
+256, the simple palette, and precise mode. A variant cannot activate until all
+cohort builds validate and their normal Arena delivery artifacts are prepared.
+
+## Blindness and rating isolation
+
+Matchup responses contain no model names, providers, keys, ratings, stable build
+IDs, or build checksums. The matchup envelope and per-matchup build capabilities
+are encrypted with AES-256-GCM, expire after two hours by default, and bind the
+prompt, sides, build checksums, and private variant. Private artifact responses
+are proxied with the per-matchup capability identity instead of redirecting to
+a stable storage path. This prevents a voter from learning a stable identifier
+in one revealed match and recognizing it before a later vote.
+
+The vote response is the only pre-release identity-reveal path. Skipping moves
+to a new matchup without revealing either identity.
+
+Private variants keep independent Glicko state. A vote updates the codenamed
+variant against the public model's current rating as a read-only anchor. It does
+not change the public model's rating, vote or impression counters, prompt
+coverage, pair coverage, rank history, or leaderboard metrics. Rating replay
+follows the same chronological rule through `pnpm elo:recompute`.
+
+## Access and reporting
+
+MineBench provisions the sponsoring organization and invites named recipients
+through Supabase Auth. Roles are:
+
+| Role | Aggregate reports | Deidentified vote export |
+| --- | --- | --- |
+| Owner | Yes | When contracted |
+| Admin | Yes | When contracted |
+| Analyst | Yes | When contracted |
+| Viewer | Yes | No |
+
+Membership and invitation changes are MineBench operator-managed.
+
+The portal reports outcomes, score, rating deviation, confidence, target
+progress, side balance, prompt performance, public-opponent performance,
+generation status, and an estimated position against the current public field.
+That position is a private estimate, not a public leaderboard placement.
+
+When `DEIDENTIFIED_VOTES` is authorized, exports include UTC date, codename,
+public prompt, public opponent, checkpoint side, and normalized outcome. They do
+not include account IDs, session IDs, vote IDs, matchup IDs, IP addresses,
+request headers, or exact timestamps. `AGGREGATES_ONLY` is the default.
+
+## Security controls
+
+- Endpoint configurations are schema-validated, encrypted with AES-256-GCM,
+  and stored in a table with row-level security and no authenticated-client
+  read policy.
+- `STEALTH_CONFIG_ENCRYPTION_KEY` is a dedicated 32-byte key. Losing it makes a
+  pending credential unrecoverable; rotating it requires re-encrypting pending
+  configurations before replacing the old key.
+- The custom-provider guard resolves and pins the endpoint target, requires
+  HTTPS outside local development, and blocks loopback, private, link-local,
+  metadata, and DNS-rebinding targets.
+- Remote generation refuses to write unless the database and Supabase Storage
+  resolve to the same project.
+- Loopback generation stays inline and skips artifact uploads, even when the
+  local shell also has remote storage credentials for read-only development.
+- The operator supplies `STEALTH_ENDPOINT_API_KEY` only to the configuration
+  command. The key is never a command-line argument, log field, generation
+  record, report field, or browser value.
+- A complete cohort disables the endpoint and deletes its encrypted credential.
+  Partial generation retains the credential only so the failed cohort can be
+  resumed. Withdrawal and closure also delete it.
+- Public model queries, leaderboard statistics, benchmark surfaces, rank
+  snapshots, coverage tables, seed operations, and upload sync explicitly
+  exclude private variants.
+- Lab pages and exports require a verified Supabase user plus an active
+  organization membership and send private, no-store responses.
+
+## Operator workflow
+
+Run `pnpm stealth:eval help` for the authoritative flag list. The lifecycle is:
+
+1. Generate a dedicated encryption key with `pnpm stealth:eval keygen`, then
+   install it as `STEALTH_CONFIG_ENCRYPTION_KEY` in the target environment.
+2. Run `create` to provision the organization and evaluation agreement record.
+3. Set `STEALTH_ENDPOINT_API_KEY` in the operator process and run `configure`
+   once per codename. Unset the process value immediately afterward.
+4. Run `invite` for each authorized recipient. Use `revoke` to remove a
+   membership without deleting a user who may belong to another organization.
+5. Run `generate`. The first missing prompt validates the endpoint before the
+   rest of the fixed cohort is generated. Successful prior prompts are reused
+   on a partial retry.
+6. Inspect `status`, generation records, artifacts, and the lab portal.
+7. Run `activate` only after the cohort is complete and alpha acceptance passes.
+8. Use `pause` for a reversible sampling stop, `stabilize` after every variant
+   reaches its decisive-vote target, `withdraw` for one variant, or `close` for
+   the full evaluation.
+9. Close the evaluation, then run `release` only after the lab attests that the
+   named public model is the exact evaluated checkpoint. The mapping is recorded, but private ratings and
+   votes are never transferred. Public evaluation starts with fresh votes.
+
+All operator commands are idempotent where repetition is safe. Configuration
+changes are refused after sampling begins, and checkpoint identity cannot
+change after a cohort has started. `disable-endpoint` is the immediate
+credential-revocation command.
+
+## Alpha acceptance gate
+
+Every private evaluation must pass the alpha environment before production
+activation:
+
+1. Apply the migration and deploy the feature branch to alpha.
+2. Create a test organization, variant, and invited account against alpha.
+3. Confirm the invitation, magic-link sign-in, organization boundary, and role
+   behavior.
+4. Generate the complete cohort and verify that the credential row is gone,
+   the variant endpoint is disabled, and every build has a checksum and Arena
+   artifact metadata.
+5. Set alpha's stealth share to 1 for acceptance traffic. Confirm exactly one
+   private variant per matchup, no names or stable IDs before voting, no reveal
+   on skip, and `Stealth • Codename` only after a successful vote.
+6. Compare public leaderboard ratings, counters, coverage, rank snapshots, and
+   benchmark surfaces before and after private votes; they must be unchanged.
+7. Confirm the lab report updates, Viewer cannot export, and an authorized CSV
+   contains no direct or pseudonymous voter identifiers.
+8. Exercise pause, resume, withdrawal, closure, retention metadata, and exact-
+   checkpoint release attestation.
+9. Run the normal lint, test, build, migration-drift, artifact-audit, and browser
+   smoke suites before promotion.
+
+Alpha uses separate database, storage, authentication, encryption, and endpoint
+credentials. No production checkpoint secret is copied into alpha unless the
+lab explicitly provides an alpha-scoped credential.

--- a/docs/staging.md
+++ b/docs/staging.md
@@ -17,8 +17,10 @@ Nothing is tested against production directly.
 The alpha Supabase branch has its own Postgres, storage, and service-role key.
 Point the branch-scoped Vercel variables (`DATABASE_URL`, `DIRECT_URL`,
 `SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY`, `SUPABASE_STORAGE_BUCKET`,
-`ADMIN_TOKEN`) at it; the app needs no code awareness of which environment it
-is in. Vercel crons only fire on production deployments, which is fine — the
+`ADMIN_TOKEN`, `NEXT_PUBLIC_SUPABASE_URL`,
+`NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY`, `SUPABASE_SECRET_KEY`, and
+`STEALTH_CONFIG_ENCRYPTION_KEY`) at it; the app needs no code awareness of
+which environment it is in. Vercel crons only fire on production deployments, which is fine — the
 drains also run inline from request `after()` hooks.
 
 Local credentials for the tooling live in `.env.staging.local` (git-ignored):
@@ -29,6 +31,10 @@ STAGING_DATABASE_URL=          # alpha branch pooled connection (what the deploy
 STAGING_SITE_URL=              # alpha deployment URL, required by every staging: command
 STAGING_SUPABASE_URL=
 STAGING_SUPABASE_SERVICE_ROLE_KEY=
+STAGING_SUPABASE_PUBLISHABLE_KEY=       # required for private evaluation sign-in
+STAGING_STEALTH_CONFIG_ENCRYPTION_KEY=  # required for private endpoint configuration
+# STAGING_SUPABASE_SECRET_KEY= (defaults to the staging service-role key)
+# STAGING_STEALTH_ARENA_SHARE= (defaults to the app's 0.25 share)
 # STAGING_ADMIN_TOKEN= (only when alpha uses its own branch-scoped ADMIN_TOKEN)
 # STAGING_SUPABASE_STORAGE_BUCKET= (defaults to SUPABASE_STORAGE_BUCKET)
 ```
@@ -101,6 +107,15 @@ Any command can be pointed at alpha the same way:
 pnpm staging:run tsx scripts/audit-arena-artifacts.ts --deep --limit 25
 pnpm staging:prisma:migrate
 ```
+
+Private checkpoint onboarding and acceptance also run through this wrapper:
+
+```bash
+pnpm staging:run pnpm stealth:eval help
+```
+
+Use alpha-only lab endpoint and encryption credentials. The complete acceptance
+gate is documented in [Private Checkpoint Evaluations](./private-evaluations.md#alpha-acceptance-gate).
 
 ## Promotion
 

--- a/lib/ai/generateVoxelBuild.ts
+++ b/lib/ai/generateVoxelBuild.ts
@@ -254,6 +254,7 @@ type ResolvedModel = {
   forceOpenRouter?: boolean;
   importOnly?: boolean;
   baseUrl?: string;
+  requireStructuredOutput?: boolean;
 };
 
 function isBilledTimeoutStyleProviderError(message: string): boolean {
@@ -457,6 +458,7 @@ export type GenerateVoxelBuildParams = {
     forceOpenRouter?: boolean;
     importOnly?: boolean;
     baseUrl?: string;
+    requireStructuredOutput?: boolean;
   };
   prompt: string;
   gridSize: 64 | 256 | 512;
@@ -518,6 +520,7 @@ async function callDirectProvider(args: {
   modelId: string;
   apiKey?: string;
   baseUrl?: string;
+  requireStructuredOutput?: boolean;
   system: string;
   user: string;
   jsonSchema: Record<string, unknown>;
@@ -638,6 +641,7 @@ async function callDirectProvider(args: {
       maxOutputTokens: args.maxOutputTokens,
       temperature: DEFAULT_TEMPERATURE,
       jsonSchema: args.jsonSchema,
+      requireStructuredOutput: args.requireStructuredOutput,
       signal: args.signal,
       onDelta: args.onDelta,
       onTrace: args.onTrace,
@@ -873,6 +877,7 @@ async function providerGenerateText(args: {
         modelId: model.modelId,
         apiKey: directKey ?? undefined,
         baseUrl: model.baseUrl,
+        requireStructuredOutput: model.requireStructuredOutput,
         system: args.system,
         user: args.user,
         jsonSchema: args.jsonSchema,

--- a/lib/arena/coverage.ts
+++ b/lib/arena/coverage.ts
@@ -415,7 +415,7 @@ async function queryArenaMatchupSamplingState(): Promise<ArenaMatchupSamplingRes
       gridSize: ARENA_GRID_SIZE,
       palette: ARENA_PALETTE,
       mode: ARENA_MODE,
-      model: { enabled: true, isBaseline: false },
+      model: { enabled: true, isBaseline: false, stealthVariant: null },
       prompt: { active: true },
     },
     select: {
@@ -488,6 +488,7 @@ async function queryArenaMatchupSamplingState(): Promise<ArenaMatchupSamplingRes
       where: {
         enabled: true,
         isBaseline: false,
+        stealthVariant: null,
         id: { in: Array.from(promptIdsByModelId.keys()) },
       },
       select: {
@@ -866,6 +867,7 @@ export async function rebuildArenaCoverageTables(client: PrismaClient = prisma):
       INNER JOIN "Matchup" matchup ON matchup.id = vote."matchupId"
       LEFT JOIN "ArenaVoteJob" job ON job."voteId" = vote.id
       WHERE vote.choice IN ('A', 'B')
+        AND matchup."stealthVariantId" IS NULL
         -- pending jobs will add themselves when drained
         AND (job.id IS NULL OR job."processedAt" IS NOT NULL)
       GROUP BY matchup."modelAId", matchup."modelBId", matchup."promptId"

--- a/lib/arena/eligibility.ts
+++ b/lib/arena/eligibility.ts
@@ -18,6 +18,7 @@ export function arenaCohortBuildWhere(modelKeys?: readonly string[]) {
     model: {
       ...(scoped ? { key: { in: [...modelKeys!] } } : { enabled: true }),
       isBaseline: false,
+      stealthVariant: null,
     },
     prompt: { active: true },
   };
@@ -39,6 +40,9 @@ export async function getArenaEligiblePromptIds(): Promise<string[]> {
       AND build."mode" = ${ARENA_BUILD_MODE}
       AND model.enabled = true
       AND model."isBaseline" = false
+      AND NOT EXISTS (
+        SELECT 1 FROM "StealthVariant" variant WHERE variant."modelId" = model.id
+      )
       AND prompt.active = true
     GROUP BY build."promptId"
     HAVING COUNT(*) >= 2

--- a/lib/arena/matchupToken.ts
+++ b/lib/arena/matchupToken.ts
@@ -1,4 +1,12 @@
-import { createHmac, randomUUID, timingSafeEqual } from "node:crypto";
+import {
+  createCipheriv,
+  createDecipheriv,
+  createHash,
+  createHmac,
+  randomBytes,
+  randomUUID,
+  timingSafeEqual,
+} from "node:crypto";
 import { normalizeArenaBuildChecksum } from "@/lib/arena/buildChecksum";
 
 type CompactArenaMatchupTokenPayload = {
@@ -12,6 +20,13 @@ type CompactArenaMatchupTokenPayload = {
   cb: string;
   l?: string;
   r?: string;
+  s?: string;
+  t: number;
+};
+
+type CompactArenaBuildAccessTokenPayload = {
+  b: string;
+  c: string;
   t: number;
 };
 
@@ -26,12 +41,25 @@ export type ArenaMatchupTokenPayload = {
   buildBChecksum: string;
   samplingLane?: string;
   samplingReason?: string;
+  stealthVariantId?: string;
+  issuedAt: number;
+};
+
+export type ArenaBuildAccessTokenPayload = {
+  buildId: string;
+  checksum: string;
   issuedAt: number;
 };
 
 const globalForArenaMatchupTokens = globalThis as typeof globalThis & {
   arenaMatchupDevSigningSecret?: string;
 };
+
+const TOKEN_VERSION = "v2";
+const BUILD_ACCESS_TOKEN_VERSION = "b1";
+const TOKEN_IV_BYTES = 12;
+const DEFAULT_TOKEN_MAX_AGE_MS = 2 * 60 * 60 * 1000;
+const TOKEN_FUTURE_SKEW_MS = 5 * 60 * 1000;
 
 function configuredArenaMatchupSigningSecret(): string | null {
   return (
@@ -61,6 +89,26 @@ function getArenaMatchupSigningSecret(): string {
   );
 }
 
+function arenaMatchupEncryptionKey(): Buffer {
+  return createHash("sha256")
+    .update("minebench:arena-matchup:v2\0")
+    .update(getArenaMatchupSigningSecret())
+    .digest();
+}
+
+function arenaBuildAccessEncryptionKey(): Buffer {
+  return createHash("sha256")
+    .update("minebench:arena-build-access:v1\0")
+    .update(getArenaMatchupSigningSecret())
+    .digest();
+}
+
+function tokenMaxAgeMs(): number {
+  const parsed = Number.parseInt(process.env.ARENA_MATCHUP_TOKEN_MAX_AGE_MS ?? "", 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) return DEFAULT_TOKEN_MAX_AGE_MS;
+  return Math.min(parsed, 24 * 60 * 60 * 1000);
+}
+
 function encodeBase64Url(value: string): string {
   return Buffer.from(value, "utf8").toString("base64url");
 }
@@ -87,6 +135,7 @@ function toCompactPayload(input: ArenaMatchupTokenPayload): CompactArenaMatchupT
     cb: input.buildBChecksum,
     l: input.samplingLane,
     r: input.samplingReason,
+    s: input.stealthVariantId,
     t: input.issuedAt,
   };
 }
@@ -103,7 +152,10 @@ function fromCompactPayload(input: CompactArenaMatchupTokenPayload): ArenaMatchu
     !input.bb ||
     !buildAChecksum ||
     !buildBChecksum ||
-    typeof input.t !== "number"
+    typeof input.t !== "number" ||
+    !Number.isInteger(input.t) ||
+    input.t > Date.now() + TOKEN_FUTURE_SKEW_MS ||
+    Date.now() - input.t > tokenMaxAgeMs()
   ) {
     return null;
   }
@@ -119,8 +171,73 @@ function fromCompactPayload(input: CompactArenaMatchupTokenPayload): ArenaMatchu
     buildBChecksum,
     samplingLane: input.l,
     samplingReason: input.r,
+    stealthVariantId: input.s,
     issuedAt: input.t,
   };
+}
+
+export function createArenaBuildAccessToken(input: {
+  buildId: string;
+  checksum: string;
+}): string {
+  const checksum = normalizeArenaBuildChecksum(input.checksum);
+  if (!input.buildId.trim() || !checksum) {
+    throw new Error("Arena build access tokens require a build id and SHA-256 checksum");
+  }
+  const payload: CompactArenaBuildAccessTokenPayload = {
+    b: input.buildId,
+    c: checksum,
+    t: Date.now(),
+  };
+  const iv = randomBytes(TOKEN_IV_BYTES);
+  const cipher = createCipheriv("aes-256-gcm", arenaBuildAccessEncryptionKey(), iv);
+  const ciphertext = Buffer.concat([
+    cipher.update(JSON.stringify(payload), "utf8"),
+    cipher.final(),
+  ]);
+  return [
+    BUILD_ACCESS_TOKEN_VERSION,
+    iv.toString("base64url"),
+    cipher.getAuthTag().toString("base64url"),
+    ciphertext.toString("base64url"),
+  ].join(".");
+}
+
+export function parseArenaBuildAccessToken(token: string): ArenaBuildAccessTokenPayload | null {
+  const [version, encodedIv, encodedTag, encodedCiphertext, extra] = token.trim().split(".");
+  if (
+    version !== BUILD_ACCESS_TOKEN_VERSION ||
+    !encodedIv ||
+    !encodedTag ||
+    !encodedCiphertext ||
+    extra
+  ) {
+    return null;
+  }
+  try {
+    const iv = Buffer.from(encodedIv, "base64url");
+    const tag = Buffer.from(encodedTag, "base64url");
+    const ciphertext = Buffer.from(encodedCiphertext, "base64url");
+    if (iv.length !== TOKEN_IV_BYTES || tag.length !== 16 || ciphertext.length === 0) return null;
+    const decipher = createDecipheriv("aes-256-gcm", arenaBuildAccessEncryptionKey(), iv);
+    decipher.setAuthTag(tag);
+    const plaintext = Buffer.concat([decipher.update(ciphertext), decipher.final()]).toString("utf8");
+    const payload = JSON.parse(plaintext) as CompactArenaBuildAccessTokenPayload;
+    const checksum = normalizeArenaBuildChecksum(payload.c);
+    if (
+      !payload.b ||
+      !checksum ||
+      typeof payload.t !== "number" ||
+      !Number.isInteger(payload.t) ||
+      payload.t > Date.now() + TOKEN_FUTURE_SKEW_MS ||
+      Date.now() - payload.t > tokenMaxAgeMs()
+    ) {
+      return null;
+    }
+    return { buildId: payload.b, checksum, issuedAt: payload.t };
+  } catch {
+    return null;
+  }
 }
 
 export function createArenaMatchupToken(input: Omit<ArenaMatchupTokenPayload, "id" | "issuedAt">): string {
@@ -136,13 +253,48 @@ export function createArenaMatchupToken(input: Omit<ArenaMatchupTokenPayload, "i
     id: randomUUID(),
     issuedAt: Date.now(),
   });
-  const encodedPayload = encodeBase64Url(JSON.stringify(payload));
-  const signature = signArenaMatchupPayload(encodedPayload);
-  return `${encodedPayload}.${signature}`;
+  const iv = randomBytes(TOKEN_IV_BYTES);
+  const cipher = createCipheriv("aes-256-gcm", arenaMatchupEncryptionKey(), iv);
+  const ciphertext = Buffer.concat([
+    cipher.update(JSON.stringify(payload), "utf8"),
+    cipher.final(),
+  ]);
+  return [
+    TOKEN_VERSION,
+    iv.toString("base64url"),
+    cipher.getAuthTag().toString("base64url"),
+    ciphertext.toString("base64url"),
+  ].join(".");
 }
 
 export function parseArenaMatchupToken(token: string): ArenaMatchupTokenPayload | null {
   const trimmed = token.trim();
+  if (trimmed.startsWith(`${TOKEN_VERSION}.`)) {
+    const [version, encodedIv, encodedTag, encodedCiphertext, extra] = trimmed.split(".");
+    if (
+      version !== TOKEN_VERSION ||
+      !encodedIv ||
+      !encodedTag ||
+      !encodedCiphertext ||
+      extra
+    ) {
+      return null;
+    }
+    try {
+      const iv = Buffer.from(encodedIv, "base64url");
+      const tag = Buffer.from(encodedTag, "base64url");
+      const ciphertext = Buffer.from(encodedCiphertext, "base64url");
+      if (iv.length !== TOKEN_IV_BYTES || tag.length !== 16 || ciphertext.length === 0) return null;
+      const decipher = createDecipheriv("aes-256-gcm", arenaMatchupEncryptionKey(), iv);
+      decipher.setAuthTag(tag);
+      const plaintext = Buffer.concat([decipher.update(ciphertext), decipher.final()]).toString("utf8");
+      return fromCompactPayload(JSON.parse(plaintext) as CompactArenaMatchupTokenPayload);
+    } catch {
+      return null;
+    }
+  }
+
+  // Briefly accept unexpired v1 tokens so a deploy does not discard matchups already on screen
   const dotIndex = trimmed.lastIndexOf(".");
   if (dotIndex <= 0 || dotIndex >= trimmed.length - 1) return null;
 

--- a/lib/arena/stats.ts
+++ b/lib/arena/stats.ts
@@ -704,7 +704,7 @@ async function queryPromptSignalSnapshot(): Promise<PromptSignalSnapshot> {
   }
 
   const models = await prisma.model.findMany({
-    where: { enabled: true, isBaseline: false },
+    where: { enabled: true, isBaseline: false, stealthVariant: null },
     select: { id: true, displayName: true },
   });
 
@@ -938,7 +938,7 @@ export async function getLeaderboardDispersionByModelId(): Promise<Map<string, S
 
 async function queryModelDetailStats(modelKey: string): Promise<ModelDetailStats | null> {
   const model = await prisma.model.findFirst({
-    where: { key: modelKey, enabled: true, isBaseline: false },
+    where: { key: modelKey, enabled: true, isBaseline: false, stealthVariant: null },
     select: {
       id: true,
       key: true,
@@ -1060,6 +1060,9 @@ async function queryModelDetailStats(modelKey: string): Promise<ModelDetailStats
         AND ${filter}
         AND opponent.enabled = true
         AND opponent."isBaseline" = false
+        AND NOT EXISTS (
+          SELECT 1 FROM "StealthVariant" variant WHERE variant."modelId" = opponent.id
+        )
       GROUP BY opponent.id, opponent.key, opponent."displayName"
     `,
     prisma.$queryRaw<RecentScoreRow[]>`

--- a/lib/arena/types.ts
+++ b/lib/arena/types.ts
@@ -3,6 +3,19 @@ import type { RenderableVoxelBuild } from "@/lib/voxel/packedBlocks";
 
 export type VoteChoice = "A" | "B" | "TIE" | "BOTH_BAD";
 
+export type ArenaModelReveal = {
+  provider: string;
+  displayName: string;
+};
+
+export type ArenaVoteResponse = {
+  ok: true;
+  reveal: {
+    a: ArenaModelReveal;
+    b: ArenaModelReveal;
+  };
+};
+
 export type ArenaBuildVariant = "preview" | "full";
 
 export type ArenaBuildDeliveryClass =
@@ -80,7 +93,7 @@ export type ArenaMatchup = {
   samplingLane?: "coverage" | "contender" | "uncertainty" | "exploration";
   prompt: { id: string; text: string };
   a: {
-    model: { key: string; provider: string; displayName: string; eloRating: number };
+    model: ArenaModelReveal | null;
     build: RenderableVoxelBuild | null;
     buildRef?: ArenaBuildRef;
     previewRef?: ArenaBuildRef;
@@ -88,7 +101,7 @@ export type ArenaMatchup = {
     buildLoadHints?: ArenaBuildLoadHints;
   };
   b: {
-    model: { key: string; provider: string; displayName: string; eloRating: number };
+    model: ArenaModelReveal | null;
     build: RenderableVoxelBuild | null;
     buildRef?: ArenaBuildRef;
     previewRef?: ArenaBuildRef;

--- a/lib/arena/voteJobs.ts
+++ b/lib/arena/voteJobs.ts
@@ -8,6 +8,8 @@ import { invalidateArenaStatsCache } from "@/lib/arena/stats";
 import { prisma } from "@/lib/prisma";
 import { ARENA_VOTE_JOB_DRAIN_LOCK_KEY } from "@/lib/arena/advisoryLocks";
 import { ARENA_WRITE_RETRY_MAX_ATTEMPTS, withArenaWriteRetry } from "@/lib/arena/writeRetry";
+import { applyStealthRatingVote } from "@/lib/stealth/rating";
+import type { VoteChoice } from "@/lib/arena/types";
 
 function readPositiveIntEnv(name: string, fallback: number, max: number): number {
   const parsed = Number.parseInt(process.env[name] ?? "", 10);
@@ -31,7 +33,8 @@ type PendingArenaVoteJob = {
   promptId: string;
   modelAId: string;
   modelBId: string;
-  choice: string;
+  choice: VoteChoice;
+  stealthVariantId: string | null;
 };
 
 type LockedModelRow = {
@@ -45,6 +48,14 @@ type MutableModelState = LockedModelRow & {
   conservativeRating: number;
 };
 
+type LockedStealthVariantRow = MutableModelState & {
+  modelId: string;
+  winCount: number;
+  lossCount: number;
+  drawCount: number;
+  bothBadCount: number;
+};
+
 type ModelUpdateRow = {
   id: string;
   eloRating: number;
@@ -53,6 +64,8 @@ type ModelUpdateRow = {
   conservativeRating: number;
   counters: CounterIncrements;
 };
+
+type StealthVariantUpdateRow = Omit<LockedStealthVariantRow, "modelId">;
 
 type VoteCacheUpdate = {
   voteJobId: string;
@@ -198,6 +211,94 @@ async function loadModelsForVoteJobs(
   );
 }
 
+async function loadStealthVariantsForVoteJobs(
+  tx: Prisma.TransactionClient,
+  variantIds: string[],
+): Promise<Map<string, LockedStealthVariantRow>> {
+  const orderedIds = Array.from(new Set(variantIds)).sort();
+  if (orderedIds.length === 0) return new Map();
+
+  const rows = await tx.$queryRaw<LockedStealthVariantRow[]>(Prisma.sql`
+    SELECT
+      "id",
+      "modelId",
+      "eloRating",
+      "glickoRd",
+      "glickoVolatility",
+      "conservativeRating",
+      "winCount",
+      "lossCount",
+      "drawCount",
+      "bothBadCount"
+    FROM "StealthVariant"
+    WHERE "id" IN (${Prisma.join(orderedIds)})
+    ORDER BY "id" ASC
+    FOR UPDATE
+  `);
+
+  if (rows.length !== orderedIds.length) {
+    throw new Error("Stealth vote variant not found");
+  }
+
+  return new Map(
+    rows.map((row) => [
+      row.id,
+      {
+        id: row.id,
+        modelId: row.modelId,
+        eloRating: Number(row.eloRating),
+        glickoRd: Number(row.glickoRd),
+        glickoVolatility: Number(row.glickoVolatility),
+        conservativeRating: Number(row.conservativeRating),
+        winCount: row.winCount,
+        lossCount: row.lossCount,
+        drawCount: row.drawCount,
+        bothBadCount: row.bothBadCount,
+      },
+    ]),
+  );
+}
+
+async function applyBatchedStealthVariantUpdates(
+  tx: Prisma.TransactionClient,
+  rows: StealthVariantUpdateRow[],
+) {
+  if (rows.length === 0) return;
+  const ordered = [...rows].sort((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0));
+  await tx.$executeRaw(Prisma.sql`
+    UPDATE "StealthVariant" AS variant
+    SET
+      "eloRating" = updated."eloRating",
+      "glickoRd" = updated."glickoRd",
+      "glickoVolatility" = updated."glickoVolatility",
+      "conservativeRating" = updated."conservativeRating",
+      "winCount" = updated."winCount",
+      "lossCount" = updated."lossCount",
+      "drawCount" = updated."drawCount",
+      "bothBadCount" = updated."bothBadCount",
+      "updatedAt" = CURRENT_TIMESTAMP
+    FROM (
+      VALUES ${Prisma.join(
+        ordered.map(
+          (row) =>
+            Prisma.sql`(${row.id}::text, ${row.eloRating}::double precision, ${row.glickoRd}::double precision, ${row.glickoVolatility}::double precision, ${row.conservativeRating}::double precision, ${row.winCount}::int, ${row.lossCount}::int, ${row.drawCount}::int, ${row.bothBadCount}::int)`,
+        ),
+      )}
+    ) AS updated(
+      "id",
+      "eloRating",
+      "glickoRd",
+      "glickoVolatility",
+      "conservativeRating",
+      "winCount",
+      "lossCount",
+      "drawCount",
+      "bothBadCount"
+    )
+    WHERE variant."id" = updated."id"
+  `);
+}
+
 async function tryAcquireVoteJobDrainLock(tx: Prisma.TransactionClient): Promise<boolean> {
   // one drain owns rating and coverage writes at a time
   const rows = await tx.$queryRaw<Array<{ locked: boolean }>>(Prisma.sql`
@@ -324,7 +425,8 @@ async function processArenaVoteJobBatch(limit = JOB_BATCH_LIMIT): Promise<VoteJo
             "promptId",
             "modelAId",
             "modelBId",
-            "choice"
+            "choice",
+            "stealthVariantId"
           FROM "ArenaVoteJob"
           WHERE "processedAt" IS NULL
           ORDER BY "createdAt" ASC
@@ -352,7 +454,15 @@ async function processArenaVoteJobBatch(limit = JOB_BATCH_LIMIT): Promise<VoteJo
             },
           ]),
         );
+        const lockedStealthVariants = await loadStealthVariantsForVoteJobs(
+          tx,
+          jobs.flatMap((job) => (job.stealthVariantId ? [job.stealthVariantId] : [])),
+        );
+        const stealthVariantStates = new Map<string, LockedStealthVariantRow>(
+          Array.from(lockedStealthVariants.entries()).map(([id, variant]) => [id, { ...variant }]),
+        );
         const counterIncrements = new Map<string, CounterIncrements>();
+        const publicTouchedModelIds = new Set<string>();
         const cacheUpdates: VoteCacheUpdate[] = [];
         const coveragePersistUpdates = new Map<string, CoveragePersistUpdate>();
 
@@ -387,6 +497,31 @@ async function processArenaVoteJobBatch(limit = JOB_BATCH_LIMIT): Promise<VoteJo
           if (!modelA || !modelB) {
             throw new Error("Vote models not found");
           }
+
+          if (job.stealthVariantId) {
+            const variant = stealthVariantStates.get(job.stealthVariantId);
+            if (!variant) throw new Error("Stealth vote variant not found");
+            const variantIsA = variant.modelId === job.modelAId;
+            const variantIsB = variant.modelId === job.modelBId;
+            if (variantIsA === variantIsB) {
+              throw new Error("Stealth vote must contain exactly one variant model");
+            }
+
+            const publicAnchor = variantIsA ? modelB : modelA;
+            Object.assign(
+              variant,
+              applyStealthRatingVote({
+                variant,
+                publicAnchor,
+                variantSide: variantIsA ? "A" : "B",
+                choice: job.choice,
+              }),
+            );
+            continue;
+          }
+
+          publicTouchedModelIds.add(job.modelAId);
+          publicTouchedModelIds.add(job.modelBId);
 
           if (job.choice === "BOTH_BAD") {
             countersForModel(job.modelAId).bothBadCount += 1;
@@ -453,7 +588,9 @@ async function processArenaVoteJobBatch(limit = JOB_BATCH_LIMIT): Promise<VoteJo
           });
         }
 
-        const modelUpdateRows: ModelUpdateRow[] = Array.from(modelStates.values()).map(
+        const modelUpdateRows: ModelUpdateRow[] = Array.from(modelStates.values())
+          .filter((model) => publicTouchedModelIds.has(model.id))
+          .map(
           (model) => ({
             id: model.id,
             eloRating: model.eloRating,
@@ -463,8 +600,12 @@ async function processArenaVoteJobBatch(limit = JOB_BATCH_LIMIT): Promise<VoteJo
             counters: counterIncrements.get(model.id) ?? emptyCounterIncrements(),
           }),
         );
+        const stealthVariantUpdateRows: StealthVariantUpdateRow[] = Array.from(
+          stealthVariantStates.values(),
+        ).map(({ modelId: _modelId, ...variant }) => variant);
 
         await applyBatchedModelUpdates(tx, modelUpdateRows);
+        await applyBatchedStealthVariantUpdates(tx, stealthVariantUpdateRows);
         // coverage rows update in the same tx as processedAt
         await applyCoveragePersistUpdates(tx, Array.from(coveragePersistUpdates.values()));
         await tx.$executeRaw(Prisma.sql`

--- a/lib/stealth/auth.ts
+++ b/lib/stealth/auth.ts
@@ -1,0 +1,93 @@
+import type { OrganizationRole } from "@prisma/client";
+import { prisma } from "@/lib/prisma";
+import { createSupabaseServerClient } from "@/lib/supabase/server";
+
+export type LabIdentity = {
+  user: {
+    id: string;
+    email: string;
+    displayName: string | null;
+  };
+  memberships: Array<{
+    role: OrganizationRole;
+    organization: {
+      id: string;
+      slug: string;
+      name: string;
+    };
+  }>;
+};
+
+export async function getLabIdentity(): Promise<LabIdentity | null> {
+  const supabase = await createSupabaseServerClient();
+  const {
+    data: { user: authUser },
+    error,
+  } = await supabase.auth.getUser();
+  const email = authUser?.email?.trim().toLowerCase();
+  if (error || !authUser || !email) return null;
+
+  const user = await prisma.user.upsert({
+    where: { id: authUser.id },
+    create: {
+      id: authUser.id,
+      email,
+      displayName:
+        typeof authUser.user_metadata?.name === "string"
+          ? authUser.user_metadata.name.trim().slice(0, 120) || null
+          : null,
+      lastSeenAt: new Date(),
+    },
+    update: {
+      email,
+      lastSeenAt: new Date(),
+    },
+    select: {
+      id: true,
+      email: true,
+      displayName: true,
+      memberships: {
+        orderBy: { organization: { name: "asc" } },
+        select: {
+          role: true,
+          organization: {
+            select: { id: true, slug: true, name: true },
+          },
+        },
+      },
+    },
+  });
+
+  if (user.memberships.length > 0) {
+    await prisma.organizationInvitation.updateMany({
+      where: {
+        authUserId: user.id,
+        acceptedAt: null,
+        revokedAt: null,
+        organizationId: { in: user.memberships.map(({ organization }) => organization.id) },
+      },
+      data: {
+        acceptedById: user.id,
+        acceptedAt: new Date(),
+      },
+    });
+  }
+
+  return {
+    user: {
+      id: user.id,
+      email: user.email,
+      displayName: user.displayName,
+    },
+    memberships: user.memberships,
+  };
+}
+
+export async function getLabOrganizationContext(organizationSlug: string) {
+  const identity = await getLabIdentity();
+  if (!identity) return null;
+  const membership = identity.memberships.find(
+    ({ organization }) => organization.slug === organizationSlug,
+  );
+  return membership ? { ...identity, membership } : null;
+}

--- a/lib/stealth/credentials.ts
+++ b/lib/stealth/credentials.ts
@@ -1,0 +1,104 @@
+import {
+  createCipheriv,
+  createDecipheriv,
+  createHmac,
+  randomBytes,
+} from "node:crypto";
+import { z } from "zod";
+
+const ENVELOPE_VERSION = "v1";
+const IV_BYTES = 12;
+
+export const stealthEndpointConfigSchema = z.object({
+  protocol: z.literal("openai-chat-completions"),
+  endpointUrl: z.string().url().max(2048),
+  apiKey: z.string().min(1).max(8192),
+  modelId: z.string().min(1).max(512),
+  requireStructuredOutput: z.boolean().default(true),
+  enableTools: z.boolean().default(true),
+  reasoning: z.string().trim().min(1).max(64).optional(),
+});
+
+export type StealthEndpointConfig = z.infer<typeof stealthEndpointConfigSchema>;
+
+function encryptionKey(raw = process.env.STEALTH_CONFIG_ENCRYPTION_KEY): Buffer {
+  const value = raw?.trim() ?? "";
+  if (!/^[A-Za-z0-9+/]+={0,2}$/.test(value)) {
+    throw new Error("STEALTH_CONFIG_ENCRYPTION_KEY must be a base64-encoded 32-byte key");
+  }
+  const key = Buffer.from(value, "base64");
+  if (key.length !== 32) {
+    throw new Error("STEALTH_CONFIG_ENCRYPTION_KEY must be a base64-encoded 32-byte key");
+  }
+  return key;
+}
+
+function canonicalConfig(config: StealthEndpointConfig): StealthEndpointConfig {
+  const parsed = stealthEndpointConfigSchema.parse(config);
+  return {
+    ...parsed,
+    endpointUrl: parsed.endpointUrl.trim().replace(/\/+$/, ""),
+    apiKey: parsed.apiKey.trim().replace(/^Bearer\s+/i, "").trim(),
+    modelId: parsed.modelId.trim(),
+  };
+}
+
+export function generateStealthConfigEncryptionKey(): string {
+  return randomBytes(32).toString("base64");
+}
+
+export function encryptStealthEndpointConfig(
+  input: StealthEndpointConfig,
+  rawKey?: string,
+): { encryptedConfig: string; fingerprint: string } {
+  const key = encryptionKey(rawKey);
+  const config = canonicalConfig(input);
+  const plaintext = Buffer.from(JSON.stringify(config), "utf8");
+  const iv = randomBytes(IV_BYTES);
+  const cipher = createCipheriv("aes-256-gcm", key, iv);
+  const ciphertext = Buffer.concat([cipher.update(plaintext), cipher.final()]);
+  const tag = cipher.getAuthTag();
+  const fingerprint = createHmac("sha256", key).update(plaintext).digest("hex");
+
+  return {
+    encryptedConfig: [
+      ENVELOPE_VERSION,
+      iv.toString("base64url"),
+      tag.toString("base64url"),
+      ciphertext.toString("base64url"),
+    ].join("."),
+    fingerprint,
+  };
+}
+
+export function decryptStealthEndpointConfig(
+  envelope: string,
+  rawKey?: string,
+): StealthEndpointConfig {
+  const [version, encodedIv, encodedTag, encodedCiphertext, extra] = envelope.split(".");
+  if (
+    version !== ENVELOPE_VERSION ||
+    !encodedIv ||
+    !encodedTag ||
+    !encodedCiphertext ||
+    extra
+  ) {
+    throw new Error("Stealth endpoint credential has an unsupported format");
+  }
+
+  try {
+    const key = encryptionKey(rawKey);
+    const iv = Buffer.from(encodedIv, "base64url");
+    const tag = Buffer.from(encodedTag, "base64url");
+    const ciphertext = Buffer.from(encodedCiphertext, "base64url");
+    if (iv.length !== IV_BYTES || tag.length !== 16 || ciphertext.length === 0) {
+      throw new Error("invalid envelope");
+    }
+    const decipher = createDecipheriv("aes-256-gcm", key, iv);
+    decipher.setAuthTag(tag);
+    const plaintext = Buffer.concat([decipher.update(ciphertext), decipher.final()]);
+    return canonicalConfig(stealthEndpointConfigSchema.parse(JSON.parse(plaintext.toString("utf8"))));
+  } catch {
+    throw new Error("Stealth endpoint credential could not be decrypted");
+  }
+}

--- a/lib/stealth/generation.ts
+++ b/lib/stealth/generation.ts
@@ -1,0 +1,215 @@
+import { createHash } from "node:crypto";
+import { gzipSync } from "node:zlib";
+import { Prisma } from "@prisma/client";
+import { maybePrecomputeArenaArtifactsForBuild } from "@/lib/arena/artifactMaintenance";
+import type { ArenaBuildSource } from "@/lib/arena/buildArtifacts";
+import {
+  isLoopbackDatabaseUrl,
+  supabaseProjectRefFromApiUrl,
+  supabaseProjectRefFromDatabaseUrl,
+} from "@/lib/db/identity";
+import { prisma } from "@/lib/prisma";
+import type { VoxelBuild } from "@/lib/voxel/types";
+
+const GRID_SIZE = 256;
+const PALETTE = "simple";
+const MODE = "precise";
+const DEFAULT_BUCKET = "builds";
+const STORAGE_PREFIX = "stealth-builds/v1";
+
+type StoredPayload = {
+  voxelData: Prisma.InputJsonValue | typeof Prisma.DbNull;
+  voxelStorageBucket: string | null;
+  voxelStoragePath: string | null;
+  voxelStorageEncoding: string | null;
+};
+
+const BUILD_SOURCE_SELECT = {
+  id: true,
+  gridSize: true,
+  palette: true,
+  blockCount: true,
+  voxelByteSize: true,
+  voxelCompressedByteSize: true,
+  voxelSha256: true,
+  voxelData: true,
+  voxelStorageBucket: true,
+  voxelStoragePath: true,
+  voxelStorageEncoding: true,
+  arenaBuildHints: true,
+} satisfies Prisma.BuildSelect;
+
+function storageConfig(): { url: string; key: string; bucket: string } | null {
+  const url = (process.env.SUPABASE_URL ?? process.env.NEXT_PUBLIC_SUPABASE_URL ?? "")
+    .trim()
+    .replace(/\/+$/, "");
+  const key = (process.env.SUPABASE_SERVICE_ROLE_KEY ?? process.env.SUPABASE_SECRET_KEY ?? "").trim();
+  if (!url && !key) return null;
+  if (!url || !key) {
+    throw new Error("Supabase build storage requires both SUPABASE_URL and a server secret key");
+  }
+  return {
+    url,
+    key,
+    bucket: process.env.SUPABASE_STORAGE_BUCKET?.trim() || DEFAULT_BUCKET,
+  };
+}
+
+function assertStorageMatchesDatabase(url: string): void {
+  const databaseUrl = process.env.DATABASE_URL ?? process.env.DIRECT_URL ?? "";
+  const databaseRef = supabaseProjectRefFromDatabaseUrl(databaseUrl);
+  const storageRef = supabaseProjectRefFromApiUrl(url);
+  if (!databaseRef || !storageRef || databaseRef !== storageRef) {
+    throw new Error("Stealth build storage and DATABASE_URL must target the same Supabase project");
+  }
+}
+
+function encodedStoragePath(path: string): string {
+  return path
+    .split("/")
+    .map((part) => encodeURIComponent(part))
+    .join("/");
+}
+
+async function storePayload(params: {
+  variantId: string;
+  promptSlug: string;
+  build: VoxelBuild;
+  gzip: Buffer;
+}): Promise<StoredPayload> {
+  const databaseUrl = process.env.DATABASE_URL ?? process.env.DIRECT_URL ?? "";
+  if (isLoopbackDatabaseUrl(databaseUrl)) {
+    return {
+      voxelData: params.build as unknown as Prisma.InputJsonValue,
+      voxelStorageBucket: null,
+      voxelStoragePath: null,
+      voxelStorageEncoding: null,
+    };
+  }
+  const config = storageConfig();
+  if (!config) {
+    throw new Error("Remote stealth generation requires Supabase build storage configuration");
+  }
+
+  assertStorageMatchesDatabase(config.url);
+  const path = `${STORAGE_PREFIX}/${params.variantId}/${params.promptSlug}.json.gz`;
+  const response = await fetch(
+    `${config.url}/storage/v1/object/${encodeURIComponent(config.bucket)}/${encodedStoragePath(path)}`,
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${config.key}`,
+        apikey: config.key,
+        "Content-Type": "application/gzip",
+        "x-upsert": "true",
+      },
+      body: new Uint8Array(
+        params.gzip.buffer as ArrayBuffer,
+        params.gzip.byteOffset,
+        params.gzip.byteLength,
+      ),
+    },
+  );
+  if (!response.ok) {
+    throw new Error(`Stealth build storage upload failed (${response.status}): ${await response.text()}`);
+  }
+  return {
+    voxelData: Prisma.DbNull,
+    voxelStorageBucket: config.bucket,
+    voxelStoragePath: path,
+    voxelStorageEncoding: "gzip",
+  };
+}
+
+export async function persistStealthBuild(params: {
+  variantId: string;
+  modelId: string;
+  promptSlug: string;
+  promptText: string;
+  build: VoxelBuild;
+  generationTimeMs: number;
+}): Promise<{ id: string; blockCount: number }> {
+  const json = Buffer.from(JSON.stringify(params.build), "utf8");
+  const gzip = gzipSync(json);
+  const sha256 = createHash("sha256").update(json).digest("hex");
+  const blockCount = params.build.blocks.length;
+  const payload = await storePayload({
+    variantId: params.variantId,
+    promptSlug: params.promptSlug,
+    build: params.build,
+    gzip,
+  });
+  const prompt = await prisma.prompt.upsert({
+    where: { text: params.promptText },
+    create: { text: params.promptText, active: true },
+    update: { active: true },
+  });
+  const build = await prisma.build.upsert({
+    where: {
+      promptId_modelId_gridSize_palette_mode: {
+        promptId: prompt.id,
+        modelId: params.modelId,
+        gridSize: GRID_SIZE,
+        palette: PALETTE,
+        mode: MODE,
+      },
+    },
+    create: {
+      promptId: prompt.id,
+      modelId: params.modelId,
+      gridSize: GRID_SIZE,
+      palette: PALETTE,
+      mode: MODE,
+      ...payload,
+      voxelByteSize: json.byteLength,
+      voxelCompressedByteSize: gzip.byteLength,
+      voxelSha256: sha256,
+      blockCount,
+      generationTimeMs: params.generationTimeMs,
+    },
+    update: {
+      ...payload,
+      voxelByteSize: json.byteLength,
+      voxelCompressedByteSize: gzip.byteLength,
+      voxelSha256: sha256,
+      arenaBuildHints: Prisma.DbNull,
+      blockCount,
+      generationTimeMs: params.generationTimeMs,
+    },
+  });
+  const source: ArenaBuildSource = {
+    id: build.id,
+    gridSize: build.gridSize,
+    palette: build.palette,
+    blockCount: build.blockCount,
+    voxelByteSize: build.voxelByteSize,
+    voxelCompressedByteSize: build.voxelCompressedByteSize,
+    voxelSha256: build.voxelSha256,
+    voxelData: build.voxelData,
+    voxelStorageBucket: build.voxelStorageBucket,
+    voxelStoragePath: build.voxelStoragePath,
+    voxelStorageEncoding: build.voxelStorageEncoding,
+    arenaBuildHints: build.arenaBuildHints,
+  };
+  const databaseUrl = process.env.DATABASE_URL ?? process.env.DIRECT_URL ?? "";
+  if (!isLoopbackDatabaseUrl(databaseUrl)) {
+    await maybePrecomputeArenaArtifactsForBuild(source);
+  }
+  return { id: build.id, blockCount };
+}
+
+export async function ensureStealthBuildArtifacts(buildId: string): Promise<void> {
+  const databaseUrl = process.env.DATABASE_URL ?? process.env.DIRECT_URL ?? "";
+  if (isLoopbackDatabaseUrl(databaseUrl)) return;
+  const config = storageConfig();
+  if (!config) {
+    throw new Error("Remote stealth generation requires Supabase build storage configuration");
+  }
+  assertStorageMatchesDatabase(config.url);
+  const build = await prisma.build.findUnique({
+    where: { id: buildId },
+    select: BUILD_SOURCE_SELECT,
+  });
+  if (!build) throw new Error(`Stealth build not found: ${buildId}`);
+  await maybePrecomputeArenaArtifactsForBuild(build);
+}

--- a/lib/stealth/policy.ts
+++ b/lib/stealth/policy.ts
@@ -1,0 +1,33 @@
+import type { OrganizationRole, StealthExperimentStatus } from "@prisma/client";
+
+const MAX_STEALTH_ARENA_SHARE = 1;
+const DEFAULT_STEALTH_ARENA_SHARE = 0.25;
+
+export const ACTIVE_STEALTH_EXPERIMENT_STATUSES: readonly StealthExperimentStatus[] = [
+  "ACTIVE",
+  "STABLE",
+];
+
+export function readStealthArenaShare(raw = process.env.STEALTH_ARENA_SHARE): number {
+  if (!raw?.trim()) return DEFAULT_STEALTH_ARENA_SHARE;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed)) return DEFAULT_STEALTH_ARENA_SHARE;
+  return Math.max(0, Math.min(MAX_STEALTH_ARENA_SHARE, parsed));
+}
+
+export function canExportStealthVotes(role: OrganizationRole): boolean {
+  return role === "OWNER" || role === "ADMIN" || role === "ANALYST";
+}
+
+export function normalizeStealthSlug(value: string): string {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 64);
+}
+
+export function opaqueStealthModelKey(experimentId: string, variantId: string): string {
+  return `stealth/${experimentId}/${variantId}`;
+}

--- a/lib/stealth/rating.ts
+++ b/lib/stealth/rating.ts
@@ -1,0 +1,59 @@
+import { conservativeScore, updateRatingPair } from "@/lib/arena/rating";
+import type { VoteChoice } from "@/lib/arena/types";
+
+export type StealthRatingState = {
+  eloRating: number;
+  glickoRd: number;
+  glickoVolatility: number;
+  conservativeRating: number;
+  winCount: number;
+  lossCount: number;
+  drawCount: number;
+  bothBadCount: number;
+};
+
+export type PublicRatingAnchor = {
+  eloRating: number;
+  glickoRd: number;
+  glickoVolatility: number;
+};
+
+export function applyStealthRatingVote(params: {
+  variant: StealthRatingState;
+  publicAnchor: PublicRatingAnchor;
+  variantSide: "A" | "B";
+  choice: VoteChoice;
+}): StealthRatingState {
+  const next = { ...params.variant };
+  if (params.choice === "BOTH_BAD") {
+    next.bothBadCount += 1;
+    return next;
+  }
+  const outcome =
+    params.choice === "A" ? "A_WIN" : params.choice === "B" ? "B_WIN" : "DRAW";
+  const variantRating = {
+    rating: params.variant.eloRating,
+    rd: params.variant.glickoRd,
+    volatility: params.variant.glickoVolatility,
+  };
+  const anchorRating = {
+    rating: params.publicAnchor.eloRating,
+    rd: params.publicAnchor.glickoRd,
+    volatility: params.publicAnchor.glickoVolatility,
+  };
+  const updated = updateRatingPair({
+    a: params.variantSide === "A" ? variantRating : anchorRating,
+    b: params.variantSide === "B" ? variantRating : anchorRating,
+    outcome,
+  });
+  const updatedVariant = params.variantSide === "A" ? updated.a : updated.b;
+  next.eloRating = updatedVariant.rating;
+  next.glickoRd = updatedVariant.rd;
+  next.glickoVolatility = updatedVariant.volatility;
+  next.conservativeRating = conservativeScore(updatedVariant.rating, updatedVariant.rd);
+
+  if (params.choice === "TIE") next.drawCount += 1;
+  else if (params.choice === params.variantSide) next.winCount += 1;
+  else next.lossCount += 1;
+  return next;
+}

--- a/lib/stealth/report.ts
+++ b/lib/stealth/report.ts
@@ -1,0 +1,371 @@
+import { Prisma } from "@prisma/client";
+import { confidenceFromRd, stabilityTier } from "@/lib/arena/rating";
+import { resolveModelDisplayName } from "@/lib/ai/modelCatalog";
+import { prisma } from "@/lib/prisma";
+
+type AggregateRow = {
+  variantId: string;
+  promptId: string;
+  promptText: string;
+  opponentKey: string;
+  opponentDisplayName: string;
+  variantSide: "A" | "B";
+  choice: "A" | "B" | "TIE" | "BOTH_BAD";
+  votes: number | bigint | string;
+};
+
+export type StealthOutcomeSummary = {
+  votes: number;
+  decisiveVotes: number;
+  wins: number;
+  losses: number;
+  draws: number;
+  bothBad: number;
+  averageScore: number | null;
+};
+
+export type StealthBreakdown = StealthOutcomeSummary & {
+  id: string;
+  label: string;
+};
+
+export type StealthVariantReport = {
+  id: string;
+  codename: string;
+  status: string;
+  generatedBuildCount: number;
+  expectedBuildCount: number;
+  cohortGeneratedAt: Date | null;
+  releasedModelKey: string | null;
+  rating: number;
+  conservativeRating: number;
+  ratingDeviation: number;
+  confidence: number;
+  stability: "Provisional" | "Established" | "Stable";
+  estimatedFieldRank: number;
+  estimatedFieldSize: number;
+  targetDecisiveVotes: number;
+  progress: number;
+  pendingVotes: number;
+  sideA: number;
+  sideB: number;
+  sideBalance: number | null;
+  promptScoreSpread: number | null;
+  outcomes: StealthOutcomeSummary;
+  prompts: StealthBreakdown[];
+  opponents: StealthBreakdown[];
+  latestGenerationRun: {
+    status: string;
+    completedBuildCount: number;
+    expectedBuildCount: number;
+    failedBuildCount: number;
+    providerCallCount: number;
+    retryCount: number;
+    startedAt: Date;
+    completedAt: Date | null;
+  } | null;
+};
+
+export type StealthExperimentReport = {
+  id: string;
+  slug: string;
+  name: string;
+  status: string;
+  exportPolicy: string;
+  agreementReference: string | null;
+  startsAt: Date | null;
+  endedAt: Date | null;
+  retentionDeleteAt: Date | null;
+  organization: { id: string; slug: string; name: string };
+  variants: StealthVariantReport[];
+};
+
+function toNumber(value: number | bigint | string): number {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function emptyOutcomes(): StealthOutcomeSummary {
+  return {
+    votes: 0,
+    decisiveVotes: 0,
+    wins: 0,
+    losses: 0,
+    draws: 0,
+    bothBad: 0,
+    averageScore: null,
+  };
+}
+
+function addOutcome(
+  target: StealthOutcomeSummary,
+  row: Pick<AggregateRow, "variantSide" | "choice">,
+  count: number,
+): void {
+  target.votes += count;
+  if (row.choice === "BOTH_BAD") {
+    target.bothBad += count;
+    return;
+  }
+  if (row.choice === "TIE") {
+    target.draws += count;
+    return;
+  }
+  target.decisiveVotes += count;
+  const won =
+    (row.variantSide === "A" && row.choice === "A") ||
+    (row.variantSide === "B" && row.choice === "B");
+  if (won) target.wins += count;
+  else target.losses += count;
+}
+
+function finalizeOutcomes<T extends StealthOutcomeSummary>(summary: T): T {
+  const scored = summary.wins + summary.losses + summary.draws;
+  return {
+    ...summary,
+    averageScore: scored > 0 ? (summary.wins + summary.draws * 0.5) / scored : null,
+  } as T;
+}
+
+function appendBreakdown(
+  map: Map<string, StealthBreakdown>,
+  id: string,
+  label: string,
+  row: AggregateRow,
+  count: number,
+): void {
+  const breakdown = map.get(id) ?? { id, label, ...emptyOutcomes() };
+  addOutcome(breakdown, row, count);
+  map.set(id, breakdown);
+}
+
+export async function getStealthExperimentReport(
+  experimentId: string,
+): Promise<StealthExperimentReport | null> {
+  const experiment = await prisma.stealthExperiment.findUnique({
+    where: { id: experimentId },
+    include: {
+      organization: { select: { id: true, slug: true, name: true } },
+      variants: {
+        orderBy: { codename: "asc" },
+        include: {
+          releasedModel: { select: { key: true } },
+          generationRuns: {
+            orderBy: { startedAt: "desc" },
+            take: 1,
+            select: {
+              status: true,
+              completedBuildCount: true,
+              expectedBuildCount: true,
+              failedBuildCount: true,
+              providerCallCount: true,
+              retryCount: true,
+              startedAt: true,
+              completedAt: true,
+            },
+          },
+          _count: { select: { voteJobs: { where: { processedAt: null } } } },
+        },
+      },
+    },
+  });
+  if (!experiment) return null;
+  const variantIds = experiment.variants.map((variant) => variant.id);
+  const [aggregateRows, publicModels] = await Promise.all([
+    variantIds.length === 0
+      ? Promise.resolve([] as AggregateRow[])
+      : prisma.$queryRaw<AggregateRow[]>(Prisma.sql`
+          SELECT
+            variant.id AS "variantId",
+            prompt.id AS "promptId",
+            prompt.text AS "promptText",
+            opponent.key AS "opponentKey",
+            opponent."displayName" AS "opponentDisplayName",
+            CASE WHEN matchup."modelAId" = variant."modelId" THEN 'A' ELSE 'B' END AS "variantSide",
+            vote.choice AS choice,
+            COUNT(*)::int AS votes
+          FROM "Vote" vote
+          INNER JOIN "Matchup" matchup ON matchup.id = vote."matchupId"
+          INNER JOIN "StealthVariant" variant ON variant.id = matchup."stealthVariantId"
+          INNER JOIN "Prompt" prompt ON prompt.id = matchup."promptId"
+          INNER JOIN "Model" opponent ON opponent.id = CASE
+            WHEN matchup."modelAId" = variant."modelId" THEN matchup."modelBId"
+            ELSE matchup."modelAId"
+          END
+          WHERE variant.id IN (${Prisma.join(variantIds)})
+          GROUP BY
+            variant.id,
+            prompt.id,
+            prompt.text,
+            opponent.key,
+            opponent."displayName",
+            "variantSide",
+            vote.choice
+        `),
+    prisma.model.findMany({
+      where: { enabled: true, stealthVariant: null },
+      orderBy: { conservativeRating: "desc" },
+      select: { conservativeRating: true },
+    }),
+  ]);
+
+  const rowsByVariant = new Map<string, AggregateRow[]>();
+  for (const row of aggregateRows) {
+    const rows = rowsByVariant.get(row.variantId) ?? [];
+    rows.push(row);
+    rowsByVariant.set(row.variantId, rows);
+  }
+
+  return {
+    id: experiment.id,
+    slug: experiment.slug,
+    name: experiment.name,
+    status: experiment.status,
+    exportPolicy: experiment.exportPolicy,
+    agreementReference: experiment.agreementReference,
+    startsAt: experiment.startsAt,
+    endedAt: experiment.endedAt,
+    retentionDeleteAt: experiment.retentionDeleteAt,
+    organization: experiment.organization,
+    variants: experiment.variants.map((variant) => {
+      const outcomes = emptyOutcomes();
+      const prompts = new Map<string, StealthBreakdown>();
+      const opponents = new Map<string, StealthBreakdown>();
+      let sideA = 0;
+      let sideB = 0;
+      for (const row of rowsByVariant.get(variant.id) ?? []) {
+        const count = toNumber(row.votes);
+        addOutcome(outcomes, row, count);
+        appendBreakdown(prompts, row.promptId, row.promptText, row, count);
+        appendBreakdown(
+          opponents,
+          row.opponentKey,
+          resolveModelDisplayName(row.opponentKey, row.opponentDisplayName),
+          row,
+          count,
+        );
+        if (row.variantSide === "A") sideA += count;
+        else sideB += count;
+      }
+      const finalizedPrompts = Array.from(prompts.values())
+        .map(finalizeOutcomes)
+        .sort((a, b) => b.votes - a.votes || a.label.localeCompare(b.label));
+      const promptScores = finalizedPrompts
+        .map((prompt) => prompt.averageScore)
+        .filter((score): score is number => score != null);
+      const totalSides = sideA + sideB;
+      const finalizedOutcomes = finalizeOutcomes(outcomes);
+      const rank = publicModels.filter(
+        (model) => model.conservativeRating > variant.conservativeRating,
+      ).length + 1;
+      const latestGenerationRun = variant.generationRuns[0] ?? null;
+      return {
+        id: variant.id,
+        codename: variant.codename,
+        status: variant.status,
+        generatedBuildCount: variant.generatedBuildCount,
+        expectedBuildCount: variant.expectedBuildCount,
+        cohortGeneratedAt: variant.cohortGeneratedAt,
+        releasedModelKey: variant.releasedModel?.key ?? null,
+        rating: variant.eloRating,
+        conservativeRating: variant.conservativeRating,
+        ratingDeviation: variant.glickoRd,
+        confidence: confidenceFromRd(variant.glickoRd),
+        stability: stabilityTier({
+          decisiveVotes: finalizedOutcomes.decisiveVotes,
+          promptCoverage:
+            finalizedPrompts.filter((prompt) => prompt.decisiveVotes > 0).length /
+            Math.max(1, variant.expectedBuildCount),
+          rd: variant.glickoRd,
+        }),
+        estimatedFieldRank: rank,
+        estimatedFieldSize: publicModels.length + 1,
+        targetDecisiveVotes: experiment.targetDecisiveVotes,
+        progress: Math.min(
+          1,
+          finalizedOutcomes.decisiveVotes / Math.max(1, experiment.targetDecisiveVotes),
+        ),
+        pendingVotes: variant._count.voteJobs,
+        sideA,
+        sideB,
+        sideBalance: totalSides > 0 ? Math.min(sideA, sideB) / totalSides : null,
+        promptScoreSpread:
+          promptScores.length > 1 ? Math.max(...promptScores) - Math.min(...promptScores) : null,
+        outcomes: finalizedOutcomes,
+        prompts: finalizedPrompts,
+        opponents: Array.from(opponents.values())
+          .map(finalizeOutcomes)
+          .sort((a, b) => b.votes - a.votes || a.label.localeCompare(b.label)),
+        latestGenerationRun,
+      };
+    }),
+  };
+}
+
+export type DeidentifiedStealthVote = {
+  day: string;
+  codename: string;
+  prompt: string;
+  opponent: string;
+  variantSide: "A" | "B";
+  choice: "WIN" | "LOSS" | "TIE" | "BOTH_BAD";
+};
+
+type ExportRow = Omit<DeidentifiedStealthVote, "choice"> & {
+  rawChoice: "A" | "B" | "TIE" | "BOTH_BAD";
+};
+
+export async function getDeidentifiedStealthVotes(
+  experimentId: string,
+): Promise<DeidentifiedStealthVote[]> {
+  const rows = await prisma.$queryRaw<ExportRow[]>(Prisma.sql`
+    SELECT
+      TO_CHAR(vote."createdAt" AT TIME ZONE 'UTC', 'YYYY-MM-DD') AS day,
+      variant.codename AS codename,
+      prompt.text AS prompt,
+      opponent."displayName" AS opponent,
+      CASE WHEN matchup."modelAId" = variant."modelId" THEN 'A' ELSE 'B' END AS "variantSide",
+      vote.choice AS "rawChoice"
+    FROM "Vote" vote
+    INNER JOIN "Matchup" matchup ON matchup.id = vote."matchupId"
+    INNER JOIN "StealthVariant" variant ON variant.id = matchup."stealthVariantId"
+    INNER JOIN "Prompt" prompt ON prompt.id = matchup."promptId"
+    INNER JOIN "Model" opponent ON opponent.id = CASE
+      WHEN matchup."modelAId" = variant."modelId" THEN matchup."modelBId"
+      ELSE matchup."modelAId"
+    END
+    WHERE variant."experimentId" = ${experimentId}
+    ORDER BY vote."createdAt" ASC
+  `);
+  return rows.map((row) => ({
+    day: row.day,
+    codename: row.codename,
+    prompt: row.prompt,
+    opponent: row.opponent,
+    variantSide: row.variantSide,
+    choice:
+      row.rawChoice === "BOTH_BAD"
+        ? "BOTH_BAD"
+        : row.rawChoice === "TIE"
+          ? "TIE"
+          : row.rawChoice === row.variantSide
+            ? "WIN"
+            : "LOSS",
+  }));
+}
+
+function csvCell(value: string): string {
+  return /[",\r\n]/.test(value) ? `"${value.replaceAll('"', '""')}"` : value;
+}
+
+export function serializeDeidentifiedStealthVotes(rows: DeidentifiedStealthVote[]): string {
+  const lines = ["date,codename,prompt,opponent,variant_side,outcome"];
+  for (const row of rows) {
+    lines.push(
+      [row.day, row.codename, row.prompt, row.opponent, row.variantSide, row.choice]
+        .map(csvCell)
+        .join(","),
+    );
+  }
+  return `${lines.join("\n")}\n`;
+}

--- a/lib/stealth/sampling.ts
+++ b/lib/stealth/sampling.ts
@@ -1,0 +1,231 @@
+import { Prisma } from "@prisma/client";
+import type {
+  ArenaMatchupSamplingState,
+  EligibleBuildMeta,
+  EligibleModel,
+  EligiblePrompt,
+} from "@/lib/arena/coverage";
+import { weightedPick } from "@/lib/arena/sampling";
+import { prisma } from "@/lib/prisma";
+import { ACTIVE_STEALTH_EXPERIMENT_STATUSES } from "@/lib/stealth/policy";
+
+const CACHE_TTL_MS = 15_000;
+const ARENA_GRID_SIZE = 256;
+const ARENA_PALETTE = "simple";
+const ARENA_MODE = "precise";
+
+type VariantSnapshot = {
+  id: string;
+  targetDecisiveVotes: number;
+  model: EligibleModel;
+  buildsByPromptId: Map<string, EligibleBuildMeta>;
+  promptVotes: Map<string, number>;
+  opponentVotes: Map<string, number>;
+  decisiveVotes: number;
+};
+
+type StealthSamplingSnapshot = {
+  variants: VariantSnapshot[];
+};
+
+export type StealthMatchupSelection = {
+  prompt: EligiblePrompt;
+  stealthVariantId: string;
+  stealthModel: EligibleModel;
+  stealthBuild: EligibleBuildMeta;
+  publicModel: EligibleModel;
+};
+
+type OpponentCountRow = {
+  stealthVariantId: string;
+  publicModelId: string;
+  votes: number | bigint | string;
+};
+
+let cachedSnapshot: { expiresAt: number; value: StealthSamplingSnapshot } | null = null;
+let snapshotInFlight: Promise<StealthSamplingSnapshot> | null = null;
+
+function toNumber(value: number | bigint | string): number {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+async function querySnapshot(): Promise<StealthSamplingSnapshot> {
+  const variants = await prisma.stealthVariant.findMany({
+    where: {
+      status: "ACTIVE",
+      experiment: { status: { in: [...ACTIVE_STEALTH_EXPERIMENT_STATUSES] } },
+      model: { enabled: true },
+    },
+    select: {
+      id: true,
+      codename: true,
+      eloRating: true,
+      conservativeRating: true,
+      glickoRd: true,
+      shownCount: true,
+      winCount: true,
+      lossCount: true,
+      experiment: { select: { targetDecisiveVotes: true } },
+      model: {
+        select: {
+          id: true,
+          key: true,
+          builds: {
+            where: {
+              gridSize: ARENA_GRID_SIZE,
+              palette: ARENA_PALETTE,
+              mode: ARENA_MODE,
+              prompt: { active: true },
+            },
+            select: {
+              id: true,
+              promptId: true,
+              gridSize: true,
+              palette: true,
+              blockCount: true,
+              voxelByteSize: true,
+              voxelCompressedByteSize: true,
+              voxelSha256: true,
+              arenaBuildHints: true,
+            },
+          },
+        },
+      },
+    },
+  });
+
+  if (variants.length === 0) return { variants: [] };
+  const variantIds = variants.map((variant) => variant.id);
+  const [promptCounts, opponentCounts] = await Promise.all([
+    prisma.matchup.groupBy({
+      by: ["stealthVariantId", "promptId"],
+      where: { stealthVariantId: { in: variantIds } },
+      _count: { _all: true },
+    }),
+    prisma.$queryRaw<OpponentCountRow[]>(Prisma.sql`
+      SELECT
+        matchup."stealthVariantId" AS "stealthVariantId",
+        CASE
+          WHEN matchup."modelAId" = variant."modelId" THEN matchup."modelBId"
+          ELSE matchup."modelAId"
+        END AS "publicModelId",
+        COUNT(*)::int AS votes
+      FROM "Matchup" matchup
+      INNER JOIN "StealthVariant" variant ON variant.id = matchup."stealthVariantId"
+      WHERE matchup."stealthVariantId" IN (${Prisma.join(variantIds)})
+      GROUP BY matchup."stealthVariantId", "publicModelId"
+    `),
+  ]);
+
+  const promptVotesByVariant = new Map<string, Map<string, number>>();
+  for (const row of promptCounts) {
+    if (!row.stealthVariantId) continue;
+    const counts = promptVotesByVariant.get(row.stealthVariantId) ?? new Map<string, number>();
+    counts.set(row.promptId, row._count._all);
+    promptVotesByVariant.set(row.stealthVariantId, counts);
+  }
+  const opponentVotesByVariant = new Map<string, Map<string, number>>();
+  for (const row of opponentCounts) {
+    const counts = opponentVotesByVariant.get(row.stealthVariantId) ?? new Map<string, number>();
+    counts.set(row.publicModelId, toNumber(row.votes));
+    opponentVotesByVariant.set(row.stealthVariantId, counts);
+  }
+
+  return {
+    variants: variants.map((variant) => ({
+      id: variant.id,
+      targetDecisiveVotes: variant.experiment.targetDecisiveVotes,
+      model: {
+        id: variant.model.id,
+        key: variant.model.key,
+        provider: "Stealth",
+        displayName: variant.codename,
+        eloRating: Number(variant.eloRating),
+        conservativeRating: Number(variant.conservativeRating),
+        ratingDeviation: Number(variant.glickoRd),
+        shownCount: variant.shownCount,
+      },
+      buildsByPromptId: new Map(
+        variant.model.builds.map(({ promptId, ...build }) => [promptId, build]),
+      ),
+      promptVotes: promptVotesByVariant.get(variant.id) ?? new Map(),
+      opponentVotes: opponentVotesByVariant.get(variant.id) ?? new Map(),
+      decisiveVotes: variant.winCount + variant.lossCount,
+    })),
+  };
+}
+
+async function getSnapshot(): Promise<StealthSamplingSnapshot> {
+  if (cachedSnapshot && cachedSnapshot.expiresAt > Date.now()) return cachedSnapshot.value;
+  snapshotInFlight ??= querySnapshot()
+    .then((value) => {
+      cachedSnapshot = { expiresAt: Date.now() + CACHE_TTL_MS, value };
+      return value;
+    })
+    .finally(() => {
+      snapshotInFlight = null;
+    });
+  return snapshotInFlight;
+}
+
+export function invalidateStealthSamplingCache(): void {
+  cachedSnapshot = null;
+  snapshotInFlight = null;
+}
+
+export async function pickStealthMatchup(params: {
+  publicState: ArenaMatchupSamplingState;
+  forcedPromptId?: string;
+}): Promise<StealthMatchupSelection | null> {
+  const snapshot = await getSnapshot();
+  const promptById = new Map(params.publicState.prompts.map((prompt) => [prompt.id, prompt]));
+  const candidates = snapshot.variants.filter((variant) => {
+    if (params.forcedPromptId) return variant.buildsByPromptId.has(params.forcedPromptId);
+    return Array.from(variant.buildsByPromptId.keys()).some((promptId) => promptById.has(promptId));
+  });
+  const variant = weightedPick(candidates, (candidate) => {
+    const remaining = Math.max(1, candidate.targetDecisiveVotes - candidate.decisiveVotes);
+    return remaining / Math.max(1, candidate.model.shownCount + 1);
+  });
+  if (!variant) return null;
+
+  const prompts = Array.from(variant.buildsByPromptId.keys())
+    .filter((promptId) => !params.forcedPromptId || promptId === params.forcedPromptId)
+    .map((promptId) => promptById.get(promptId) ?? null)
+    .filter((prompt): prompt is EligiblePrompt => prompt != null && prompt.modelIds.length > 0);
+  const prompt = weightedPick(prompts, (candidate) => 1 / ((variant.promptVotes.get(candidate.id) ?? 0) + 1));
+  if (!prompt) return null;
+
+  const publicModels = prompt.modelIds
+    .map((modelId) => params.publicState.modelsById.get(modelId) ?? null)
+    .filter((model): model is EligibleModel => model != null);
+  const publicModel = weightedPick(publicModels, (candidate) => {
+    const pairVotes = variant.opponentVotes.get(candidate.id) ?? 0;
+    const ratingDistance = Math.abs(candidate.eloRating - variant.model.eloRating);
+    return (1 / (pairVotes + 1)) * (1 / (1 + ratingDistance / 400));
+  });
+  const stealthBuild = variant.buildsByPromptId.get(prompt.id) ?? null;
+  if (!publicModel || !stealthBuild) return null;
+
+  const stillActive = await prisma.stealthVariant.count({
+    where: {
+      id: variant.id,
+      status: "ACTIVE",
+      experiment: { status: { in: [...ACTIVE_STEALTH_EXPERIMENT_STATUSES] } },
+      model: { enabled: true },
+    },
+  });
+  if (stillActive === 0) {
+    invalidateStealthSamplingCache();
+    return null;
+  }
+
+  return {
+    prompt,
+    stealthVariantId: variant.id,
+    stealthModel: variant.model,
+    stealthBuild,
+    publicModel,
+  };
+}

--- a/lib/supabase/admin.ts
+++ b/lib/supabase/admin.ts
@@ -1,0 +1,13 @@
+import { createClient } from "@supabase/supabase-js";
+import { getSupabasePublicConfig, getSupabaseSecretKey } from "@/lib/supabase/config";
+
+export function createSupabaseAdminClient() {
+  const config = getSupabasePublicConfig();
+  return createClient(config.url, getSupabaseSecretKey(), {
+    auth: {
+      autoRefreshToken: false,
+      persistSession: false,
+      detectSessionInUrl: false,
+    },
+  });
+}

--- a/lib/supabase/config.ts
+++ b/lib/supabase/config.ts
@@ -1,0 +1,27 @@
+export type SupabasePublicConfig = {
+  url: string;
+  publishableKey: string;
+};
+
+export function getSupabasePublicConfig(): SupabasePublicConfig {
+  const url = (process.env.NEXT_PUBLIC_SUPABASE_URL ?? process.env.SUPABASE_URL ?? "").trim();
+  const publishableKey = (process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY ?? "").trim();
+  if (!url || !publishableKey) {
+    throw new Error(
+      "Lab authentication requires NEXT_PUBLIC_SUPABASE_URL and NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY",
+    );
+  }
+  return { url: url.replace(/\/+$/, ""), publishableKey };
+}
+
+export function getSupabaseSecretKey(): string {
+  const key = (
+    process.env.SUPABASE_SECRET_KEY ??
+    process.env.SUPABASE_SERVICE_ROLE_KEY ??
+    ""
+  ).trim();
+  if (!key) {
+    throw new Error("Supabase admin operations require SUPABASE_SECRET_KEY or SUPABASE_SERVICE_ROLE_KEY");
+  }
+  return key;
+}

--- a/lib/supabase/middleware.ts
+++ b/lib/supabase/middleware.ts
@@ -1,0 +1,35 @@
+import { createServerClient } from "@supabase/ssr";
+import { NextRequest, NextResponse } from "next/server";
+import { getSupabasePublicConfig } from "@/lib/supabase/config";
+
+export async function refreshSupabaseSession(request: NextRequest): Promise<NextResponse> {
+  let config: ReturnType<typeof getSupabasePublicConfig>;
+  try {
+    config = getSupabasePublicConfig();
+  } catch {
+    return NextResponse.next({ request });
+  }
+
+  let response = NextResponse.next({ request });
+  const supabase = createServerClient(config.url, config.publishableKey, {
+    cookies: {
+      getAll: () => request.cookies.getAll(),
+      setAll: (cookiesToSet, headers) => {
+        for (const { name, value } of cookiesToSet) {
+          request.cookies.set(name, value);
+        }
+        response = NextResponse.next({ request });
+        for (const { name, value, options } of cookiesToSet) {
+          response.cookies.set(name, value, options);
+        }
+        for (const [name, value] of Object.entries(headers)) {
+          response.headers.set(name, value);
+        }
+      },
+    },
+  });
+
+  await supabase.auth.getClaims();
+  response.headers.set("Cache-Control", "private, no-store");
+  return response;
+}

--- a/lib/supabase/server.ts
+++ b/lib/supabase/server.ts
@@ -1,0 +1,23 @@
+import { createServerClient } from "@supabase/ssr";
+import { cookies } from "next/headers";
+import { getSupabasePublicConfig } from "@/lib/supabase/config";
+
+export async function createSupabaseServerClient() {
+  const config = getSupabasePublicConfig();
+  const cookieStore = await cookies();
+
+  return createServerClient(config.url, config.publishableKey, {
+    cookies: {
+      getAll: () => cookieStore.getAll(),
+      setAll: (cookiesToSet) => {
+        try {
+          for (const { name, value, options } of cookiesToSet) {
+            cookieStore.set(name, value, options);
+          }
+        } catch {
+          // Server Components cannot write cookies; middleware refreshes them
+        }
+      },
+    },
+  });
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -193,11 +193,15 @@ function getRateLimitSession(req: NextRequest, fallbackBucketId: string) {
   };
 }
 
-export function middleware(req: NextRequest) {
+export async function middleware(req: NextRequest) {
   const canonicalRedirect = maybeRedirectToCanonicalHost(req);
   if (canonicalRedirect) return canonicalRedirect;
 
   const { pathname } = req.nextUrl;
+  if (pathname.startsWith("/lab") || pathname.startsWith("/api/lab/")) {
+    const { refreshSupabaseSession } = await import("@/lib/supabase/middleware");
+    return refreshSupabaseSession(req);
+  }
   if (!pathname.startsWith("/api/")) return NextResponse.next();
   if (pathname.startsWith("/api/admin/")) return NextResponse.next();
   const isArenaApi = pathname.startsWith("/api/arena/");

--- a/package.json
+++ b/package.json
@@ -55,10 +55,13 @@
     "staging:storage:sync": "node scripts/sync-staging-storage.mjs",
     "staging:run": "node scripts/with-staging-env.mjs",
     "staging:publish": "node scripts/with-staging-env.mjs tsx scripts/model-publish.ts",
-    "staging:prisma:migrate": "node scripts/with-staging-env.mjs prisma migrate deploy"
+    "staging:prisma:migrate": "node scripts/with-staging-env.mjs prisma migrate deploy",
+    "stealth:eval": "tsx scripts/stealth-eval.ts"
   },
   "dependencies": {
     "@prisma/client": "^6.0.0",
+    "@supabase/ssr": "0.12.4",
+    "@supabase/supabase-js": "2.112.3",
     "@vercel/analytics": "^1.6.1",
     "fflate": "^0.8.3",
     "gifenc": "^1.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,12 @@ importers:
       '@prisma/client':
         specifier: ^6.0.0
         version: 6.19.1(prisma@6.19.1(typescript@5.9.3))(typescript@5.9.3)
+      '@supabase/ssr':
+        specifier: 0.12.4
+        version: 0.12.4(@supabase/supabase-js@2.112.3)
+      '@supabase/supabase-js':
+        specifier: 2.112.3
+        version: 2.112.3
       '@vercel/analytics':
         specifier: ^1.6.1
         version: 1.6.1(next@15.5.9(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)
@@ -569,6 +575,43 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
+  '@supabase/auth-js@2.112.3':
+    resolution: {integrity: sha512-NA0rsgAlWZPvbhw8aUdmgfpHVgUAcd8zK5ov43l++o1bLIPXZhRiAlRobhwF5AatQuovpqxsMH50F4oyyV4XZw==}
+    engines: {node: '>=22.0.0'}
+
+  '@supabase/functions-js@2.112.3':
+    resolution: {integrity: sha512-gfv481mTOVWtZIJgXupxZpni2V2UWPf6jeF/jOK7HdMHdH+mt6sU0sHHwf0POsPip8ltlulu9OUHgwVzl5ddRw==}
+    engines: {node: '>=22.0.0'}
+
+  '@supabase/phoenix@0.4.5':
+    resolution: {integrity: sha512-aAn9H9ovVyeApKy11OWOrrOGq8DV68yWeH4ud2lN9fzn4aO8Zb5GLL9m1pUg9nLqIcT+ZDfAcsZe0E/nqdv2lw==}
+
+  '@supabase/postgrest-js@2.112.3':
+    resolution: {integrity: sha512-+Mf6uCpzr00bqxwX8hTK2X2L9eAL/1vuOjdEjx6upz9ulb0RmQT16XeU/JkMUlVHw/B46ZnPa2busY4Kd9YCzw==}
+    engines: {node: '>=22.0.0'}
+
+  '@supabase/realtime-js@2.112.3':
+    resolution: {integrity: sha512-E6wljXWs7DUOloyIB69i3YFInWE6IyCvgTAbQ0KYxOHv26FdA1KzEXTuzxrYEdf70t406Z9BRwUlGyclGF2FXA==}
+    engines: {node: '>=22.0.0'}
+
+  '@supabase/ssr@0.12.4':
+    resolution: {integrity: sha512-xHzcgI8cC1TpBKSwJcR5Yd8CCwfIq0SBc5yb4yz/YFw5tbCrEQ0QT3a+2jymCxHgQWLfzwN93HZ6eRbcoMkOlA==}
+    peerDependencies:
+      '@supabase/supabase-js': ^2.111.0
+
+  '@supabase/storage-js@2.112.3':
+    resolution: {integrity: sha512-oSK61tzlUvg+BWPqpKQCu9qqonsO26btaoAR9D6Gest2aj7xUqToj9rKyaoYOJczkhg9BjqA1REbYy9tPI4bDA==}
+    engines: {node: '>=22.0.0'}
+
+  '@supabase/supabase-js@2.112.3':
+    resolution: {integrity: sha512-Jv1bxVQmEJNkjvPEhFaKjPzsh+Ozyew6lWGD+SoYcsclDEP1z7yEvKvfUQfzy0DkxRIQnZNxmmWtAzw5XLTQoA==}
+    engines: {node: '>=22.0.0'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0'
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
+
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
 
@@ -961,6 +1004,10 @@ packages:
   consola@3.4.2:
     resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
     engines: {node: ^14.18.0 || >=16.10.0}
+
+  cookie@1.1.1:
+    resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
+    engines: {node: '>=18'}
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -1368,6 +1415,10 @@ packages:
   hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
+
+  iceberg-js@0.8.1:
+    resolution: {integrity: sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==}
+    engines: {node: '>=20.0.0'}
 
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
@@ -2498,6 +2549,43 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
+  '@supabase/auth-js@2.112.3':
+    dependencies:
+      tslib: 2.8.1
+
+  '@supabase/functions-js@2.112.3':
+    dependencies:
+      tslib: 2.8.1
+
+  '@supabase/phoenix@0.4.5': {}
+
+  '@supabase/postgrest-js@2.112.3':
+    dependencies:
+      tslib: 2.8.1
+
+  '@supabase/realtime-js@2.112.3':
+    dependencies:
+      '@supabase/phoenix': 0.4.5
+      tslib: 2.8.1
+
+  '@supabase/ssr@0.12.4(@supabase/supabase-js@2.112.3)':
+    dependencies:
+      '@supabase/supabase-js': 2.112.3
+      cookie: 1.1.1
+
+  '@supabase/storage-js@2.112.3':
+    dependencies:
+      iceberg-js: 0.8.1
+      tslib: 2.8.1
+
+  '@supabase/supabase-js@2.112.3':
+    dependencies:
+      '@supabase/auth-js': 2.112.3
+      '@supabase/functions-js': 2.112.3
+      '@supabase/postgrest-js': 2.112.3
+      '@supabase/realtime-js': 2.112.3
+      '@supabase/storage-js': 2.112.3
+
   '@swc/helpers@0.5.15':
     dependencies:
       tslib: 2.8.1
@@ -2906,6 +2994,8 @@ snapshots:
   confbox@0.2.2: {}
 
   consola@3.4.2: {}
+
+  cookie@1.1.1: {}
 
   cross-spawn@7.0.6:
     dependencies:
@@ -3479,6 +3569,8 @@ snapshots:
   hasown@2.0.2:
     dependencies:
       function-bind: 1.1.2
+
+  iceberg-js@0.8.1: {}
 
   ignore@5.3.2: {}
 

--- a/prisma/migrations/20260821060000_stealth_evaluations/migration.sql
+++ b/prisma/migrations/20260821060000_stealth_evaluations/migration.sql
@@ -1,0 +1,436 @@
+-- CreateEnum
+CREATE TYPE "OrganizationRole" AS ENUM ('OWNER', 'ADMIN', 'ANALYST', 'VIEWER');
+
+-- CreateEnum
+CREATE TYPE "StealthExportPolicy" AS ENUM ('AGGREGATES_ONLY', 'DEIDENTIFIED_VOTES');
+
+-- CreateEnum
+CREATE TYPE "StealthExperimentStatus" AS ENUM ('DRAFT', 'VALIDATING', 'GENERATING', 'READY', 'ACTIVE', 'PAUSED', 'STABLE', 'DEGRADED', 'WITHDRAWN', 'CLOSED', 'RELEASED');
+
+-- CreateEnum
+CREATE TYPE "StealthVariantStatus" AS ENUM ('DRAFT', 'VALIDATING', 'GENERATING', 'READY', 'ACTIVE', 'DEGRADED', 'WITHDRAWN', 'RELEASED');
+
+-- CreateEnum
+CREATE TYPE "StealthGenerationRunStatus" AS ENUM ('RUNNING', 'SUCCEEDED', 'PARTIAL', 'FAILED');
+
+-- CreateEnum
+CREATE TYPE "StealthGenerationResultStatus" AS ENUM ('SUCCEEDED', 'FAILED');
+
+-- AlterTable
+ALTER TABLE "ArenaVoteJob" ADD COLUMN     "stealthVariantId" TEXT;
+
+-- AlterTable
+ALTER TABLE "Matchup" ADD COLUMN     "stealthVariantId" TEXT;
+
+-- CreateTable
+CREATE TABLE "User" (
+    "id" UUID NOT NULL,
+    "email" TEXT NOT NULL,
+    "displayName" TEXT,
+    "lastSeenAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "User_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Organization" (
+    "id" TEXT NOT NULL,
+    "slug" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Organization_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "OrganizationMembership" (
+    "organizationId" TEXT NOT NULL,
+    "userId" UUID NOT NULL,
+    "role" "OrganizationRole" NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "OrganizationMembership_pkey" PRIMARY KEY ("organizationId","userId")
+);
+
+-- CreateTable
+CREATE TABLE "OrganizationInvitation" (
+    "id" TEXT NOT NULL,
+    "organizationId" TEXT NOT NULL,
+    "email" TEXT NOT NULL,
+    "role" "OrganizationRole" NOT NULL,
+    "authUserId" UUID,
+    "acceptedById" UUID,
+    "acceptedAt" TIMESTAMP(3),
+    "revokedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "OrganizationInvitation_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "StealthExperiment" (
+    "id" TEXT NOT NULL,
+    "organizationId" TEXT NOT NULL,
+    "slug" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "status" "StealthExperimentStatus" NOT NULL DEFAULT 'DRAFT',
+    "exportPolicy" "StealthExportPolicy" NOT NULL DEFAULT 'AGGREGATES_ONLY',
+    "targetDecisiveVotes" INTEGER NOT NULL DEFAULT 1000,
+    "agreementReference" TEXT,
+    "startsAt" TIMESTAMP(3),
+    "endedAt" TIMESTAMP(3),
+    "retentionDeleteAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "StealthExperiment_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "StealthVariant" (
+    "id" TEXT NOT NULL,
+    "experimentId" TEXT NOT NULL,
+    "codename" TEXT NOT NULL,
+    "status" "StealthVariantStatus" NOT NULL DEFAULT 'DRAFT',
+    "modelId" TEXT NOT NULL,
+    "releasedModelId" TEXT,
+    "checkpointFingerprint" TEXT,
+    "endpointEnabled" BOOLEAN NOT NULL DEFAULT false,
+    "lastValidatedAt" TIMESTAMP(3),
+    "cohortGeneratedAt" TIMESTAMP(3),
+    "releasedAt" TIMESTAMP(3),
+    "expectedBuildCount" INTEGER NOT NULL DEFAULT 0,
+    "generatedBuildCount" INTEGER NOT NULL DEFAULT 0,
+    "generationFailureCount" INTEGER NOT NULL DEFAULT 0,
+    "lastGenerationError" TEXT,
+    "eloRating" DOUBLE PRECISION NOT NULL DEFAULT 1500,
+    "glickoRd" DOUBLE PRECISION NOT NULL DEFAULT 350,
+    "glickoVolatility" DOUBLE PRECISION NOT NULL DEFAULT 0.06,
+    "conservativeRating" DOUBLE PRECISION NOT NULL DEFAULT 800,
+    "shownCount" INTEGER NOT NULL DEFAULT 0,
+    "winCount" INTEGER NOT NULL DEFAULT 0,
+    "lossCount" INTEGER NOT NULL DEFAULT 0,
+    "drawCount" INTEGER NOT NULL DEFAULT 0,
+    "bothBadCount" INTEGER NOT NULL DEFAULT 0,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "StealthVariant_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "StealthEndpointCredential" (
+    "id" TEXT NOT NULL,
+    "variantId" TEXT NOT NULL,
+    "encryptedConfig" TEXT NOT NULL,
+    "fingerprint" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "StealthEndpointCredential_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "StealthGenerationRun" (
+    "id" TEXT NOT NULL,
+    "variantId" TEXT NOT NULL,
+    "status" "StealthGenerationRunStatus" NOT NULL DEFAULT 'RUNNING',
+    "promptCohortId" TEXT NOT NULL,
+    "configuration" JSONB NOT NULL,
+    "expectedBuildCount" INTEGER NOT NULL,
+    "completedBuildCount" INTEGER NOT NULL DEFAULT 0,
+    "failedBuildCount" INTEGER NOT NULL DEFAULT 0,
+    "providerCallCount" INTEGER NOT NULL DEFAULT 0,
+    "retryCount" INTEGER NOT NULL DEFAULT 0,
+    "startedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "completedAt" TIMESTAMP(3),
+    "error" TEXT,
+
+    CONSTRAINT "StealthGenerationRun_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "StealthGenerationResult" (
+    "id" TEXT NOT NULL,
+    "runId" TEXT NOT NULL,
+    "promptId" TEXT NOT NULL,
+    "buildId" TEXT,
+    "status" "StealthGenerationResultStatus" NOT NULL,
+    "attempts" INTEGER NOT NULL,
+    "generationTimeMs" INTEGER NOT NULL,
+    "requestConfiguration" TEXT,
+    "error" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "StealthGenerationResult_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "User_email_key" ON "User"("email");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Organization_slug_key" ON "Organization"("slug");
+
+-- CreateIndex
+CREATE INDEX "OrganizationMembership_userId_idx" ON "OrganizationMembership"("userId");
+
+-- CreateIndex
+CREATE INDEX "OrganizationInvitation_authUserId_idx" ON "OrganizationInvitation"("authUserId");
+
+-- CreateIndex
+CREATE INDEX "OrganizationInvitation_acceptedById_idx" ON "OrganizationInvitation"("acceptedById");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "OrganizationInvitation_organizationId_email_key" ON "OrganizationInvitation"("organizationId", "email");
+
+-- CreateIndex
+CREATE INDEX "StealthExperiment_organizationId_status_idx" ON "StealthExperiment"("organizationId", "status");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "StealthExperiment_organizationId_slug_key" ON "StealthExperiment"("organizationId", "slug");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "StealthVariant_modelId_key" ON "StealthVariant"("modelId");
+
+-- CreateIndex
+CREATE INDEX "StealthVariant_experimentId_status_idx" ON "StealthVariant"("experimentId", "status");
+
+-- CreateIndex
+CREATE INDEX "StealthVariant_releasedModelId_idx" ON "StealthVariant"("releasedModelId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "StealthVariant_experimentId_codename_key" ON "StealthVariant"("experimentId", "codename");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "StealthEndpointCredential_variantId_key" ON "StealthEndpointCredential"("variantId");
+
+-- CreateIndex
+CREATE INDEX "StealthGenerationRun_variantId_startedAt_idx" ON "StealthGenerationRun"("variantId", "startedAt");
+
+-- CreateIndex
+CREATE INDEX "StealthGenerationResult_promptId_idx" ON "StealthGenerationResult"("promptId");
+
+-- CreateIndex
+CREATE INDEX "StealthGenerationResult_buildId_idx" ON "StealthGenerationResult"("buildId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "StealthGenerationResult_runId_promptId_key" ON "StealthGenerationResult"("runId", "promptId");
+
+-- CreateIndex
+CREATE INDEX "ArenaVoteJob_stealthVariantId_processedAt_idx" ON "ArenaVoteJob"("stealthVariantId", "processedAt");
+
+-- CreateIndex
+CREATE INDEX "Matchup_stealthVariantId_createdAt_idx" ON "Matchup"("stealthVariantId", "createdAt");
+
+-- AddForeignKey
+ALTER TABLE "OrganizationMembership" ADD CONSTRAINT "OrganizationMembership_organizationId_fkey" FOREIGN KEY ("organizationId") REFERENCES "Organization"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "OrganizationMembership" ADD CONSTRAINT "OrganizationMembership_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "OrganizationInvitation" ADD CONSTRAINT "OrganizationInvitation_organizationId_fkey" FOREIGN KEY ("organizationId") REFERENCES "Organization"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "OrganizationInvitation" ADD CONSTRAINT "OrganizationInvitation_acceptedById_fkey" FOREIGN KEY ("acceptedById") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "StealthExperiment" ADD CONSTRAINT "StealthExperiment_organizationId_fkey" FOREIGN KEY ("organizationId") REFERENCES "Organization"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "StealthVariant" ADD CONSTRAINT "StealthVariant_experimentId_fkey" FOREIGN KEY ("experimentId") REFERENCES "StealthExperiment"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "StealthVariant" ADD CONSTRAINT "StealthVariant_modelId_fkey" FOREIGN KEY ("modelId") REFERENCES "Model"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "StealthVariant" ADD CONSTRAINT "StealthVariant_releasedModelId_fkey" FOREIGN KEY ("releasedModelId") REFERENCES "Model"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "StealthEndpointCredential" ADD CONSTRAINT "StealthEndpointCredential_variantId_fkey" FOREIGN KEY ("variantId") REFERENCES "StealthVariant"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "StealthGenerationRun" ADD CONSTRAINT "StealthGenerationRun_variantId_fkey" FOREIGN KEY ("variantId") REFERENCES "StealthVariant"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "StealthGenerationResult" ADD CONSTRAINT "StealthGenerationResult_runId_fkey" FOREIGN KEY ("runId") REFERENCES "StealthGenerationRun"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "StealthGenerationResult" ADD CONSTRAINT "StealthGenerationResult_promptId_fkey" FOREIGN KEY ("promptId") REFERENCES "Prompt"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "StealthGenerationResult" ADD CONSTRAINT "StealthGenerationResult_buildId_fkey" FOREIGN KEY ("buildId") REFERENCES "Build"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Matchup" ADD CONSTRAINT "Matchup_stealthVariantId_fkey" FOREIGN KEY ("stealthVariantId") REFERENCES "StealthVariant"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ArenaVoteJob" ADD CONSTRAINT "ArenaVoteJob_stealthVariantId_fkey" FOREIGN KEY ("stealthVariantId") REFERENCES "StealthVariant"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- Guard lifecycle and aggregate fields even when writes bypass Prisma
+ALTER TABLE "StealthExperiment"
+  ADD CONSTRAINT "StealthExperiment_targetDecisiveVotes_check"
+  CHECK ("targetDecisiveVotes" > 0);
+
+ALTER TABLE "StealthVariant"
+  ADD CONSTRAINT "StealthVariant_counts_check"
+  CHECK (
+    "expectedBuildCount" >= 0 AND
+    "generatedBuildCount" >= 0 AND
+    "generationFailureCount" >= 0 AND
+    "shownCount" >= 0 AND
+    "winCount" >= 0 AND
+    "lossCount" >= 0 AND
+    "drawCount" >= 0 AND
+    "bothBadCount" >= 0
+  );
+
+ALTER TABLE "StealthGenerationRun"
+  ADD CONSTRAINT "StealthGenerationRun_counts_check"
+  CHECK (
+    "expectedBuildCount" > 0 AND
+    "completedBuildCount" >= 0 AND
+    "failedBuildCount" >= 0 AND
+    "providerCallCount" >= 0 AND
+    "retryCount" >= 0
+  );
+
+ALTER TABLE "StealthGenerationResult"
+  ADD CONSTRAINT "StealthGenerationResult_metrics_check"
+  CHECK ("attempts" >= 0 AND "generationTimeMs" >= 0);
+
+-- Lab data is readable only by authenticated members of its organization
+-- Endpoint credentials intentionally have no readable client policy
+ALTER TABLE "User" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "Organization" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "OrganizationMembership" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "OrganizationInvitation" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "StealthExperiment" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "StealthVariant" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "StealthEndpointCredential" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "StealthGenerationRun" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "StealthGenerationResult" ENABLE ROW LEVEL SECURITY;
+
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'authenticated') THEN
+    GRANT USAGE ON TYPE
+      "OrganizationRole",
+      "StealthExportPolicy",
+      "StealthExperimentStatus",
+      "StealthVariantStatus",
+      "StealthGenerationRunStatus",
+      "StealthGenerationResultStatus"
+    TO authenticated;
+
+    GRANT SELECT ON
+      "User",
+      "Organization",
+      "OrganizationMembership",
+      "OrganizationInvitation",
+      "StealthExperiment",
+      "StealthVariant",
+      "StealthGenerationRun",
+      "StealthGenerationResult"
+    TO authenticated;
+
+    REVOKE ALL ON "StealthEndpointCredential" FROM authenticated;
+
+    CREATE POLICY "lab_user_self_select"
+      ON "User" FOR SELECT TO authenticated
+      USING ("id" = (SELECT auth.uid()));
+
+    CREATE POLICY "lab_membership_self_select"
+      ON "OrganizationMembership" FOR SELECT TO authenticated
+      USING ("userId" = (SELECT auth.uid()));
+
+    CREATE POLICY "lab_organization_member_select"
+      ON "Organization" FOR SELECT TO authenticated
+      USING (EXISTS (
+        SELECT 1
+        FROM "OrganizationMembership" membership
+        WHERE membership."organizationId" = "Organization"."id"
+          AND membership."userId" = (SELECT auth.uid())
+      ));
+
+    CREATE POLICY "lab_invitation_admin_select"
+      ON "OrganizationInvitation" FOR SELECT TO authenticated
+      USING (EXISTS (
+        SELECT 1
+        FROM "OrganizationMembership" membership
+        WHERE membership."organizationId" = "OrganizationInvitation"."organizationId"
+          AND membership."userId" = (SELECT auth.uid())
+          AND membership."role" IN ('OWNER', 'ADMIN')
+      ));
+
+    CREATE POLICY "lab_experiment_member_select"
+      ON "StealthExperiment" FOR SELECT TO authenticated
+      USING (EXISTS (
+        SELECT 1
+        FROM "OrganizationMembership" membership
+        WHERE membership."organizationId" = "StealthExperiment"."organizationId"
+          AND membership."userId" = (SELECT auth.uid())
+      ));
+
+    CREATE POLICY "lab_variant_member_select"
+      ON "StealthVariant" FOR SELECT TO authenticated
+      USING (EXISTS (
+        SELECT 1
+        FROM "StealthExperiment" experiment
+        INNER JOIN "OrganizationMembership" membership
+          ON membership."organizationId" = experiment."organizationId"
+        WHERE experiment."id" = "StealthVariant"."experimentId"
+          AND membership."userId" = (SELECT auth.uid())
+      ));
+
+    CREATE POLICY "lab_generation_run_member_select"
+      ON "StealthGenerationRun" FOR SELECT TO authenticated
+      USING (EXISTS (
+        SELECT 1
+        FROM "StealthVariant" variant
+        INNER JOIN "StealthExperiment" experiment
+          ON experiment."id" = variant."experimentId"
+        INNER JOIN "OrganizationMembership" membership
+          ON membership."organizationId" = experiment."organizationId"
+        WHERE variant."id" = "StealthGenerationRun"."variantId"
+          AND membership."userId" = (SELECT auth.uid())
+      ));
+
+    CREATE POLICY "lab_generation_result_member_select"
+      ON "StealthGenerationResult" FOR SELECT TO authenticated
+      USING (EXISTS (
+        SELECT 1
+        FROM "StealthGenerationRun" run
+        INNER JOIN "StealthVariant" variant ON variant."id" = run."variantId"
+        INNER JOIN "StealthExperiment" experiment
+          ON experiment."id" = variant."experimentId"
+        INNER JOIN "OrganizationMembership" membership
+          ON membership."organizationId" = experiment."organizationId"
+        WHERE run."id" = "StealthGenerationResult"."runId"
+          AND membership."userId" = (SELECT auth.uid())
+      ));
+
+    CREATE POLICY "deny_client_access"
+      ON "StealthEndpointCredential" FOR ALL TO authenticated
+      USING (false) WITH CHECK (false);
+  END IF;
+
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'anon') THEN
+    REVOKE ALL ON
+      "User",
+      "Organization",
+      "OrganizationMembership",
+      "OrganizationInvitation",
+      "StealthExperiment",
+      "StealthVariant",
+      "StealthEndpointCredential",
+      "StealthGenerationRun",
+      "StealthGenerationResult"
+    FROM anon;
+  END IF;
+END $$;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -8,6 +8,231 @@ datasource db {
   directUrl = env("DIRECT_URL")
 }
 
+enum OrganizationRole {
+  OWNER
+  ADMIN
+  ANALYST
+  VIEWER
+}
+
+enum StealthExportPolicy {
+  AGGREGATES_ONLY
+  DEIDENTIFIED_VOTES
+}
+
+enum StealthExperimentStatus {
+  DRAFT
+  VALIDATING
+  GENERATING
+  READY
+  ACTIVE
+  PAUSED
+  STABLE
+  DEGRADED
+  WITHDRAWN
+  CLOSED
+  RELEASED
+}
+
+enum StealthVariantStatus {
+  DRAFT
+  VALIDATING
+  GENERATING
+  READY
+  ACTIVE
+  DEGRADED
+  WITHDRAWN
+  RELEASED
+}
+
+enum StealthGenerationRunStatus {
+  RUNNING
+  SUCCEEDED
+  PARTIAL
+  FAILED
+}
+
+enum StealthGenerationResultStatus {
+  SUCCEEDED
+  FAILED
+}
+
+model User {
+  id          String    @id @db.Uuid
+  email       String    @unique
+  displayName String?
+  lastSeenAt  DateTime?
+  createdAt   DateTime  @default(now())
+  updatedAt   DateTime  @updatedAt
+
+  memberships     OrganizationMembership[]
+  acceptedInvites OrganizationInvitation[] @relation("AcceptedOrganizationInvites")
+}
+
+model Organization {
+  id        String   @id @default(cuid())
+  slug      String   @unique
+  name      String
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  memberships OrganizationMembership[]
+  invitations OrganizationInvitation[]
+  experiments StealthExperiment[]
+}
+
+model OrganizationMembership {
+  organizationId String
+  userId         String           @db.Uuid
+  role           OrganizationRole
+  createdAt      DateTime         @default(now())
+  updatedAt      DateTime         @updatedAt
+
+  organization Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  user         User         @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@id([organizationId, userId])
+  @@index([userId])
+}
+
+model OrganizationInvitation {
+  id             String           @id @default(cuid())
+  organizationId String
+  email          String
+  role           OrganizationRole
+  authUserId     String?          @db.Uuid
+  acceptedById   String?          @db.Uuid
+  acceptedAt     DateTime?
+  revokedAt      DateTime?
+  createdAt      DateTime         @default(now())
+  updatedAt      DateTime         @updatedAt
+
+  organization Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  acceptedBy   User?        @relation("AcceptedOrganizationInvites", fields: [acceptedById], references: [id], onDelete: SetNull)
+
+  @@unique([organizationId, email])
+  @@index([authUserId])
+  @@index([acceptedById])
+}
+
+model StealthExperiment {
+  id                  String                  @id @default(cuid())
+  organizationId      String
+  slug                String
+  name                String
+  status              StealthExperimentStatus @default(DRAFT)
+  exportPolicy        StealthExportPolicy     @default(AGGREGATES_ONLY)
+  targetDecisiveVotes Int                     @default(1000)
+  agreementReference  String?
+  startsAt            DateTime?
+  endedAt             DateTime?
+  retentionDeleteAt   DateTime?
+  createdAt           DateTime                @default(now())
+  updatedAt           DateTime                @updatedAt
+
+  organization Organization     @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  variants     StealthVariant[]
+
+  @@unique([organizationId, slug])
+  @@index([organizationId, status])
+}
+
+model StealthVariant {
+  id                     String               @id @default(cuid())
+  experimentId           String
+  codename               String
+  status                 StealthVariantStatus @default(DRAFT)
+  modelId                String               @unique
+  releasedModelId        String?
+  checkpointFingerprint  String?
+  endpointEnabled        Boolean              @default(false)
+  lastValidatedAt        DateTime?
+  cohortGeneratedAt      DateTime?
+  releasedAt             DateTime?
+  expectedBuildCount     Int                  @default(0)
+  generatedBuildCount    Int                  @default(0)
+  generationFailureCount Int                  @default(0)
+  lastGenerationError    String?
+
+  eloRating          Float @default(1500)
+  glickoRd           Float @default(350)
+  glickoVolatility   Float @default(0.06)
+  conservativeRating Float @default(800)
+  shownCount         Int   @default(0)
+  winCount           Int   @default(0)
+  lossCount          Int   @default(0)
+  drawCount          Int   @default(0)
+  bothBadCount       Int   @default(0)
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  experiment     StealthExperiment          @relation(fields: [experimentId], references: [id], onDelete: Cascade)
+  model          Model                      @relation("StealthOpaqueModel", fields: [modelId], references: [id], onDelete: Restrict)
+  releasedModel  Model?                     @relation("StealthReleasedModel", fields: [releasedModelId], references: [id], onDelete: SetNull)
+  credential     StealthEndpointCredential?
+  generationRuns StealthGenerationRun[]
+  matchups       Matchup[]
+  voteJobs       ArenaVoteJob[]
+
+  @@unique([experimentId, codename])
+  @@index([experimentId, status])
+  @@index([releasedModelId])
+}
+
+model StealthEndpointCredential {
+  id              String   @id @default(cuid())
+  variantId       String   @unique
+  encryptedConfig String
+  fingerprint     String
+  createdAt       DateTime @default(now())
+  updatedAt       DateTime @updatedAt
+
+  variant StealthVariant @relation(fields: [variantId], references: [id], onDelete: Cascade)
+}
+
+model StealthGenerationRun {
+  id                  String                     @id @default(cuid())
+  variantId           String
+  status              StealthGenerationRunStatus @default(RUNNING)
+  promptCohortId      String
+  configuration       Json
+  expectedBuildCount  Int
+  completedBuildCount Int                        @default(0)
+  failedBuildCount    Int                        @default(0)
+  providerCallCount   Int                        @default(0)
+  retryCount          Int                        @default(0)
+  startedAt           DateTime                   @default(now())
+  completedAt         DateTime?
+  error               String?
+
+  variant StealthVariant            @relation(fields: [variantId], references: [id], onDelete: Cascade)
+  results StealthGenerationResult[]
+
+  @@index([variantId, startedAt])
+}
+
+model StealthGenerationResult {
+  id                   String                        @id @default(cuid())
+  runId                String
+  promptId             String
+  buildId              String?
+  status               StealthGenerationResultStatus
+  attempts             Int
+  generationTimeMs     Int
+  requestConfiguration String?
+  error                String?
+  createdAt            DateTime                      @default(now())
+
+  run    StealthGenerationRun @relation(fields: [runId], references: [id], onDelete: Cascade)
+  prompt Prompt               @relation(fields: [promptId], references: [id], onDelete: Restrict)
+  build  Build?               @relation(fields: [buildId], references: [id], onDelete: SetNull)
+
+  @@unique([runId, promptId])
+  @@index([promptId])
+  @@index([buildId])
+}
+
 model Model {
   id          String   @id @default(cuid())
   key         String   @unique
@@ -37,6 +262,8 @@ model Model {
   coveragePairPromptsLow ArenaCoveragePairPrompt[] @relation("ArenaCoveragePairPromptLow")
   coveragePairPromptsHigh ArenaCoveragePairPrompt[] @relation("ArenaCoveragePairPromptHigh")
   shownJobs ArenaShownJob[]
+  stealthVariant StealthVariant? @relation("StealthOpaqueModel")
+  releasedStealthVariants StealthVariant[] @relation("StealthReleasedModel")
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
@@ -71,6 +298,7 @@ model Prompt {
   matchups Matchup[]
   coverageByModel ArenaCoverageModelPrompt[]
   coveragePairs ArenaCoveragePairPrompt[]
+  stealthGenerationResults StealthGenerationResult[]
 
   @@unique([text])
   @@index([active])
@@ -103,6 +331,7 @@ model Build {
 
   matchupsAsA Matchup[] @relation("MatchupBuildA")
   matchupsAsB Matchup[] @relation("MatchupBuildB")
+  stealthGenerationResults StealthGenerationResult[]
 
   @@unique([promptId, modelId, gridSize, palette, mode])
   @@index([gridSize, palette, mode, promptId, modelId])
@@ -131,11 +360,15 @@ model Matchup {
   buildBId String
   buildB   Build @relation("MatchupBuildB", fields: [buildBId], references: [id], onDelete: Restrict)
 
+  stealthVariantId String?
+  stealthVariant   StealthVariant? @relation(fields: [stealthVariantId], references: [id], onDelete: Restrict)
+
   votes Vote[]
 
   @@index([promptId, createdAt])
   @@index([modelAId])
   @@index([modelBId])
+  @@index([stealthVariantId, createdAt])
   @@index([samplingLane, createdAt])
 }
 
@@ -170,7 +403,11 @@ model ArenaVoteJob {
   modelBId  String
   choice    String
 
+  stealthVariantId String?
+  stealthVariant   StealthVariant? @relation(fields: [stealthVariantId], references: [id], onDelete: Restrict)
+
   @@index([matchupId])
+  @@index([stealthVariantId, processedAt])
 }
 
 model ArenaShownJob {

--- a/scripts/recompute-elo.ts
+++ b/scripts/recompute-elo.ts
@@ -16,6 +16,7 @@ import {
   conservativeScore,
   updateRatingPair,
 } from "../lib/arena/rating";
+import { applyStealthRatingVote } from "../lib/stealth/rating";
 
 type Choice = "A" | "B" | "TIE" | "BOTH_BAD";
 
@@ -58,12 +59,28 @@ Usage:
     return;
   }
 
-  const [models, votes] = await Promise.all([
+  const [models, variants, votes] = await Promise.all([
     prisma.model.findMany({
+      where: { stealthVariant: null },
       select: {
         id: true,
         key: true,
         displayName: true,
+        eloRating: true,
+        glickoRd: true,
+        glickoVolatility: true,
+        conservativeRating: true,
+        winCount: true,
+        lossCount: true,
+        drawCount: true,
+        bothBadCount: true,
+      },
+    }),
+    prisma.stealthVariant.findMany({
+      select: {
+        id: true,
+        codename: true,
+        modelId: true,
         eloRating: true,
         glickoRd: true,
         glickoVolatility: true,
@@ -82,6 +99,7 @@ Usage:
           select: {
             modelAId: true,
             modelBId: true,
+            stealthVariantId: true,
           },
         },
       },
@@ -100,9 +118,61 @@ Usage:
       bothBadCount: 0,
     });
   }
+  const stateByVariantId = new Map<string, ModelState>();
+  const variantById = new Map(variants.map((variant) => [variant.id, variant]));
+  for (const variant of variants) {
+    stateByVariantId.set(variant.id, {
+      rating: INITIAL_RATING,
+      rd: INITIAL_RD,
+      volatility: INITIAL_VOLATILITY,
+      winCount: 0,
+      lossCount: 0,
+      drawCount: 0,
+      bothBadCount: 0,
+    });
+  }
 
   for (const vote of votes) {
     if (!isChoice(vote.choice)) continue;
+    if (vote.matchup.stealthVariantId) {
+      const variantRecord = variantById.get(vote.matchup.stealthVariantId);
+      const variant = stateByVariantId.get(vote.matchup.stealthVariantId);
+      if (!variantRecord || !variant) continue;
+      const variantIsA = vote.matchup.modelAId === variantRecord.modelId;
+      const variantIsB = vote.matchup.modelBId === variantRecord.modelId;
+      if (variantIsA === variantIsB) continue;
+      const publicModel = stateByModelId.get(
+        variantIsA ? vote.matchup.modelBId : vote.matchup.modelAId,
+      );
+      if (!publicModel) continue;
+      const updated = applyStealthRatingVote({
+        variant: {
+          eloRating: variant.rating,
+          glickoRd: variant.rd,
+          glickoVolatility: variant.volatility,
+          conservativeRating: conservativeScore(variant.rating, variant.rd),
+          winCount: variant.winCount,
+          lossCount: variant.lossCount,
+          drawCount: variant.drawCount,
+          bothBadCount: variant.bothBadCount,
+        },
+        publicAnchor: {
+          eloRating: publicModel.rating,
+          glickoRd: publicModel.rd,
+          glickoVolatility: publicModel.volatility,
+        },
+        variantSide: variantIsA ? "A" : "B",
+        choice: vote.choice,
+      });
+      variant.rating = updated.eloRating;
+      variant.rd = updated.glickoRd;
+      variant.volatility = updated.glickoVolatility;
+      variant.winCount = updated.winCount;
+      variant.lossCount = updated.lossCount;
+      variant.drawCount = updated.drawCount;
+      variant.bothBadCount = updated.bothBadCount;
+      continue;
+    }
     const a = stateByModelId.get(vote.matchup.modelAId);
     const b = stateByModelId.get(vote.matchup.modelBId);
     if (!a || !b) continue;
@@ -172,12 +242,35 @@ Usage:
         Math.abs(a.newConservative - a.oldConservative),
     );
 
+  const variantDiffs = variants.map((variant) => {
+    const recomputed = stateByVariantId.get(variant.id) as ModelState;
+    return {
+      id: variant.id,
+      codename: variant.codename,
+      oldConservative: Number(variant.conservativeRating),
+      newRating: recomputed.rating,
+      newRd: recomputed.rd,
+      newVolatility: recomputed.volatility,
+      newConservative: conservativeScore(recomputed.rating, recomputed.rd),
+      winCount: recomputed.winCount,
+      lossCount: recomputed.lossCount,
+      drawCount: recomputed.drawCount,
+      bothBadCount: recomputed.bothBadCount,
+    };
+  });
+
   console.log(`models: ${models.length}`);
+  console.log(`stealth variants: ${variants.length}`);
   console.log(`votes replayed: ${votes.length}`);
   console.log("top conservative-score deltas:");
   for (const diff of diffs.slice(0, 10)) {
     console.log(
       `- ${diff.displayName} (${diff.key}): ${diff.oldConservative.toFixed(2)} -> ${diff.newConservative.toFixed(2)} (${formatDelta(diff.newConservative - diff.oldConservative)})`,
+    );
+  }
+  for (const diff of variantDiffs) {
+    console.log(
+      `- Stealth ${diff.codename}: ${diff.oldConservative.toFixed(2)} -> ${diff.newConservative.toFixed(2)} (${formatDelta(diff.newConservative - diff.oldConservative)})`,
     );
   }
 
@@ -199,6 +292,21 @@ Usage:
           lossCount: diff.newLossCount,
           drawCount: diff.newDrawCount,
           bothBadCount: diff.newBothBadCount,
+        },
+      });
+    }
+    for (const diff of variantDiffs) {
+      await tx.stealthVariant.update({
+        where: { id: diff.id },
+        data: {
+          eloRating: diff.newRating,
+          glickoRd: diff.newRd,
+          glickoVolatility: diff.newVolatility,
+          conservativeRating: diff.newConservative,
+          winCount: diff.winCount,
+          lossCount: diff.lossCount,
+          drawCount: diff.drawCount,
+          bothBadCount: diff.bothBadCount,
         },
       });
     }

--- a/scripts/reset-elo.ts
+++ b/scripts/reset-elo.ts
@@ -102,6 +102,20 @@ Usage:
     }
 
     const updatedModels = await tx.model.updateMany({
+      where: { stealthVariant: null },
+      data: {
+        eloRating: 1500,
+        glickoRd: 350,
+        glickoVolatility: 0.06,
+        conservativeRating: 800,
+        shownCount: 0,
+        winCount: 0,
+        lossCount: 0,
+        drawCount: 0,
+        bothBadCount: 0,
+      },
+    });
+    const updatedStealthVariants = await tx.stealthVariant.updateMany({
       data: {
         eloRating: 1500,
         glickoRd: 350,
@@ -122,11 +136,13 @@ Usage:
       deletedCoveragePairs,
       deletedCoveragePairPrompts,
       updatedModels: updatedModels.count,
+      updatedStealthVariants: updatedStealthVariants.count,
     };
   });
 
   console.log("done");
   console.log(`models reset: ${result.updatedModels}`);
+  console.log(`stealth variants reset: ${result.updatedStealthVariants}`);
   if (args.keepHistory) {
     console.log("history kept: matchups/votes unchanged");
   } else {

--- a/scripts/stealth-eval.ts
+++ b/scripts/stealth-eval.ts
@@ -1,0 +1,965 @@
+#!/usr/bin/env -S tsx
+
+import "dotenv/config";
+import { createHash, randomUUID } from "node:crypto";
+import type {
+  OrganizationRole,
+  StealthExperimentStatus,
+  StealthVariantStatus,
+} from "@prisma/client";
+import { generateVoxelBuild } from "../lib/ai/generateVoxelBuild";
+import {
+  BENCHMARK_PROMPT_COHORT_ID,
+  BENCHMARK_PROMPT_MAP,
+} from "../lib/benchmark/prompts";
+import { prisma } from "../lib/prisma";
+import {
+  decryptStealthEndpointConfig,
+  encryptStealthEndpointConfig,
+  generateStealthConfigEncryptionKey,
+  type StealthEndpointConfig,
+} from "../lib/stealth/credentials";
+import {
+  ensureStealthBuildArtifacts,
+  persistStealthBuild,
+} from "../lib/stealth/generation";
+import {
+  normalizeStealthSlug,
+  opaqueStealthModelKey,
+} from "../lib/stealth/policy";
+
+type CliArgs = {
+  command: string;
+  values: Map<string, string>;
+  flags: Set<string>;
+};
+
+const EXPERIMENT_ACTIVATABLE: readonly StealthExperimentStatus[] = ["READY", "PAUSED"];
+const EXPERIMENT_CONFIGURABLE: readonly StealthExperimentStatus[] = ["DRAFT", "READY", "DEGRADED"];
+const VARIANT_CONFIGURABLE: readonly StealthVariantStatus[] = ["DRAFT", "READY", "DEGRADED"];
+
+function parseArgs(argv = process.argv.slice(2)): CliArgs {
+  const [command = "help", ...rest] = argv;
+  const values = new Map<string, string>();
+  const flags = new Set<string>();
+  for (let index = 0; index < rest.length; index += 1) {
+    const name = rest[index];
+    if (!name?.startsWith("--")) throw new Error(`Unexpected argument: ${name}`);
+    const next = rest[index + 1];
+    if (!next || next.startsWith("--")) {
+      flags.add(name);
+      continue;
+    }
+    values.set(name, next);
+    index += 1;
+  }
+  return { command, values, flags };
+}
+
+function value(args: CliArgs, name: string, required = true): string | undefined {
+  const result = args.values.get(name)?.trim();
+  if (!result && required) throw new Error(`Missing ${name}`);
+  return result || undefined;
+}
+
+function positiveInt(args: CliArgs, name: string, fallback: number, max: number): number {
+  const raw = value(args, name, false);
+  if (!raw) return fallback;
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isInteger(parsed) || parsed <= 0 || parsed > max) {
+    throw new Error(`${name} must be an integer from 1 to ${max}`);
+  }
+  return parsed;
+}
+
+function slugValue(args: CliArgs, name: string): string {
+  const raw = value(args, name) as string;
+  const slug = normalizeStealthSlug(raw);
+  if (!slug) throw new Error(`${name} must contain letters or numbers`);
+  return slug;
+}
+
+function endpointApiKey(): string {
+  const apiKey = process.env.STEALTH_ENDPOINT_API_KEY?.trim();
+  if (!apiKey) throw new Error("Missing STEALTH_ENDPOINT_API_KEY");
+  return apiKey;
+}
+
+async function findExperiment(orgSlug: string, experimentSlug: string) {
+  const experiment = await prisma.stealthExperiment.findFirst({
+    where: {
+      slug: experimentSlug,
+      organization: { slug: orgSlug },
+    },
+    include: { organization: true },
+  });
+  if (!experiment) throw new Error(`Experiment not found: ${orgSlug}/${experimentSlug}`);
+  return experiment;
+}
+
+async function findVariant(orgSlug: string, experimentSlug: string, codename: string) {
+  const variant = await prisma.stealthVariant.findFirst({
+    where: {
+      codename,
+      experiment: {
+        slug: experimentSlug,
+        organization: { slug: orgSlug },
+      },
+    },
+    include: {
+      credential: true,
+      experiment: { include: { organization: true } },
+      model: true,
+    },
+  });
+  if (!variant) throw new Error(`Variant not found: ${orgSlug}/${experimentSlug}/${codename}`);
+  return variant;
+}
+
+function checkpointFingerprint(endpointUrl: string, modelId: string): string {
+  return createHash("sha256")
+    .update(`${endpointUrl.trim().replace(/\/+$/, "")}\n${modelId.trim()}`)
+    .digest("hex");
+}
+
+async function createExperiment(args: CliArgs): Promise<void> {
+  const orgSlug = slugValue(args, "--org");
+  const orgName = value(args, "--org-name") as string;
+  const experimentSlug = slugValue(args, "--experiment");
+  const experimentName = value(args, "--experiment-name") as string;
+  const targetDecisiveVotes = positiveInt(args, "--target-votes", 1000, 1_000_000);
+  const exportPolicyRaw =
+    value(args, "--export-policy", false)?.toUpperCase().replaceAll("-", "_") ??
+    "AGGREGATES_ONLY";
+  if (exportPolicyRaw !== "AGGREGATES_ONLY" && exportPolicyRaw !== "DEIDENTIFIED_VOTES") {
+    throw new Error("--export-policy must be aggregates-only or deidentified-votes");
+  }
+  const exportPolicy = exportPolicyRaw as
+    | "AGGREGATES_ONLY"
+    | "DEIDENTIFIED_VOTES";
+  const agreementReference = value(args, "--agreement", false);
+
+  const organization = await prisma.organization.upsert({
+    where: { slug: orgSlug },
+    create: { slug: orgSlug, name: orgName },
+    update: { name: orgName },
+  });
+  const experiment = await prisma.stealthExperiment.upsert({
+    where: { organizationId_slug: { organizationId: organization.id, slug: experimentSlug } },
+    create: {
+      organizationId: organization.id,
+      slug: experimentSlug,
+      name: experimentName,
+      targetDecisiveVotes,
+      exportPolicy,
+      agreementReference,
+    },
+    update: {
+      name: experimentName,
+      targetDecisiveVotes,
+      exportPolicy,
+      agreementReference,
+    },
+  });
+  console.log(`Experiment ready for configuration: ${organization.slug}/${experiment.slug}`);
+}
+
+function endpointConfig(args: CliArgs): StealthEndpointConfig {
+  return {
+    protocol: "openai-chat-completions",
+    endpointUrl: value(args, "--endpoint") as string,
+    apiKey: endpointApiKey(),
+    modelId: value(args, "--model-id") as string,
+    requireStructuredOutput: !args.flags.has("--allow-unstructured"),
+    enableTools: !args.flags.has("--no-tools"),
+    reasoning: value(args, "--reasoning", false),
+  };
+}
+
+async function configureVariant(args: CliArgs): Promise<void> {
+  const orgSlug = slugValue(args, "--org");
+  const experimentSlug = slugValue(args, "--experiment");
+  const codename = value(args, "--codename") as string;
+  const experiment = await findExperiment(orgSlug, experimentSlug);
+  if (!EXPERIMENT_CONFIGURABLE.includes(experiment.status)) {
+    throw new Error(`Experiment ${experiment.status.toLowerCase()} cannot accept endpoint changes`);
+  }
+  const config = endpointConfig(args);
+  const encrypted = encryptStealthEndpointConfig(config);
+  const fingerprint = checkpointFingerprint(config.endpointUrl, config.modelId);
+  const existing = await prisma.stealthVariant.findUnique({
+    where: { experimentId_codename: { experimentId: experiment.id, codename } },
+    include: { _count: { select: { matchups: true } } },
+  });
+
+  if (existing) {
+    if (!VARIANT_CONFIGURABLE.includes(existing.status)) {
+      throw new Error(`Variant ${existing.status.toLowerCase()} cannot be reconfigured`);
+    }
+    if (existing._count.matchups > 0) throw new Error("A sampled variant cannot be reconfigured");
+    if (
+      existing.generatedBuildCount > 0 &&
+      existing.checkpointFingerprint &&
+      existing.checkpointFingerprint !== fingerprint
+    ) {
+      throw new Error("Checkpoint identity cannot change after cohort generation has started");
+    }
+    await prisma.$transaction([
+      prisma.stealthVariant.update({
+        where: { id: existing.id },
+        data: {
+          checkpointFingerprint: fingerprint,
+          endpointEnabled: true,
+          lastGenerationError: null,
+        },
+      }),
+      prisma.stealthEndpointCredential.upsert({
+        where: { variantId: existing.id },
+        create: { variantId: existing.id, ...encrypted },
+        update: encrypted,
+      }),
+    ]);
+    console.log(`Endpoint configuration updated: ${orgSlug}/${experimentSlug}/${codename}`);
+    return;
+  }
+
+  const variantId = randomUUID();
+  const modelId = randomUUID();
+  await prisma.$transaction(async (tx) => {
+    await tx.model.create({
+      data: {
+        id: modelId,
+        key: opaqueStealthModelKey(experiment.id, variantId),
+        provider: "Stealth",
+        modelId: variantId,
+        displayName: codename,
+        enabled: false,
+      },
+    });
+    await tx.stealthVariant.create({
+      data: {
+        id: variantId,
+        experimentId: experiment.id,
+        codename,
+        modelId,
+        checkpointFingerprint: fingerprint,
+        endpointEnabled: true,
+        expectedBuildCount: Object.keys(BENCHMARK_PROMPT_MAP).length,
+        credential: { create: encrypted },
+      },
+    });
+  });
+  console.log(`Variant configured: ${orgSlug}/${experimentSlug}/${codename}`);
+}
+
+async function findAuthUserByEmail(email: string) {
+  const { createSupabaseAdminClient } = await import("../lib/supabase/admin");
+  const supabase = createSupabaseAdminClient();
+  for (let page = 1; page <= 10; page += 1) {
+    const { data, error } = await supabase.auth.admin.listUsers({ page, perPage: 1000 });
+    if (error) throw error;
+    const found = data.users.find((user) => user.email?.trim().toLowerCase() === email);
+    if (found) return { supabase, user: found, invited: false };
+    if (data.users.length < 1000) break;
+  }
+  const siteUrl = (process.env.MINEBENCH_SITE_URL ?? "").trim().replace(/\/+$/, "");
+  if (!siteUrl) throw new Error("Missing MINEBENCH_SITE_URL for the invitation redirect");
+  const { data, error } = await supabase.auth.admin.inviteUserByEmail(email, {
+    redirectTo: `${siteUrl}/lab/auth/confirm?next=/lab`,
+  });
+  if (error) throw error;
+  if (!data.user) throw new Error("Supabase did not return the invited user");
+  return { supabase, user: data.user, invited: true };
+}
+
+async function inviteMember(args: CliArgs): Promise<void> {
+  const orgSlug = slugValue(args, "--org");
+  const email = (value(args, "--email") as string).toLowerCase();
+  const role = (value(args, "--role") as string).toUpperCase() as OrganizationRole;
+  if (!(["OWNER", "ADMIN", "ANALYST", "VIEWER"] as const).includes(role)) {
+    throw new Error("--role must be owner, admin, analyst, or viewer");
+  }
+  const organization = await prisma.organization.findUnique({ where: { slug: orgSlug } });
+  if (!organization) throw new Error(`Organization not found: ${orgSlug}`);
+  const { user, invited } = await findAuthUserByEmail(email);
+  await prisma.$transaction([
+    prisma.user.upsert({
+      where: { id: user.id },
+      create: { id: user.id, email },
+      update: { email },
+    }),
+    prisma.organizationMembership.upsert({
+      where: { organizationId_userId: { organizationId: organization.id, userId: user.id } },
+      create: { organizationId: organization.id, userId: user.id, role },
+      update: { role },
+    }),
+    prisma.organizationInvitation.upsert({
+      where: { organizationId_email: { organizationId: organization.id, email } },
+      create: { organizationId: organization.id, email, role, authUserId: user.id },
+      update: { role, authUserId: user.id, revokedAt: null },
+    }),
+  ]);
+  console.log(`${invited ? "Invitation sent" : "Access granted"}: ${email} -> ${orgSlug} (${role.toLowerCase()})`);
+}
+
+async function revokeMember(args: CliArgs): Promise<void> {
+  const orgSlug = slugValue(args, "--org");
+  const email = (value(args, "--email") as string).toLowerCase();
+  const organization = await prisma.organization.findUnique({ where: { slug: orgSlug } });
+  if (!organization) throw new Error(`Organization not found: ${orgSlug}`);
+  const [membership, invitation] = await prisma.$transaction([
+    prisma.organizationMembership.deleteMany({
+      where: { organizationId: organization.id, user: { email } },
+    }),
+    prisma.organizationInvitation.updateMany({
+      where: { organizationId: organization.id, email, revokedAt: null },
+      data: { revokedAt: new Date() },
+    }),
+  ]);
+  console.log(
+    membership.count + invitation.count > 0
+      ? `Access revoked: ${email} -> ${orgSlug}`
+      : `Access already absent: ${email} -> ${orgSlug}`,
+  );
+}
+
+async function prepareCohortPrompts() {
+  const entries = Object.entries(BENCHMARK_PROMPT_MAP);
+  const prompts = await Promise.all(
+    entries.map(async ([slug, text]) => ({
+      slug,
+      text,
+      prompt: await prisma.prompt.upsert({
+        where: { text },
+        create: { text, active: true },
+        update: { active: true },
+      }),
+    })),
+  );
+  return prompts.sort((a, b) => {
+    if (a.slug === "astronaut") return -1;
+    if (b.slug === "astronaut") return 1;
+    return a.slug.localeCompare(b.slug);
+  });
+}
+
+async function generateVariant(args: CliArgs): Promise<void> {
+  const orgSlug = slugValue(args, "--org");
+  const experimentSlug = slugValue(args, "--experiment");
+  const codename = value(args, "--codename") as string;
+  const maxAttempts = positiveInt(args, "--attempts", 3, 10);
+  const concurrency = positiveInt(args, "--concurrency", 1, 4);
+  const variant = await findVariant(orgSlug, experimentSlug, codename);
+  if (!variant.endpointEnabled || !variant.credential) {
+    throw new Error("Variant endpoint is disabled; configure it before generation");
+  }
+  if (!VARIANT_CONFIGURABLE.includes(variant.status)) {
+    throw new Error(`Variant ${variant.status.toLowerCase()} cannot generate a cohort`);
+  }
+  const config = decryptStealthEndpointConfig(variant.credential.encryptedConfig);
+  const prompts = await prepareCohortPrompts();
+  const expectedBuildCount = prompts.length;
+  const run = await prisma.$transaction(async (tx) => {
+    await tx.stealthVariant.update({
+      where: { id: variant.id },
+      data: { status: "VALIDATING", expectedBuildCount, lastGenerationError: null },
+    });
+    await tx.stealthExperiment.update({
+      where: { id: variant.experimentId },
+      data: { status: "VALIDATING" },
+    });
+    return tx.stealthGenerationRun.create({
+      data: {
+        variantId: variant.id,
+        promptCohortId: BENCHMARK_PROMPT_COHORT_ID,
+        expectedBuildCount,
+        configuration: {
+          protocol: config.protocol,
+          credentialFingerprint: variant.credential?.fingerprint,
+          gridSize: 256,
+          palette: "simple",
+          mode: "precise",
+          enableTools: config.enableTools,
+          requireStructuredOutput: config.requireStructuredOutput,
+          reasoning: config.reasoning ?? null,
+          maxAttempts,
+          concurrency,
+        },
+      },
+    });
+  });
+
+  let providerCallCount = 0;
+  let retryCount = 0;
+  let completedBuildCount = 0;
+  let failedBuildCount = 0;
+  let lastError: string | null = null;
+
+  const generateOne = async (entry: Awaited<ReturnType<typeof prepareCohortPrompts>>[number]) => {
+    const existing = await prisma.build.findUnique({
+      where: {
+        promptId_modelId_gridSize_palette_mode: {
+          promptId: entry.prompt.id,
+          modelId: variant.modelId,
+          gridSize: 256,
+          palette: "simple",
+          mode: "precise",
+        },
+      },
+      select: { id: true },
+    });
+    if (existing) {
+      try {
+        await ensureStealthBuildArtifacts(existing.id);
+        completedBuildCount += 1;
+        await prisma.stealthGenerationResult.upsert({
+          where: { runId_promptId: { runId: run.id, promptId: entry.prompt.id } },
+          create: {
+            runId: run.id,
+            promptId: entry.prompt.id,
+            buildId: existing.id,
+            status: "SUCCEEDED",
+            attempts: 0,
+            generationTimeMs: 0,
+          },
+          update: { buildId: existing.id, status: "SUCCEEDED", error: null },
+        });
+        console.log(`Reused ${entry.slug}`);
+        return true;
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        failedBuildCount += 1;
+        lastError = message;
+        await prisma.stealthGenerationResult.upsert({
+          where: { runId_promptId: { runId: run.id, promptId: entry.prompt.id } },
+          create: {
+            runId: run.id,
+            promptId: entry.prompt.id,
+            buildId: existing.id,
+            status: "FAILED",
+            attempts: 0,
+            generationTimeMs: 0,
+            error: message.slice(0, 4000),
+          },
+          update: { status: "FAILED", error: message.slice(0, 4000) },
+        });
+        console.error(`Failed ${entry.slug}: ${message}`);
+        return false;
+      }
+    }
+
+    let attempts = 1;
+    const result = await generateVoxelBuild({
+      model: {
+        key: variant.model.key,
+        provider: "custom",
+        modelId: config.modelId,
+        displayName: codename,
+        baseUrl: config.endpointUrl,
+        requireStructuredOutput: config.requireStructuredOutput,
+      },
+      prompt: entry.text,
+      gridSize: 256,
+      palette: "simple",
+      maxAttempts,
+      enableTools: config.enableTools,
+      reasoning: config.reasoning,
+      providerKeys: { custom: config.apiKey },
+      allowServerKeys: false,
+      onProviderRequest: () => {
+        providerCallCount += 1;
+      },
+      onRetry: (attempt) => {
+        attempts = Math.max(attempts, attempt);
+        retryCount += 1;
+      },
+    });
+    if (!result.ok) {
+      failedBuildCount += 1;
+      lastError = result.error;
+      await prisma.stealthGenerationResult.create({
+        data: {
+          runId: run.id,
+          promptId: entry.prompt.id,
+          status: "FAILED",
+          attempts,
+          generationTimeMs: result.generationTimeMs,
+          requestConfiguration: result.requestConfiguration,
+          error: result.error.slice(0, 4000),
+        },
+      });
+      console.error(`Failed ${entry.slug}: ${result.error}`);
+      return false;
+    }
+
+    try {
+      const build = await persistStealthBuild({
+        variantId: variant.id,
+        modelId: variant.modelId,
+        promptSlug: entry.slug,
+        promptText: entry.text,
+        build: result.build,
+        generationTimeMs: result.generationTimeMs,
+      });
+      completedBuildCount += 1;
+      await prisma.stealthGenerationResult.create({
+        data: {
+          runId: run.id,
+          promptId: entry.prompt.id,
+          buildId: build.id,
+          status: "SUCCEEDED",
+          attempts,
+          generationTimeMs: result.generationTimeMs,
+          requestConfiguration: result.requestConfiguration,
+        },
+      });
+      console.log(`Generated ${entry.slug} (${build.blockCount} blocks)`);
+      return true;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      failedBuildCount += 1;
+      lastError = message;
+      await prisma.stealthGenerationResult.create({
+        data: {
+          runId: run.id,
+          promptId: entry.prompt.id,
+          status: "FAILED",
+          attempts,
+          generationTimeMs: result.generationTimeMs,
+          requestConfiguration: result.requestConfiguration,
+          error: message.slice(0, 4000),
+        },
+      });
+      console.error(`Failed ${entry.slug}: ${message}`);
+      return false;
+    }
+  };
+
+  const pending = [] as typeof prompts;
+  for (const prompt of prompts) {
+    const exists = await prisma.build.findUnique({
+      where: {
+        promptId_modelId_gridSize_palette_mode: {
+          promptId: prompt.prompt.id,
+          modelId: variant.modelId,
+          gridSize: 256,
+          palette: "simple",
+          mode: "precise",
+        },
+      },
+      select: { id: true },
+    });
+    if (exists) pending.push(prompt);
+    else pending.unshift(prompt);
+  }
+  const validationPrompt = pending.shift();
+  const validated = validationPrompt ? await generateOne(validationPrompt) : true;
+  if (validated) {
+    await prisma.$transaction([
+      prisma.stealthVariant.update({
+        where: { id: variant.id },
+        data: { status: "GENERATING", lastValidatedAt: new Date() },
+      }),
+      prisma.stealthExperiment.update({
+        where: { id: variant.experimentId },
+        data: { status: "GENERATING" },
+      }),
+    ]);
+    let next = 0;
+    await Promise.all(
+      Array.from({ length: concurrency }, async () => {
+        while (next < pending.length) {
+          const entry = pending[next];
+          next += 1;
+          if (entry) await generateOne(entry);
+        }
+      }),
+    );
+  }
+
+  const generatedBuildCount = await prisma.build.count({
+    where: {
+      modelId: variant.modelId,
+      gridSize: 256,
+      palette: "simple",
+      mode: "precise",
+      prompt: { text: { in: prompts.map((entry) => entry.text) } },
+    },
+  });
+  const complete = generatedBuildCount === expectedBuildCount && failedBuildCount === 0;
+  const runStatus = complete ? "SUCCEEDED" : completedBuildCount > 0 ? "PARTIAL" : "FAILED";
+  await prisma.$transaction(async (tx) => {
+    await tx.stealthGenerationRun.update({
+      where: { id: run.id },
+      data: {
+        status: runStatus,
+        completedBuildCount,
+        failedBuildCount,
+        providerCallCount,
+        retryCount,
+        completedAt: new Date(),
+        error: lastError?.slice(0, 4000) ?? null,
+      },
+    });
+    await tx.stealthVariant.update({
+      where: { id: variant.id },
+      data: {
+        status: complete ? "READY" : "DEGRADED",
+        endpointEnabled: !complete,
+        expectedBuildCount,
+        generatedBuildCount,
+        generationFailureCount: failedBuildCount,
+        lastGenerationError: lastError?.slice(0, 4000) ?? null,
+        cohortGeneratedAt: complete ? new Date() : null,
+      },
+    });
+    if (complete) {
+      await tx.stealthEndpointCredential.deleteMany({ where: { variantId: variant.id } });
+    }
+    const incompleteVariants = await tx.stealthVariant.count({
+      where: { experimentId: variant.experimentId, status: { not: "READY" } },
+    });
+    await tx.stealthExperiment.update({
+      where: { id: variant.experimentId },
+      data: { status: incompleteVariants === 0 ? "READY" : "DEGRADED" },
+    });
+  });
+  if (!complete) throw new Error(lastError ?? "Cohort generation did not complete");
+  console.log(`Cohort ready: ${generatedBuildCount}/${expectedBuildCount} builds; endpoint credential deleted`);
+}
+
+async function activateExperiment(args: CliArgs): Promise<void> {
+  const experiment = await findExperiment(slugValue(args, "--org"), slugValue(args, "--experiment"));
+  if (!EXPERIMENT_ACTIVATABLE.includes(experiment.status)) {
+    throw new Error(`Experiment must be ready or paused, not ${experiment.status.toLowerCase()}`);
+  }
+  const variants = await prisma.stealthVariant.findMany({ where: { experimentId: experiment.id } });
+  const runnableVariants = variants.filter(
+    (variant) => variant.status !== "WITHDRAWN" && variant.status !== "RELEASED",
+  );
+  if (runnableVariants.length === 0) throw new Error("Experiment has no runnable variants");
+  for (const variant of runnableVariants) {
+    if (variant.status !== "READY" && !(experiment.status === "PAUSED" && variant.status === "ACTIVE")) {
+      throw new Error(`Variant ${variant.codename} is not ready`);
+    }
+    if (variant.generatedBuildCount !== variant.expectedBuildCount || variant.expectedBuildCount === 0) {
+      throw new Error(`Variant ${variant.codename} does not have a complete cohort`);
+    }
+  }
+  await prisma.$transaction([
+    prisma.model.updateMany({
+      where: { id: { in: runnableVariants.map((variant) => variant.modelId) } },
+      data: { enabled: true },
+    }),
+    prisma.stealthVariant.updateMany({
+      where: { id: { in: runnableVariants.map((variant) => variant.id) } },
+      data: { status: "ACTIVE", endpointEnabled: false },
+    }),
+    prisma.stealthExperiment.update({
+      where: { id: experiment.id },
+      data: { status: "ACTIVE", startsAt: experiment.startsAt ?? new Date(), endedAt: null },
+    }),
+  ]);
+  console.log(`Experiment active: ${experiment.organization.slug}/${experiment.slug}`);
+}
+
+async function pauseExperiment(args: CliArgs): Promise<void> {
+  const experiment = await findExperiment(slugValue(args, "--org"), slugValue(args, "--experiment"));
+  if (experiment.status !== "ACTIVE" && experiment.status !== "STABLE") {
+    throw new Error("Only an active or stable experiment can be paused");
+  }
+  const variants = await prisma.stealthVariant.findMany({
+    where: { experimentId: experiment.id },
+    select: { modelId: true },
+  });
+  await prisma.$transaction([
+    prisma.model.updateMany({
+      where: { id: { in: variants.map((variant) => variant.modelId) } },
+      data: { enabled: false },
+    }),
+    prisma.stealthExperiment.update({ where: { id: experiment.id }, data: { status: "PAUSED" } }),
+  ]);
+  console.log(`Experiment paused: ${experiment.organization.slug}/${experiment.slug}`);
+}
+
+async function stabilizeExperiment(args: CliArgs): Promise<void> {
+  const experiment = await findExperiment(slugValue(args, "--org"), slugValue(args, "--experiment"));
+  if (experiment.status !== "ACTIVE") throw new Error("Only an active experiment can be stabilized");
+  const variants = await prisma.stealthVariant.findMany({
+    where: { experimentId: experiment.id, status: "ACTIVE" },
+  });
+  if (variants.length === 0) throw new Error("Experiment has no active variants");
+  const short = variants.find(
+    (variant) => variant.winCount + variant.lossCount < experiment.targetDecisiveVotes,
+  );
+  if (short) {
+    throw new Error(
+      `${short.codename} has ${short.winCount + short.lossCount}/${experiment.targetDecisiveVotes} decisive votes`,
+    );
+  }
+  await prisma.stealthExperiment.update({ where: { id: experiment.id }, data: { status: "STABLE" } });
+  console.log(`Experiment stable: ${experiment.organization.slug}/${experiment.slug}`);
+}
+
+async function closeExperiment(args: CliArgs): Promise<void> {
+  const experiment = await findExperiment(slugValue(args, "--org"), slugValue(args, "--experiment"));
+  if (experiment.status === "RELEASED") {
+    throw new Error("A released evaluation cannot be closed again");
+  }
+  if (experiment.status === "CLOSED") {
+    console.log(
+      `Experiment already closed; retention deadline ${experiment.retentionDeleteAt?.toISOString() ?? "not set"}`,
+    );
+    return;
+  }
+  const retentionDays = positiveInt(args, "--retention-days", 30, 3650);
+  const variants = await prisma.stealthVariant.findMany({
+    where: { experimentId: experiment.id },
+    select: { id: true, modelId: true },
+  });
+  const endedAt = new Date();
+  const retentionDeleteAt = new Date(endedAt.getTime() + retentionDays * 86_400_000);
+  await prisma.$transaction([
+    prisma.model.updateMany({
+      where: { id: { in: variants.map((variant) => variant.modelId) } },
+      data: { enabled: false },
+    }),
+    prisma.stealthVariant.updateMany({
+      where: { experimentId: experiment.id, status: { not: "RELEASED" } },
+      data: { status: "WITHDRAWN", endpointEnabled: false },
+    }),
+    prisma.stealthEndpointCredential.deleteMany({
+      where: { variantId: { in: variants.map((variant) => variant.id) } },
+    }),
+    prisma.stealthExperiment.update({
+      where: { id: experiment.id },
+      data: { status: "CLOSED", endedAt, retentionDeleteAt },
+    }),
+  ]);
+  console.log(`Experiment closed; retention deadline ${retentionDeleteAt.toISOString()}`);
+}
+
+async function withdrawVariant(args: CliArgs): Promise<void> {
+  const variant = await findVariant(
+    slugValue(args, "--org"),
+    slugValue(args, "--experiment"),
+    value(args, "--codename") as string,
+  );
+  if (variant.status === "RELEASED") {
+    throw new Error("A released variant cannot be withdrawn");
+  }
+  if (variant.status === "WITHDRAWN") {
+    console.log(`Variant already withdrawn: ${variant.codename}`);
+    return;
+  }
+  await prisma.$transaction(async (tx) => {
+    await tx.model.update({ where: { id: variant.modelId }, data: { enabled: false } });
+    await tx.stealthVariant.update({
+      where: { id: variant.id },
+      data: { status: "WITHDRAWN", endpointEnabled: false },
+    });
+    await tx.stealthEndpointCredential.deleteMany({ where: { variantId: variant.id } });
+    const remaining = await tx.stealthVariant.count({
+      where: { experimentId: variant.experimentId, status: { in: ["ACTIVE", "READY"] } },
+    });
+    if (remaining === 0) {
+      const endedAt = new Date();
+      await tx.stealthExperiment.update({
+        where: { id: variant.experimentId },
+        data: {
+          status: "WITHDRAWN",
+          endedAt,
+          retentionDeleteAt:
+            variant.experiment.retentionDeleteAt ?? new Date(endedAt.getTime() + 30 * 86_400_000),
+        },
+      });
+    }
+  });
+  console.log(`Variant withdrawn: ${variant.codename}`);
+}
+
+async function releaseVariant(args: CliArgs): Promise<void> {
+  if (!args.flags.has("--attest-exact-checkpoint")) {
+    throw new Error("Release requires --attest-exact-checkpoint");
+  }
+  const variant = await findVariant(
+    slugValue(args, "--org"),
+    slugValue(args, "--experiment"),
+    value(args, "--codename") as string,
+  );
+  if (!variant.checkpointFingerprint || !variant.cohortGeneratedAt) {
+    throw new Error("Variant has no completed checkpoint cohort to attest");
+  }
+  if (variant.experiment.status !== "CLOSED" && variant.experiment.status !== "RELEASED") {
+    throw new Error("Close the evaluation before recording a public release mapping");
+  }
+  const publicModelKey = value(args, "--public-model") as string;
+  const publicModel = await prisma.model.findUnique({
+    where: { key: publicModelKey },
+    include: { stealthVariant: true },
+  });
+  if (!publicModel || publicModel.stealthVariant) {
+    throw new Error(`Public model not found: ${publicModelKey}`);
+  }
+  if (variant.status === "RELEASED") {
+    if (variant.releasedModelId === publicModel.id) {
+      console.log(`Release mapping already recorded: ${variant.codename} -> ${publicModel.key}`);
+      return;
+    }
+    throw new Error("A released variant cannot be mapped to a different public model");
+  }
+  await prisma.$transaction(async (tx) => {
+    await tx.model.update({ where: { id: variant.modelId }, data: { enabled: false } });
+    await tx.stealthEndpointCredential.deleteMany({ where: { variantId: variant.id } });
+    await tx.stealthVariant.update({
+      where: { id: variant.id },
+      data: {
+        status: "RELEASED",
+        endpointEnabled: false,
+        releasedModelId: publicModel.id,
+        releasedAt: new Date(),
+      },
+    });
+    const unreleased = await tx.stealthVariant.count({
+      where: { experimentId: variant.experimentId, status: { not: "RELEASED" } },
+    });
+    if (unreleased === 0) {
+      await tx.stealthExperiment.update({
+        where: { id: variant.experimentId },
+        data: { status: "RELEASED", endedAt: variant.experiment.endedAt ?? new Date() },
+      });
+    }
+  });
+  console.log(`Release mapping recorded: ${variant.codename} -> ${publicModel.key}`);
+  console.log("Private ratings were not transferred; the public model starts with its own votes");
+}
+
+async function disableEndpoint(args: CliArgs): Promise<void> {
+  const variant = await findVariant(
+    slugValue(args, "--org"),
+    slugValue(args, "--experiment"),
+    value(args, "--codename") as string,
+  );
+  await prisma.$transaction([
+    prisma.stealthVariant.update({
+      where: { id: variant.id },
+      data: { endpointEnabled: false },
+    }),
+    prisma.stealthEndpointCredential.deleteMany({ where: { variantId: variant.id } }),
+  ]);
+  console.log(`Endpoint credential deleted: ${variant.codename}`);
+}
+
+async function printStatus(args: CliArgs): Promise<void> {
+  const experiment = await prisma.stealthExperiment.findFirst({
+    where: {
+      slug: slugValue(args, "--experiment"),
+      organization: { slug: slugValue(args, "--org") },
+    },
+    include: {
+      organization: true,
+      variants: {
+        orderBy: { codename: "asc" },
+        include: {
+          releasedModel: { select: { key: true } },
+          generationRuns: { orderBy: { startedAt: "desc" }, take: 1 },
+        },
+      },
+    },
+  });
+  if (!experiment) throw new Error("Experiment not found");
+  console.log(`${experiment.organization.name} / ${experiment.name}`);
+  console.log(`status=${experiment.status.toLowerCase()} export=${experiment.exportPolicy.toLowerCase()}`);
+  for (const variant of experiment.variants) {
+    const decisive = variant.winCount + variant.lossCount;
+    const latestRun = variant.generationRuns[0];
+    console.log(
+      [
+        variant.codename,
+        `status=${variant.status.toLowerCase()}`,
+        `cohort=${variant.generatedBuildCount}/${variant.expectedBuildCount}`,
+        `votes=${decisive}/${experiment.targetDecisiveVotes}`,
+        `record=${variant.winCount}-${variant.lossCount}-${variant.drawCount}`,
+        `rd=${variant.glickoRd.toFixed(1)}`,
+        `endpoint=${variant.endpointEnabled ? "enabled" : "disabled"}`,
+        latestRun ? `last_run=${latestRun.status.toLowerCase()}` : null,
+        variant.releasedModel ? `released_as=${variant.releasedModel.key}` : null,
+      ]
+        .filter(Boolean)
+        .join(" "),
+    );
+  }
+}
+
+function printHelp(): void {
+  console.log(`MineBench private evaluation operator
+
+Commands:
+  keygen
+  create --org NAME --org-name NAME --experiment NAME --experiment-name NAME [--target-votes N] [--export-policy aggregates-only|deidentified-votes] [--agreement REF]
+  configure --org NAME --experiment NAME --codename NAME --endpoint URL --model-id ID [--reasoning MODE] [--no-tools] [--allow-unstructured]
+  invite --org NAME --email EMAIL --role owner|admin|analyst|viewer
+  revoke --org NAME --email EMAIL
+  generate --org NAME --experiment NAME --codename NAME [--attempts N] [--concurrency N]
+  activate --org NAME --experiment NAME
+  pause --org NAME --experiment NAME
+  stabilize --org NAME --experiment NAME
+  close --org NAME --experiment NAME [--retention-days N]
+  withdraw --org NAME --experiment NAME --codename NAME
+  release --org NAME --experiment NAME --codename NAME --public-model KEY --attest-exact-checkpoint
+  disable-endpoint --org NAME --experiment NAME --codename NAME
+  status --org NAME --experiment NAME
+
+Set STEALTH_ENDPOINT_API_KEY only for configure. Never pass checkpoint keys on the command line.`);
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs();
+  switch (args.command) {
+    case "keygen":
+      console.log(generateStealthConfigEncryptionKey());
+      return;
+    case "create":
+      return createExperiment(args);
+    case "configure":
+      return configureVariant(args);
+    case "invite":
+      return inviteMember(args);
+    case "revoke":
+      return revokeMember(args);
+    case "generate":
+      return generateVariant(args);
+    case "activate":
+      return activateExperiment(args);
+    case "pause":
+      return pauseExperiment(args);
+    case "stabilize":
+      return stabilizeExperiment(args);
+    case "close":
+      return closeExperiment(args);
+    case "withdraw":
+      return withdrawVariant(args);
+    case "release":
+      return releaseVariant(args);
+    case "disable-endpoint":
+      return disableEndpoint(args);
+    case "status":
+      return printStatus(args);
+    case "help":
+    case "--help":
+    case "-h":
+      printHelp();
+      return;
+    default:
+      throw new Error(`Unknown command: ${args.command}`);
+  }
+}
+
+main()
+  .catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/scripts/sync-uploads-from-db.ts
+++ b/scripts/sync-uploads-from-db.ts
@@ -341,7 +341,7 @@ async function main() {
         gridSize: args.gridSize,
         palette: args.palette,
         mode: args.mode,
-        model: { isBaseline: false },
+        model: { isBaseline: false, stealthVariant: null },
       },
       select: {
         id: true,

--- a/scripts/with-staging-env.mjs
+++ b/scripts/with-staging-env.mjs
@@ -41,11 +41,20 @@ function required(name) {
 }
 
 const directUrl = required("STAGING_DIRECT_URL");
+const stagingSupabaseUrl = required("STAGING_SUPABASE_URL");
+const stagingServiceRoleKey = required("STAGING_SUPABASE_SERVICE_ROLE_KEY");
 const stagingEnv = {
   DATABASE_URL: staging.STAGING_DATABASE_URL?.trim() || directUrl,
   DIRECT_URL: directUrl,
-  SUPABASE_URL: required("STAGING_SUPABASE_URL"),
-  SUPABASE_SERVICE_ROLE_KEY: required("STAGING_SUPABASE_SERVICE_ROLE_KEY"),
+  SUPABASE_URL: stagingSupabaseUrl,
+  SUPABASE_SERVICE_ROLE_KEY: stagingServiceRoleKey,
+  SUPABASE_SECRET_KEY: staging.STAGING_SUPABASE_SECRET_KEY?.trim() || stagingServiceRoleKey,
+  NEXT_PUBLIC_SUPABASE_URL: stagingSupabaseUrl,
+  NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY:
+    staging.STAGING_SUPABASE_PUBLISHABLE_KEY?.trim() || "",
+  STEALTH_CONFIG_ENCRYPTION_KEY:
+    staging.STAGING_STEALTH_CONFIG_ENCRYPTION_KEY?.trim() || "",
+  STEALTH_ARENA_SHARE: staging.STAGING_STEALTH_ARENA_SHARE?.trim() || "0.25",
   SUPABASE_STORAGE_BUCKET: staging.STAGING_SUPABASE_STORAGE_BUCKET?.trim() || sourceBucket,
   MINEBENCH_SITE_URL: required("STAGING_SITE_URL"),
   // the alpha deployment may carry its own branch-scoped ADMIN_TOKEN; without

--- a/tests/unit/arena/matchup-token.test.ts
+++ b/tests/unit/arena/matchup-token.test.ts
@@ -1,7 +1,9 @@
 import assert from "node:assert/strict";
 import { createHmac } from "node:crypto";
 import {
+  createArenaBuildAccessToken,
   createArenaMatchupToken,
+  parseArenaBuildAccessToken,
   parseArenaMatchupToken,
 } from "../../../lib/arena/matchupToken";
 import { normalizeArenaBuildChecksum } from "../../../lib/arena/buildChecksum";
@@ -46,12 +48,21 @@ try {
   assert.equal(parsed.buildAChecksum, "a".repeat(64));
   assert.equal(parsed.buildBChecksum, "b".repeat(64));
   assert.ok(Number.isInteger(parsed.issuedAt));
+  assert.equal(parsed.stealthVariantId, undefined);
+  assert.ok(token.startsWith("v2."));
+  assert.equal(token.includes("model-a"), false, "encrypted tokens must not expose model ids");
 
-  const [encodedPayload] = token.split(".");
-  assert.ok(encodedPayload);
-  const legacyPayload = JSON.parse(
-    Buffer.from(encodedPayload, "base64url").toString("utf8"),
-  ) as Record<string, unknown>;
+  const legacyPayload: Record<string, unknown> = {
+    i: "legacy-matchup",
+    p: "prompt-1",
+    ma: "model-a",
+    mb: "model-b",
+    ba: "build-a",
+    bb: "build-b",
+    ca: "a".repeat(64),
+    cb: "b".repeat(64),
+    t: Date.now(),
+  };
   delete legacyPayload.ca;
   delete legacyPayload.cb;
   const encodedLegacyPayload = Buffer.from(JSON.stringify(legacyPayload), "utf8").toString(
@@ -65,6 +76,33 @@ try {
     null,
     "tokens without build versions must be rejected",
   );
+
+  const stealthToken = createArenaMatchupToken({
+    promptId: "prompt-1",
+    modelAId: "private-model",
+    modelBId: "model-b",
+    buildAId: "private-build",
+    buildBId: "build-b",
+    buildAChecksum: "c".repeat(64),
+    buildBChecksum: "b".repeat(64),
+    stealthVariantId: "variant-1",
+  });
+  assert.equal(parseArenaMatchupToken(stealthToken)?.stealthVariantId, "variant-1");
+  assert.equal(stealthToken.includes("variant-1"), false);
+
+  const buildAccessToken = createArenaBuildAccessToken({
+    buildId: "private-build",
+    checksum: "c".repeat(64),
+  });
+  const parsedBuildAccess = parseArenaBuildAccessToken(buildAccessToken);
+  assert.ok(parsedBuildAccess);
+  assert.equal(parsedBuildAccess.buildId, "private-build");
+  assert.equal(parsedBuildAccess.checksum, "c".repeat(64));
+  assert.ok(Number.isInteger(parsedBuildAccess.issuedAt));
+  assert.ok(buildAccessToken.startsWith("b1."));
+  assert.equal(buildAccessToken.includes("private-build"), false);
+  assert.equal(buildAccessToken.includes("c".repeat(64)), false);
+  assert.equal(parseArenaBuildAccessToken(`${buildAccessToken}x`), null);
 
   assert.equal(parseArenaMatchupToken(`${token}x`), null, "tampered tokens must be rejected");
   console.log("arena matchup token checks passed");

--- a/tests/unit/middleware-no-ip-global-cap.test.ts
+++ b/tests/unit/middleware-no-ip-global-cap.test.ts
@@ -20,10 +20,10 @@ async function main() {
         },
       },
     );
-    assert.equal(middleware(request).status, 200);
+    assert.equal((await middleware(request)).status, 200);
   }
 
-  const limited = middleware(
+  const limited = await middleware(
     new NextRequest("http://localhost/api/leaderboard/models/global-model-180", {
       headers: {
         cookie: "mb_rls=rotating-session-180",

--- a/tests/unit/middleware-rate-limit.test.ts
+++ b/tests/unit/middleware-rate-limit.test.ts
@@ -12,17 +12,17 @@ async function main() {
       `http://localhost/api/leaderboard/models/model-${index}`,
       { headers: { "x-real-ip": ip } },
     );
-    assert.equal(middleware(request).status, 200);
+    assert.equal((await middleware(request)).status, 200);
   }
 
-  const limited = middleware(
+  const limited = await middleware(
     new NextRequest("http://localhost/api/leaderboard/models/model-18", {
       headers: { "x-real-ip": ip },
     }),
   );
   assert.equal(limited.status, 429);
 
-  const firstAnonymous = middleware(
+  const firstAnonymous = await middleware(
     new NextRequest("http://localhost/api/leaderboard/models/anonymous-model-0"),
   );
   assert.equal(firstAnonymous.status, 200);
@@ -32,10 +32,10 @@ async function main() {
     const request = new NextRequest(
       `http://localhost/api/leaderboard/models/anonymous-model-${index}`,
     );
-    assert.equal(middleware(request).status, 200);
+    assert.equal((await middleware(request)).status, 200);
   }
 
-  const anonymousLimited = middleware(
+  const anonymousLimited = await middleware(
     new NextRequest("http://localhost/api/leaderboard/models/anonymous-model-18"),
   );
   assert.equal(anonymousLimited.status, 429);
@@ -50,7 +50,7 @@ async function main() {
         },
       },
     );
-    assert.equal(middleware(request).status, 200);
+    assert.equal((await middleware(request)).status, 200);
   }
 
   for (let index = 0; index < 18; index += 1) {
@@ -63,10 +63,10 @@ async function main() {
         },
       },
     );
-    assert.equal(middleware(request).status, 200);
+    assert.equal((await middleware(request)).status, 200);
   }
 
-  const sessionLimited = middleware(
+  const sessionLimited = await middleware(
     new NextRequest("http://localhost/api/leaderboard/models/session-model-18", {
       headers: {
         cookie: "mb_rls=review-session",

--- a/tests/unit/stealth/credentials.test.ts
+++ b/tests/unit/stealth/credentials.test.ts
@@ -1,0 +1,58 @@
+import assert from "node:assert/strict";
+import {
+  decryptStealthEndpointConfig,
+  encryptStealthEndpointConfig,
+  generateStealthConfigEncryptionKey,
+} from "../../../lib/stealth/credentials";
+
+const originalKey = process.env.STEALTH_CONFIG_ENCRYPTION_KEY;
+
+try {
+  const key = generateStealthConfigEncryptionKey();
+  process.env.STEALTH_CONFIG_ENCRYPTION_KEY = key;
+  assert.equal(Buffer.from(key, "base64").length, 32);
+
+  const encrypted = encryptStealthEndpointConfig({
+    protocol: "openai-chat-completions",
+    endpointUrl: "https://checkpoints.example.ai/v1/",
+    apiKey: "Bearer private-lab-key",
+    modelId: "checkpoint-2026-08-21",
+    requireStructuredOutput: true,
+    enableTools: true,
+    reasoning: "high",
+  });
+  assert.match(encrypted.encryptedConfig, /^v1\./);
+  assert.match(encrypted.fingerprint, /^[a-f0-9]{64}$/);
+  assert.equal(encrypted.encryptedConfig.includes("private-lab-key"), false);
+  assert.deepEqual(decryptStealthEndpointConfig(encrypted.encryptedConfig), {
+    protocol: "openai-chat-completions",
+    endpointUrl: "https://checkpoints.example.ai/v1",
+    apiKey: "private-lab-key",
+    modelId: "checkpoint-2026-08-21",
+    requireStructuredOutput: true,
+    enableTools: true,
+    reasoning: "high",
+  });
+
+  const tampered = `${encrypted.encryptedConfig.slice(0, -1)}${encrypted.encryptedConfig.endsWith("a") ? "b" : "a"}`;
+  assert.throws(() => decryptStealthEndpointConfig(tampered), /could not be decrypted/);
+  assert.throws(
+    () => decryptStealthEndpointConfig(encrypted.encryptedConfig, generateStealthConfigEncryptionKey()),
+    /could not be decrypted/,
+  );
+  assert.throws(
+    () => encryptStealthEndpointConfig({
+      protocol: "openai-chat-completions",
+      endpointUrl: "not-a-url",
+      apiKey: "key",
+      modelId: "checkpoint",
+      requireStructuredOutput: true,
+      enableTools: true,
+    }),
+  );
+
+  console.log("stealth credential envelope checks passed");
+} finally {
+  if (originalKey === undefined) delete process.env.STEALTH_CONFIG_ENCRYPTION_KEY;
+  else process.env.STEALTH_CONFIG_ENCRYPTION_KEY = originalKey;
+}

--- a/tests/unit/stealth/policy-export.test.ts
+++ b/tests/unit/stealth/policy-export.test.ts
@@ -1,0 +1,38 @@
+import assert from "node:assert/strict";
+import {
+  canExportStealthVotes,
+  normalizeStealthSlug,
+  readStealthArenaShare,
+} from "../../../lib/stealth/policy";
+import { serializeDeidentifiedStealthVotes } from "../../../lib/stealth/report";
+
+assert.equal(readStealthArenaShare(undefined), 0.25);
+assert.equal(readStealthArenaShare("0.5"), 0.5);
+assert.equal(readStealthArenaShare("3"), 1);
+assert.equal(readStealthArenaShare("-2"), 0);
+assert.equal(readStealthArenaShare("invalid"), 0.25);
+assert.equal(normalizeStealthSlug("  Frontier Lab / Run 7  "), "frontier-lab-run-7");
+
+assert.equal(canExportStealthVotes("OWNER"), true);
+assert.equal(canExportStealthVotes("ADMIN"), true);
+assert.equal(canExportStealthVotes("ANALYST"), true);
+assert.equal(canExportStealthVotes("VIEWER"), false);
+
+const csv = serializeDeidentifiedStealthVotes([
+  {
+    day: "2026-08-21",
+    codename: "Orchid",
+    prompt: "A castle, with towers",
+    opponent: 'Public "Model"',
+    variantSide: "B",
+    choice: "WIN",
+  },
+]);
+assert.equal(
+  csv,
+  'date,codename,prompt,opponent,variant_side,outcome\n2026-08-21,Orchid,"A castle, with towers","Public ""Model""",B,WIN\n',
+);
+assert.equal(csv.includes("session"), false);
+assert.equal(csv.includes("matchup"), false);
+
+console.log("stealth policy and deidentified export checks passed");

--- a/tests/unit/stealth/privacy-contract.test.ts
+++ b/tests/unit/stealth/privacy-contract.test.ts
@@ -1,0 +1,62 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const root = process.cwd();
+const read = (path: string) => readFileSync(join(root, path), "utf8");
+
+const migration = read("prisma/migrations/20260821060000_stealth_evaluations/migration.sql");
+assert.match(migration, /ALTER TABLE "StealthEndpointCredential" ENABLE ROW LEVEL SECURITY/);
+assert.match(migration, /REVOKE ALL ON "StealthEndpointCredential" FROM authenticated/);
+assert.match(migration, /ON "StealthEndpointCredential" FOR ALL TO authenticated\s+USING \(false\) WITH CHECK \(false\)/);
+assert.match(migration, /CHECK \("attempts" >= 0 AND "generationTimeMs" >= 0\)/);
+
+const matchupRoute = read("app/api/arena/matchup/route.ts");
+assert.equal((matchupRoute.match(/model: null/g) ?? []).length, 2);
+assert.match(matchupRoute, /stealthVariantId: picked\.stealthVariantId/);
+assert.match(matchupRoute, /createArenaBuildAccessToken/);
+assert.match(matchupRoute, /checksum: null/);
+
+for (const path of [
+  "app/api/arena/builds/[buildId]/route.ts",
+  "app/api/arena/builds/[buildId]/stream/route.ts",
+]) {
+  const buildRoute = read(path);
+  assert.match(buildRoute, /parseArenaBuildAccessToken/);
+  assert.match(buildRoute, /private, no-store/);
+}
+
+const voteRoute = read("app/api/arena/vote/route.ts");
+assert.match(voteRoute, /const responseBody: ArenaVoteResponse/);
+assert.match(voteRoute, /provider: "Stealth", displayName: model\.stealthVariant\.codename/);
+assert.match(voteRoute, /queuedVoteJobInput && !queuedVoteJobInput\.stealthVariantId/);
+
+const voteJobs = read("lib/arena/voteJobs.ts");
+const variantLoader = voteJobs.slice(
+  voteJobs.indexOf("async function loadStealthVariantsForVoteJobs"),
+  voteJobs.indexOf("async function applyBatchedStealthVariantUpdates"),
+);
+assert.doesNotMatch(variantLoader, /status[^\n]*ACTIVE/);
+const privateBranch = voteJobs.indexOf("if (job.stealthVariantId)");
+const publicTouch = voteJobs.indexOf("publicTouchedModelIds.add", privateBranch);
+assert.ok(privateBranch >= 0 && publicTouch > privateBranch);
+assert.match(voteJobs.slice(privateBranch, publicTouch), /applyStealthRatingVote/);
+assert.match(voteJobs.slice(privateBranch, publicTouch), /continue/);
+
+for (const path of [
+  "app/api/leaderboard/route.ts",
+  "app/api/sandbox/benchmark/route.ts",
+  "lib/arena/coverage.ts",
+  "lib/arena/eligibility.ts",
+  "lib/arena/stats.ts",
+]) {
+  assert.match(read(path), /stealthVariant|StealthVariant/, `${path} must exclude private variants`);
+}
+
+assert.match(
+  read("lib/arena/coverage.ts"),
+  /matchup\."stealthVariantId" IS NULL/,
+  "coverage rebuilds must exclude private votes",
+);
+
+console.log("stealth privacy boundary checks passed");

--- a/tests/unit/stealth/rating.test.ts
+++ b/tests/unit/stealth/rating.test.ts
@@ -1,0 +1,68 @@
+import assert from "node:assert/strict";
+import { applyStealthRatingVote } from "../../../lib/stealth/rating";
+
+const initial = {
+  eloRating: 1500,
+  glickoRd: 350,
+  glickoVolatility: 0.06,
+  conservativeRating: 800,
+  winCount: 0,
+  lossCount: 0,
+  drawCount: 0,
+  bothBadCount: 0,
+};
+const publicAnchor = {
+  eloRating: 1620,
+  glickoRd: 70,
+  glickoVolatility: 0.06,
+};
+const anchorBefore = structuredClone(publicAnchor);
+
+const win = applyStealthRatingVote({
+  variant: initial,
+  publicAnchor,
+  variantSide: "A",
+  choice: "A",
+});
+assert.equal(win.winCount, 1);
+assert.equal(win.lossCount, 0);
+assert.ok(win.eloRating > initial.eloRating);
+assert.deepEqual(publicAnchor, anchorBefore, "a stealth vote must not mutate its public anchor");
+
+const loss = applyStealthRatingVote({
+  variant: initial,
+  publicAnchor,
+  variantSide: "B",
+  choice: "A",
+});
+assert.equal(loss.lossCount, 1);
+assert.ok(loss.eloRating < initial.eloRating);
+
+const tie = applyStealthRatingVote({
+  variant: initial,
+  publicAnchor,
+  variantSide: "B",
+  choice: "TIE",
+});
+assert.equal(tie.drawCount, 1);
+
+const bothBad = applyStealthRatingVote({
+  variant: initial,
+  publicAnchor,
+  variantSide: "A",
+  choice: "BOTH_BAD",
+});
+assert.equal(bothBad.bothBadCount, 1);
+assert.equal(bothBad.eloRating, initial.eloRating);
+assert.deepEqual(initial, {
+  eloRating: 1500,
+  glickoRd: 350,
+  glickoVolatility: 0.06,
+  conservativeRating: 800,
+  winCount: 0,
+  lossCount: 0,
+  drawCount: 0,
+  bothBadCount: 0,
+});
+
+console.log("stealth rating isolation checks passed");


### PR DESCRIPTION
## Summary

- add operator-managed private checkpoint evaluations with encrypted endpoint configuration, fixed-cohort generation, invitations, and lifecycle controls
- place one codenamed checkpoint against one public model in normal Arena matchups, reveal identities after voting, and keep private ratings and coverage out of public model state
- add an organization-scoped results workspace and policy-gated vote export

## Validation

- `pnpm lint`
- `pnpm exec tsc --noEmit`
- `pnpm test` (57 test files)
- `npm run build`
- Prisma validation and zero-diff migration check against an isolated database
- browser checks for anonymous matchup payloads, proxied build capabilities, post-vote reveal, and the responsive results workspace

## Before review

- [ ] deploy the migration and branch with alpha-only credentials
- [ ] exercise invitation and organization boundaries
- [ ] verify a complete generated cohort and credential deletion
- [ ] force private sampling and recheck reveal timing and public-state isolation
- [ ] exercise export policy and lifecycle controls

*(PR written by Codex)*
