### PR TITLE
fix(arena): restore blind binary build delivery

### DIFF
--- a/app/api/arena/builds/[buildId]/route.ts
+++ b/app/api/arena/builds/[buildId]/route.ts
@@ -15,6 +15,7 @@ import {
   fetchArenaBuildSnapshotArtifact,
 } from "@/lib/arena/buildSnapshotArtifacts";
 import type { ArenaSnapshotArtifactFormat } from "@/lib/arena/artifactOwnership";
+import { rewriteBlindBinaryArtifactIdentity } from "@/lib/arena/binaryArtifact";
 import {
   getArenaBuildMeta,
   invalidateArenaBuildMeta,
@@ -268,7 +269,7 @@ export async function GET(
     arenaBuildHints: buildMeta.arenaBuildHints,
   });
   const deliveryClass = variant === "preview" ? shellHints.initialDeliveryClass : shellHints.deliveryClass;
-  const binaryFormatRequested = !buildAccess && url.searchParams.get("format") === "v4";
+  const binaryFormatRequested = url.searchParams.get("format") === "v4";
   const binaryArtifactRequested =
     binaryFormatRequested && isBinarySnapshotArtifactEnabled();
   const fullUsesStreamDelivery =
@@ -404,7 +405,9 @@ export async function GET(
         timing.end("artifact_hit", artifactStartedAt);
         timing.end("total", requestStartedAt);
         const responseArtifactBytes = buildAccess
-          ? rewriteBlindSnapshotIdentity(artifactBytes, clientBuildId)
+          ? servedArtifactFormat === "binary"
+            ? rewriteBlindBinaryArtifactIdentity(artifactBytes, clientBuildId)
+            : rewriteBlindSnapshotIdentity(artifactBytes, clientBuildId)
           : artifactBytes;
         // the stored object is gzip; proxying it verbatim to a gzip-capable
         // client keeps snapshot-class fallbacks off the uncompressed path

--- a/app/api/arena/builds/[buildId]/stream/route.ts
+++ b/app/api/arena/builds/[buildId]/stream/route.ts
@@ -10,6 +10,7 @@ import {
   iterateArenaBuildChunks,
   iterateArenaBuildStreamEvents,
   planArenaBuildStream,
+  rewriteBlindArenaBuildStreamIdentity,
   uploadArenaBuildStreamArtifact,
 } from "@/lib/arena/buildStream";
 import {
@@ -137,40 +138,6 @@ function chunkStreamArtifactBytes(events: Iterable<ArenaBuildStreamEvent>) {
     offset += part.length;
   }
   return out;
-}
-
-function rewriteBlindStreamIdentity(
-  body: ReadableStream<Uint8Array>,
-  buildId: string,
-): ReadableStream<Uint8Array> {
-  const decoder = new TextDecoder();
-  const encoder = new TextEncoder();
-  let pending = "";
-  const rewriteLine = (line: string) => {
-    if (!line.trim()) return line;
-    try {
-      const event = JSON.parse(line) as ArenaBuildStreamEvent;
-      return event.type === "hello"
-        ? JSON.stringify({ ...event, buildId, checksum: null })
-        : line;
-    } catch {
-      return line;
-    }
-  };
-  return body.pipeThrough(
-    new TransformStream<Uint8Array, Uint8Array>({
-      transform(chunk, controller) {
-        pending += decoder.decode(chunk, { stream: true });
-        const lines = pending.split("\n");
-        pending = lines.pop() ?? "";
-        for (const line of lines) controller.enqueue(encoder.encode(`${rewriteLine(line)}\n`));
-      },
-      flush(controller) {
-        pending += decoder.decode();
-        if (pending) controller.enqueue(encoder.encode(rewriteLine(pending)));
-      },
-    }),
-  );
 }
 
 function warmStreamArtifactInBackground(opts: {
@@ -331,9 +298,17 @@ export async function GET(
             privateAccess: true,
           });
           timing.apply(headers);
-          return new Response(rewriteBlindStreamIdentity(artifactResponse.body, clientBuildId), {
-            headers,
-          });
+          const body = await withTimeout(
+            (signal) =>
+              rewriteBlindArenaBuildStreamIdentity(
+                artifactResponse.body!,
+                clientBuildId,
+                signal,
+              ),
+            ARTIFACT_FETCH_TIMEOUT_MS,
+            "artifact decode",
+          );
+          return new Response(body, { headers });
         }
       } else {
         const artifactSignedUrl = await withTimeout(

--- a/lib/arena/binaryArtifact.ts
+++ b/lib/arena/binaryArtifact.ts
@@ -1,7 +1,9 @@
 import {
+  BINARY_BUILD_HEADER_BYTES,
   decodeBinaryVoxelBuild,
   encodeBinaryVoxelBuild,
   BinaryBuildFormatError,
+  readBinaryVoxelBuildHeader,
 } from "@/lib/voxel/binaryBuild";
 import type { PackedVoxelBlocks } from "@/lib/voxel/packedBlocks";
 import type { VoxelBlock } from "@/lib/voxel/types";
@@ -31,6 +33,11 @@ export type DecodedBinaryArtifact = {
   blocks: PackedVoxelBlocks;
 };
 
+type ParsedBinaryArtifact = {
+  envelope: BinaryArtifactEnvelope;
+  body: Uint8Array;
+};
+
 export function isBinaryArtifact(bytes: Uint8Array): boolean {
   if (bytes.length < BINARY_ARTIFACT_HEADER_BYTES) return false;
   return bytes[0] === 0x4d && bytes[1] === 0x42 && bytes[2] === 0x41 && bytes[3] === 0x34;
@@ -58,7 +65,7 @@ export function encodeBinaryArtifact(
   return bytes;
 }
 
-export function decodeBinaryArtifact(bytes: Uint8Array): DecodedBinaryArtifact {
+function parseBinaryArtifact(bytes: Uint8Array): ParsedBinaryArtifact {
   if (!isBinaryArtifact(bytes)) {
     throw new BinaryBuildFormatError("Not a binary arena build artifact");
   }
@@ -84,8 +91,43 @@ export function decodeBinaryArtifact(bytes: Uint8Array): DecodedBinaryArtifact {
     throw new BinaryBuildFormatError("Artifact envelope is not an object");
   }
 
-  const blocks = decodeBinaryVoxelBuild(
-    bytes.subarray(BINARY_ARTIFACT_HEADER_BYTES + envelopeBytes),
+  return {
+    envelope: envelope as BinaryArtifactEnvelope,
+    body: bytes.subarray(BINARY_ARTIFACT_HEADER_BYTES + envelopeBytes),
+  };
+}
+
+export function rewriteBlindBinaryArtifactIdentity(
+  bytes: Uint8Array,
+  buildId: string,
+): Uint8Array {
+  if (!buildId.trim()) {
+    throw new BinaryBuildFormatError("Blind build ID is required");
+  }
+  const parsed = parseBinaryArtifact(bytes);
+  readBinaryVoxelBuildHeader(parsed.body);
+
+  const envelopeJson = new TextEncoder().encode(
+    JSON.stringify({ ...parsed.envelope, buildId, checksum: null }),
   );
-  return { envelope: envelope as BinaryArtifactEnvelope, blocks };
+  if (envelopeJson.length > MAX_ENVELOPE_BYTES) {
+    throw new BinaryBuildFormatError(
+      `Artifact envelope of ${envelopeJson.length} bytes exceeds the container limit`,
+    );
+  }
+
+  const bodyAt = BINARY_ARTIFACT_HEADER_BYTES + envelopeJson.length;
+  const rewritten = new Uint8Array(bodyAt + parsed.body.length);
+  const view = new DataView(rewritten.buffer);
+  view.setUint32(0, BINARY_ARTIFACT_MAGIC, false);
+  view.setUint32(4, envelopeJson.length, false);
+  rewritten.set(envelopeJson, BINARY_ARTIFACT_HEADER_BYTES);
+  rewritten.set(parsed.body, bodyAt);
+  view.setUint32(bodyAt + BINARY_BUILD_HEADER_BYTES - 4, 0, false);
+  return rewritten;
+}
+
+export function decodeBinaryArtifact(bytes: Uint8Array): DecodedBinaryArtifact {
+  const parsed = parseBinaryArtifact(bytes);
+  return { envelope: parsed.envelope, blocks: decodeBinaryVoxelBuild(parsed.body) };
 }

--- a/lib/arena/buildStream.ts
+++ b/lib/arena/buildStream.ts
@@ -219,6 +219,94 @@ export function encodeArenaBuildStreamEvent(event: ArenaBuildStreamEvent): Uint8
   return ENCODER.encode(`${JSON.stringify(event)}\n`);
 }
 
+async function readArtifactChunk(
+  reader: ReadableStreamDefaultReader<Uint8Array>,
+  signal?: AbortSignal,
+) {
+  if (!signal) return reader.read();
+  if (signal.aborted) throw signal.reason;
+  return new Promise<ReadableStreamReadResult<Uint8Array>>((resolve, reject) => {
+    const cleanup = () => signal.removeEventListener("abort", onAbort);
+    const onAbort = () => {
+      cleanup();
+      void reader.cancel(signal.reason).catch(() => undefined);
+      reject(signal.reason);
+    };
+    signal.addEventListener("abort", onAbort, { once: true });
+    reader.read().then(
+      (value) => {
+        cleanup();
+        resolve(value);
+      },
+      (error) => {
+        cleanup();
+        reject(error);
+      },
+    );
+  });
+}
+
+export async function rewriteBlindArenaBuildStreamIdentity(
+  body: ReadableStream<Uint8Array>,
+  buildId: string,
+  signal?: AbortSignal,
+): Promise<ReadableStream<Uint8Array>> {
+  const [probe, replay] = body.tee();
+  const reader = probe.getReader();
+  const prefix: number[] = [];
+  try {
+    while (prefix.length < 2) {
+      const next = await readArtifactChunk(reader, signal);
+      if (next.done) break;
+      for (const byte of next.value) {
+        prefix.push(byte);
+        if (prefix.length === 2) break;
+      }
+    }
+  } catch (error) {
+    void replay.cancel(error).catch(() => undefined);
+    throw error;
+  } finally {
+    void reader.cancel().catch(() => undefined);
+    reader.releaseLock();
+  }
+
+  const decoded =
+    prefix[0] === 0x1f && prefix[1] === 0x8b
+      ? replay.pipeThrough(
+          new DecompressionStream("gzip") as unknown as TransformStream<Uint8Array, Uint8Array>,
+        )
+      : replay;
+  const decoder = new TextDecoder();
+  const encoder = new TextEncoder();
+  let pending = "";
+  const rewriteLine = (line: string) => {
+    if (!line.trim()) return line;
+    try {
+      const event = JSON.parse(line) as ArenaBuildStreamEvent;
+      return event.type === "hello"
+        ? JSON.stringify({ ...event, buildId, checksum: null })
+        : line;
+    } catch {
+      return line;
+    }
+  };
+  return decoded.pipeThrough(
+    new TransformStream<Uint8Array, Uint8Array>({
+      transform(chunk, controller) {
+        pending += decoder.decode(chunk, { stream: true });
+        const lines = pending.split("\n");
+        pending = lines.pop() ?? "";
+        for (const line of lines) controller.enqueue(encoder.encode(`${rewriteLine(line)}\n`));
+      },
+      flush(controller) {
+        pending += decoder.decode();
+        if (pending) controller.enqueue(encoder.encode(rewriteLine(pending)));
+      },
+    }),
+  );
+}
+
 export const ARENA_BUILD_STREAM_HELLO_PAD =
   ARENA_STREAM_HELLO_PAD_BYTES > 0 ? " ".repeat(ARENA_STREAM_HELLO_PAD_BYTES) : "";
 

--- a/tests/unit/arena/binary-artifact.test.ts
+++ b/tests/unit/arena/binary-artifact.test.ts
@@ -3,8 +3,12 @@ import {
   decodeBinaryArtifact,
   encodeBinaryArtifact,
   isBinaryArtifact,
+  rewriteBlindBinaryArtifactIdentity,
 } from "../../../lib/arena/binaryArtifact";
-import { BinaryBuildFormatError } from "../../../lib/voxel/binaryBuild";
+import {
+  BinaryBuildFormatError,
+  readBinaryVoxelBuildHeader,
+} from "../../../lib/voxel/binaryBuild";
 import { unpackVoxelBlocks } from "../../../lib/voxel/packedBlocks";
 import type { VoxelBlock } from "../../../lib/voxel/types";
 
@@ -32,6 +36,25 @@ async function main() {
     assert.deepEqual(decoded.envelope, envelope);
     assert.equal(decoded.blocks.count, blocks.length);
     assert.deepEqual(unpackVoxelBlocks(decoded.blocks), blocks);
+  }
+
+  {
+    const encoded = encodeBinaryArtifact(envelope, blocks, "deadbeef" + "0".repeat(56));
+    const blinded = rewriteBlindBinaryArtifactIdentity(encoded, "b1.blind-build");
+    const decoded = decodeBinaryArtifact(blinded);
+    const envelopeBytes = new DataView(
+      blinded.buffer,
+      blinded.byteOffset,
+      blinded.byteLength,
+    ).getUint32(4, false);
+
+    assert.deepEqual(decoded.envelope, {
+      ...envelope,
+      buildId: "b1.blind-build",
+      checksum: null,
+    });
+    assert.deepEqual(unpackVoxelBlocks(decoded.blocks), blocks);
+    assert.equal(readBinaryVoxelBuildHeader(blinded.subarray(8 + envelopeBytes)).checksumPrefix, 0);
   }
 
   {

--- a/tests/unit/arena/blind-stream-identity.test.ts
+++ b/tests/unit/arena/blind-stream-identity.test.ts
@@ -1,0 +1,65 @@
+import assert from "node:assert/strict";
+import { gzipSync } from "node:zlib";
+
+const encoder = new TextEncoder();
+
+async function main() {
+  process.env.ARENA_STREAM_ARTIFACTS_ENABLED = "0";
+
+  const { rewriteBlindArenaBuildStreamIdentity } = await import(
+    "../../../lib/arena/buildStream"
+  );
+  const { readBuildVariantStream } = await import(
+    "../../../lib/arena/clientBuildResponse"
+  );
+
+  const blocks = [{ x: 1, y: 2, z: 3, type: "stone" }];
+  const body = encoder.encode(
+    [
+      {
+        type: "hello",
+        buildId: "real-build-id",
+        variant: "full",
+        checksum: "real-checksum",
+        serverValidated: true,
+        totalBlocks: 1,
+        chunkCount: 1,
+        chunkBlockCount: 1,
+        estimatedBytes: 34,
+        source: "artifact",
+      },
+      {
+        type: "chunk",
+        index: 1,
+        chunkCount: 1,
+        receivedBlocks: 1,
+        totalBlocks: 1,
+        blocks,
+      },
+      { type: "complete", totalBlocks: 1, durationMs: 0 },
+    ]
+      .map((event) => JSON.stringify(event))
+      .join("\n") + "\n",
+  );
+  const compressed = new Uint8Array(gzipSync(body));
+  const artifact = new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(compressed.slice(0, 1));
+      controller.enqueue(compressed.slice(1));
+      controller.close();
+    },
+  });
+
+  const rewritten = await rewriteBlindArenaBuildStreamIdentity(artifact, "b1.blind-build");
+  const decoded = await readBuildVariantStream(new Response(rewritten));
+
+  assert.equal(decoded.buildId, "b1.blind-build");
+  assert.equal(decoded.checksum, null);
+  assert.equal(decoded.voxelBuild.packed?.count, 1);
+  assert.equal(decoded.voxelBuild.packed?.typeNames[0], "stone");
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/tests/unit/stealth/privacy-contract.test.ts
+++ b/tests/unit/stealth/privacy-contract.test.ts
@@ -28,7 +28,10 @@ for (const path of [
   assert.match(buildRoute, /private, no-store/);
   assert.match(buildRoute, /privateAccessOnly && !buildAccess/);
 }
-assert.match(read("app/api/arena/builds/[buildId]/route.ts"), /cache: buildAccess \? "no-store"/);
+const arenaBuildRoute = read("app/api/arena/builds/[buildId]/route.ts");
+assert.match(arenaBuildRoute, /cache: buildAccess \? "no-store"/);
+assert.match(arenaBuildRoute, /const binaryFormatRequested = url\.searchParams\.get\("format"\) === "v4"/);
+assert.match(arenaBuildRoute, /rewriteBlindBinaryArtifactIdentity\(artifactBytes, clientBuildId\)/);
 assert.match(read("app/api/arena/matchup/route.ts"), /cache: privateAccessOnly \? "no-store"/);
 
 const generation = read("lib/stealth/generation.ts");


### PR DESCRIPTION
## Summary

- restore v4 binary artifact delivery for opaque Arena build references
- redact blind identity fields without decoding or re-encoding binary block arrays
- decompress protected gzip stream artifacts before rewriting their identity fallback
- cover the binary privacy boundary and gzip fallback with focused regressions

## Verification

- `pnpm lint`
- `pnpm test` (69 test files)
- `pnpm exec tsc --noEmit`
- `pnpm build`

*(PR written by Codex)*