### PR TITLE
feat(ui): visual overhaul and theme redesign

### DIFF
--- a/app/error.tsx
+++ b/app/error.tsx
@@ -19,7 +19,7 @@ export default function RouteError({ error, reset }: { error: Error & { digest?:
 
   return (
     <div className="flex min-h-[60vh] w-full items-center justify-center px-4 py-10">
-      <div className="mx-auto w-full max-w-sm rounded-xl border border-border bg-card p-6 shadow-soft">
+      <div className="mx-auto w-full max-w-sm rounded-md border border-border bg-card p-6">
         <div className="space-y-3">
           <h1 className="text-xl font-semibold leading-tight tracking-tight">{title}</h1>
           <p className="max-w-[32ch] text-sm leading-6 text-muted">{message}</p>

--- a/app/faq/page.tsx
+++ b/app/faq/page.tsx
@@ -93,6 +93,7 @@ export default function FaqPage() {
               items: section.items.map((item) => ({
                 id: item.id,
                 question: item.question,
+                navLabel: item.navLabel,
               })),
             }))}
           />

--- a/app/globals.css
+++ b/app/globals.css
@@ -4,6 +4,8 @@
 
 @layer base {
   :root {
+    color-scheme: light;
+
     /* Colors (HSL channels) */
     --bg: 0 0% 99%;
     --bg2: 220 20% 97%;
@@ -21,12 +23,17 @@
     --warn: 40 95% 52%;
     --success: 152 60% 34%;
 
-    /* Background effects */
-    --bg-halo-opacity: 0.45;
-    --bg-grid-opacity: 0.26;
+    /* The canvas renders with alpha, so this is the sky behind every build. */
+    --viewer-bg: 220 20% 97%;
   }
 
-  :root[data-theme="dark"] {
+  /* Dark has to be correct on the very first paint, before the theme script
+     runs — otherwise the page flashes light. The media query covers the
+     no-choice-yet case; the attribute selector lets an explicit choice win in
+     either direction. */
+  @media (prefers-color-scheme: dark) {
+    :root:not([data-theme="light"]) {
+      color-scheme: dark;
     --bg: 222 35% 6%;
     --bg2: 224 40% 4%;
     --card: 223 28% 10%;
@@ -42,8 +49,32 @@
     --warn: 40 95% 58%;
     --success: 152 70% 44%;
 
-    --bg-halo-opacity: 0.55;
-    --bg-grid-opacity: 0.30;
+    /* Lifted off the page background so near-black blocks (birds, dark wool)
+       still read against the sky. */
+    --viewer-bg: 222 24% 12%;
+    }
+  }
+
+  :root[data-theme="dark"] {
+    color-scheme: dark;
+    --bg: 222 35% 6%;
+    --bg2: 224 40% 4%;
+    --card: 223 28% 10%;
+    --card2: 223 24% 12%;
+    --border: 223 18% 18%;
+    --fg: 220 25% 96%;
+    --muted: 220 10% 72%;
+    --muted2: 220 9% 56%;
+
+    --accent: 168 88% 52%;
+    --accent2: 282 82% 68%;
+    --danger: 0 80% 62%;
+    --warn: 40 95% 58%;
+    --success: 152 70% 44%;
+
+    /* Lifted off the page background so near-black blocks (birds, dark wool)
+       still read against the sky. */
+    --viewer-bg: 222 24% 12%;
   }
 
   html,
@@ -88,46 +119,6 @@
 
   body.mb-page-fixed #mb-footer {
     flex-shrink: 0;
-  }
-
-  .mb-bg-grid {
-    opacity: var(--bg-grid-opacity);
-    background-image:
-      linear-gradient(to right, hsl(var(--border) / 0.26) 1px, transparent 1px),
-      linear-gradient(to bottom, hsl(var(--border) / 0.26) 1px, transparent 1px),
-      linear-gradient(to right, hsl(var(--border) / 0.40) 1px, transparent 1px),
-      linear-gradient(to bottom, hsl(var(--border) / 0.40) 1px, transparent 1px);
-    background-size: 26px 26px, 26px 26px, 156px 156px, 156px 156px;
-  }
-
-  :root[data-theme="dark"] .mb-bg-grid {
-    opacity: var(--bg-grid-opacity);
-    background-image:
-      linear-gradient(to right, hsl(var(--fg) / 0.05) 1px, transparent 1px),
-      linear-gradient(to bottom, hsl(var(--fg) / 0.05) 1px, transparent 1px),
-      linear-gradient(to right, hsl(var(--fg) / 0.09) 1px, transparent 1px),
-      linear-gradient(to bottom, hsl(var(--fg) / 0.09) 1px, transparent 1px);
-  }
-
-  /* Single brand-accent halo. Positioned just off the top-right corner so it
-     reads as a distant light source rather than a decorative wash. The
-     secondary gradient is a very subtle accent2 echo from the opposite corner
-     — matches the logo's accent-dominant gradient (accent as the bright spot,
-     accent2 as a quieter supporting tone). */
-  .mb-bg-halo {
-    opacity: var(--bg-halo-opacity);
-    background:
-      radial-gradient(
-        ellipse 90% 70% at 88% -8%,
-        hsl(var(--accent) / 0.32) 0%,
-        hsl(var(--accent) / 0.12) 28%,
-        transparent 62%
-      ),
-      radial-gradient(
-        ellipse 70% 60% at 8% 102%,
-        hsl(var(--accent2) / 0.14) 0%,
-        transparent 58%
-      );
   }
 
   ::selection {
@@ -270,30 +261,6 @@
     }
   }
 
-  @keyframes mb-vote-pulse {
-    0% {
-      box-shadow: 0 0 0 0 hsl(var(--accent) / 0.5);
-    }
-    70% {
-      box-shadow: 0 0 0 8px hsl(var(--accent) / 0);
-    }
-    100% {
-      box-shadow: 0 0 0 0 hsl(var(--accent) / 0);
-    }
-  }
-
-  @keyframes mb-vote-pulse-accent2 {
-    0% {
-      box-shadow: 0 0 0 0 hsl(var(--accent2) / 0.5);
-    }
-    70% {
-      box-shadow: 0 0 0 8px hsl(var(--accent2) / 0);
-    }
-    100% {
-      box-shadow: 0 0 0 0 hsl(var(--accent2) / 0);
-    }
-  }
-
   @keyframes mb-progress-wait-slide {
     0% {
       transform: translateX(-115%);
@@ -306,21 +273,7 @@
 
 @layer components {
   .mb-panel {
-    @apply relative overflow-hidden rounded-2xl bg-card/80 shadow-soft backdrop-blur-xl ring-1 ring-border sm:rounded-3xl;
-  }
-
-  .mb-panel::before {
-    content: "";
-    position: absolute;
-    inset: -1px;
-    border-radius: inherit;
-    pointer-events: none;
-    background:
-      radial-gradient(520px 260px at 0% 0%, hsl(var(--accent) / 0.18), transparent 62%),
-      radial-gradient(640px 300px at 100% 0%, hsl(var(--accent2) / 0.16), transparent 58%),
-      linear-gradient(to bottom, hsl(var(--card2) / 0.60), transparent 60%);
-    mix-blend-mode: screen;
-    opacity: 0.66;
+    @apply relative overflow-hidden rounded-md border border-border;
   }
 
   .mb-panel-pulse {
@@ -731,8 +684,7 @@
   }
 
   .mb-curve-tooltip {
-    @apply pointer-events-none -translate-y-full transform-gpu rounded-xl bg-card/95 px-3 py-2 text-xs ring-1 ring-border backdrop-blur;
-    box-shadow: 0 6px 16px -6px hsl(220 40% 2% / 0.35);
+    @apply pointer-events-none -translate-y-full transform-gpu rounded-md bg-card px-3 py-2 text-xs ring-1 ring-border;
     transition: opacity 150ms ease-out;
   }
 
@@ -749,32 +701,15 @@
   }
 
   .mb-head-to-head-card {
-    @apply rounded-2xl bg-bg/40 p-3.5 ring-1 ring-border/60;
+    @apply rounded-md p-3.5 ring-1 ring-border/60;
     transition-property: box-shadow, background-color, ring-color;
     transition-duration: 200ms;
   }
 
   .mb-head-to-head-card:hover,
   .mb-head-to-head-card:focus-within {
-    background-color: hsl(var(--bg) / 0.58);
+    background-color: hsl(var(--fg) / 0.04);
     border-color: hsl(var(--accent) / 0.24);
-    box-shadow: 0 16px 32px -28px hsl(var(--accent) / 0.55);
-  }
-
-  /* for long-form readable content on top of the mesh bg */
-  .mb-panel-solid {
-    background-color: hsl(var(--card) / 0.96);
-  }
-
-  :root[data-theme="dark"] .mb-panel-solid {
-    background-color: hsl(var(--card) / 0.86);
-  }
-
-  .mb-panel-solid::before {
-    background:
-      radial-gradient(520px 260px at 0% 0%, hsl(var(--accent) / 0.10), transparent 62%),
-      radial-gradient(640px 300px at 100% 0%, hsl(var(--accent2) / 0.10), transparent 58%),
-      linear-gradient(to bottom, hsl(var(--card2) / 0.40), transparent 60%);
   }
 
   .mb-panel-inner {
@@ -799,24 +734,21 @@
 
   .mb-back-link:hover {
     border-color: hsl(var(--accent) / 0.35);
-    background-color: hsl(var(--bg) / 0.8);
+    background-color: hsl(var(--fg) / 0.05);
     color: hsl(var(--accent));
-    box-shadow: 0 12px 24px -24px hsl(var(--accent) / 0.75);
   }
 
   .mb-back-link:focus-visible {
     outline: none;
-    box-shadow:
-      0 0 0 2px hsl(var(--accent) / 0.45),
-      0 12px 24px -24px hsl(var(--accent) / 0.75);
+    box-shadow: 0 0 0 2px hsl(var(--accent) / 0.45);
   }
 
   .mb-subpanel {
-    @apply rounded-xl bg-bg/60 ring-1 ring-border/70 sm:rounded-2xl;
+    @apply rounded-md border border-border/70;
   }
 
   .mb-badge {
-    @apply inline-flex items-center gap-2 rounded-full bg-bg/70 px-3 py-1 text-xs font-medium text-muted ring-1 ring-border/80;
+    @apply inline-flex items-center gap-2 rounded-md px-3 py-1 text-xs font-medium text-muted ring-1 ring-border/80;
   }
 
   /* Shared eyebrow label used across sections to label a region without a
@@ -836,18 +768,16 @@
   }
 
   .mb-field {
-    @apply w-full rounded-xl border border-border bg-bg/70 px-3 text-sm text-fg shadow-[inset_0_1px_0_hsl(0_0%_100%_/_0.06)] outline-none transition;
+    @apply w-full rounded-md border border-border bg-bg px-3 text-sm text-fg outline-none transition;
   }
 
   .mb-field:focus-visible {
     border-color: hsl(var(--accent) / 0.55);
-    box-shadow:
-      0 0 0 4px hsl(var(--accent) / 0.18),
-      inset 0 1px 0 hsl(0 0% 100% / 0.06);
+    box-shadow: 0 0 0 3px hsl(var(--accent) / 0.16);
   }
 
   .mb-btn {
-    @apply inline-flex select-none items-center justify-center gap-2 rounded-xl px-4 py-2 text-sm font-semibold text-fg focus-visible:outline-none;
+    @apply inline-flex select-none items-center justify-center gap-2 rounded-md px-4 py-2 text-sm font-semibold text-fg focus-visible:outline-none;
     transition:
       background-image 140ms ease-out,
       background-color 140ms ease-out,
@@ -860,12 +790,7 @@
     box-shadow: 0 0 0 3px hsl(var(--accent) / 0.22);
   }
 
-  .mb-btn:hover:not(:disabled) {
-    transform: translateY(-1px);
-  }
-
   .mb-btn:active:not(:disabled) {
-    transform: translateY(0);
     transition-duration: 60ms;
   }
 
@@ -881,41 +806,114 @@
 
   .mb-btn-primary {
     @apply ring-1 ring-accent/45;
-    background-image: linear-gradient(to bottom, hsl(var(--accent) / 0.30), hsl(var(--accent) / 0.16));
+    background-color: hsl(var(--accent) / 0.14);
   }
 
   .mb-btn-primary:hover:not(:disabled) {
     @apply ring-accent/70;
-    background-image: linear-gradient(to bottom, hsl(var(--accent) / 0.38), hsl(var(--accent) / 0.22));
+    background-color: hsl(var(--accent) / 0.22);
   }
 
   .mb-btn-primary:active:not(:disabled) {
     @apply ring-accent/70;
-    background-image: linear-gradient(to bottom, hsl(var(--accent) / 0.44), hsl(var(--accent) / 0.28));
+    background-color: hsl(var(--accent) / 0.30);
   }
 
   .mb-btn-ghost {
     @apply ring-1 ring-border/80;
-    background-image: linear-gradient(to bottom, hsl(var(--bg) / 0.72), hsl(var(--bg) / 0.46));
+    background-color: transparent;
   }
 
   .mb-btn-ghost:hover:not(:disabled) {
     @apply ring-border;
-    background-image: linear-gradient(to bottom, hsl(var(--bg) / 0.86), hsl(var(--bg) / 0.58));
+    background-color: hsl(var(--fg) / 0.05);
   }
 
   .mb-btn-ghost:active:not(:disabled) {
     @apply ring-border;
-    background-image: linear-gradient(to bottom, hsl(var(--bg) / 0.94), hsl(var(--bg) / 0.68));
+    background-color: hsl(var(--fg) / 0.09);
   }
 
   .mb-btn-danger {
-    @apply ring-1 ring-danger/45 hover:shadow-soft;
-    background-image: linear-gradient(to bottom, hsl(var(--danger) / 0.28), hsl(var(--danger) / 0.14));
+    @apply ring-1 ring-danger/45;
+    background-color: hsl(var(--danger) / 0.12);
   }
 
   .mb-btn-danger:hover {
-    background-image: linear-gradient(to bottom, hsl(var(--danger) / 0.32), hsl(var(--danger) / 0.16));
+    background-color: hsl(var(--danger) / 0.20);
+  }
+
+  /* Prompt disclosure. Overlays the builds instead of pushing them down —
+     a reflow here would stall the Three.js canvas mid-transition. Transform
+     and opacity only, so it composites. */
+  .mb-prompt-reveal {
+    opacity: 0;
+    transform: translateY(-0.375rem);
+    transform-origin: top center;
+    pointer-events: none;
+    visibility: hidden;
+    transition:
+      opacity 160ms cubic-bezier(0.22, 1, 0.36, 1),
+      transform 200ms cubic-bezier(0.22, 1, 0.36, 1),
+      visibility 0s linear 200ms;
+  }
+
+  .mb-prompt-reveal.is-open {
+    opacity: 1;
+    transform: translateY(0);
+    pointer-events: auto;
+    visibility: visible;
+    transition:
+      opacity 140ms cubic-bezier(0.22, 1, 0.36, 1),
+      transform 200ms cubic-bezier(0.22, 1, 0.36, 1),
+      visibility 0s;
+  }
+
+  /* Flip rather than rotate: a symmetric chevron passes through a flat line
+     at the midpoint, which reads as the control inverting, not spinning. */
+  .mb-disclosure-chevron {
+    transform: scaleY(1);
+    transform-origin: center;
+    transition: transform 200ms cubic-bezier(0.22, 1, 0.36, 1);
+  }
+
+  .mb-disclosure-chevron path {
+    vector-effect: non-scaling-stroke;
+  }
+
+  .mb-disclosure-chevron.is-open {
+    transform: scaleY(-1);
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .mb-prompt-reveal,
+    .mb-prompt-reveal.is-open,
+    .mb-disclosure-chevron {
+      transition: none;
+      transform: none;
+    }
+  }
+
+  /* Arena fills the first screen so the section rule below it stays in view
+     as a scroll cue, instead of leaving dead space under the vote bar. */
+  .mb-arena-stage {
+    /* The vote controls land exactly on the fold: subtract only the chrome
+       above them. The gap to the next section falls below the fold, so the
+       first screen has no dead space and nothing is left half-cut. */
+    --mb-arena-header: 6.75rem;
+    --mb-arena-pad: 1rem;
+    min-height: calc(100svh - var(--mb-arena-header) - var(--mb-arena-pad));
+  }
+
+  @media (min-width: 640px) {
+    .mb-arena-stage {
+      --mb-arena-header: 4rem;
+      --mb-arena-pad: 1.5rem;
+    }
+  }
+
+  .mb-viewer-stage {
+    background-color: hsl(var(--viewer-bg));
   }
 
   .mb-kbd {
@@ -931,7 +929,7 @@
   }
 
   .mb-chip[aria-pressed="true"] {
-    @apply bg-accent/20 ring-accent/40 shadow-glow;
+    @apply bg-accent/16 ring-accent/45;
   }
 
   .mb-chip[disabled] {
@@ -944,10 +942,8 @@
   }
 
   .mb-collapse-toggle:hover {
-    @apply shadow-soft;
     --tw-ring-color: hsl(var(--accent) / 0.36);
-    background-color: hsl(var(--bg) / 0.78);
-    transform: translateY(-1px);
+    background-color: hsl(var(--fg) / 0.05);
   }
 
   .mb-clamp-3 {
@@ -999,7 +995,7 @@
   }
 
   .mb-prompt-scroll::-webkit-scrollbar-thumb {
-    background: linear-gradient(to bottom, hsl(var(--accent) / 0.62), hsl(var(--accent2) / 0.52));
+    background: hsl(var(--accent) / 0.55);
     border-radius: 999px;
     border: 1px solid hsl(var(--border) / 0.75);
   }
@@ -1032,7 +1028,7 @@
     width: 100%;
     height: 6px;
     border-radius: 999px;
-    background: linear-gradient(to right, hsl(var(--accent) / 0.22), hsl(var(--accent2) / 0.24));
+    background: hsl(var(--accent) / 0.20);
     border: 1px solid hsl(var(--border) / 0.75);
     touch-action: none;
     user-select: none;
@@ -1045,11 +1041,8 @@
     height: 14px;
     min-width: 36px;
     border-radius: 999px;
-    background: linear-gradient(to bottom, hsl(var(--card) / 0.96), hsl(var(--card2) / 0.92));
+    background: hsl(var(--card));
     border: 1px solid hsl(var(--border));
-    box-shadow:
-      0 2px 7px hsl(0 0% 0% / 0.2),
-      0 0 0 1px hsl(var(--fg) / 0.04) inset;
     transition: background 150ms ease;
   }
 
@@ -1064,24 +1057,18 @@
   }
 
   .mb-mobile-stage-toggle {
-    @apply rounded-[1rem] p-1 ring-1 ring-border/55;
+    @apply rounded-md p-1 ring-1 ring-border/70;
     display: grid;
     grid-template-columns: repeat(2, minmax(0, 1fr));
     gap: 0.18rem;
-    background:
-      linear-gradient(180deg, hsl(var(--bg) / 0.54), hsl(var(--bg) / 0.42)),
-      radial-gradient(circle at top, hsl(var(--fg) / 0.02), transparent 56%);
-    box-shadow: inset 0 1px 0 hsl(0 0% 100% / 0.03);
   }
 
   .mb-mobile-stage-tab {
-    @apply rounded-[0.82rem] px-3 py-2.5 text-center ring-1 ring-transparent;
+    @apply rounded-[0.3rem] px-3 py-2.5 text-center ring-1 ring-transparent;
     display: flex;
     align-items: center;
     justify-content: center;
-    background:
-      linear-gradient(180deg, hsl(var(--bg) / 0.28), hsl(var(--bg) / 0.18)),
-      radial-gradient(circle at top, hsl(var(--fg) / 0.02), transparent 60%);
+    background: transparent;
     transition:
       transform 180ms ease,
       border-color 180ms ease,
@@ -1102,12 +1089,7 @@
 
   .mb-mobile-stage-tab-active {
     border-color: hsl(var(--accent) / 0.28);
-    background:
-      linear-gradient(180deg, hsl(var(--card) / 0.68), hsl(var(--bg) / 0.44)),
-      radial-gradient(circle at top, hsl(var(--accent) / 0.06), transparent 58%);
-    box-shadow:
-      inset 0 0 0 1px hsl(var(--accent) / 0.14),
-      inset 0 1px 0 hsl(0 0% 100% / 0.04);
+    background: hsl(var(--accent) / 0.12);
   }
 
   .mb-mobile-stage-label {
@@ -1213,19 +1195,96 @@
     animation-delay: 60ms;
   }
 
-  .mb-reveal-highlight-a {
-    @apply ring-2 ring-accent/50 shadow-glow;
-    animation: mb-vote-pulse 900ms ease-out 1;
+  /* One transitioned state, not a pulse that ends and then snaps back into a
+     separate static glow — that double hit is what read as a stutter. */
+  #mb-arena .mb-reveal-highlight-a,
+  #mb-arena .mb-reveal-highlight-b {
+    transition:
+      border-color 320ms cubic-bezier(0.22, 1, 0.36, 1) 60ms,
+      box-shadow 320ms cubic-bezier(0.22, 1, 0.36, 1) 60ms;
   }
 
-  .mb-reveal-highlight-b {
-    @apply ring-2 ring-accent2/50 shadow-glow;
-    animation: mb-vote-pulse-accent2 900ms ease-out 1;
+  #mb-arena .mb-reveal-highlight-a {
+    --reveal-tone: var(--accent);
+    border-color: hsl(var(--accent) / 0.55);
+    box-shadow: inset 0 0 0 1px hsl(var(--accent) / 0.35);
   }
 
-  .mb-reveal-dim {
-    opacity: 0.72;
-    filter: saturate(0.9);
+  #mb-arena .mb-reveal-highlight-b {
+    --reveal-tone: var(--accent2);
+    border-color: hsl(var(--accent2) / 0.55);
+    box-shadow: inset 0 0 0 1px hsl(var(--accent2) / 0.35);
+  }
+
+  /* The payoff: two rings ripple off the winning build and fade. They live on
+     pseudo-elements so the resting highlight above is never animated — that
+     hand-off from animation back to a static glow is what used to stutter.
+     Transform and opacity only, and the 1.4% swell stays inside the column
+     gap, so it cannot touch the other build. */
+  .mb-reveal-highlight-a::before,
+  .mb-reveal-highlight-a::after,
+  .mb-reveal-highlight-b::before,
+  .mb-reveal-highlight-b::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    border: 1px solid hsl(var(--reveal-tone) / 0.85);
+    pointer-events: none;
+    transform-origin: center;
+    animation: mb-reveal-ripple 820ms cubic-bezier(0.22, 1, 0.36, 1) both;
+  }
+
+  .mb-reveal-highlight-a::after,
+  .mb-reveal-highlight-b::after {
+    animation-delay: 140ms;
+  }
+
+  @keyframes mb-reveal-ripple {
+    0% {
+      opacity: 0.9;
+      transform: scale(1);
+    }
+    100% {
+      opacity: 0;
+      transform: scale(1.014);
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .mb-reveal-highlight-a::before,
+    .mb-reveal-highlight-a::after,
+    .mb-reveal-highlight-b::before,
+    .mb-reveal-highlight-b::after {
+      animation: none;
+      opacity: 0;
+    }
+  }
+
+  /* Reveal lanes arrive as one beat, A then B. */
+  @keyframes mb-lane-in {
+    from {
+      opacity: 0;
+      transform: translateY(3px);
+    }
+    to {
+      opacity: 1;
+      transform: none;
+    }
+  }
+
+  .mb-reveal-lane {
+    animation: mb-lane-in 280ms cubic-bezier(0.22, 1, 0.36, 1) both;
+  }
+
+  .mb-reveal-lane-delay {
+    animation-delay: 70ms;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .mb-reveal-lane {
+      animation: none;
+    }
   }
 
   @media (prefers-reduced-motion: reduce) {
@@ -1276,28 +1335,21 @@
 
   @keyframes mb-vote-confirm {
     0% {
-      transform: scale(1);
-      box-shadow:
-        0 0 0 0 hsl(var(--vote-confirm-color, var(--accent)) / 0.55),
-        0 0 0 0 hsl(var(--vote-confirm-color, var(--accent)) / 0.35);
+      box-shadow: inset 0 0 0 1px hsl(var(--vote-confirm-color, var(--accent)) / 0);
+      background-color: hsl(var(--vote-confirm-color, var(--accent)) / 0.14);
     }
-    28% {
-      transform: scale(1.045);
-      box-shadow:
-        0 0 0 4px hsl(var(--vote-confirm-color, var(--accent)) / 0.28),
-        0 10px 28px -8px hsl(var(--vote-confirm-color, var(--accent)) / 0.45);
+    22% {
+      box-shadow: inset 0 0 0 1px hsl(var(--vote-confirm-color, var(--accent)) / 0.85);
+      background-color: hsl(var(--vote-confirm-color, var(--accent)) / 0.42);
     }
     100% {
-      transform: scale(1);
-      box-shadow:
-        0 0 0 18px hsl(var(--vote-confirm-color, var(--accent)) / 0),
-        0 10px 28px -8px hsl(var(--vote-confirm-color, var(--accent)) / 0);
+      box-shadow: inset 0 0 0 1px hsl(var(--vote-confirm-color, var(--accent)) / 0);
+      background-color: hsl(var(--vote-confirm-color, var(--accent)) / 0.14);
     }
   }
 
   .mb-vote-confirmed {
-    animation: mb-vote-confirm 560ms cubic-bezier(0.22, 1, 0.36, 1) both;
-    z-index: 1;
+    animation: mb-vote-confirm 420ms cubic-bezier(0.22, 1, 0.36, 1) both;
   }
 
   .mb-vote-a.mb-vote-confirmed {
@@ -1319,14 +1371,6 @@
       animation: none;
       box-shadow: 0 0 0 3px hsl(var(--vote-confirm-color, var(--accent)) / 0.35);
     }
-  }
-
-  .mb-vote-a:hover:not(:disabled),
-  .mb-vote-b:hover:not(:disabled),
-  .mb-vote-tie:hover:not(:disabled),
-  .mb-vote-bad:hover:not(:disabled),
-  .mb-vote-skip:hover:not(:disabled) {
-    transform: translateY(-1px);
   }
 
   .mb-vote-a:active:not(:disabled),
@@ -1361,77 +1405,72 @@
   }
 
   .mb-vote-a {
-    @apply ring-1 ring-accent/40;
-    background: linear-gradient(135deg, hsl(var(--accent) / 0.22) 0%, hsl(var(--accent) / 0.10) 100%);
+    @apply ring-1 ring-accent/45;
+    background: hsl(var(--accent) / 0.14);
   }
 
   .mb-vote-a:hover:not(:disabled) {
     @apply ring-accent/70;
-    background: linear-gradient(135deg, hsl(var(--accent) / 0.32) 0%, hsl(var(--accent) / 0.16) 100%);
+    background: hsl(var(--accent) / 0.22);
   }
 
   .mb-vote-a:active:not(:disabled) {
-    background: linear-gradient(135deg, hsl(var(--accent) / 0.38) 0%, hsl(var(--accent) / 0.22) 100%);
-    box-shadow: inset 0 1px 2px hsl(0 0% 0% / 0.12);
+    background: hsl(var(--accent) / 0.30);
   }
 
   .mb-vote-b {
-    @apply ring-1 ring-accent2/40;
-    background: linear-gradient(135deg, hsl(var(--accent2) / 0.18) 0%, hsl(var(--accent2) / 0.08) 100%);
+    @apply ring-1 ring-accent2/45;
+    background: hsl(var(--accent2) / 0.14);
   }
 
   .mb-vote-b:hover:not(:disabled) {
     @apply ring-accent2/70;
-    background: linear-gradient(135deg, hsl(var(--accent2) / 0.28) 0%, hsl(var(--accent2) / 0.14) 100%);
+    background: hsl(var(--accent2) / 0.22);
   }
 
   .mb-vote-b:active:not(:disabled) {
-    background: linear-gradient(135deg, hsl(var(--accent2) / 0.34) 0%, hsl(var(--accent2) / 0.20) 100%);
-    box-shadow: inset 0 1px 2px hsl(0 0% 0% / 0.12);
+    background: hsl(var(--accent2) / 0.30);
   }
 
   .mb-vote-tie {
-    @apply ring-1 ring-border/60;
-    background: linear-gradient(135deg, hsl(var(--bg) / 0.70) 0%, hsl(var(--bg) / 0.50) 100%);
+    @apply ring-1 ring-border/70;
+    background: transparent;
   }
 
   .mb-vote-tie:hover:not(:disabled) {
     @apply ring-border;
-    background: linear-gradient(135deg, hsl(var(--bg) / 0.88) 0%, hsl(var(--bg) / 0.62) 100%);
+    background: hsl(var(--fg) / 0.05);
   }
 
   .mb-vote-tie:active:not(:disabled) {
-    background: linear-gradient(135deg, hsl(var(--bg) / 0.95) 0%, hsl(var(--bg) / 0.72) 100%);
-    box-shadow: inset 0 1px 2px hsl(0 0% 0% / 0.10);
+    background: hsl(var(--fg) / 0.09);
   }
 
   .mb-vote-bad {
-    @apply ring-1 ring-danger/30;
-    background: linear-gradient(135deg, hsl(var(--danger) / 0.12) 0%, hsl(var(--danger) / 0.05) 100%);
+    @apply ring-1 ring-danger/35;
+    background: hsl(var(--danger) / 0.09);
   }
 
   .mb-vote-bad:hover:not(:disabled) {
     @apply ring-danger/55;
-    background: linear-gradient(135deg, hsl(var(--danger) / 0.20) 0%, hsl(var(--danger) / 0.09) 100%);
+    background: hsl(var(--danger) / 0.16);
   }
 
   .mb-vote-bad:active:not(:disabled) {
-    background: linear-gradient(135deg, hsl(var(--danger) / 0.24) 0%, hsl(var(--danger) / 0.12) 100%);
-    box-shadow: inset 0 1px 2px hsl(0 0% 0% / 0.10);
+    background: hsl(var(--danger) / 0.22);
   }
 
   .mb-vote-skip {
-    @apply ring-1 ring-border/50;
-    background: linear-gradient(135deg, hsl(var(--muted) / 0.08) 0%, hsl(var(--muted) / 0.03) 100%);
+    @apply ring-1 ring-border/60;
+    background: transparent;
   }
 
   .mb-vote-skip:hover:not(:disabled) {
     @apply ring-border/80;
-    background: linear-gradient(135deg, hsl(var(--muted) / 0.16) 0%, hsl(var(--muted) / 0.07) 100%);
+    background: hsl(var(--fg) / 0.05);
   }
 
   .mb-vote-skip:active:not(:disabled) {
-    background: linear-gradient(135deg, hsl(var(--muted) / 0.20) 0%, hsl(var(--muted) / 0.09) 100%);
-    box-shadow: inset 0 1px 2px hsl(0 0% 0% / 0.08);
+    background: hsl(var(--fg) / 0.09);
   }
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -894,24 +894,6 @@
     }
   }
 
-  /* Arena fills the first screen so the section rule below it stays in view
-     as a scroll cue, instead of leaving dead space under the vote bar. */
-  .mb-arena-stage {
-    /* The vote controls land exactly on the fold: subtract only the chrome
-       above them. The gap to the next section falls below the fold, so the
-       first screen has no dead space and nothing is left half-cut. */
-    --mb-arena-header: 6.75rem;
-    --mb-arena-pad: 1rem;
-    min-height: calc(100svh - var(--mb-arena-header) - var(--mb-arena-pad));
-  }
-
-  @media (min-width: 640px) {
-    .mb-arena-stage {
-      --mb-arena-header: 4rem;
-      --mb-arena-pad: 1.5rem;
-    }
-  }
-
   .mb-viewer-stage {
     background-color: hsl(var(--viewer-bg));
   }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,5 @@
 import type { Metadata, Viewport } from "next";
 import { IBM_Plex_Mono, Spline_Sans, Unbounded } from "next/font/google";
-import Script from "next/script";
 import { Analytics } from "@vercel/analytics/next";
 import "./globals.css";
 import { OfflineBanner } from "@/components/OfflineBanner";
@@ -113,33 +112,24 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   return (
     <html
       lang="en"
-      data-theme="dark"
       suppressHydrationWarning
       className={`${fontSans.variable} ${fontDisplay.variable} ${fontMono.variable}`}
     >
       <body className="relative min-h-dvh bg-bg text-fg antialiased isolate">
         <script
+          // Applies a stored theme choice before first paint. With no stored
+          // choice the stylesheet's prefers-color-scheme rules already match,
+          // so nothing is written and nothing flashes.
+          dangerouslySetInnerHTML={{
+            __html: `(()=>{try{var t=localStorage.getItem("mb-theme");if(t==="light"||t==="dark"){var d=document.documentElement;d.dataset.theme=t;d.style.colorScheme=t}}catch(e){}})();`,
+          }}
+        />
+
+        <script
           type="application/ld+json"
           // Structured data for search engines.
           dangerouslySetInnerHTML={{ __html: JSON.stringify(structuredData) }}
         />
-
-        <Script id="mb-theme" strategy="beforeInteractive">{`
-(() => {
-  try {
-    const key = "mb-theme";
-    const saved = localStorage.getItem(key);
-    const theme = saved === "light" ? "light" : "dark";
-    document.documentElement.dataset.theme = theme;
-    document.documentElement.style.colorScheme = theme;
-  } catch {}
-})();
-        `}</Script>
-
-        <div aria-hidden="true" className="pointer-events-none fixed inset-0 z-0">
-          <div className="absolute inset-0 mb-bg-halo" />
-          <div className="absolute inset-0 mb-bg-grid" />
-        </div>
 
         <OfflineBanner />
         <SiteHealthBanner />

--- a/app/leaderboard/[modelKey]/loading.tsx
+++ b/app/leaderboard/[modelKey]/loading.tsx
@@ -4,12 +4,12 @@ export default function ModelDetailLoading() {
       <section className="mb-panel overflow-hidden p-4 sm:p-5">
         <div className="mb-panel-inner space-y-3.5">
           <div className="h-5 w-28 animate-pulse rounded-full bg-border/70" />
-          <div className="h-12 w-3/4 animate-pulse rounded-xl bg-border/55 sm:h-16" />
+          <div className="h-12 w-3/4 animate-pulse rounded-md bg-border/55 sm:h-16" />
           <div className="grid grid-cols-2 gap-2.5 sm:grid-cols-4">
-            <div className="h-16 animate-pulse rounded-xl bg-border/45" />
-            <div className="h-16 animate-pulse rounded-xl bg-border/45" />
-            <div className="h-16 animate-pulse rounded-xl bg-border/45" />
-            <div className="h-16 animate-pulse rounded-xl bg-border/45" />
+            <div className="h-16 animate-pulse rounded-md bg-border/45" />
+            <div className="h-16 animate-pulse rounded-md bg-border/45" />
+            <div className="h-16 animate-pulse rounded-md bg-border/45" />
+            <div className="h-16 animate-pulse rounded-md bg-border/45" />
           </div>
         </div>
       </section>
@@ -17,7 +17,7 @@ export default function ModelDetailLoading() {
       <section className="mb-panel overflow-hidden p-4 sm:p-5">
         <div className="mb-panel-inner space-y-3">
           <div className="h-4 w-40 animate-pulse rounded bg-border/60" />
-          <div className="h-64 animate-pulse rounded-2xl bg-border/45" />
+          <div className="h-64 animate-pulse rounded-md bg-border/45" />
         </div>
       </section>
 
@@ -28,7 +28,7 @@ export default function ModelDetailLoading() {
             {Array.from({ length: 6 }).map((_, index) => (
               <div
                 key={index}
-                className="h-56 animate-pulse rounded-2xl bg-border/45"
+                className="h-56 animate-pulse rounded-md bg-border/45"
               />
             ))}
           </div>

--- a/components/ErrorState.tsx
+++ b/components/ErrorState.tsx
@@ -25,7 +25,7 @@ export function ErrorState({ error, onRetry, retrying, compact, title, hint, cla
       role="alert"
       aria-live="polite"
       className={[
-        "rounded-xl ring-1 ring-danger/30 bg-danger/10 text-fg",
+        "rounded-md ring-1 ring-danger/30 bg-danger/10 text-fg",
         compact ? "px-3 py-2" : "px-3.5 py-3",
         className ?? "",
       ].join(" ").trim()}
@@ -44,7 +44,7 @@ export function ErrorState({ error, onRetry, retrying, compact, title, hint, cla
             type="button"
             onClick={onRetry}
             disabled={retrying}
-            className="mb-btn mb-btn-ghost h-8 shrink-0 rounded-full px-3 text-xs disabled:cursor-not-allowed disabled:opacity-60"
+            className="mb-btn mb-btn-ghost h-8 shrink-0 px-3 text-xs disabled:cursor-not-allowed disabled:opacity-60"
           >
             {retrying ? "Retrying…" : "Try again"}
           </button>

--- a/components/OfflineBanner.tsx
+++ b/components/OfflineBanner.tsx
@@ -25,7 +25,7 @@ export function OfflineBanner() {
       aria-live="polite"
       className="fixed inset-x-0 top-0 z-50 flex justify-center px-3 pt-3"
     >
-      <div className="mb-subpanel flex items-center gap-2 rounded-full px-3.5 py-1.5 text-xs font-medium text-warn ring-1 ring-warn/40 shadow-soft">
+      <div className="mb-subpanel flex items-center gap-2 rounded-md px-3.5 py-1.5 text-xs font-medium text-warn ring-1 ring-warn/40">
         <span className="h-1.5 w-1.5 rounded-full bg-warn shadow-[0_0_0_3px_hsl(var(--warn)_/_0.22)]" aria-hidden="true" />
         <span>You&apos;re offline. Changes may not save.</span>
       </div>

--- a/components/SiteHeader.tsx
+++ b/components/SiteHeader.tsx
@@ -11,18 +11,28 @@ type Theme = "light" | "dark";
 const THEME_KEY = "mb-theme";
 const BUY_ME_A_COFFEE_URL = "https://buymeacoffee.com/ammaaralam";
 
+function getSystemTheme(): Theme {
+  if (typeof window === "undefined") return "dark";
+  return window.matchMedia("(prefers-color-scheme: light)").matches ? "light" : "dark";
+}
+
+function getStoredTheme(): Theme | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const saved = window.localStorage.getItem(THEME_KEY);
+    if (saved === "dark" || saved === "light") return saved;
+  } catch {}
+  return null;
+}
+
 function getInitialTheme(): Theme {
+  const stored = getStoredTheme();
+  if (stored) return stored;
   if (typeof document !== "undefined") {
     const fromDom = document.documentElement.dataset.theme;
     if (fromDom === "dark" || fromDom === "light") return fromDom;
   }
-  if (typeof window !== "undefined") {
-    try {
-      const saved = window.localStorage.getItem(THEME_KEY);
-      if (saved === "dark" || saved === "light") return saved;
-    } catch {}
-  }
-  return "dark";
+  return getSystemTheme();
 }
 
 function applyTheme(theme: Theme) {
@@ -35,7 +45,7 @@ function applyTheme(theme: Theme) {
 
 function CubeMark() {
   return (
-    <div className="grid h-10 w-10 place-items-center overflow-hidden rounded-xl bg-gradient-to-br from-card/70 via-bg/40 to-accent/15 shadow-soft ring-1 ring-border backdrop-blur sm:h-9 sm:w-9">
+    <div className="grid h-10 w-10 place-items-center overflow-hidden rounded-lg sm:h-9 sm:w-9">
       <Image
         src={faviconIcon}
         alt="MineBench icon"
@@ -58,8 +68,20 @@ function ThemeToggle() {
         applyTheme(e.newValue);
       }
     };
+    const media = window.matchMedia("(prefers-color-scheme: light)");
+    const onSystemChange = () => {
+      if (getStoredTheme()) return;
+      const next = getSystemTheme();
+      setTheme(next);
+      document.documentElement.dataset.theme = next;
+      document.documentElement.style.colorScheme = next;
+    };
     window.addEventListener("storage", onStorage);
-    return () => window.removeEventListener("storage", onStorage);
+    media.addEventListener("change", onSystemChange);
+    return () => {
+      window.removeEventListener("storage", onStorage);
+      media.removeEventListener("change", onSystemChange);
+    };
   }, []);
 
   function toggleTheme() {
@@ -73,7 +95,7 @@ function ThemeToggle() {
       type="button"
       aria-label={theme === "dark" ? "Switch to light mode" : "Switch to dark mode"}
       title={theme === "dark" ? "Switch to light mode" : "Switch to dark mode"}
-      className="grid h-10 w-10 place-items-center rounded-full bg-gradient-to-b from-bg/70 to-bg/45 text-muted ring-1 ring-border/80 shadow-[inset_0_1px_0_hsl(0_0%_100%_/_0.06)] transition hover:from-bg/80 hover:to-bg/55 hover:text-fg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
+      className="grid h-10 w-10 place-items-center rounded-md text-muted transition-colors hover:text-fg focus-visible:outline-none focus-visible:text-accent"
       onClick={toggleTheme}
     >
       <svg aria-hidden="true" className="h-[18px] w-[18px]" viewBox="0 0 24 24" fill="none">
@@ -105,14 +127,18 @@ function NavLink({ href, label }: { href: string; label: string }) {
   return (
     <Link
       aria-current={active ? "page" : undefined}
-      className={
-        active
-          ? "inline-flex h-10 shrink-0 items-center rounded-full border border-accent/45 bg-gradient-to-b from-accent/22 via-accent/14 to-accent2/18 px-4 text-[13px] font-semibold text-fg shadow-[0_10px_28px_-18px_rgba(45,211,191,0.95),inset_0_1px_0_rgba(255,255,255,0.08)] ring-1 ring-accent/20 sm:text-sm"
-          : "inline-flex h-10 shrink-0 items-center rounded-full border border-transparent px-4 text-[13px] text-muted/90 transition hover:border-border/60 hover:bg-bg/60 hover:text-fg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 sm:text-sm"
-      }
+      className={`relative inline-flex h-10 shrink-0 items-center px-1 text-[13px] transition-colors focus-visible:outline-none focus-visible:text-accent sm:text-sm ${
+        active ? "font-medium text-fg" : "text-muted hover:text-fg"
+      }`}
       href={href}
     >
       <span>{label}</span>
+      <span
+        aria-hidden="true"
+        className={`absolute inset-x-0 bottom-0 h-px origin-left bg-fg transition-transform duration-200 ease-out motion-reduce:transition-none ${
+          active ? "scale-x-100" : "scale-x-0"
+        }`}
+      />
     </Link>
   );
 }
@@ -125,7 +151,7 @@ function SupportLink() {
       rel="noreferrer"
       title="Support MineBench on Buy Me a Coffee"
       aria-label="Support MineBench on Buy Me a Coffee"
-      className="inline-flex h-10 shrink-0 items-center gap-1.5 rounded-full border border-success/40 bg-success/10 px-3.5 text-[13px] font-semibold text-success transition hover:bg-success/18 hover:text-fg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-success/40 sm:text-sm"
+      className="inline-flex h-10 shrink-0 items-center gap-1.5 px-1 text-[13px] text-success transition-colors hover:text-fg focus-visible:outline-none focus-visible:text-accent sm:text-sm"
     >
       <svg
         aria-hidden="true"
@@ -171,7 +197,7 @@ function SocialIconLink({
 
 export function SiteHeader() {
   return (
-    <header className="relative sticky top-0 z-40 border-b border-border bg-bg/75 backdrop-blur">
+    <header className="relative sticky top-0 z-40 border-b border-border bg-bg">
       <div className="mx-auto flex w-full max-w-[92rem] flex-col gap-2 px-3 py-2.5 sm:flex-row sm:items-center sm:justify-between sm:gap-4 sm:px-6 sm:py-3 lg:px-8">
         <a
           href="#main"
@@ -229,9 +255,9 @@ export function SiteHeader() {
         </div>
 
         {/* Row 2: nav – grid keeps ThemeToggle pinned right, links scroll left */}
-        <nav className="grid w-full grid-cols-[1fr_auto] items-center gap-2 rounded-full bg-bg/55 p-1 shadow-soft ring-1 ring-border sm:flex sm:w-auto sm:flex-nowrap sm:items-center sm:gap-1 sm:bg-transparent sm:p-0 sm:shadow-none sm:ring-0">
+        <nav className="grid w-full grid-cols-[1fr_auto] items-center gap-2 sm:flex sm:w-auto sm:flex-nowrap sm:items-center sm:gap-1">
           <div className="relative min-w-0">
-            <div className="flex items-center gap-1 overflow-x-auto [scrollbar-width:none] [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden">
+            <div className="flex items-center gap-5 overflow-x-auto [scrollbar-width:none] [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden">
               <NavLink href="/" label="Arena" />
               <NavLink href="/sandbox" label="Sandbox" />
               <NavLink href="/leaderboard" label="Leaderboard" />
@@ -240,7 +266,7 @@ export function SiteHeader() {
               <SupportLink />
             </div>
             {/* fade mask so partially-visible Support fades out cleanly on mobile */}
-            <div className="pointer-events-none absolute inset-y-0 right-0 w-6 bg-gradient-to-l from-[hsl(var(--bg)/0.55)] to-transparent sm:hidden" aria-hidden="true" />
+            <div className="pointer-events-none absolute inset-y-0 right-0 w-6 bg-gradient-to-l from-bg to-transparent sm:hidden" aria-hidden="true" />
           </div>
           <div className="mx-1 hidden h-6 w-px bg-border sm:block" aria-hidden="true" />
           <ThemeToggle />

--- a/components/SiteHealthBanner.tsx
+++ b/components/SiteHealthBanner.tsx
@@ -29,7 +29,7 @@ export function SiteHealthBanner() {
       aria-live="polite"
       className="fixed inset-x-0 top-0 z-50 flex justify-center px-3 pt-3"
     >
-      <div className="mb-subpanel flex items-center gap-2 rounded-full px-3.5 py-1.5 text-xs font-medium text-warn ring-1 ring-warn/40 shadow-soft backdrop-blur-md">
+      <div className="mb-subpanel flex items-center gap-2 rounded-md bg-bg px-3.5 py-1.5 text-xs font-medium text-warn ring-1 ring-warn/40">
         <span
           className="h-1.5 w-1.5 rounded-full bg-warn shadow-[0_0_0_3px_hsl(var(--warn)_/_0.22)]"
           aria-hidden="true"

--- a/components/arena/Arena.tsx
+++ b/components/arena/Arena.tsx
@@ -1072,7 +1072,7 @@ function RevealLane({
   delayed,
 }: {
   side: "A" | "B";
-  model?: ArenaModelReveal | null;
+  model?: { provider?: string; displayName?: string } | null;
   chosen: boolean;
   faded: boolean;
   delayed?: boolean;

--- a/components/arena/Arena.tsx
+++ b/components/arena/Arena.tsx
@@ -1103,6 +1103,42 @@ const BUILD_STUCK_AUTOSKIP_MS = Number.parseInt(
   10,
 );
 
+function RevealLane({
+  side,
+  model,
+  chosen,
+  faded,
+  delayed,
+}: {
+  side: "A" | "B";
+  model?: { provider: string; displayName: string; eloRating: number };
+  chosen: boolean;
+  faded: boolean;
+  delayed?: boolean;
+}) {
+  const isA = side === "A";
+  const chosenRule = isA ? "border-accent" : "border-accent2";
+  const sideTone = isA ? "text-accent" : "text-accent2";
+  return (
+    <div
+      className={`mb-reveal-lane ${delayed ? "mb-reveal-lane-delay" : ""} flex min-w-0 flex-1 items-baseline gap-2 border-t-2 pt-1.5 transition-opacity duration-200 ${
+        chosen ? chosenRule : "border-border/70"
+      } ${faded ? "opacity-45" : "opacity-100"}`}
+    >
+      <span className={`shrink-0 font-mono text-[11px] font-semibold ${sideTone}`}>{side}</span>
+      <span className="min-w-0 truncate text-[13px] font-medium text-fg">
+        {model?.displayName ?? "—"}
+      </span>
+      <span className="hidden shrink-0 font-mono text-[11px] text-muted2 sm:inline">
+        {model?.provider ?? ""}
+      </span>
+      <span className="ml-auto shrink-0 pl-2 font-mono text-[12px] tabular-nums text-muted">
+        {model ? Math.round(model.eloRating) : ""}
+      </span>
+    </div>
+  );
+}
+
 function PipelineArrow() {
   return (
     <div
@@ -1152,6 +1188,7 @@ export function Arena() {
   const [viewerReady, setViewerReady] = useState<{ matchupId: string; a: boolean; b: boolean } | null>(null);
   const [customPrompt, setCustomPrompt] = useState("");
   const [promptDialogOpen, setPromptDialogOpen] = useState(false);
+  const promptRowRef = useRef<HTMLDivElement | null>(null);
   const [transitioning, setTransitioning] = useState(false);
   const [mobileBuildView, setMobileBuildView] = useState<"a" | "b">("a");
   const [isCoarsePointer, setIsCoarsePointer] = useState(false);
@@ -1412,9 +1449,23 @@ export function Arena() {
     const onKeyDown = (e: KeyboardEvent) => {
       if (e.key === "Escape") setPromptDialogOpen(false);
     };
+    const onPointerDown = (e: PointerEvent) => {
+      const row = promptRowRef.current;
+      if (row && e.target instanceof Node && !row.contains(e.target)) {
+        setPromptDialogOpen(false);
+      }
+    };
     window.addEventListener("keydown", onKeyDown);
-    return () => window.removeEventListener("keydown", onKeyDown);
+    window.addEventListener("pointerdown", onPointerDown);
+    return () => {
+      window.removeEventListener("keydown", onKeyDown);
+      window.removeEventListener("pointerdown", onPointerDown);
+    };
   }, [promptDialogOpen]);
+
+  useEffect(() => {
+    setPromptDialogOpen(false);
+  }, [matchup?.id]);
 
   useEffect(() => {
     const media = window.matchMedia("(pointer: coarse)");
@@ -2169,6 +2220,15 @@ export function Arena() {
     };
   }, [matchup, sideLoadState]);
 
+  const revealVerdict =
+    revealAction === "SKIP"
+      ? "Skipped"
+      : revealAction === "TIE"
+        ? "Tie"
+        : revealAction === "BOTH_BAD"
+          ? "Both bad"
+          : null;
+
   const revealMeta = (() => {
     if (!matchup || reveal.kind !== "reveal" || reveal.matchupId !== matchup.id) {
       return {
@@ -2541,67 +2601,61 @@ export function Arena() {
   const buildSwitchDisabled = state.kind !== "ready" || transitioning;
 
   return (
-    <div className="flex flex-col gap-4 md:gap-6">
-      <div className="mb-panel flex flex-col gap-2 p-2.5 sm:p-4 md:gap-2.5 md:p-3">
+    <div id="mb-arena" className="flex flex-col gap-10 md:gap-12">
+      <div className="mb-arena-stage flex flex-col gap-3">
           {/* prompt */}
-          <div className="mb-subpanel relative overflow-hidden px-3 py-2.5 sm:px-4 sm:py-3 md:py-2.5">
-            <div className="relative z-10 flex items-center gap-3 sm:gap-3.5">
+          <div ref={promptRowRef} className="relative border-b border-border/70 pb-3">
+            <div className="flex items-center gap-3 sm:gap-4">
               <span className="mb-eyebrow shrink-0">Prompt</span>
               <div
-                title={promptText}
-                className={`min-w-0 flex-1 overflow-hidden whitespace-nowrap text-ellipsis pr-1 text-[14px] font-medium leading-tight text-fg/95 sm:text-[15px] ${isLongPrompt ? "cursor-help" : ""}`}
+                className={`relative min-w-0 flex-1 overflow-hidden whitespace-nowrap text-ellipsis text-[15px] leading-snug text-fg transition-opacity duration-150 ease-out motion-reduce:transition-none sm:text-base ${isLongPrompt ? "pr-10" : ""} ${promptDialogOpen ? "opacity-0" : "opacity-100"}`}
               >
                 <AnimatedPrompt text={promptText || "Loading…"} isExpanded={false} />
+                {isLongPrompt ? (
+                  <span
+                    aria-hidden="true"
+                    className="pointer-events-none absolute inset-y-0 right-0 w-14 bg-gradient-to-l from-bg to-transparent"
+                  />
+                ) : null}
               </div>
               {isLongPrompt ? (
                 <button
                   type="button"
-                  className="mb-btn mb-btn-ghost h-8 shrink-0 rounded-full px-3 text-[11px] sm:text-[11px]"
-                  title="View full prompt"
-                  onClick={() => setPromptDialogOpen(true)}
+                  aria-expanded={promptDialogOpen}
+                  className="inline-flex h-7 shrink-0 items-center gap-1 text-[11px] font-medium text-muted transition-colors hover:text-fg focus-visible:text-accent focus-visible:outline-none"
+                  onClick={() => setPromptDialogOpen((open) => !open)}
                 >
                   <span className="hidden sm:inline">Full prompt</span>
                   <span className="sm:hidden">Full</span>
+                  <svg
+                    aria-hidden="true"
+                    className={`mb-disclosure-chevron h-3 w-3 ${promptDialogOpen ? "is-open" : ""}`}
+                    viewBox="0 0 16 16"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="1.75"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  >
+                    <path d="M4 6.5L8 10.5L12 6.5" />
+                  </svg>
                 </button>
               ) : null}
             </div>
+
+            {/* Drops out of the prompt rule rather than pushing the viewers down:
+               reflowing the canvas mid-transition costs a frame budget we do not have. */}
             {isLongPrompt ? (
-              <div className="pointer-events-none absolute inset-y-0 right-0 z-0 w-16 bg-gradient-to-l from-bg/95 to-transparent md:w-20" />
+              <div
+                className={`mb-prompt-reveal absolute inset-x-0 top-full z-30 ${promptDialogOpen ? "is-open" : ""}`}
+                aria-hidden={!promptDialogOpen}
+              >
+                <p className="border-b border-border bg-bg px-0 pb-4 pt-3 text-[15px] leading-relaxed text-fg/90 sm:text-base">
+                  {promptText}
+                </p>
+              </div>
             ) : null}
           </div>
-
-          {promptDialogOpen ? (
-            <div className="fixed inset-0 z-50 flex items-end justify-center p-4 sm:items-center">
-              <button
-                type="button"
-                aria-label="Close"
-                className="absolute inset-0 bg-bg/60 backdrop-blur-sm"
-                onClick={() => setPromptDialogOpen(false)}
-              />
-              <div
-                role="dialog"
-                aria-modal="true"
-                aria-label="Full prompt"
-                className="relative w-full max-w-2xl overflow-hidden rounded-3xl bg-card/90 shadow-soft ring-1 ring-border backdrop-blur-xl"
-              >
-                <div className="flex items-center justify-between gap-3 border-b border-border/60 px-4 py-3">
-                  <span className="mb-eyebrow">Prompt</span>
-                  <button
-                    type="button"
-                    className="mb-btn mb-btn-ghost h-9 rounded-full px-4 text-xs"
-                    onClick={() => setPromptDialogOpen(false)}
-                  >
-                    Close <span className="hidden sm:inline"><span className="mb-kbd">Esc</span></span>
-                  </button>
-                </div>
-                <div className="max-h-[70vh] overflow-auto px-4 py-4">
-                  <p className="whitespace-pre-wrap break-words text-[15px] leading-relaxed text-fg/90">
-                    {promptText}
-                  </p>
-                </div>
-              </div>
-            </div>
-          ) : null}
 
           {state.kind === "error" ? (
             <ErrorState
@@ -2617,7 +2671,7 @@ export function Arena() {
             <div
               role="status"
               aria-live="polite"
-              className="flex items-center gap-2 rounded-xl bg-bg/50 px-3 py-2 text-xs text-muted ring-1 ring-border/60"
+              className="flex items-center gap-2 rounded-md bg-bg/50 px-3 py-2 text-xs text-muted ring-1 ring-border/60"
             >
               <span className="mb-progress-wait relative h-1.5 w-6 overflow-hidden rounded-full bg-border/40" aria-hidden="true" />
               <span>Taking longer than usual — MineBench may be under heavy load.</span>
@@ -2628,7 +2682,7 @@ export function Arena() {
             <div
               role="status"
               aria-live="polite"
-              className="flex items-start gap-2 rounded-xl bg-warn/8 px-3 py-2 text-xs text-warn ring-1 ring-warn/30"
+              className="flex items-start gap-2 rounded-md bg-warn/8 px-3 py-2 text-xs text-warn ring-1 ring-warn/30"
             >
               <svg
                 aria-hidden="true"
@@ -2669,10 +2723,10 @@ export function Arena() {
           {/* builds grid */}
           <div
             ref={cardsScrollRef}
-            className={`mb-x-scroll -mx-0.5 flex w-[calc(100%+0.25rem)] snap-x snap-mandatory gap-2 overflow-x-auto overscroll-x-contain px-0.5 pb-1 scroll-smooth transition-[opacity,transform] duration-200 ease-out motion-reduce:transition-none md:mx-0 md:w-full md:grid md:snap-none md:grid-cols-2 md:gap-3 md:overflow-visible md:px-0 md:pb-0 ${transitioning ? "opacity-0 translate-y-1" : "opacity-100 translate-y-0"}`}
+            className={`mb-x-scroll -mx-0.5 flex min-h-0 w-[calc(100%+0.25rem)] flex-1 snap-x snap-mandatory gap-2 overflow-x-auto overscroll-x-contain px-0.5 pb-1 scroll-smooth transition-[opacity,transform] duration-200 ease-out motion-reduce:transition-none md:mx-0 md:w-full md:grid md:snap-none md:grid-cols-2 md:gap-3 md:overflow-visible md:px-0 md:pb-0 ${transitioning ? "opacity-0 translate-y-1" : "opacity-100 translate-y-0"}`}
           >
             <div
-              className={`relative mb-card-enter min-w-full shrink-0 snap-center [scroll-snap-stop:always] rounded-2xl transition-all duration-200 ease-out motion-reduce:transition-none sm:rounded-3xl md:min-w-0 md:shrink md:snap-none ${mobileBuildView === "a" ? "ring-1 ring-accent/30 md:ring-border/60 md:shadow-none" : "ring-1 ring-border/60"} ${revealModels && revealAction === "A" ? "mb-reveal-highlight-a" : ""} ${revealModels && revealAction === "B" ? "mb-reveal-dim" : ""}`}
+              className={`relative mb-card-enter flex min-h-0 min-w-full shrink-0 flex-col snap-center [scroll-snap-stop:always] rounded-md border transition-all duration-200 ease-out motion-reduce:transition-none md:min-w-0 md:shrink md:snap-none ${mobileBuildView === "a" ? "border-accent/40 md:border-border/70" : "border-border/70"} ${revealModels && revealAction === "A" ? "mb-reveal-highlight-a" : ""}`}
             >
               <VoxelViewerCard
                 key={matchup ? `${matchup.id}:a` : "arena-build-a"}
@@ -2714,7 +2768,7 @@ export function Arena() {
                   laneNeedsFullA ? (
                     <button
                       type="button"
-                      className="mb-btn mb-btn-ghost h-8 rounded-full px-3 text-[11px] sm:text-xs"
+                      className="mb-btn mb-btn-ghost h-8 px-3 text-[11px] sm:text-xs"
                       disabled={laneLoadA === "loading-full"}
                       onClick={() => requestFullLaneDetail("a")}
                     >
@@ -2725,7 +2779,7 @@ export function Arena() {
               />
             </div>
             <div
-              className={`relative mb-card-enter mb-card-enter-delay min-w-full shrink-0 snap-center [scroll-snap-stop:always] rounded-2xl transition-all duration-200 ease-out motion-reduce:transition-none sm:rounded-3xl md:min-w-0 md:shrink md:snap-none ${mobileBuildView === "b" ? "ring-1 ring-accent2/30 md:ring-border/60 md:shadow-none" : "ring-1 ring-border/60"} ${revealModels && revealAction === "B" ? "mb-reveal-highlight-b" : ""} ${revealModels && revealAction === "A" ? "mb-reveal-dim" : ""}`}
+              className={`relative mb-card-enter mb-card-enter-delay flex min-h-0 min-w-full shrink-0 flex-col snap-center [scroll-snap-stop:always] rounded-md border transition-all duration-200 ease-out motion-reduce:transition-none md:min-w-0 md:shrink md:snap-none ${mobileBuildView === "b" ? "border-accent2/40 md:border-border/70" : "border-border/70"} ${revealModels && revealAction === "B" ? "mb-reveal-highlight-b" : ""}`}
             >
               <VoxelViewerCard
                 key={matchup ? `${matchup.id}:b` : "arena-build-b"}
@@ -2767,7 +2821,7 @@ export function Arena() {
                   laneNeedsFullB ? (
                     <button
                       type="button"
-                      className="mb-btn mb-btn-ghost h-8 rounded-full px-3 text-[11px] sm:text-xs"
+                      className="mb-btn mb-btn-ghost h-8 px-3 text-[11px] sm:text-xs"
                       disabled={laneLoadB === "loading-full"}
                       onClick={() => requestFullLaneDetail("b")}
                     >
@@ -2781,7 +2835,7 @@ export function Arena() {
 
           {/* segmented build switcher – mobile only */}
           <div className="md:hidden">
-            <div className="flex rounded-xl border border-border/55 bg-bg/45 p-0.5 shadow-[inset_0_1px_0_hsl(var(--fg)_/_0.04)] backdrop-blur-sm">
+            <div className="flex rounded-md border border-border/70">
               <button
                 type="button"
                 aria-pressed={mobileBuildView === "a"}
@@ -2816,12 +2870,12 @@ export function Arena() {
           </div>
 
 	          {buildLoadError ? (
-	            <div className="mb-subpanel flex items-center justify-between gap-3 px-3 py-2 text-sm text-muted sm:px-4">
+	            <div className="flex items-center justify-between gap-3 border-t border-border/70 px-1 py-2 text-sm text-muted">
 	              <span>{buildLoadError}</span>
 	              <div className="flex shrink-0 items-center gap-2">
 	                <button
 	                  type="button"
-	                  className="mb-btn mb-btn-ghost h-8 rounded-full px-3 text-[11px] sm:text-xs"
+	                  className="mb-btn mb-btn-ghost h-8 px-3 text-[11px] sm:text-xs"
 	                  onClick={() => {
 	                    if (laneErrorA) retryLaneBuild("a");
 	                    if (laneErrorB) retryLaneBuild("b");
@@ -2831,7 +2885,7 @@ export function Arena() {
 	                </button>
 	                <button
 	                  type="button"
-	                  className="mb-btn mb-btn-ghost h-8 rounded-full px-3 text-[11px] sm:text-xs"
+	                  className="mb-btn mb-btn-ghost h-8 px-3 text-[11px] sm:text-xs"
 	                  onClick={() => {
 	                    void handleSkip();
 	                  }}
@@ -2843,154 +2897,89 @@ export function Arena() {
 	          ) : null}
 
 	          {/* action bar (vote buttons ↔ reveal status) */}
-          <div className="relative h-[8.5rem] sm:h-[7.5rem]">
-            <div className="relative h-full">
-              <div className="relative h-full">
-                <div
-                  className={`absolute inset-0 transition-[opacity,transform] duration-200 ease-out motion-reduce:transition-none ${revealMeta.visible ? "pointer-events-none opacity-0 translate-y-1" : "opacity-100 translate-y-0"}`}
-                  >
-                    <VoteBar
-                      disabled={state.kind !== "ready" || submitting || transitioning}
-                      disableVotes={state.kind !== "ready" || matchupBuildLoading}
-                      onVote={handleVote}
-                      onSkip={handleSkip}
-                      confirming={voteConfirming}
+          {/* Both states share one grid cell, so the bar is exactly as tall as
+             the vote controls need and the crossfade shifts nothing. */}
+          <div className="grid">
+            <div
+              className={`[grid-area:1/1] transition-[opacity,transform] duration-200 ease-out motion-reduce:transition-none ${revealMeta.visible ? "pointer-events-none opacity-0 translate-y-1" : "opacity-100 translate-y-0"}`}
+            >
+              <VoteBar
+                disabled={state.kind !== "ready" || submitting || transitioning}
+                disableVotes={state.kind !== "ready" || matchupBuildLoading}
+                onVote={handleVote}
+                onSkip={handleSkip}
+                confirming={voteConfirming}
+              />
+            </div>
+
+            <div
+              aria-hidden={!revealMeta.visible}
+              className={`[grid-area:1/1] transition-[opacity,transform] duration-200 ease-out motion-reduce:transition-none ${revealMeta.visible ? "opacity-100 translate-y-0" : "pointer-events-none opacity-0 -translate-y-1"}`}
+            >
+              <div className="flex h-full flex-col justify-center gap-3 border-t border-border/70 px-1 py-2 sm:py-3">
+                <div key={matchup?.id} className="flex items-baseline gap-3 sm:gap-5">
+                  <RevealLane
+                    side="A"
+                    model={matchup?.a.model}
+                    chosen={revealAction === "A"}
+                    faded={revealAction === "B"}
+                  />
+                  <RevealLane
+                    side="B"
+                    model={matchup?.b.model}
+                    chosen={revealAction === "B"}
+                    faded={revealAction === "A"}
+                    delayed
+                  />
+                  {revealVerdict ? (
+                    <span className="mb-reveal-lane mb-reveal-lane-delay hidden shrink-0 font-mono text-[11px] uppercase tracking-[0.18em] text-muted2 md:inline">
+                      {revealVerdict}
+                    </span>
+                  ) : null}
+                </div>
+
+                <div className="flex items-center gap-3">
+                  <div className="relative h-px min-w-0 flex-1 bg-border/50">
+                    <div
+                      className="absolute inset-y-0 left-0 bg-accent/70 transition-[width] duration-100 ease-linear motion-reduce:transition-none"
+                      style={{ width: `${(revealMeta.progress * 100).toFixed(1)}%` }}
                     />
+                    {revealMeta.waitingForNext ? (
+                      <div className="mb-progress-wait absolute inset-0" />
+                    ) : null}
                   </div>
 
-                  <div
-                    className={`absolute inset-0 transition-[opacity,transform] duration-200 ease-out motion-reduce:transition-none ${revealMeta.visible ? "opacity-100 translate-y-0" : "pointer-events-none opacity-0 -translate-y-1"}`}
+                  <button
+                    type="button"
+                    className="mb-btn mb-btn-ghost h-8 shrink-0 px-3 text-xs"
+                    disabled={transitioning}
+                    onClick={() => {
+                      if (reveal.kind !== "reveal" || reveal.matchupId !== matchup?.id) return;
+                      if (!reveal.next) {
+                        requestAdvanceNow(reveal.matchupId);
+                        return;
+                      }
+                      void advanceToNext(reveal.matchupId, reveal.next);
+                    }}
                   >
-                    <div className="mb-subpanel h-full px-3 py-2 sm:px-4 sm:py-2.5">
-                      <div className="flex h-full flex-col justify-between gap-2">
-                        <div className="flex min-w-0 flex-col items-stretch gap-2 sm:flex-row sm:items-center sm:justify-between">
-                          <div className="flex min-w-0 items-center gap-2">
-                            <span className="mb-badge bg-bg/40 text-muted ring-border/60">
-                              {revealAction === "SKIP"
-                                ? "Skipped"
-                                : revealAction === "TIE"
-                                  ? "You voted: Tie"
-                                  : revealAction === "BOTH_BAD"
-                                    ? "You voted: Both bad"
-                                    : revealAction === "A"
-                                      ? "You voted: A"
-                                      : revealAction === "B"
-                                        ? "You voted: B"
-                                        : "Revealed"}
-                            </span>
-
-                            <div className="hidden min-w-0 items-center gap-2 text-xs sm:flex">
-                              <span className="inline-flex h-5 items-center rounded-full bg-accent/10 px-2 font-mono text-[11px] font-semibold text-accent ring-1 ring-accent/20">
-                                A
-                              </span>
-                              <span className="min-w-0 max-w-[10rem] truncate font-medium text-fg md:max-w-[16rem]">
-                                {matchup?.a.model.displayName}
-                              </span>
-                              <span className="text-muted">vs</span>
-                              <span className="inline-flex h-5 items-center rounded-full bg-accent2/10 px-2 font-mono text-[11px] font-semibold text-accent2 ring-1 ring-accent2/20">
-                                B
-                              </span>
-                              <span className="min-w-0 max-w-[10rem] truncate font-medium text-fg md:max-w-[16rem]">
-                                {matchup?.b.model.displayName}
-                              </span>
-                            </div>
-                          </div>
-
-                          <div className="flex items-center justify-between gap-3 sm:shrink-0 sm:justify-start">
-                            <div className="flex items-center gap-2 text-xs text-muted">
-                              {revealMeta.nextReady ? (
-                                <span className="font-mono">
-                                  Next in {Math.max(0, Math.ceil(revealMeta.secondsLeft))}s
-                                </span>
-                              ) : (
-                                <span className="inline-flex items-center gap-2 font-mono">
-                                  <span
-                                    className={`h-3 w-3 rounded-full border-2 border-muted/30 ${
-                                      revealMeta.waitingForNext
-                                        ? "animate-pulse border-t-muted/60"
-                                        : "animate-spin border-t-muted/80"
-                                    }`}
-                                  />
-                                  {revealMeta.waitingForNext
-                                    ? "Loading next…"
-                                    : "Loading…"}
-                                </span>
-                              )}
-                            </div>
-
-                            <button
-                              type="button"
-                              className="mb-btn mb-btn-ghost h-9 px-4 text-xs"
-                              disabled={transitioning}
-                              onClick={() => {
-                                if (reveal.kind !== "reveal" || reveal.matchupId !== matchup?.id) return;
-                                if (!reveal.next) {
-                                  requestAdvanceNow(reveal.matchupId);
-                                  return;
-                                }
-                                void advanceToNext(reveal.matchupId, reveal.next);
-                              }}
-                            >
-                              Next{" "}
-                              <span className="hidden md:inline"><span className="mb-kbd">Space</span></span>
-                            </button>
-                          </div>
-                        </div>
-
-                        {/* Mobile-only: show both model names so user doesn't have to swipe */}
-                        <div className="flex items-center gap-2 text-[11px] sm:hidden">
-                          <div
-                            className={`flex min-w-0 flex-1 items-center gap-1.5 rounded-lg bg-accent/8 px-2 py-1 ring-1 ring-accent/20 ${
-                              revealAction === "A" ? "ring-accent/50" : ""
-                            }`}
-                          >
-                            <span className="inline-flex h-4 items-center rounded-full bg-accent/15 px-1.5 font-mono text-[10px] font-semibold text-accent ring-1 ring-accent/30">
-                              A
-                            </span>
-                            <span className="min-w-0 flex-1 truncate font-medium text-fg/95">
-                              {matchup?.a.model.displayName ?? "—"}
-                            </span>
-                          </div>
-                          <div
-                            className={`flex min-w-0 flex-1 items-center gap-1.5 rounded-lg bg-accent2/8 px-2 py-1 ring-1 ring-accent2/20 ${
-                              revealAction === "B" ? "ring-accent2/50" : ""
-                            }`}
-                          >
-                            <span className="inline-flex h-4 items-center rounded-full bg-accent2/15 px-1.5 font-mono text-[10px] font-semibold text-accent2 ring-1 ring-accent2/30">
-                              B
-                            </span>
-                            <span className="min-w-0 flex-1 truncate font-medium text-fg/95">
-                              {matchup?.b.model.displayName ?? "—"}
-                            </span>
-                          </div>
-                        </div>
-
-                        <div className="relative h-1.5 w-full overflow-hidden rounded-full bg-border/40">
-                          <div
-                            className="h-full rounded-full bg-accent/70 transition-[width] duration-100 ease-linear motion-reduce:transition-none"
-                            style={{ width: `${(revealMeta.progress * 100).toFixed(1)}%` }}
-                          />
-                          {revealMeta.waitingForNext ? (
-                            <div className="mb-progress-wait absolute inset-0" />
-                          ) : null}
-                        </div>
-                      </div>
-                    </div>
-                  </div>
+                    Next
+                    <span className="hidden md:inline"><span className="mb-kbd">Space</span></span>
+                  </button>
                 </div>
               </div>
             </div>
+          </div>
       </div>
 
       {/* how it works — pipeline diagram */}
-      <div className="mb-panel mb-panel-solid overflow-hidden p-5 sm:p-7 md:p-10">
-        <div className="mx-auto flex w-full max-w-5xl flex-col items-center">
-          <h2 className="mb-3 text-center font-display text-2xl font-semibold tracking-tight text-fg sm:text-[1.75rem] md:mb-4 md:text-3xl">
+      <section className="border-t border-border/70 pt-8 sm:pt-10">
+        <div className="flex w-full flex-col">
+          <h2 className="font-display text-[clamp(1.6rem,3.4vw,2.4rem)] font-semibold leading-tight tracking-tight text-fg">
             How it works
           </h2>
-          <p className="mb-8 max-w-2xl text-center text-[15px] leading-relaxed text-fg/80 sm:mb-10 sm:text-base">
-            Models read a text prompt and output raw JSON coordinates for voxel blocks — no images,
-            no 3D tools. Humans vote pair-wise and rankings emerge from Elo.
+          <p className="mb-8 mt-3 max-w-[62ch] text-[15px] leading-relaxed text-muted sm:mb-10 sm:text-base">
+            Models read a text prompt and output raw block coordinates — no images, no 3D tools.
+            Humans vote pair-wise, and the rankings follow.
           </p>
 
           <div className="grid w-full grid-cols-1 items-stretch gap-5 md:grid-cols-[1fr_auto_1fr_auto_1fr] md:gap-6">
@@ -3000,7 +2989,7 @@ export function Arena() {
                 <span className="mb-step-num">01</span>
                 <span className="mb-eyebrow">Prompt</span>
               </div>
-              <figure className="rounded-xl border border-border/60 bg-bg/40 p-4 font-mono text-[12px] italic leading-relaxed text-fg/85">
+              <figure className="border-t border-border/70 pt-4 font-mono text-[12px] italic leading-relaxed text-fg/85">
                 &ldquo;A warm wooden cabin beside a pond, with a stone chimney, a small dock, and a few trees.&rdquo;
               </figure>
               <p className="text-sm leading-relaxed text-fg/70">
@@ -3016,7 +3005,7 @@ export function Arena() {
                 <span className="mb-step-num">02</span>
                 <span className="mb-eyebrow">Generate</span>
               </div>
-              <figure className="relative rounded-xl border border-accent/25 bg-bg/40 p-4 font-mono text-[11px] leading-relaxed text-fg/85">
+              <figure className="relative border-t border-accent/40 pt-4 font-mono text-[11px] leading-relaxed text-fg/85">
                 <pre className="overflow-x-auto whitespace-pre">
 {`{
   "version": "1.0",
@@ -3027,7 +3016,7 @@ export function Arena() {
   ]
 }`}
                 </pre>
-                <span className="absolute bottom-2 right-3 font-mono text-[10px] text-muted/70">
+                <span className="absolute bottom-0 right-0 font-mono text-[10px] text-muted/70">
                   1,247 blocks
                 </span>
               </figure>
@@ -3044,17 +3033,17 @@ export function Arena() {
                 <span className="mb-step-num">03</span>
                 <span className="mb-eyebrow">Vote &amp; rank</span>
               </div>
-              <figure className="flex flex-col gap-3 rounded-xl border border-border/60 bg-bg/40 p-4">
+              <figure className="flex flex-col gap-3 border-t border-border/70 pt-4">
                 <div className="flex flex-wrap items-center justify-center gap-1.5 text-[11px]">
-                  <span className="inline-flex h-7 items-center rounded-lg bg-accent/15 px-2.5 font-semibold text-accent ring-1 ring-accent/30">
+                  <span className="inline-flex h-7 items-center rounded-md border border-accent/40 px-2.5 font-medium text-accent">
                     A wins
                   </span>
                   <span className="hidden text-muted/60 sm:inline">·</span>
-                  <span className="inline-flex h-7 items-center rounded-lg bg-muted/10 px-2.5 font-semibold text-muted/90 ring-1 ring-border/70">
+                  <span className="inline-flex h-7 items-center rounded-md border border-border/70 px-2.5 font-medium text-muted">
                     Tie
                   </span>
                   <span className="hidden text-muted/60 sm:inline">·</span>
-                  <span className="inline-flex h-7 items-center rounded-lg bg-accent2/15 px-2.5 font-semibold text-accent2 ring-1 ring-accent2/30">
+                  <span className="inline-flex h-7 items-center rounded-md border border-accent2/40 px-2.5 font-medium text-accent2">
                     B wins
                   </span>
                 </div>
@@ -3079,20 +3068,20 @@ export function Arena() {
             </div>
           </div>
         </div>
-      </div>
+      </section>
 
       {/* sandbox cta - moved to bottom & polished */}
-      <div className="mb-panel mb-panel-solid flex flex-col items-center gap-4 p-5 text-center sm:p-6 md:p-7">
-        <div className="flex flex-col items-center gap-1.5">
-          <h3 className="font-display text-lg font-semibold tracking-tight text-fg sm:text-xl">
-            Want to test a model yourself?
-          </h3>
-          <p className="text-sm leading-relaxed text-fg/70">
-            Enter any prompt to generate a 3D build in the Sandbox.
+      <section className="flex flex-col gap-4 border-t border-border/70 pt-8 sm:flex-row sm:items-end sm:justify-between sm:gap-10 sm:pt-10">
+        <div className="flex flex-col gap-2">
+          <h2 className="font-display text-[clamp(1.6rem,3.4vw,2.4rem)] font-semibold leading-tight tracking-tight text-fg">
+            Build your own
+          </h2>
+          <p className="max-w-[48ch] text-[15px] leading-relaxed text-muted">
+            Any prompt, any model, rendered live.
           </p>
         </div>
         <form
-          className="relative flex w-full max-w-md items-center"
+          className="relative flex w-full items-center sm:max-w-md"
           onSubmit={(e) => {
             e.preventDefault();
             const q = customPrompt.trim();
@@ -3107,13 +3096,13 @@ export function Arena() {
             onChange={(e) => setCustomPrompt(e.target.value)}
           />
           <a
-            className="mb-btn mb-btn-primary absolute right-1.5 top-1.5 bottom-1.5 flex items-center rounded-md px-4 text-sm"
+            className="mb-btn mb-btn-primary absolute right-1.5 top-1.5 bottom-1.5 flex items-center px-4 text-sm"
             href={`/sandbox${customPrompt.trim() ? `?prompt=${encodeURIComponent(customPrompt.trim())}` : ""}`}
           >
             Generate
           </a>
         </form>
-      </div>
+      </section>
     </div>
   );
 }

--- a/components/arena/Arena.tsx
+++ b/components/arena/Arena.tsx
@@ -2562,7 +2562,7 @@ export function Arena() {
 
   return (
     <div id="mb-arena" className="flex flex-col gap-10 md:gap-12">
-      <div className="mb-arena-stage flex flex-col gap-3">
+      <div className="flex flex-col gap-3">
           {/* prompt */}
           <div ref={promptRowRef} className="relative border-b border-border/70 pb-3">
             <div className="flex items-center gap-3 sm:gap-4">
@@ -2683,10 +2683,10 @@ export function Arena() {
           {/* builds grid */}
           <div
             ref={cardsScrollRef}
-            className={`mb-x-scroll -mx-0.5 flex min-h-0 w-[calc(100%+0.25rem)] flex-1 snap-x snap-mandatory gap-2 overflow-x-auto overscroll-x-contain px-0.5 pb-1 scroll-smooth transition-[opacity,transform] duration-200 ease-out motion-reduce:transition-none md:mx-0 md:w-full md:grid md:snap-none md:grid-cols-2 md:gap-3 md:overflow-visible md:px-0 md:pb-0 ${transitioning ? "opacity-0 translate-y-1" : "opacity-100 translate-y-0"}`}
+            className={`mb-x-scroll -mx-0.5 flex w-[calc(100%+0.25rem)] snap-x snap-mandatory gap-2 overflow-x-auto overscroll-x-contain px-0.5 pb-1 scroll-smooth transition-[opacity,transform] duration-200 ease-out motion-reduce:transition-none md:mx-0 md:w-full md:grid md:snap-none md:grid-cols-2 md:gap-3 md:overflow-visible md:px-0 md:pb-0 ${transitioning ? "opacity-0 translate-y-1" : "opacity-100 translate-y-0"}`}
           >
             <div
-              className={`relative mb-card-enter flex min-h-0 min-w-full shrink-0 flex-col snap-center [scroll-snap-stop:always] rounded-md border transition-all duration-200 ease-out motion-reduce:transition-none md:min-w-0 md:shrink md:snap-none ${mobileBuildView === "a" ? "border-accent/40 md:border-border/70" : "border-border/70"} ${revealModels && revealAction === "A" ? "mb-reveal-highlight-a" : ""}`}
+              className={`relative mb-card-enter min-w-full shrink-0 snap-center [scroll-snap-stop:always] rounded-md border transition-all duration-200 ease-out motion-reduce:transition-none md:min-w-0 md:shrink md:snap-none ${mobileBuildView === "a" ? "border-accent/40 md:border-border/70" : "border-border/70"} ${revealModels && revealAction === "A" ? "mb-reveal-highlight-a" : ""}`}
             >
               <VoxelViewerCard
                 key={matchup ? `${matchup.id}:a` : "arena-build-a"}
@@ -2739,7 +2739,7 @@ export function Arena() {
               />
             </div>
             <div
-              className={`relative mb-card-enter mb-card-enter-delay flex min-h-0 min-w-full shrink-0 flex-col snap-center [scroll-snap-stop:always] rounded-md border transition-all duration-200 ease-out motion-reduce:transition-none md:min-w-0 md:shrink md:snap-none ${mobileBuildView === "b" ? "border-accent2/40 md:border-border/70" : "border-border/70"} ${revealModels && revealAction === "B" ? "mb-reveal-highlight-b" : ""}`}
+              className={`relative mb-card-enter mb-card-enter-delay min-w-full shrink-0 snap-center [scroll-snap-stop:always] rounded-md border transition-all duration-200 ease-out motion-reduce:transition-none md:min-w-0 md:shrink md:snap-none ${mobileBuildView === "b" ? "border-accent2/40 md:border-border/70" : "border-border/70"} ${revealModels && revealAction === "B" ? "mb-reveal-highlight-b" : ""}`}
             >
               <VoxelViewerCard
                 key={matchup ? `${matchup.id}:b` : "arena-build-b"}

--- a/components/arena/Arena.tsx
+++ b/components/arena/Arena.tsx
@@ -2877,7 +2877,7 @@ export function Arena() {
               className={`[grid-area:1/1] transition-[opacity,transform] duration-200 ease-out motion-reduce:transition-none ${revealMeta.visible ? "opacity-100 translate-y-0" : "pointer-events-none opacity-0 -translate-y-1"}`}
             >
               <div className="flex h-full flex-col justify-center gap-3 border-t border-border/70 px-1 py-2 sm:py-3">
-                <div key={matchup?.id} className="flex items-baseline gap-3 sm:gap-5">
+                <div key={matchup?.id} className="grid grid-cols-2 gap-2 sm:gap-3">
                   <RevealLane
                     side="A"
                     model={matchup?.a.model}
@@ -2891,11 +2891,6 @@ export function Arena() {
                     faded={revealAction === "A"}
                     delayed
                   />
-                  {revealVerdict ? (
-                    <span className="mb-reveal-lane mb-reveal-lane-delay hidden shrink-0 font-mono text-[11px] uppercase tracking-[0.18em] text-muted2 md:inline">
-                      {revealVerdict}
-                    </span>
-                  ) : null}
                 </div>
 
                 <div className="flex items-center gap-3">
@@ -2908,6 +2903,12 @@ export function Arena() {
                       <div className="mb-progress-wait absolute inset-0" />
                     ) : null}
                   </div>
+
+                  {revealVerdict ? (
+                    <span className="shrink-0 font-mono text-[11px] uppercase tracking-[0.18em] text-muted2">
+                      {revealVerdict}
+                    </span>
+                  ) : null}
 
                   <button
                     type="button"

--- a/components/arena/Arena.tsx
+++ b/components/arena/Arena.tsx
@@ -10,6 +10,7 @@ import {
   VoteChoice,
 } from "@/lib/arena/types";
 import { readBuildVariantArtifact } from "@/lib/arena/clientBuildResponse";
+import { readClientErrorResponse } from "@/lib/clientErrorResponse";
 import {
   appendPackedVoxelBlocks,
   createPackedVoxelBlocks,
@@ -66,46 +67,6 @@ const PREFETCH_INITIAL_MAX_BYTES = Number.parseInt(
 let snapshotStorageRedirectBlocked = false;
 let streamStorageRedirectBlocked = false;
 
-async function readErrorResponse(res: Response, fallback: string): Promise<string> {
-  // Categorize common statuses so the UI isn't showing a raw HTML error page.
-  const statusHint =
-    res.status === 429
-      ? "Slow down — you're going a bit fast. Try again in a few seconds."
-      : res.status === 503 || res.status === 504
-        ? "The server is overloaded right now. Please try again shortly."
-        : res.status >= 500
-          ? "The server had a problem. Please try again."
-          : res.status === 404
-            ? "Not found."
-            : res.status === 401 || res.status === 403
-              ? "You don't have access to this."
-              : null;
-
-  // Best-effort body extraction: JSON { error | message } → string, else truncated text.
-  let detail: string | null = null;
-  try {
-    const body = await res.clone().json();
-    if (body && typeof body === "object") {
-      const candidate = (body as Record<string, unknown>).error ?? (body as Record<string, unknown>).message;
-      if (typeof candidate === "string" && candidate.trim()) detail = candidate.trim();
-    }
-  } catch {
-    // not JSON — fall through to text
-  }
-  if (!detail) {
-    try {
-      const text = (await res.text()).trim();
-      // Skip raw HTML error pages
-      if (text && !text.startsWith("<") && text.length <= 500) detail = text;
-    } catch {
-      // ignore
-    }
-  }
-
-  if (statusHint && detail && detail !== statusHint) return `${statusHint} (${detail})`;
-  return statusHint ?? detail ?? fallback;
-}
-
 // Parsing JSON produces one object per block. Packing at the delivery boundary
 // lets that array go instead of keeping it alive for as long as a lane holds
 // the build, which on a matchup means two of them at once.
@@ -145,7 +106,7 @@ async function fetchMatchupOnce(promptId?: string, signal?: AbortSignal): Promis
   // Adaptive mode keeps small builds instant while deferring large payloads.
   url.searchParams.set("payload", "adaptive");
   const res = await fetch(url, { method: "GET", credentials: "include", signal });
-  if (!res.ok) throw new Error(await readErrorResponse(res, "Failed to load matchup"));
+  if (!res.ok) throw new Error(await readClientErrorResponse(res, "Failed to load matchup"));
   const matchup = (await res.json()) as ArenaMatchup;
   return {
     ...matchup,
@@ -209,7 +170,7 @@ async function submitVote(matchupId: string, choice: VoteChoice) {
       body: JSON.stringify({ matchupId, choice }),
       signal: timed.signal,
     });
-    if (!res.ok) throw new Error(await readErrorResponse(res, "Couldn't record your vote."));
+    if (!res.ok) throw new Error(await readClientErrorResponse(res, "Couldn't record your vote."));
   } catch (err) {
     if (err instanceof Error && err.name === "AbortError") {
       throw new Error("Vote timed out — the site may be under heavy load. Please try again.");
@@ -561,7 +522,7 @@ async function fetchBuildVariantSnapshot(
       if (allowRedirect && shouldRetrySnapshotWithoutRedirect(res.status)) {
         return fetchBuildVariantSnapshot(ref, signal, timeoutMs, { redirect: false });
       }
-      const message = await readErrorResponse(res, "Couldn't load build");
+      const message = await readClientErrorResponse(res, "Couldn't load build");
       throw new Error(message);
     }
     return await readBuildVariantPayload(res);
@@ -610,7 +571,7 @@ async function fetchBuildVariantStreamOnce(
   }
   if (!res.ok) {
     const retryAfterMs = readRetryAfterMs(res, 1000);
-    const message = await readErrorResponse(res, "Couldn't load build");
+    const message = await readClientErrorResponse(res, "Couldn't load build");
     if (useArtifact && ref.variant === "full" && res.status === 503) {
       throw new BuildRetryAfterError(message, retryAfterMs);
     }

--- a/components/arena/Arena.tsx
+++ b/components/arena/Arena.tsx
@@ -1072,7 +1072,7 @@ function RevealLane({
   delayed,
 }: {
   side: "A" | "B";
-  model?: { provider: string; displayName: string; eloRating: number };
+  model?: ArenaModelReveal | null;
   chosen: boolean;
   faded: boolean;
   delayed?: boolean;
@@ -1090,12 +1090,11 @@ function RevealLane({
       <span className="min-w-0 truncate text-[13px] font-medium text-fg">
         {model?.displayName ?? "—"}
       </span>
-      <span className="hidden shrink-0 font-mono text-[11px] text-muted2 sm:inline">
-        {model?.provider ?? ""}
-      </span>
-      <span className="ml-auto shrink-0 pl-2 font-mono text-[12px] tabular-nums text-muted">
-        {model ? Math.round(model.eloRating) : ""}
-      </span>
+      {model?.provider ? (
+        <span className="hidden shrink-0 font-mono text-[11px] text-muted2 sm:inline">
+          {model.provider}
+        </span>
+      ) : null}
     </div>
   );
 }

--- a/components/arena/VoteBar.tsx
+++ b/components/arena/VoteBar.tsx
@@ -60,16 +60,16 @@ export function VoteBar({
 }) {
   const voteDisabled = Boolean(disabled || disableVotes);
   const buttonBase =
-    "inline-flex touch-manipulation select-none items-center justify-center gap-1.5 rounded-xl font-semibold transition-all duration-150 ease-out focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 disabled:cursor-not-allowed disabled:opacity-40";
+    "relative inline-flex touch-manipulation select-none items-center justify-center gap-1.5 rounded-md font-semibold transition-all duration-150 ease-out focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 disabled:cursor-not-allowed disabled:opacity-40";
   const mobilePrimary =
     "h-11 px-3 text-[13px]";
   const mobileSecondary = "h-9 px-2.5 text-[12px]";
-  const desktopBase = "h-11 px-4 text-sm sm:rounded-xl";
+  const desktopBase = "h-11 px-4 text-sm";
 
   const flash = (target: VoteConfirmTarget) => (confirming === target ? " mb-vote-confirmed" : "");
 
   return (
-    <div className="mb-subpanel relative h-full px-2 py-2 sm:px-3.5 sm:py-3">
+    <div className="relative h-full border-t border-border/70 px-1 py-2 sm:py-3">
       <div className="flex h-full flex-col justify-center gap-1.5">
         <div className="grid grid-cols-2 gap-1.5 sm:hidden">
           <button
@@ -135,7 +135,7 @@ export function VoteBar({
             >
               <ChevronLeft className="h-4 w-4 opacity-70" />
               <span>A wins</span>
-              <span className="hidden md:inline-flex"><span className="mb-kbd">1</span></span>
+              <span className="mb-kbd absolute right-3 top-1/2 hidden -translate-y-1/2 font-normal md:inline-flex">1</span>
             </button>
 
             <button
@@ -154,8 +154,8 @@ export function VoteBar({
               disabled={voteDisabled}
               onClick={() => onVote("B")}
             >
+              <span className="mb-kbd absolute left-3 top-1/2 hidden -translate-y-1/2 font-normal md:inline-flex">2</span>
               <span>B wins</span>
-              <span className="hidden md:inline-flex"><span className="mb-kbd">2</span></span>
               <ChevronRight className="h-4 w-4 opacity-70" />
             </button>
           </div>

--- a/components/faq/FaqNavigation.tsx
+++ b/components/faq/FaqNavigation.tsx
@@ -47,7 +47,6 @@ export function FaqNavigation({
 
   useLayoutEffect(() => {
     let animationFrame = 0;
-    const reducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)");
 
     function measureRail() {
       const track = trackRef.current;
@@ -65,7 +64,7 @@ export function FaqNavigation({
         const linkRect = link.getBoundingClientRect();
         contentTops.push(content.getBoundingClientRect().top + window.scrollY);
         markerTops.push(
-          linkRect.top - trackTop + Math.min(linkRect.height, 20) / 2 - 3,
+          linkRect.top - trackTop + linkRect.height / 2 - 4,
         );
       }
 
@@ -82,57 +81,28 @@ export function FaqNavigation({
       const lastIndex = itemIds.length - 1;
       const atPageEnd =
         window.scrollY + window.innerHeight >=
-        document.documentElement.scrollHeight - 2;
-      const readingLine = window.scrollY + Math.min(window.innerHeight * 0.32, 280);
+        document.documentElement.scrollHeight - 4;
+      const readingLine = window.scrollY + window.innerHeight * 0.45;
 
-      let fromIndex = 0;
+      let activeIndex = 0;
       if (atPageEnd) {
-        fromIndex = lastIndex;
+        activeIndex = lastIndex;
       } else {
         while (
-          fromIndex < lastIndex &&
-          readingLine >= measurements.contentTops[fromIndex + 1]
+          activeIndex < lastIndex &&
+          readingLine >= measurements.contentTops[activeIndex + 1]
         ) {
-          fromIndex += 1;
+          activeIndex += 1;
         }
       }
 
-      const toIndex = Math.min(fromIndex + 1, lastIndex);
-      const start = measurements.contentTops[fromIndex];
-      const end = measurements.contentTops[toIndex];
-      const rawProgress =
-        fromIndex === toIndex ? 0 : clamp((readingLine - start) / (end - start), 0, 1);
-      const travelProgress = reducedMotion.matches
-        ? rawProgress >= 0.7
-          ? 1
-          : 0
-        : smoothstep(rawProgress);
-      const emphasisProgress = reducedMotion.matches
-        ? travelProgress
-        : smoothstep(clamp((rawProgress - 0.5) / 0.4, 0, 1));
-      const markerTop =
-        measurements.markerTops[fromIndex] +
-        (measurements.markerTops[toIndex] - measurements.markerTops[fromIndex]) *
-          travelProgress;
-
+      const markerTop = measurements.markerTops[activeIndex] ?? 0;
       marker.style.opacity = "1";
       marker.style.transform = `translate3d(0, ${markerTop}px, 0)`;
 
-      for (const [index, id] of itemIds.entries()) {
-        const link = document.getElementById(`faq-nav-${id}`);
-        if (!link) continue;
-
-        let emphasis = 0;
-        if (fromIndex === toIndex && index === fromIndex) emphasis = 1;
-        else if (index === fromIndex) emphasis = 1 - emphasisProgress;
-        else if (index === toIndex) emphasis = emphasisProgress;
-        link.style.opacity = String(0.55 + emphasis * 0.45);
-      }
-
-      const nextActiveIndex = emphasisProgress >= 0.5 ? toIndex : fromIndex;
-      if (nextActiveIndex !== activeIndexRef.current) {
-        activeIndexRef.current = nextActiveIndex;
-        setActiveId(itemIds[nextActiveIndex]);
+      if (activeIndex !== activeIndexRef.current) {
+        activeIndexRef.current = activeIndex;
+        setActiveId(itemIds[activeIndex]);
       }
     }
 
@@ -151,16 +121,14 @@ export function FaqNavigation({
     window.addEventListener("scroll", requestRailUpdate, { passive: true });
     window.addEventListener("resize", handleResize);
     window.addEventListener("hashchange", requestRailUpdate);
-    reducedMotion.addEventListener("change", requestRailUpdate);
 
     return () => {
       window.cancelAnimationFrame(animationFrame);
       window.removeEventListener("scroll", requestRailUpdate);
       window.removeEventListener("resize", handleResize);
       window.removeEventListener("hashchange", requestRailUpdate);
-      reducedMotion.removeEventListener("change", requestRailUpdate);
     };
-  }, [itemIds]);
+  }, [itemIds, activeId]);
 
   function navigateTo(id: string) {
     setActiveId(id);
@@ -192,21 +160,18 @@ export function FaqNavigation({
         })}
       </nav>
 
-      <aside className="sticky top-16 hidden self-start lg:block">
-        <nav
-          aria-label="FAQ questions"
-          className="max-h-[calc(100vh-5rem)] overflow-y-auto py-1 pr-2 [scrollbar-width:none] [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden"
-        >
+      <aside className="sticky top-1/2 -translate-y-1/2 hidden self-start lg:block">
+        <nav aria-label="FAQ questions" className="py-1 pl-3 pr-2">
           <div className="relative space-y-4" ref={trackRef}>
             <span
               aria-hidden="true"
-              className="pointer-events-none absolute -left-[3px] top-0 z-10 h-1.5 w-1.5 rounded-full bg-accent opacity-0 shadow-[0_0_0_4px_hsl(var(--accent)/0.12),0_0_12px_hsl(var(--accent)/0.65)] will-change-transform motion-reduce:transition-none"
+              className="pointer-events-none absolute -left-[4px] top-0 z-10 h-2 w-2 rounded-full bg-accent opacity-0 shadow-[0_0_0_4px_hsl(var(--accent)/0.18),0_0_12px_hsl(var(--accent)/0.7)] transition-transform duration-200 ease-out will-change-transform motion-reduce:transition-none"
               ref={markerRef}
             />
             {sections.map((section) => (
               <div key={section.id}>
                 <a
-                  className="text-xs font-semibold uppercase tracking-wider text-muted transition-colors hover:text-fg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 motion-reduce:transition-none"
+                  className="text-[11px] font-semibold uppercase tracking-wider text-muted transition-colors hover:text-fg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 motion-reduce:transition-none"
                   href={`#${section.id}`}
                 >
                   {section.title}
@@ -215,15 +180,21 @@ export function FaqNavigation({
                   {section.items.map((item) => {
                     const active = activeId === item.id;
                     return (
-                      <li key={item.id}>
+                      <li key={item.id} className="transition-all duration-150 ease-out">
                         <a
                           aria-current={active ? "location" : undefined}
-                          className="relative block py-0.5 text-xs leading-5 text-fg opacity-55 transition-opacity duration-150 hover:!opacity-100 focus-visible:!opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
+                          className={`relative block transition-all duration-150 ease-out focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 ${
+                            active
+                              ? "py-1 text-xs font-semibold text-fg"
+                              : "py-0.5 text-xs text-muted/70 hover:text-fg"
+                          }`}
                           href={`#${item.id}`}
                           id={`faq-nav-${item.id}`}
                           onClick={() => navigateTo(item.id)}
                         >
-                          {item.navLabel ?? item.question}
+                          <span className="block leading-snug">
+                            {active ? item.question : (item.navLabel ?? item.question)}
+                          </span>
                         </a>
                       </li>
                     );

--- a/components/faq/FaqNavigation.tsx
+++ b/components/faq/FaqNavigation.tsx
@@ -5,6 +5,7 @@ import { useLayoutEffect, useMemo, useRef, useState } from "react";
 interface FaqNavigationItem {
   id: string;
   question: string;
+  navLabel?: string;
 }
 
 interface FaqNavigationSection {
@@ -191,9 +192,12 @@ export function FaqNavigation({
         })}
       </nav>
 
-      <aside className="sticky top-20 hidden self-start lg:block">
-        <nav aria-label="FAQ questions">
-          <div className="relative space-y-6" ref={trackRef}>
+      <aside className="sticky top-16 hidden self-start lg:block">
+        <nav
+          aria-label="FAQ questions"
+          className="max-h-[calc(100vh-5rem)] overflow-y-auto py-1 pr-2 [scrollbar-width:none] [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden"
+        >
+          <div className="relative space-y-4" ref={trackRef}>
             <span
               aria-hidden="true"
               className="pointer-events-none absolute -left-[3px] top-0 z-10 h-1.5 w-1.5 rounded-full bg-accent opacity-0 shadow-[0_0_0_4px_hsl(var(--accent)/0.12),0_0_12px_hsl(var(--accent)/0.65)] will-change-transform motion-reduce:transition-none"
@@ -202,24 +206,24 @@ export function FaqNavigation({
             {sections.map((section) => (
               <div key={section.id}>
                 <a
-                  className="text-sm font-semibold text-fg transition-colors hover:text-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 motion-reduce:transition-none"
+                  className="text-xs font-semibold uppercase tracking-wider text-muted transition-colors hover:text-fg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 motion-reduce:transition-none"
                   href={`#${section.id}`}
                 >
                   {section.title}
                 </a>
-                <ol className="mt-2 border-l border-border/70 pl-4">
+                <ol className="mt-1.5 border-l border-border/70 pl-3.5">
                   {section.items.map((item) => {
                     const active = activeId === item.id;
                     return (
                       <li key={item.id}>
                         <a
                           aria-current={active ? "location" : undefined}
-                          className="relative block py-1 text-xs leading-5 text-fg opacity-55 hover:!opacity-100 focus-visible:!opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
+                          className="relative block py-0.5 text-xs leading-5 text-fg opacity-55 transition-opacity duration-150 hover:!opacity-100 focus-visible:!opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
                           href={`#${item.id}`}
                           id={`faq-nav-${item.id}`}
                           onClick={() => navigateTo(item.id)}
                         >
-                          {item.question}
+                          {item.navLabel ?? item.question}
                         </a>
                       </li>
                     );

--- a/components/leaderboard/Leaderboard.tsx
+++ b/components/leaderboard/Leaderboard.tsx
@@ -222,7 +222,7 @@ function ModelSearchEmptyState({ onClear }: { onClear: () => void }) {
       <button
         type="button"
         onClick={onClear}
-        className="mb-btn mb-btn-ghost h-11 rounded-full px-4 text-xs"
+        className="mb-btn mb-btn-ghost h-11 px-4 text-xs"
       >
         Clear
       </button>
@@ -365,15 +365,11 @@ export function Leaderboard() {
       <div className="mb-panel shrink-0 px-5 py-5 ring-inset before:hidden">
         <div className="grid grid-cols-1 gap-4 sm:grid-cols-[auto_minmax(0,1fr)] sm:items-center xl:grid-cols-[minmax(0,1fr)_auto_auto] xl:gap-x-6 xl:gap-y-0">
           {topModel ? (
-            <div className="mb-leaderboard-champion mb-model-reveal mb-model-reveal-in order-1 inline-flex min-h-[72px] max-w-full min-w-0 self-start items-center gap-2 py-0 pl-0 pr-2 min-[340px]:min-h-20 min-[340px]:gap-3 min-[340px]:pr-3 sm:order-none sm:col-span-2 sm:gap-4 sm:pr-4 xl:col-span-1">
+            <div className="mb-leaderboard-champion mb-model-reveal-in opacity-0 order-1 inline-flex min-h-[72px] max-w-full min-w-0 self-start items-center gap-2 py-0 pl-0 pr-2 min-[340px]:min-h-20 min-[340px]:gap-3 min-[340px]:pr-3 sm:order-none sm:col-span-2 sm:gap-4 sm:pr-4 xl:col-span-1">
               <span
                 aria-hidden="true"
                 className="relative flex h-[72px] w-[72px] shrink-0 items-center justify-center rounded-full bg-accent/10 ring-1 ring-accent/35 min-[340px]:h-20 min-[340px]:w-20"
               >
-                <span
-                  aria-hidden="true"
-                  className="pointer-events-none absolute inset-0 rounded-full shadow-[0_0_0_4px_hsl(var(--accent)/0.06),0_10px_24px_-10px_hsl(var(--accent)/0.45)]"
-                />
                 <span className="relative -translate-y-px text-center font-mono text-2xl font-semibold leading-none text-accent tabular-nums sm:text-[1.75rem]">
                   1
                 </span>
@@ -450,7 +446,7 @@ export function Leaderboard() {
                 onClick={handleRetry}
                 disabled={retrying}
                 aria-live="polite"
-                className="mb-refresh-retry inline-flex h-11 items-center gap-1.5 rounded-full px-3 font-mono text-[11px] text-warn ring-1 ring-warn/30 transition hover:bg-warn/5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-warn/40 disabled:cursor-not-allowed disabled:opacity-60"
+                className="mb-refresh-retry inline-flex h-11 items-center gap-1.5 rounded-md px-3 font-mono text-[11px] text-warn ring-1 ring-warn/30 transition hover:bg-warn/5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-warn/40 disabled:cursor-not-allowed disabled:opacity-60"
               >
                 <span className="h-1.5 w-1.5 rounded-full bg-warn" aria-hidden="true" />
                 <span>
@@ -465,7 +461,7 @@ export function Leaderboard() {
               onClick={() => setShowDetailed((v) => !v)}
               aria-label={showDetailed ? "Hide details" : "Show details"}
               aria-pressed={showDetailed}
-              className={`mb-btn mb-details-toggle hidden h-11 rounded-full bg-transparent px-3.5 text-[11px] ring-1 ring-inset sm:inline-flex ${
+              className={`mb-btn mb-details-toggle hidden h-11 bg-transparent px-3.5 text-[11px] ring-1 ring-inset sm:inline-flex ${
                 showDetailed
                   ? "text-accent ring-accent/45"
                   : "text-muted ring-border/60 hover:text-fg hover:ring-border"
@@ -476,7 +472,7 @@ export function Leaderboard() {
             <div
               role="search"
               aria-label="Leaderboard models"
-              className="relative h-11 w-full rounded-full bg-bg/70 text-sm ring-1 ring-inset ring-border transition-colors hover:bg-bg/80 focus-within:ring-2 focus-within:ring-accent/50 sm:w-56 md:w-64 xl:w-72"
+              className="relative h-11 w-full rounded-md bg-bg text-sm ring-1 ring-inset ring-border transition-colors focus-within:ring-2 focus-within:ring-accent/50 sm:w-56 md:w-64 xl:w-72"
             >
               <label htmlFor="leaderboard-model-search" className="sr-only">
                 Search models
@@ -509,7 +505,7 @@ export function Leaderboard() {
                   type="button"
                   onClick={clearModelQuery}
                   aria-label="Clear model search"
-                  className="absolute inset-y-0 right-0 grid w-11 place-items-center rounded-full text-muted2 transition-colors hover:text-fg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-accent/50"
+                  className="absolute inset-y-0 right-0 grid w-11 place-items-center rounded-md text-muted2 transition-colors hover:text-fg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-accent/50"
                 >
                   <CloseIcon className="h-3.5 w-3.5" />
                 </button>
@@ -534,13 +530,13 @@ export function Leaderboard() {
         <div
           role="status"
           aria-live="polite"
-          className="mb-subpanel shrink-0 flex items-center gap-2 rounded-xl px-3 py-2 text-xs text-muted"
+          className="mb-subpanel shrink-0 flex items-center gap-2 rounded-md px-3 py-2 text-xs text-muted"
         >
           <span className="mb-progress-wait relative h-1.5 w-6 overflow-hidden rounded-full bg-border/40" aria-hidden="true" />
           <span>Taking longer than usual — MineBench may be under heavy load.</span>
         </div>
       ) : null}
-      <div className="relative flex min-h-0 flex-1 flex-col overflow-hidden rounded-3xl bg-card/60 shadow-soft ring-1 ring-border">
+      <div className="relative flex min-h-0 flex-1 flex-col overflow-hidden rounded-md border border-border">
         <div className="pointer-events-none absolute inset-y-0 right-0 z-20 hidden w-8 bg-gradient-to-l from-bg/70 to-transparent sm:block md:hidden" />
 
         <div
@@ -556,7 +552,7 @@ export function Leaderboard() {
 	              return (
 	                <div
 	                  key={m.key}
-	                  className={`w-full rounded-2xl bg-gradient-to-b from-bg/62 to-bg/44 p-3 text-left ring-1 ring-border/70 transition ${
+	                  className={`w-full rounded-md p-3 text-left ring-1 ring-border/70 transition ${
 	                    navigatingModelKey === m.key
 	                      ? "opacity-75"
 	                      : "active:ring-accent/45 active:from-bg/72"

--- a/components/leaderboard/ModelBenchmarkDetails.tsx
+++ b/components/leaderboard/ModelBenchmarkDetails.tsx
@@ -437,7 +437,7 @@ export function ModelBenchmarkDetails({
               id={detailsId}
               role="region"
               aria-label={`${displayName} run details`}
-              className={`fixed z-30 overflow-visible rounded-lg border border-border bg-card shadow-soft ${
+              className={`fixed z-30 overflow-visible rounded-md border border-border bg-card ${
                 position ? "opacity-100" : "pointer-events-none opacity-0"
               }`}
               style={{

--- a/components/leaderboard/ModelDetail.tsx
+++ b/components/leaderboard/ModelDetail.tsx
@@ -973,7 +973,7 @@ const PromptBuildPreview = memo(function PromptBuildPreview({
 
   if (loading && !build) {
     return (
-      <div className={`relative flex w-full items-center justify-center overflow-hidden rounded-xl bg-bg/42 ring-1 ring-border/65 ${heightClass}`}>
+      <div className={`relative flex w-full items-center justify-center overflow-hidden rounded-md bg-bg/42 ring-1 ring-border/65 ${heightClass}`}>
         <VoxelLoadingHud
           label={overlayLabel}
           progress={overlayProgress}
@@ -985,14 +985,14 @@ const PromptBuildPreview = memo(function PromptBuildPreview({
 
   if (!build) {
     return (
-      <div className={`relative flex w-full items-center justify-center overflow-hidden rounded-xl bg-bg/42 ring-1 ring-border/65 ${heightClass}`}>
+      <div className={`relative flex w-full items-center justify-center overflow-hidden rounded-md bg-bg/42 ring-1 ring-border/65 ${heightClass}`}>
         <div className="text-xs text-muted">{error ? "Build unavailable" : "No build yet"}</div>
       </div>
     );
   }
 
   return (
-    <div className={`relative w-full overflow-hidden rounded-xl bg-bg/32 ring-1 ring-border/65 ${heightClass}`}>
+    <div className={`relative w-full overflow-hidden rounded-md bg-bg/32 ring-1 ring-border/65 ${heightClass}`}>
       <LazyVoxelViewer
         ref={viewerRef}
         voxelBuild={build.voxelBuild}
@@ -1997,7 +1997,7 @@ export function ModelDetail({ data }: { data: ModelDetailStats }) {
                     lastPromptTriggerRef.current = event.currentTarget;
                     setPromptWithUrl(prompt);
                   }}
-                  className="relative mb-card-enter h-full cursor-pointer rounded-2xl bg-bg/40 p-3.5 ring-1 ring-border/60 transition duration-200 hover:-translate-y-0.5 hover:bg-bg/55 hover:ring-accent/45 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/50 sm:p-4"
+                  className="relative mb-card-enter h-full cursor-pointer rounded-md p-3.5 ring-1 ring-border/60 transition duration-200 hover:-translate-y-0.5 hover:bg-bg/55 hover:ring-accent/45 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/50 sm:p-4"
                 >
                   <div className="flex flex-wrap items-start justify-between gap-2">
                     <div className="min-w-0 flex-1">
@@ -2114,7 +2114,7 @@ export function ModelDetail({ data }: { data: ModelDetailStats }) {
             role="dialog"
             aria-modal="true"
             aria-label="Full prompt details"
-            className="relative w-full max-w-3xl overflow-hidden rounded-3xl bg-card/92 shadow-soft ring-1 ring-border backdrop-blur-xl"
+            className="relative w-full max-w-3xl overflow-hidden rounded-md bg-card ring-1 ring-border-xl"
           >
             <div className="flex items-center justify-between gap-2 border-b border-border/60 px-3 py-3 sm:gap-3 sm:px-4">
               <PromptLateralNav
@@ -2128,7 +2128,7 @@ export function ModelDetail({ data }: { data: ModelDetailStats }) {
               <button
                 type="button"
                 ref={modalCloseRef}
-                className="mb-btn mb-btn-ghost h-9 shrink-0 rounded-full px-3 text-xs sm:px-4"
+                className="mb-btn mb-btn-ghost h-9 shrink-0 px-3 text-xs sm:px-4"
                 onClick={() => setPromptWithUrl(null)}
                 aria-label="Close prompt details"
               >

--- a/components/leaderboard/ModelDetail.tsx
+++ b/components/leaderboard/ModelDetail.tsx
@@ -4,6 +4,7 @@ import dynamic from "next/dynamic";
 import { memo, useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import Link from "next/link";
 import { usePathname, useSearchParams } from "next/navigation";
+import { readClientErrorResponse } from "@/lib/clientErrorResponse";
 import type {
   ModelDetailStats,
   ModelOpponentBreakdown,
@@ -221,27 +222,6 @@ function shouldRetrySnapshotWithoutRedirect(status: number): boolean {
   return [400, 403, 404, 500, 502, 504].includes(status);
 }
 
-async function readErrorResponse(res: Response, fallback: string): Promise<string> {
-  let detail: string | null = null;
-  try {
-    const body = await res.clone().json();
-    if (body && typeof body === "object") {
-      const candidate = (body as Record<string, unknown>).error ?? (body as Record<string, unknown>).message;
-      if (typeof candidate === "string" && candidate.trim()) detail = candidate.trim();
-    }
-  } catch {
-    // fall through to text
-  }
-  if (!detail) {
-    try {
-      const text = (await res.text()).trim();
-      if (text && !text.startsWith("<") && text.length <= 500) detail = text;
-    } catch {
-      // ignore
-    }
-  }
-  return detail ?? fallback;
-}
 
 function rememberLoadedBuild(
   current: Record<string, LoadedPromptBuild>,
@@ -294,7 +274,7 @@ async function fetchBuildVariantSnapshot(
       if (allowRedirect && shouldRetrySnapshotWithoutRedirect(res.status)) {
         return fetchBuildVariantSnapshot(ref, signal, timeoutMs, { redirect: false });
       }
-      throw new Error(await readErrorResponse(res, "Failed to load build"));
+      throw new Error(await readClientErrorResponse(res, "Failed to load build"));
     }
     try {
       return await readBuildVariantJson<BuildVariantResponse>(res);
@@ -334,7 +314,7 @@ async function fetchBuildVariantStreamOnce(
   } finally {
     requestTimed.cleanup();
   }
-  if (!res.ok) throw new Error(await readErrorResponse(res, "Failed to load build"));
+  if (!res.ok) throw new Error(await readClientErrorResponse(res, "Failed to load build"));
 
   const contentType = res.headers.get("content-type") ?? "";
   if (!res.body || !contentType.includes("application/x-ndjson")) {

--- a/components/local/LocalLab.tsx
+++ b/components/local/LocalLab.tsx
@@ -137,7 +137,7 @@ function CopyButton({
         type="button"
         aria-describedby={description ? descriptionId : undefined}
         className={cx(
-          "mb-btn h-8 rounded-full px-2.5 text-[11px] sm:h-9 sm:px-3 sm:text-xs",
+          "mb-btn h-8 px-2.5 text-[11px] sm:h-9 sm:px-3 sm:text-xs",
           tone === "primary" ? "mb-btn-primary" : "mb-btn-ghost",
           className,
         )}
@@ -153,7 +153,7 @@ function CopyButton({
         <span
           id={descriptionId}
           role="tooltip"
-          className="pointer-events-none invisible absolute bottom-[calc(100%+0.625rem)] right-0 z-50 w-64 rounded-xl bg-card px-3 py-2.5 text-left text-[11px] leading-relaxed text-fg/90 opacity-0 shadow-2xl ring-1 ring-border transition-opacity after:absolute after:-bottom-1 after:right-8 after:h-2 after:w-2 after:rotate-45 after:border-b after:border-r after:border-border after:bg-card group-hover:visible group-hover:opacity-100 group-focus-within:visible group-focus-within:opacity-100 sm:w-72"
+          className="pointer-events-none invisible absolute bottom-[calc(100%+0.625rem)] right-0 z-50 w-64 rounded-md bg-card px-3 py-2.5 text-left text-[11px] leading-relaxed text-fg/90 opacity-0 shadow-2xl ring-1 ring-border transition-opacity after:absolute after:-bottom-1 after:right-8 after:h-2 after:w-2 after:rotate-45 after:border-b after:border-r after:border-border after:bg-card group-hover:visible group-hover:opacity-100 group-focus-within:visible group-focus-within:opacity-100 sm:w-72"
         >
           {description}
         </span>
@@ -184,7 +184,7 @@ function SegmentedControl({
   return (
     <div
       className={cx(
-        "relative flex rounded-xl bg-bg/60 p-1 ring-1 ring-border",
+        "relative flex rounded-md bg-bg/60 p-1 ring-1 ring-border",
         className,
       )}
     >
@@ -649,7 +649,7 @@ export function LocalLab() {
                 />
                 <button
                   type="button"
-                  className="mb-btn mb-btn-ghost h-8 rounded-full px-2.5 text-[11px] sm:h-9 sm:px-3 sm:text-xs"
+                  className="mb-btn mb-btn-ghost h-8 px-2.5 text-[11px] sm:h-9 sm:px-3 sm:text-xs"
                   disabled={systemIsDefault}
                   onClick={() => {
                     setSystemPrompt(defaultSystem);
@@ -716,7 +716,7 @@ export function LocalLab() {
               onChange={(e) => setTaskPrompt(e.target.value)}
               placeholder="Describe the build..."
             />
-            <div className="mt-2 min-h-[142px] rounded-xl border border-border/70 bg-bg/40 p-3 font-mono text-[12px] leading-snug text-muted">
+            <div className="mt-2 min-h-[142px] rounded-md border border-border/70 bg-bg/40 p-3 font-mono text-[12px] leading-snug text-muted">
               {taskPrompt.trim() ? (
                 <pre className="max-h-56 overflow-auto whitespace-pre-wrap">{userPrompt}</pre>
               ) : (
@@ -737,7 +737,7 @@ export function LocalLab() {
               <div className="flex items-center gap-2">
                 <button
                   type="button"
-                  className="mb-btn mb-btn-ghost h-8 rounded-full px-3 text-xs sm:h-9 sm:px-4"
+                  className="mb-btn mb-btn-ghost h-8 px-3 text-xs sm:h-9 sm:px-4"
                   onClick={clearModelInput}
                   disabled={!hasInput}
                 >
@@ -745,7 +745,7 @@ export function LocalLab() {
                 </button>
                 <button
                   type="button"
-                  className="mb-btn mb-btn-primary h-8 rounded-full px-3 text-xs sm:h-9 sm:px-4"
+                  className="mb-btn mb-btn-primary h-8 px-3 text-xs sm:h-9 sm:px-4"
                   onClick={renderFromInput}
                 >
                   <span className="inline-flex items-center gap-1.5">

--- a/components/sandbox/SandboxBenchmark.tsx
+++ b/components/sandbox/SandboxBenchmark.tsx
@@ -1346,7 +1346,7 @@ export function SandboxBenchmark() {
 
             <button
               type="button"
-              className="mb-btn mb-btn-ghost h-8 rounded-full px-2.5 text-[11px] sm:h-9 sm:px-3 sm:text-xs"
+              className="mb-btn mb-btn-ghost h-8 px-2.5 text-[11px] sm:h-9 sm:px-3 sm:text-xs"
               onClick={() => {
                 setSelectionReloading(true);
                 clearVisibleBuilds();
@@ -1474,7 +1474,7 @@ export function SandboxBenchmark() {
             <button
               type="button"
               aria-label="Previous prompt"
-              className="mb-btn mb-btn-ghost h-9 w-9 rounded-full p-0"
+              className="mb-btn mb-btn-ghost h-9 w-9 p-0"
               onClick={() => navigatePrompt(-1)}
               disabled={loading || refreshing || !canNavigatePrompts}
             >
@@ -1484,25 +1484,17 @@ export function SandboxBenchmark() {
             </button>
             <button
               type="button"
-              className="mb-btn mb-btn-ghost h-9 rounded-full px-3 text-xs"
+              className="mb-btn mb-btn-ghost h-9 px-3 text-xs"
               onClick={handleRandomPrompt}
               disabled={loading || refreshing || !canNavigatePrompts}
               title="Pick a random prompt"
             >
-              <span className="inline-flex items-center gap-1.5">
-                <svg aria-hidden="true" viewBox="0 0 24 24" className="h-4 w-4">
-                  <rect x="5" y="5" width="14" height="14" rx="3" fill="none" stroke="currentColor" strokeWidth="1.7" />
-                  <circle cx="9" cy="9" r="1.1" fill="currentColor" />
-                  <circle cx="12" cy="12" r="1.1" fill="currentColor" />
-                  <circle cx="15" cy="15" r="1.1" fill="currentColor" />
-                </svg>
-                <span>Random</span>
-              </span>
+              Random
             </button>
             <button
               type="button"
               aria-label="Next prompt"
-              className="mb-btn mb-btn-ghost h-9 w-9 rounded-full p-0"
+              className="mb-btn mb-btn-ghost h-9 w-9 p-0"
               onClick={() => navigatePrompt(1)}
               disabled={loading || refreshing || !canNavigatePrompts}
             >

--- a/components/sandbox/SandboxBenchmark.tsx
+++ b/components/sandbox/SandboxBenchmark.tsx
@@ -17,6 +17,7 @@ import type { VoxelViewerHandle } from "@/components/voxel/VoxelViewer";
 import { formatVoxelLoadingMessage } from "@/components/voxel/VoxelLoadingHud";
 import { VoxelViewerCard } from "@/components/voxel/VoxelViewerCard";
 import { ErrorState } from "@/components/ErrorState";
+import { readClientErrorResponse } from "@/lib/clientErrorResponse";
 import type {
   ArenaBuildDeliveryClass,
   ArenaBuildLoadHints,
@@ -379,22 +380,9 @@ async function fetchBenchmarkResponse(args: {
   const url = query ? `/api/sandbox/benchmark?${query}` : "/api/sandbox/benchmark";
   const res = await fetch(url, { method: "GET", cache: "no-store", signal: args.signal });
   if (!res.ok) {
-    const text = await res.text().catch(() => "");
-    let message = text || "Failed to load benchmark comparison data";
-    try {
-      const parsed = JSON.parse(text) as unknown;
-      if (
-        parsed &&
-        typeof parsed === "object" &&
-        "error" in parsed &&
-        typeof (parsed as { error?: unknown }).error === "string"
-      ) {
-        message = (parsed as { error: string }).error;
-      }
-    } catch {
-      // ignore
-    }
-    throw new Error(message);
+    throw new Error(
+      await readClientErrorResponse(res, "Failed to load benchmark comparison data"),
+    );
   }
   return (await res.json()) as BenchmarkResponse;
 }
@@ -413,7 +401,7 @@ async function fetchBuildVariantSnapshot(
       method: "GET",
       signal: timed.signal,
     });
-    if (!res.ok) throw new Error(await res.text());
+    if (!res.ok) throw new Error(await readClientErrorResponse(res, "Failed to load build"));
     return await readBuildVariantJson(res);
   } finally {
     timed.cleanup();
@@ -476,7 +464,7 @@ async function fetchBuildVariantStreamOnce(
   } finally {
     requestTimed.cleanup();
   }
-  if (!res.ok) throw new Error(await res.text());
+  if (!res.ok) throw new Error(await readClientErrorResponse(res, "Failed to load build"));
 
   const contentType = res.headers.get("content-type") ?? "";
   if (!res.body || !contentType.includes("application/x-ndjson")) {

--- a/components/sandbox/SandboxLive.tsx
+++ b/components/sandbox/SandboxLive.tsx
@@ -10,6 +10,7 @@ import {
 import type { VoxelViewerHandle } from "@/components/voxel/VoxelViewer";
 import { VoxelViewerCard } from "@/components/voxel/VoxelViewerCard";
 import { extractBestVoxelBuildJson } from "@/lib/ai/jsonExtract";
+import { readClientErrorResponse } from "@/lib/clientErrorResponse";
 import type { VoxelBuild } from "@/lib/voxel/types";
 import { parseVoxelBuildSpec, validateVoxelBuild } from "@/lib/voxel/validate";
 import { getPalette } from "@/lib/blocks/palettes";
@@ -679,10 +680,7 @@ export function SandboxLive({ initialPrompt }: { initialPrompt?: string }) {
       });
 
       if (!res.ok || !res.body) {
-        const txt = await res.text().catch(() => "");
-        const obj = safeJsonParseObject(txt);
-        const message = obj && typeof obj.error === "string" ? obj.error : txt || "Request failed";
-        throw new Error(message);
+        throw new Error(await readClientErrorResponse(res, "Request failed"));
       }
 
       const reader = res.body.getReader();

--- a/components/sandbox/SandboxLive.tsx
+++ b/components/sandbox/SandboxLive.tsx
@@ -906,7 +906,7 @@ export function SandboxLive({ initialPrompt }: { initialPrompt?: string }) {
               aria-label="Export JSON"
               title={hasJsonExport ? "Export JSON" : "No JSON to export yet"}
               disabled={!hasJsonExport}
-              className="mb-btn mb-btn-ghost h-8 w-8 rounded-full border border-border/70 bg-bg/55 p-0 text-muted hover:text-fg disabled:cursor-not-allowed disabled:opacity-45"
+              className="mb-btn mb-btn-ghost h-8 w-8 border border-border/70 bg-bg/55 p-0 text-muted hover:text-fg disabled:cursor-not-allowed disabled:opacity-45"
               onClick={() =>
                 exportModelJson({
                   modelName,
@@ -1009,7 +1009,7 @@ export function SandboxLive({ initialPrompt }: { initialPrompt?: string }) {
                     aria-pressed={compareEnabled}
                     onClick={() => setCompareEnabled((v) => !v)}
                     disabled={running || !canCompare}
-                    className={`mb-btn h-7 rounded-full px-2.5 text-[11px] ${compareEnabled ? "mb-btn-primary" : "mb-btn-ghost"} disabled:cursor-not-allowed disabled:opacity-50`}
+                    className={`mb-btn h-7 px-2.5 text-[11px] ${compareEnabled ? "mb-btn-primary" : "mb-btn-ghost"} disabled:cursor-not-allowed disabled:opacity-50`}
                   >
                     {compareEnabled ? "Stop comparing" : "Compare models"}
                   </button>
@@ -1108,7 +1108,7 @@ export function SandboxLive({ initialPrompt }: { initialPrompt?: string }) {
                 </div>
 
                 {usesAdHocModel ? (
-                  <div className="mt-3 rounded-xl border border-border/70 bg-bg/35 p-3">
+                  <div className="mt-3 rounded-md border border-border/70 bg-bg/35 p-3">
                     <div className="text-xs font-medium text-muted">
                       {usesOpenRouterModel ? "OpenRouter model" : "OpenAI-compatible model"}
                     </div>
@@ -1163,7 +1163,7 @@ export function SandboxLive({ initialPrompt }: { initialPrompt?: string }) {
               <div className="flex flex-wrap items-center gap-2">
                 <button
                   type="button"
-                  className="mb-btn mb-btn-ghost h-7 rounded-full px-2.5 text-[11px] disabled:cursor-not-allowed disabled:opacity-50"
+                  className="mb-btn mb-btn-ghost h-7 px-2.5 text-[11px] disabled:cursor-not-allowed disabled:opacity-50"
                   onClick={() => {
                     setProviderKeys({});
                     setRequestError(null);
@@ -1175,7 +1175,7 @@ export function SandboxLive({ initialPrompt }: { initialPrompt?: string }) {
                 <button
                   type="button"
                   aria-pressed={showKeys}
-                  className={`mb-btn h-7 rounded-full px-2.5 text-[11px] ${showKeys ? "mb-btn-primary" : "mb-btn-ghost"} disabled:cursor-not-allowed disabled:opacity-50`}
+                  className={`mb-btn h-7 px-2.5 text-[11px] ${showKeys ? "mb-btn-primary" : "mb-btn-ghost"} disabled:cursor-not-allowed disabled:opacity-50`}
                   onClick={() => setShowKeys((v) => !v)}
                   disabled={running}
                 >
@@ -1221,7 +1221,7 @@ export function SandboxLive({ initialPrompt }: { initialPrompt?: string }) {
                 </label>
               ) : null}
 
-              <details className="md:col-span-2 rounded-xl border border-border/70 bg-bg/35 px-3 py-2">
+              <details className="md:col-span-2 rounded-md border border-border/70 bg-bg/35 px-3 py-2">
                 <summary className="cursor-pointer select-none text-xs font-medium text-muted">
                   Use a provider-specific key instead (optional)
                 </summary>

--- a/components/voxel/VoxelBuildExportButton.tsx
+++ b/components/voxel/VoxelBuildExportButton.tsx
@@ -203,7 +203,7 @@ export function VoxelBuildExportButton({
         aria-controls={menuId}
         disabled={isDisabled}
         onClick={() => setMenuOpen((open) => !open)}
-        className="mb-btn mb-btn-ghost h-8 w-8 rounded-full border border-border/70 bg-bg/55 p-0 text-muted shadow-sm backdrop-blur-sm hover:border-accent/60 hover:bg-accent/10 hover:text-fg disabled:cursor-not-allowed disabled:opacity-45"
+        className="mb-btn mb-btn-ghost h-8 w-8 border border-border/70 bg-bg/55 p-0 text-muted shadow-sm backdrop-blur-sm hover:border-accent/60 hover:bg-accent/10 hover:text-fg disabled:cursor-not-allowed disabled:opacity-45"
         title={disabledReason ?? "Export build"}
       >
         <svg

--- a/components/voxel/VoxelLoadingHud.tsx
+++ b/components/voxel/VoxelLoadingHud.tsx
@@ -43,49 +43,38 @@ export function VoxelLoadingHud({
   retryReason,
   className = "pointer-events-none absolute left-3 top-3 z-30",
 }: VoxelLoadingHudProps) {
-  const received = progress?.receivedBlocks ?? 0;
   const total = progress?.totalBlocks ?? null;
   const pct = clampPercent(progress);
 
   return (
     <div className={className}>
-      <div className="flex max-w-[92vw] flex-col gap-2 rounded-xl border border-border/70 bg-bg/60 px-3 py-2 text-xs text-muted shadow-soft backdrop-blur-sm sm:max-w-xs">
-        <div className="flex items-center gap-2 text-fg/90">
-          <span className="relative h-2 w-2 shrink-0" aria-hidden="true">
-            <span className="absolute inset-0 rounded-full bg-accent" />
-            <span className="absolute inset-0 animate-ping rounded-full bg-accent/60 motion-reduce:animate-none" />
-          </span>
-          <span className="font-medium">{label}</span>
-        </div>
-
-        <div className="flex flex-col gap-1.5">
-          <div className="h-1.5 w-full overflow-hidden rounded-full bg-border/35">
-            {pct != null ? (
-              <span
-                className="block h-full rounded-full bg-accent/75 transition-[width] duration-300 ease-out motion-reduce:transition-none"
-                style={{ width: `${pct}%` }}
-              />
-            ) : (
-              <span className="mb-progress-wait block h-full w-full" />
-            )}
-          </div>
-
-          {(received > 0 || total) ? (
-            <div className="flex items-center justify-between gap-3 font-mono text-[11px] tabular-nums text-muted/90">
-              <span>{received > 0 ? received.toLocaleString() : ""}</span>
-              <span>{total ? total.toLocaleString() : ""}</span>
-            </div>
+      <div className="flex w-[13.5rem] max-w-[70vw] flex-col gap-1.5 rounded-md bg-bg/[0.55] px-2.5 py-1.5 backdrop-blur-sm sm:px-3">
+        <div className="flex items-baseline justify-between gap-3 text-[10px] font-medium leading-none text-muted/70">
+          <span className="truncate text-fg/65">{label}</span>
+          {pct != null ? (
+            <span className="shrink-0 font-mono tabular-nums">{pct}%</span>
           ) : null}
         </div>
 
-        {(elapsed || (attempt && attempt > 1)) ? (
-          <div className="flex items-center gap-3 font-mono text-[11px] tabular-nums text-muted/80">
-            {elapsed ? <span>{elapsed}</span> : null}
-            {attempt && attempt > 1 ? <span>retry {attempt}</span> : null}
+        <div className="h-px w-full overflow-hidden bg-border/50">
+          {pct != null ? (
+            <span
+              className="block h-full bg-accent/70 transition-[width] duration-300 ease-out motion-reduce:transition-none"
+              style={{ width: `${pct}%` }}
+            />
+          ) : (
+            <span className="mb-progress-wait block h-full w-full" />
+          )}
+        </div>
+
+        {(total || elapsed || (attempt && attempt > 1) || retryReason) ? (
+          <div className="flex items-baseline justify-between gap-3 font-mono text-[10px] leading-none tabular-nums text-muted/45">
+            <span className="truncate">
+              {retryReason || (attempt && attempt > 1 ? `retry ${attempt}` : elapsed) || ""}
+            </span>
+            {total ? <span className="shrink-0">{total.toLocaleString()}</span> : null}
           </div>
         ) : null}
-
-        {retryReason ? <div className="text-[11px] text-muted/75">{retryReason}</div> : null}
       </div>
     </div>
   );

--- a/components/voxel/VoxelViewer.tsx
+++ b/components/voxel/VoxelViewer.tsx
@@ -326,17 +326,12 @@ function ViewerControlHint({ isPanMode, spinEnabled }: { isPanMode: boolean; spi
 
   return (
     <div className="pointer-events-none absolute bottom-[4.15rem] left-2.5 right-2.5 z-10 flex sm:bottom-3 sm:left-3 sm:right-auto">
-      <div className="inline-flex max-w-full flex-wrap items-center gap-x-2 gap-y-1 rounded-full border border-border/40 bg-bg/[0.50] px-2.5 py-1 text-[10px] font-medium leading-none text-muted/70 backdrop-blur-sm sm:px-3">
+      <div className="inline-flex max-w-full flex-wrap items-center gap-x-2 gap-y-1 rounded-md bg-bg/[0.55] px-2.5 py-1 text-[10px] font-medium leading-none text-muted/70 backdrop-blur-sm sm:px-3">
         <span className={itemClass}>
           <span className={inputLabelClass}>Drag</span>
           <span>{isPanMode ? "Pan" : "Rotate"}</span>
         </span>
         <span className={dividerClass} aria-hidden="true" />
-        <span className={desktopItemClass}>
-          <span className={keyClass}>Ctrl</span>
-          <span>Pan</span>
-        </span>
-        <span className={`${dividerClass} hidden sm:inline-flex`} aria-hidden="true" />
         <span className={itemClass}>
           <span className={`${inputLabelClass} sm:hidden`}>Pinch</span>
           <span className={`${inputLabelClass} hidden sm:inline`}>Scroll</span>
@@ -1173,13 +1168,15 @@ export const VoxelViewer = forwardRef<VoxelViewerHandle, ViewerProps>(function V
     if (autoRotate) requestRenderRef.current?.();
   }, [autoRotate, spinPreferenceEnabled]);
 
+  // Same register as the hint strip below and the loading HUD: translucent
+  // slab, no ring, muted label. Hover carries the affordance instead.
   const controlButtonClass =
-    "mb-btn h-11 flex-1 gap-1.5 rounded-lg px-3 text-[12px] leading-none sm:h-8 sm:flex-none sm:px-2.5 sm:text-[11px]";
-  const controlGhostClass = `${controlButtonClass} ring-1 ring-border/60 bg-bg/[0.46] text-fg/85 hover:bg-bg/[0.64] hover:ring-border/80`;
-  const controlActiveClass = `${controlButtonClass} ring-1 ring-border/75 bg-card/65 text-fg hover:bg-card/80 hover:ring-border`;
+    "mb-btn h-11 flex-1 gap-1.5 rounded-md bg-bg/[0.55] px-3 text-[12px] font-medium leading-none backdrop-blur-sm transition-colors sm:h-7 sm:flex-none sm:px-2.5 sm:text-[11px]";
+  const controlGhostClass = `${controlButtonClass} text-muted/80 hover:bg-bg/[0.72] hover:text-fg`;
+  const controlActiveClass = `${controlButtonClass} bg-accent/[0.14] text-accent hover:bg-accent/[0.2]`;
   const controlKeyClass =
-    "hidden h-5 min-w-5 items-center justify-center rounded-md border border-border/55 bg-bg/45 px-1.5 font-mono text-[10px] font-semibold leading-none text-muted/75 sm:inline-flex";
-  const activeControlKeyClass = `${controlKeyClass} border-border/60 bg-bg/55 text-fg/80`;
+    "hidden h-4 min-w-4 items-center justify-center rounded border border-border/40 bg-bg/40 px-1 font-mono text-[9px] font-semibold leading-none text-muted/70 sm:inline-flex";
+  const activeControlKeyClass = `${controlKeyClass} border-accent/25 bg-accent/[0.07] text-accent/75`;
 
   return (
     <div
@@ -1227,12 +1224,15 @@ export const VoxelViewer = forwardRef<VoxelViewerHandle, ViewerProps>(function V
         if (isPanModifierKey(e)) setPanModifierHeld(hasPanModifier(e));
       }}
     >
-      <div ref={mountRef} className="h-full w-full" />
+      {/* Out of flow: the renderer writes a pixel height onto the canvas, and in
+          normal flow that measurement props the stage open so a flex parent can
+          never shrink it back down. */}
+      <div ref={mountRef} className="absolute inset-0" />
 
       {showControls ? (
         <>
           <ViewerControlHint isPanMode={effectivePanMode} spinEnabled={Boolean(autoRotate && spinPreferenceEnabled)} />
-          <div className="absolute inset-x-2.5 bottom-2 flex items-center gap-1 rounded-xl border border-border/60 bg-bg/65 p-1 backdrop-blur-md sm:inset-x-auto sm:bottom-auto sm:right-3 sm:top-3 sm:gap-1.5 sm:rounded-full sm:border-transparent sm:bg-transparent sm:p-0 sm:shadow-none sm:backdrop-blur-0">
+          <div className="absolute inset-x-2.5 bottom-2 flex items-center gap-1 sm:inset-x-auto sm:bottom-auto sm:right-3 sm:top-3 sm:gap-1.5">
             <button
               aria-pressed={effectivePanMode}
               aria-label={effectivePanMode ? "Switch to rotate mode" : "Switch to pan mode"}

--- a/components/voxel/VoxelViewer.tsx
+++ b/components/voxel/VoxelViewer.tsx
@@ -1227,7 +1227,7 @@ export const VoxelViewer = forwardRef<VoxelViewerHandle, ViewerProps>(function V
       {/* Out of flow: the renderer writes a pixel height onto the canvas, and in
           normal flow that measurement props the stage open so a flex parent can
           never shrink it back down. */}
-      <div ref={mountRef} className="absolute inset-0" />
+      <div ref={mountRef} className="mb-viewer-stage absolute inset-0" />
 
       {showControls ? (
         <>

--- a/components/voxel/VoxelViewerCard.tsx
+++ b/components/voxel/VoxelViewerCard.tsx
@@ -268,32 +268,24 @@ export function VoxelViewerCard({
   return (
     <div className={isArena ? "mb-panel flex min-h-0 flex-1 flex-col" : "mb-panel"}>
       <div className={isArena ? "mb-panel-inner flex min-h-0 flex-1 flex-col" : "mb-panel-inner"}>
-        <div className="border-b border-border bg-bg/10 px-3 py-2 sm:px-4 sm:py-2.5">
-          <div className="flex flex-col gap-1.5 sm:flex-row sm:items-center sm:justify-between sm:gap-3">
-            <div className="min-w-0">
-              <div className="flex min-w-0 items-center gap-2">
-                <div className="font-display text-base font-semibold tracking-tight text-fg">
-                  {title}
-                </div>
-                {subtitle ? (
-                  <div className="min-h-[1.1rem] text-[12px] sm:text-[13px]">{subtitle}</div>
-                ) : null}
+        <div className="border-b border-border/70 bg-bg/10 px-3 py-2 sm:px-4 sm:py-2.5">
+          <div className="flex items-center justify-between gap-2 sm:gap-3">
+            <div className="flex min-w-0 flex-1 items-center gap-2">
+              <div className="shrink-0 font-display text-sm font-semibold tracking-tight text-fg sm:text-base">
+                {title}
               </div>
+              {subtitle ? (
+                <div className="min-w-0 truncate text-xs sm:text-[13px]">{subtitle}</div>
+              ) : null}
               {build ? (
-                <div className="mt-0.5 flex flex-wrap items-center gap-1.5 text-[11px] text-muted sm:hidden">
-                  <span className="font-mono">
-                    {blockCount.toLocaleString()} blocks
-                  </span>
-                  {timing ? (
-                    <span className="font-mono text-muted2">
-                      {timing}
-                    </span>
-                  ) : null}
+                <div className="flex items-center gap-1 font-mono text-[11px] text-muted sm:hidden">
+                  <span className="text-muted/40">•</span>
+                  <span>{blockCount.toLocaleString()}</span>
                 </div>
               ) : null}
             </div>
 
-            <div className="flex items-center justify-between gap-2 sm:shrink-0 sm:justify-end sm:gap-2">
+            <div className="flex shrink-0 items-center justify-end gap-1.5 sm:gap-2">
               {showViewToggle ? (
                 <div className="relative flex w-[182px] rounded-full bg-bg/55 p-1 ring-1 ring-border/80 sm:w-[210px]">
                   <div className="pointer-events-none absolute inset-1 rounded-full">

--- a/components/voxel/VoxelViewerCard.tsx
+++ b/components/voxel/VoxelViewerCard.tsx
@@ -190,10 +190,10 @@ export function VoxelViewerCard({
     return `${minutes}:${seconds.toString().padStart(2, "0")}`;
   }, [elapsedMs]);
 
-  const viewerHeightClass =
-    viewerSize === "arena"
-      ? "relative h-[42svh] min-h-[250px] max-h-[360px] w-full sm:h-[44vh] sm:min-h-[260px] sm:max-h-[360px] md:h-[52vh] md:min-h-[320px] md:max-h-[420px] lg:h-[56vh] lg:max-h-[480px] xl:h-[60vh] xl:max-h-[520px]"
-      : "relative h-[300px] w-full sm:h-[360px] md:h-[420px] lg:h-[480px] xl:h-[520px]";
+  const isArena = viewerSize === "arena";
+  const viewerHeightClass = isArena
+    ? "mb-viewer-stage relative w-full min-h-[250px] flex-1"
+    : "mb-viewer-stage relative h-[300px] w-full sm:h-[360px] md:h-[420px] lg:h-[480px] xl:h-[520px]";
   const loadingLabel =
     loadingMessage?.trim() ||
     (attempt === 0
@@ -266,8 +266,8 @@ export function VoxelViewerCard({
   }, []);
 
   return (
-    <div className="mb-panel">
-      <div className="mb-panel-inner">
+    <div className={isArena ? "mb-panel flex min-h-0 flex-1 flex-col" : "mb-panel"}>
+      <div className={isArena ? "mb-panel-inner flex min-h-0 flex-1 flex-col" : "mb-panel-inner"}>
         <div className="border-b border-border bg-bg/10 px-3 py-2 sm:px-4 sm:py-2.5">
           <div className="flex flex-col gap-1.5 sm:flex-row sm:items-center sm:justify-between sm:gap-3">
             <div className="min-w-0">

--- a/components/voxel/VoxelViewerCard.tsx
+++ b/components/voxel/VoxelViewerCard.tsx
@@ -190,10 +190,10 @@ export function VoxelViewerCard({
     return `${minutes}:${seconds.toString().padStart(2, "0")}`;
   }, [elapsedMs]);
 
-  const isArena = viewerSize === "arena";
-  const viewerHeightClass = isArena
-    ? "mb-viewer-stage relative w-full min-h-[250px] flex-1"
-    : "mb-viewer-stage relative h-[300px] w-full sm:h-[360px] md:h-[420px] lg:h-[480px] xl:h-[520px]";
+  const viewerHeightClass =
+    viewerSize === "arena"
+      ? "relative h-[48svh] min-h-[260px] max-h-[440px] w-full sm:h-[48vh] sm:min-h-[280px] sm:max-h-[450px] md:h-[52vh] md:min-h-[320px] md:max-h-[420px] lg:h-[56vh] lg:max-h-[480px] xl:h-[60vh] xl:max-h-[520px]"
+      : "relative h-[300px] w-full sm:h-[360px] md:h-[420px] lg:h-[480px] xl:h-[520px]";
   const loadingLabel =
     loadingMessage?.trim() ||
     (attempt === 0
@@ -266,8 +266,8 @@ export function VoxelViewerCard({
   }, []);
 
   return (
-    <div className={isArena ? "mb-panel flex min-h-0 flex-1 flex-col" : "mb-panel"}>
-      <div className={isArena ? "mb-panel-inner flex min-h-0 flex-1 flex-col" : "mb-panel-inner"}>
+    <div className="mb-panel">
+      <div className="mb-panel-inner">
         <div className="border-b border-border/70 bg-bg/10 px-3 py-2 sm:px-4 sm:py-2.5">
           <div className="flex items-center justify-between gap-2 sm:gap-3">
             <div className="flex min-w-0 flex-1 items-center gap-2">

--- a/lib/clientErrorResponse.ts
+++ b/lib/clientErrorResponse.ts
@@ -1,0 +1,51 @@
+function statusMessage(status: number): string | null {
+  if (status === 429) {
+    return "Slow down — you're going a bit fast. Try again in a few seconds.";
+  }
+  if (status === 503 || status === 504) {
+    return "The server is overloaded right now. Please try again shortly.";
+  }
+  if (status >= 500) {
+    return "The server had a problem. Please try again.";
+  }
+  if (status === 404) return "Not found.";
+  if (status === 401 || status === 403) return "You don't have access to this.";
+  return null;
+}
+
+export async function readClientErrorResponse(
+  response: Response,
+  fallback: string,
+): Promise<string> {
+  // Never expose server failure details to the browser
+  const safeStatusMessage = statusMessage(response.status);
+  if (safeStatusMessage) return safeStatusMessage;
+
+  let detail: string | null = null;
+  try {
+    const body = await response.clone().json();
+    if (body && typeof body === "object") {
+      const candidate =
+        (body as Record<string, unknown>).error ??
+        (body as Record<string, unknown>).message;
+      if (typeof candidate === "string" && candidate.trim()) {
+        detail = candidate.trim();
+      }
+    }
+  } catch {
+    // fall through to text
+  }
+
+  if (!detail) {
+    try {
+      const text = (await response.text()).trim();
+      if (text && !text.startsWith("<") && text.length <= 500) {
+        detail = text;
+      }
+    } catch {
+      // ignore unreadable response bodies
+    }
+  }
+
+  return detail ?? fallback;
+}

--- a/lib/db/errors.ts
+++ b/lib/db/errors.ts
@@ -4,14 +4,34 @@ const DB_UNAVAILABLE_PATTERNS = [
   "ECIRCUITBREAKER",
   "Connection terminated due to connection timeout",
   "Error in PostgreSQL connection",
+  "Failed to connect to database",
   "P1001",
 ];
+
+// Prisma reports these on the error object rather than in the message, so
+// matching text alone misses them — pool exhaustion (P2024) in particular,
+// which is the one that shows up under load.
+const DB_UNAVAILABLE_CODES = new Set([
+  "P1001", // can't reach the database server
+  "P1002", // server reached but timed out
+  "P1008", // operation timed out
+  "P1017", // server closed the connection
+  "P2024", // timed out fetching a connection from the pool
+]);
+
+function getErrorCode(error: unknown): string | null {
+  if (typeof error !== "object" || error === null) return null;
+  const code = (error as { code?: unknown }).code;
+  return typeof code === "string" ? code : null;
+}
 
 export function getErrorMessage(error: unknown, fallback: string): string {
   return error instanceof Error ? error.message : fallback;
 }
 
 export function isDatabaseUnavailableError(error: unknown): boolean {
+  const code = getErrorCode(error);
+  if (code && DB_UNAVAILABLE_CODES.has(code)) return true;
   const message = getErrorMessage(error, "");
   return DB_UNAVAILABLE_PATTERNS.some((pattern) => message.includes(pattern));
 }

--- a/lib/faq.ts
+++ b/lib/faq.ts
@@ -6,6 +6,7 @@ export interface FaqLink {
 export interface FaqItem {
   id: string;
   question: string;
+  navLabel?: string;
   answer: readonly string[];
   links?: readonly FaqLink[];
 }
@@ -24,6 +25,7 @@ export const FAQ_SECTIONS: readonly FaqSection[] = [
       {
         id: "what-is-minebench",
         question: "What is MineBench?",
+        navLabel: "What is MineBench?",
         answer: [
           "MineBench evaluates spatial reasoning through 3D voxel construction.",
           "Models receive natural-language prompts and construct the requested scene programmatically. Their outputs are rendered into 3D builds and compared through blind human pairwise voting.",
@@ -33,6 +35,7 @@ export const FAQ_SECTIONS: readonly FaqSection[] = [
       {
         id: "how-do-models-create-builds",
         question: "How do models actually create the builds?",
+        navLabel: "How models create builds",
         answer: [
           "Models generate JavaScript using MineBench's voxel-building API.",
           "The API exposes primitives for constructing geometry, such as blocks, boxes, and lines. The model writes JavaScript that calls those primitives to construct the requested scene.",
@@ -49,6 +52,7 @@ export const FAQ_SECTIONS: readonly FaqSection[] = [
       {
         id: "why-do-models-add-extra-scenery",
         question: "Why do some models add objects or scenery that were not explicitly requested?",
+        navLabel: "Extra scenery & creativity",
         answer: [
           "The system prompt intentionally allows models to use creativity, environmental context, detail, and composition when constructing the requested scene.",
           "Additional content is not automatically rewarded. A model can add substantially more geometry and still lose if those additions hurt prompt adherence, composition, or the quality of the requested object.",
@@ -65,6 +69,7 @@ export const FAQ_SECTIONS: readonly FaqSection[] = [
       {
         id: "how-are-models-ranked",
         question: "How are models ranked if there is no single correct build?",
+        navLabel: "Head-to-head ranking",
         answer: [
           "MineBench uses blind head-to-head voting.",
           "Two builds generated from the same prompt are shown without revealing which model produced either one. Pairwise preferences are then aggregated into the leaderboard rating.",
@@ -82,6 +87,7 @@ export const FAQ_SECTIONS: readonly FaqSection[] = [
       {
         id: "can-minebench-be-contaminated-or-benchmaxxed",
         question: "Can models train on MineBench or “benchmax” it?",
+        navLabel: "Contamination & benchmaxxing",
         answer: [
           "Potentially, but MineBench does not have a fixed answer key that a model can simply memorize.",
           "There is no canonical correct output for a castle, fighter jet, city, or any other prompt. Simply knowing that a prompt asks for a castle does not give a model the ability to actually construct a good castle in 3D. The model still has to reason about its structure, proportions, geometry, spatial relationships, and composition, then generate the JavaScript required to construct the build.",
@@ -94,6 +100,7 @@ export const FAQ_SECTIONS: readonly FaqSection[] = [
       {
         id: "how-do-grid-size-block-limits-and-leaderboard-settings-work",
         question: "How do grid size, block limits, and different leaderboard settings work?",
+        navLabel: "Grid sizes & block limits",
         answer: [
           "Models compared on the same leaderboard need to be generated under the same conditions.",
           "Grid size matters because it determines how much 3D space is available. A larger grid gives models more room for larger structures, scenery, separation between objects, and fine detail. Builds generated on different grid sizes therefore cannot be fairly mixed into the same leaderboard.",
@@ -105,6 +112,7 @@ export const FAQ_SECTIONS: readonly FaqSection[] = [
       {
         id: "why-not-add-more-evaluation-modes",
         question: "Why not add more prompts, grid sizes, block-limited settings, and other evaluation modes?",
+        navLabel: "More evaluation modes",
         answer: [
           "The primary limitation is API cost.",
           "A new prompt needs to be generated across the model set. A new grid size, block limit, or other configuration effectively creates another evaluation suite and requires another set of generations across the relevant prompts and models.",
@@ -115,6 +123,7 @@ export const FAQ_SECTIONS: readonly FaqSection[] = [
       {
         id: "are-generations-one-shot",
         question: "Are generations one-shot?",
+        navLabel: "One-shot generation",
         answer: [
           "Models do not see renders of their builds and iteratively revise them based on visual feedback.",
           "They receive the prompt and voxel-building interface, generate the JavaScript used to construct the scene, and that program produces the final voxel output.",
@@ -131,6 +140,7 @@ export const FAQ_SECTIONS: readonly FaqSection[] = [
       {
         id: "can-i-compare-models-directly",
         question: "Can I compare different models directly?",
+        navLabel: "Direct model comparison",
         answer: [
           "Yes.",
           "The MineBench Sandbox allows direct comparisons of up to four models at once for the same prompt and evaluation setting.",
@@ -141,16 +151,19 @@ export const FAQ_SECTIONS: readonly FaqSection[] = [
       {
         id: "can-unofficial-models-be-tested",
         question: "Can models that are not on the official leaderboard be tested?",
+        navLabel: "Unofficial & custom models",
         answer: [
           "Yes.",
           "The Sandbox Import workspace allows MineBench instructions to be used with models that are not directly integrated. The model can generate the expected output externally, and the result can then be loaded into MineBench and rendered.",
           "Those generations are useful for experimentation but should not be treated as official leaderboard results unless they were produced under the same controlled settings.",
+          "The Sandbox also allows live generations through the site with any provider endpoint (e.g. testing custom openrouter models).",
         ],
         links: [{ label: "Open Import", href: "/sandbox?mode=import" }],
       },
       {
         id: "why-is-a-model-missing",
         question: "Why isn't a particular model on the leaderboard?",
+        navLabel: "Missing models",
         answer: [
           "The usual reasons are API availability, integration work, or API cost.",
           "New models are released much faster than the full MineBench evaluation can reasonably be rerun, so models have to be prioritized.",
@@ -166,6 +179,7 @@ export const FAQ_SECTIONS: readonly FaqSection[] = [
       {
         id: "can-i-export-builds",
         question: "Can MineBench builds be exported?",
+        navLabel: "Exporting builds",
         answer: [
           "Yes.",
           "MineBench supports WorldEdit .schem for Minecraft-compatible workflows, GLB for general 3D workflows, and STL for applications such as 3D printing.",
@@ -181,6 +195,7 @@ export const FAQ_SECTIONS: readonly FaqSection[] = [
       {
         id: "is-this-minecraft-mcp-blender-mcp-or-a-coding-agent",
         question: "Is MineBench using Minecraft MCP, Blender MCP, or a coding agent?",
+        navLabel: "MCP & coding agents",
         answer: [
           "No.",
           "MineBench uses its own constrained voxel-building interface so that models are evaluated with the same tools.",
@@ -191,6 +206,7 @@ export const FAQ_SECTIONS: readonly FaqSection[] = [
       {
         id: "how-can-i-support-or-contribute",
         question: "How can MineBench be supported or contributed to?",
+        navLabel: "Contributing & support",
         answer: [
           "MineBench is open source. Useful contributions include harder prompts, model integrations, renderer improvements, methodology improvements, UI changes, and bug fixes.",
           "Financial support primarily goes toward API inference, which is the largest constraint on expanding the set of models, prompts, and evaluation settings.",

--- a/tests/unit/client-error-response.test.ts
+++ b/tests/unit/client-error-response.test.ts
@@ -1,0 +1,54 @@
+import assert from "node:assert/strict";
+import { readClientErrorResponse } from "../../lib/clientErrorResponse";
+
+async function main() {
+  const prismaError = new Response(
+    JSON.stringify({
+      error:
+        "Invalid `prisma.build.findMany()` invocation: FATAL: Failed to connect to database: {:error, :timeout}",
+    }),
+    {
+      status: 500,
+      headers: { "Content-Type": "application/json" },
+    },
+  );
+  assert.equal(
+    await readClientErrorResponse(prismaError, "Request failed"),
+    "The server had a problem. Please try again.",
+  );
+
+  const unavailable = new Response(
+    JSON.stringify({ error: "Database is temporarily unavailable." }),
+    {
+      status: 503,
+      headers: { "Content-Type": "application/json" },
+    },
+  );
+  assert.equal(
+    await readClientErrorResponse(unavailable, "Request failed"),
+    "The server is overloaded right now. Please try again shortly.",
+  );
+
+  const validationError = new Response(
+    JSON.stringify({ error: "Prompt is required." }),
+    {
+      status: 400,
+      headers: { "Content-Type": "application/json" },
+    },
+  );
+  assert.equal(
+    await readClientErrorResponse(validationError, "Request failed"),
+    "Prompt is required.",
+  );
+
+  const htmlError = new Response("<html>Internal Server Error</html>", {
+    status: 400,
+    headers: { "Content-Type": "text/html" },
+  });
+  assert.equal(await readClientErrorResponse(htmlError, "Request failed"), "Request failed");
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/tests/unit/db-errors.test.ts
+++ b/tests/unit/db-errors.test.ts
@@ -1,0 +1,26 @@
+import assert from "node:assert/strict";
+import { isDatabaseUnavailableError } from "../../lib/db/errors";
+
+assert.equal(
+  isDatabaseUnavailableError(
+    new Error(
+      "Error querying the database: FATAL: Failed to connect to database: {:error, :timeout}",
+    ),
+  ),
+  true,
+);
+assert.equal(
+  isDatabaseUnavailableError(
+    Object.assign(new Error("Timed out fetching a new connection"), { code: "P2024" }),
+  ),
+  true,
+);
+assert.equal(
+  isDatabaseUnavailableError(
+    Object.assign(new Error("Server has closed the connection"), { code: "P1017" }),
+  ),
+  true,
+);
+assert.equal(isDatabaseUnavailableError(new Error("Unique constraint failed")), false);
+
+console.log("database error classification checks passed");


### PR DESCRIPTION
### Summary

Comprehensive redesign of the public interface, transitioning from heavy card containers to a clean, rule-separated visual hierarchy with refined theming and first-paint dark mode stability:

- **Surface Redesign**: Replaces boxed containers and heavy drop-shadows with subtle 1px hairline rules, uniform `rounded-md` radii, and clean border hierarchy across the Arena, Leaderboard, Sandbox, and Local Lab.
- **Theme & Palette Overhaul**:
  - Eliminates dark-mode flash on first paint by declaring the dark palette directly under both `prefers-color-scheme: dark` and `data-theme="dark"`.
  - Introduces lifted `--viewer-bg` sky backdrop behind the transparent canvas so dark blocks (e.g. obsidian, dark wool) remain clearly legible against the background.
  - Streamlines header navigation into an underline tab strip and unifies button/field styles without heavy gradient fills.
- **Arena Stage & Motion Refinement**:
  - Rebalances viewport sizing so arena voting controls sit cleanly on the fold without scrolling.
  - Unifies the vote bar and post-vote model reveal into a single persistent layout footprint to eliminate empty space reservation and layout jumping.
  - Refines vote confirmation feedback and model reveal highlights with smooth non-clipping transitions.
- **Error Boundary Sanitization**: Centralizes client fetch error handling through `lib/clientErrorResponse.ts` and enhances database error classification (e.g., connection pool exhaustion `P2024` and dropped connections `P1017`) so internal server traces never leak into public UI notifications.

*(PR written by Codex)*