### PR TITLE
feat(arena): add end-to-end build observability

### DIFF
--- a/app/api/arena/builds/[buildId]/route.ts
+++ b/app/api/arena/builds/[buildId]/route.ts
@@ -13,6 +13,7 @@ import {
   isBinarySnapshotArtifactEnabled,
   healArenaBuildSnapshotArtifactsOnce,
   fetchArenaBuildSnapshotArtifact,
+  type ArenaSnapshotArtifactFetchMetrics,
 } from "@/lib/arena/buildSnapshotArtifacts";
 import type { ArenaSnapshotArtifactFormat } from "@/lib/arena/artifactOwnership";
 import { rewriteBlindBinaryArtifactIdentity } from "@/lib/arena/binaryArtifact";
@@ -24,6 +25,16 @@ import { parseArenaBuildAccessToken } from "@/lib/arena/matchupToken";
 import { isLoopbackDatabaseUrl } from "@/lib/db/identity";
 import { prisma } from "@/lib/prisma";
 import { ServerTiming } from "@/lib/serverTiming";
+import { trackServerEvent } from "@/lib/analytics.server";
+import {
+  getArenaBlockCountBucket,
+  roundMetricMs,
+} from "@/lib/observability/arenaMetrics";
+import {
+  setActiveServerSpanAttributes,
+  withServerSpan,
+  withServerSpanSync,
+} from "@/lib/observability/serverTracing";
 
 export const runtime = "nodejs";
 
@@ -62,6 +73,96 @@ type CachedJsonResponse = {
   byteWeight: number;
   touchedAt: number;
 };
+
+type ArenaBuildTimingStage =
+  | "token_validate"
+  | "artifact_resolve"
+  | "artifact_fetch"
+  | "inflate"
+  | "identity_rewrite"
+  | "deflate"
+  | "body_ready"
+  | "total";
+
+type ArenaBuildDeliveryObservation = {
+  access: "blind" | "public";
+  variant: ArenaBuildVariant;
+  requestedFormat: "v4" | "legacy";
+  servedFormat: "binary" | "json" | "ndjson" | "none";
+  deliveryClass: string;
+  source: string;
+  artifactOutcome: string;
+  artifactCacheStatus: string;
+  fallbackReason: string | null;
+  blockCount: number | null;
+  responseBytes: number | null;
+  transferBytes: number | null;
+  decodedBytes: number | null;
+  gzip: boolean;
+  optimizedExpected: boolean;
+  optimizedDelivered: boolean;
+};
+
+function logArenaBuildDelivery(
+  observation: ArenaBuildDeliveryObservation,
+  stages: Partial<Record<ArenaBuildTimingStage, number>>,
+  status: number,
+) {
+  const blockCountBucket = getArenaBlockCountBucket(observation.blockCount);
+  const path = [
+    observation.variant,
+    observation.requestedFormat,
+    observation.servedFormat,
+    observation.source,
+    observation.artifactOutcome,
+  ].join(":");
+  const roundedStages = {
+    tokenValidateMs: roundMetricMs(stages.token_validate),
+    artifactResolveMs: roundMetricMs(stages.artifact_resolve),
+    artifactFetchMs: roundMetricMs(stages.artifact_fetch),
+    inflateMs: roundMetricMs(stages.inflate),
+    identityRewriteMs: roundMetricMs(stages.identity_rewrite),
+    deflateMs: roundMetricMs(stages.deflate),
+    bodyReadyMs: roundMetricMs(stages.body_ready),
+    totalMs: roundMetricMs(stages.total),
+  };
+
+  console.info(
+    JSON.stringify({
+      event: "arena_build_delivery",
+      status,
+      ...observation,
+      blockCountBucket,
+      ...roundedStages,
+    }),
+  );
+
+  // Web Analytics Plus accepts at most eight properties per custom event
+  after(async () => {
+    await trackServerEvent("arena_build_server_timing", {
+      path,
+      blockCountBucket,
+      tokenMs: roundedStages.tokenValidateMs,
+      resolveMs: roundedStages.artifactResolveMs,
+      bodyReadyMs: roundedStages.bodyReadyMs,
+      totalMs: roundedStages.totalMs,
+      status,
+      optimized: observation.optimizedDelivered,
+    });
+    if (stages.artifact_fetch != null) {
+      await trackServerEvent("arena_artifact_server_timing", {
+        path,
+        cache: observation.artifactCacheStatus,
+        fetchMs: roundedStages.artifactFetchMs,
+        inflateMs: roundedStages.inflateMs,
+        rewriteMs: roundedStages.identityRewriteMs,
+        deflateMs: roundedStages.deflateMs,
+        transferBytes: observation.transferBytes,
+        decodedBytes: observation.decodedBytes,
+      });
+    }
+  });
+}
 
 // short process cache avoids rebuilding the same snapshot json
 const jsonResponseCache = new Map<string, CachedJsonResponse>();
@@ -226,10 +327,113 @@ export async function GET(
 ) {
   const timing = new ServerTiming();
   const requestStartedAt = timing.start();
+  const stages: Partial<Record<ArenaBuildTimingStage, number>> = {};
+  const url = new URL(request.url);
+  const variant = parseVariant(url.searchParams.get("variant"));
+  const binaryFormatRequested = url.searchParams.get("format") === "v4";
+  const shouldGzip = acceptsGzip(request);
+  let observation: ArenaBuildDeliveryObservation = {
+    access: "public",
+    variant,
+    requestedFormat: binaryFormatRequested ? "v4" : "legacy",
+    servedFormat: "none",
+    deliveryClass: "unknown",
+    source: "unknown",
+    artifactOutcome: "not-attempted",
+    artifactCacheStatus: "not-attempted",
+    fallbackReason: null,
+    blockCount: null,
+    responseBytes: null,
+    transferBytes: null,
+    decodedBytes: null,
+    gzip: shouldGzip,
+    optimizedExpected: binaryFormatRequested,
+    optimizedDelivered: false,
+  };
+
+  const recordStage = (stage: ArenaBuildTimingStage, durationMs: number) => {
+    if (!Number.isFinite(durationMs) || durationMs < 0) return;
+    stages[stage] = (stages[stage] ?? 0) + durationMs;
+    timing.add(stage, durationMs);
+  };
+  const measureStageSync = <T,>(
+    stage: ArenaBuildTimingStage,
+    spanName: string,
+    attributes: Record<string, string | number | boolean>,
+    operation: () => T,
+  ): T => {
+    const startedAt = performance.now();
+    try {
+      return withServerSpanSync(spanName, attributes, () => operation());
+    } finally {
+      recordStage(stage, performance.now() - startedAt);
+    }
+  };
+  const measureStage = async <T,>(
+    stage: ArenaBuildTimingStage,
+    spanName: string,
+    attributes: Record<string, string | number | boolean>,
+    operation: () => Promise<T>,
+  ): Promise<T> => {
+    const startedAt = performance.now();
+    try {
+      return await withServerSpan(spanName, attributes, () => operation());
+    } finally {
+      recordStage(stage, performance.now() - startedAt);
+    }
+  };
+  const finishResponse = (
+    response: Response,
+    updates?: Partial<ArenaBuildDeliveryObservation>,
+  ): Response => {
+    observation = { ...observation, ...updates };
+    if (observation.responseBytes == null) {
+      const contentLength = Number.parseInt(response.headers.get("content-length") ?? "", 10);
+      if (Number.isFinite(contentLength) && contentLength >= 0) {
+        observation.responseBytes = contentLength;
+      }
+    }
+    recordStage("body_ready", performance.now() - requestStartedAt);
+    recordStage("total", performance.now() - requestStartedAt);
+    timing.apply(response.headers);
+    setActiveServerSpanAttributes({
+      "arena.access": observation.access,
+      "arena.variant": observation.variant,
+      "arena.requested_format": observation.requestedFormat,
+      "arena.served_format": observation.servedFormat,
+      "arena.delivery_class": observation.deliveryClass,
+      "arena.source": observation.source,
+      "arena.artifact_outcome": observation.artifactOutcome,
+      "arena.artifact_cache": observation.artifactCacheStatus,
+      "arena.optimized_expected": observation.optimizedExpected,
+      "arena.optimized_delivered": observation.optimizedDelivered,
+      "arena.block_count_bucket": getArenaBlockCountBucket(observation.blockCount),
+      ...(observation.fallbackReason
+        ? { "arena.fallback_reason": observation.fallbackReason }
+        : {}),
+    });
+    logArenaBuildDelivery(observation, stages, response.status);
+    return response;
+  };
+
   const { buildId: requestedBuildId } = await params;
-  const buildAccess = parseArenaBuildAccessToken(requestedBuildId);
+  observation.access = requestedBuildId.startsWith("b1.") ? "blind" : "public";
+  const buildAccess = measureStageSync(
+    "token_validate",
+    "arena.token.validate",
+    {
+      "arena.access": observation.access,
+      "arena.variant": variant,
+      "arena.requested_format": observation.requestedFormat,
+    },
+    () => parseArenaBuildAccessToken(requestedBuildId),
+  );
   if (requestedBuildId.startsWith("b1.") && !buildAccess) {
-    return NextResponse.json({ error: "Build not found" }, { status: 404 });
+    return finishResponse(NextResponse.json({ error: "Build not found" }, { status: 404 }), {
+      source: "rejected",
+      artifactOutcome: "invalid-token",
+      servedFormat: "json",
+    });
   }
   const buildId = buildAccess?.buildId ?? requestedBuildId;
   const clientBuildId = buildAccess ? requestedBuildId : buildId;
@@ -237,23 +441,44 @@ export async function GET(
     buildAccess &&
       isLoopbackDatabaseUrl(process.env.DATABASE_URL ?? process.env.DIRECT_URL ?? ""),
   );
-  const url = new URL(request.url);
-  const variant = parseVariant(url.searchParams.get("variant"));
   const requestedChecksum = url.searchParams.get("checksum")?.trim() || null;
   if (buildAccess && requestedChecksum && requestedChecksum !== buildAccess.checksum) {
-    return NextResponse.json({ error: "Build checksum mismatch" }, { status: 409 });
+    return finishResponse(
+      NextResponse.json({ error: "Build checksum mismatch" }, { status: 409 }),
+      {
+        source: "rejected",
+        artifactOutcome: "checksum-mismatch",
+        servedFormat: "json",
+      },
+    );
   }
   const expectedChecksum = buildAccess?.checksum ?? requestedChecksum;
-  const shouldGzip = acceptsGzip(request);
   // pass the client-supplied checksum so the meta cache can detect stale
   // entries left behind by an overwrite import that landed on another lambda
-  const buildMeta = await getArenaBuildMeta(buildId, expectedChecksum);
+  const buildMeta = await measureStage(
+    "artifact_resolve",
+    "arena.artifact.resolve",
+    {
+      "arena.access": observation.access,
+      "arena.variant": variant,
+      "arena.requested_format": observation.requestedFormat,
+    },
+    () => getArenaBuildMeta(buildId, expectedChecksum),
+  );
 
   if (!buildMeta) {
-    return NextResponse.json({ error: "Build not found" }, { status: 404 });
+    return finishResponse(NextResponse.json({ error: "Build not found" }, { status: 404 }), {
+      source: "metadata-miss",
+      artifactOutcome: "not-found",
+      servedFormat: "json",
+    });
   }
   if (buildMeta.privateAccessOnly && !buildAccess) {
-    return NextResponse.json({ error: "Build not found" }, { status: 404 });
+    return finishResponse(NextResponse.json({ error: "Build not found" }, { status: 404 }), {
+      source: "rejected",
+      artifactOutcome: "private",
+      servedFormat: "json",
+    });
   }
 
   const storedChecksum = buildMeta.voxelSha256?.trim() || null;
@@ -269,7 +494,9 @@ export async function GET(
     arenaBuildHints: buildMeta.arenaBuildHints,
   });
   const deliveryClass = variant === "preview" ? shellHints.initialDeliveryClass : shellHints.deliveryClass;
-  const binaryFormatRequested = url.searchParams.get("format") === "v4";
+  observation.deliveryClass = deliveryClass;
+  observation.blockCount =
+    variant === "preview" ? shellHints.previewBlockCount : shellHints.fullBlockCount;
   const binaryArtifactRequested =
     binaryFormatRequested && isBinarySnapshotArtifactEnabled();
   const fullUsesStreamDelivery =
@@ -289,15 +516,22 @@ export async function GET(
   const avoidWholeBodyJsonFallback = binaryFormatRequested && fullUsesStreamDelivery;
   let shouldRequireStreamFallbackOnSnapshotMiss = avoidWholeBodyJsonFallback;
   if (expectedChecksum && storedChecksum && expectedChecksum !== storedChecksum) {
-    return NextResponse.json(
-      buildAccess
-        ? { error: "Build changed" }
-        : {
-            error: "Build checksum mismatch",
-            expectedChecksum,
-            actualChecksum: storedChecksum,
-          },
-      { status: 409 },
+    return finishResponse(
+      NextResponse.json(
+        buildAccess
+          ? { error: "Build changed" }
+          : {
+              error: "Build checksum mismatch",
+              expectedChecksum,
+              actualChecksum: storedChecksum,
+            },
+        { status: 409 },
+      ),
+      {
+        source: "rejected",
+        artifactOutcome: "checksum-mismatch",
+        servedFormat: "json",
+      },
     );
   }
 
@@ -326,18 +560,28 @@ export async function GET(
       let signedUrl: string | null = null;
       for (const format of artifactFormats) {
         try {
-          signedUrl = await withTimeout(
-            (signal) =>
-              createArenaBuildSnapshotArtifactSignedUrl(buildId, variant, storedChecksum, {
-                signal,
-                expiresInSec: SNAPSHOT_ARTIFACT_SIGN_URL_TTL_SEC,
-                format,
-              }),
-            SNAPSHOT_ARTIFACT_SIGN_TIMEOUT_MS,
-            "snapshot artifact sign",
+          signedUrl = await withServerSpan(
+            "arena.artifact.sign",
+            {
+              "arena.access": observation.access,
+              "arena.variant": variant,
+              "arena.format": format,
+            },
+            () =>
+              withTimeout(
+                (signal) =>
+                  createArenaBuildSnapshotArtifactSignedUrl(buildId, variant, storedChecksum, {
+                    signal,
+                    expiresInSec: SNAPSHOT_ARTIFACT_SIGN_URL_TTL_SEC,
+                    format,
+                  }),
+                SNAPSHOT_ARTIFACT_SIGN_TIMEOUT_MS,
+                "snapshot artifact sign",
+              ),
           );
         } catch (error) {
           if (format === "json") throw error;
+          observation.fallbackReason = "binary-sign-error";
           console.warn("arena binary snapshot artifact sign failed; falling back", error);
           continue;
         }
@@ -347,20 +591,25 @@ export async function GET(
         }
       }
       if (signedUrl) {
-        timing.end("total", requestStartedAt);
         const headers = new Headers({
           "Cache-Control": createSignedRedirectCacheControl(SNAPSHOT_ARTIFACT_SIGN_URL_TTL_SEC),
           Location: signedUrl,
           "x-build-delivery-class": deliveryClass,
           "x-build-source": "artifact-redirect",
         });
-        timing.apply(headers);
-        return new Response(null, { status: 307, headers });
+        return finishResponse(new Response(null, { status: 307, headers }), {
+          source: "artifact-redirect",
+          artifactOutcome: "redirect",
+          servedFormat: servedArtifactFormat === "binary" ? "binary" : "json",
+          optimizedDelivered: servedArtifactFormat === "binary",
+        });
       }
     } catch {
       // snapshot miss can still use the db snapshot
+      observation.fallbackReason ??= "artifact-sign-error";
     }
     if (requireStreamFallbackOnMiss) {
+      observation.artifactOutcome = "redirect-miss";
       shouldRequireStreamFallbackOnSnapshotMiss = true;
     }
   }
@@ -375,44 +624,96 @@ export async function GET(
         shouldGzip,
       );
   // storage-first: the checksum-addressed artifact is the canonical snapshot
+  let artifactFetchStartedAt: number | null = null;
   try {
     if (artifactAllowed && canServeSnapshotArtifact) {
-      const artifactStartedAt = timing.start();
+      artifactFetchStartedAt = performance.now();
       let artifactBytes: Uint8Array | null = null;
       for (const format of artifactFormats) {
+        const fetchMetrics: ArenaSnapshotArtifactFetchMetrics = { cacheStatus: "miss" };
         try {
-          artifactBytes = await withTimeout(
-            (signal) =>
-              fetchArenaBuildSnapshotArtifact(buildId, variant, storedChecksum, {
-                signal,
-                format,
-                cache: buildAccess ? "no-store" : "default",
-              }),
-            SNAPSHOT_ARTIFACT_FETCH_TIMEOUT_MS,
-            "snapshot artifact fetch",
+          artifactBytes = await withServerSpan(
+            "arena.artifact.fetch",
+            {
+              "arena.access": observation.access,
+              "arena.variant": variant,
+              "arena.format": format,
+            },
+            async (span) => {
+              const bytes = await withTimeout(
+                (signal) =>
+                  fetchArenaBuildSnapshotArtifact(buildId, variant, storedChecksum, {
+                    signal,
+                    format,
+                    cache: buildAccess ? "no-store" : "default",
+                    metrics: fetchMetrics,
+                  }),
+                SNAPSHOT_ARTIFACT_FETCH_TIMEOUT_MS,
+                "snapshot artifact fetch",
+              );
+              span.setAttributes({
+                "arena.artifact_cache": fetchMetrics.cacheStatus,
+                "arena.artifact_hit": Boolean(bytes),
+                ...(fetchMetrics.transferBytes != null
+                  ? { "arena.transfer_bytes": fetchMetrics.transferBytes }
+                  : {}),
+                ...(fetchMetrics.decodedBytes != null
+                  ? { "arena.decoded_bytes": fetchMetrics.decodedBytes }
+                  : {}),
+              });
+              return bytes;
+            },
           );
         } catch (error) {
           if (format === "json") throw error;
+          observation.fallbackReason = "binary-artifact-error";
           console.warn("arena binary snapshot artifact fetch failed; falling back", error);
           continue;
+        } finally {
+          observation.artifactCacheStatus = fetchMetrics.cacheStatus;
+          observation.transferBytes = fetchMetrics.transferBytes ?? observation.transferBytes;
+          observation.decodedBytes = fetchMetrics.decodedBytes ?? observation.decodedBytes;
+          if (fetchMetrics.inflateMs != null) {
+            recordStage("inflate", fetchMetrics.inflateMs);
+          }
         }
         if (artifactBytes) {
           servedArtifactFormat = format;
           break;
         }
       }
+      const artifactFetchMs = performance.now() - artifactFetchStartedAt;
+      recordStage("artifact_fetch", artifactFetchMs);
+      artifactFetchStartedAt = null;
       if (artifactBytes) {
-        timing.end("artifact_hit", artifactStartedAt);
-        timing.end("total", requestStartedAt);
+        timing.add("artifact_hit", artifactFetchMs);
+        observation.artifactOutcome = "hit";
         const responseArtifactBytes = buildAccess
-          ? servedArtifactFormat === "binary"
-            ? rewriteBlindBinaryArtifactIdentity(artifactBytes, clientBuildId)
-            : rewriteBlindSnapshotIdentity(artifactBytes, clientBuildId)
+          ? measureStageSync(
+              "identity_rewrite",
+              "arena.artifact.identity_rewrite",
+              {
+                "arena.variant": variant,
+                "arena.format": servedArtifactFormat,
+              },
+              () =>
+                servedArtifactFormat === "binary"
+                  ? rewriteBlindBinaryArtifactIdentity(artifactBytes, clientBuildId)
+                  : rewriteBlindSnapshotIdentity(artifactBytes, clientBuildId),
+            )
           : artifactBytes;
         // the stored object is gzip; proxying it verbatim to a gzip-capable
         // client keeps snapshot-class fallbacks off the uncompressed path
         const body = shouldGzip
-          ? gzipSync(Buffer.from(responseArtifactBytes))
+          ? measureStageSync(
+              "deflate",
+              "arena.response.deflate",
+              {
+                "arena.variant": variant,
+                "arena.format": servedArtifactFormat,
+              },
+              () => gzipSync(Buffer.from(responseArtifactBytes)),
+            )
           : responseArtifactBytes;
         const headers = new Headers({
           "Cache-Control": buildAccess
@@ -430,12 +731,27 @@ export async function GET(
           headers.set("Content-Encoding", "gzip");
           headers.set("Vary", "Accept-Encoding");
         }
-        timing.apply(headers);
-        return new Response(Buffer.from(body), { headers });
+        return finishResponse(new Response(Buffer.from(body), { headers }), {
+          source: "artifact",
+          servedFormat: servedArtifactFormat === "binary" ? "binary" : "json",
+          optimizedDelivered: servedArtifactFormat === "binary",
+          fallbackReason:
+            binaryFormatRequested && servedArtifactFormat !== "binary"
+              ? observation.fallbackReason ?? "binary-artifact-miss"
+              : observation.fallbackReason,
+          responseBytes: body.byteLength,
+        });
       }
-      timing.end("artifact_miss", artifactStartedAt);
+      observation.artifactOutcome = "miss";
+      timing.add("artifact_miss", artifactFetchMs);
     }
   } catch (error) {
+    if (artifactFetchStartedAt != null) {
+      recordStage("artifact_fetch", performance.now() - artifactFetchStartedAt);
+      artifactFetchStartedAt = null;
+    }
+    observation.artifactOutcome = "error";
+    observation.fallbackReason ??= "artifact-fetch-error";
     console.warn("arena snapshot artifact fetch failed", error);
   }
 
@@ -462,15 +778,25 @@ export async function GET(
     after(async () => {
       await healArenaBuildSnapshotArtifactsOnce(cachedPreparedForHeal);
     });
-    timing.end("total", requestStartedAt);
     const headers = createJsonHeaders({
       byteLength: cachedJsonResponse.bytes.byteLength,
       deliveryClass: variant === "preview" ? shellHints.initialDeliveryClass : shellHints.deliveryClass,
       source: `response-cache:${cachedJsonResponse.source}`,
       gzip: shouldGzip,
     });
-    timing.apply(headers);
-    return new Response(Buffer.from(cachedJsonResponse.bytes), { headers });
+    return finishResponse(new Response(Buffer.from(cachedJsonResponse.bytes), { headers }), {
+      source: `response-cache:${cachedJsonResponse.source}`,
+      artifactOutcome:
+        observation.artifactOutcome === "not-attempted"
+          ? "response-cache"
+          : observation.artifactOutcome,
+      servedFormat: "json",
+      optimizedDelivered: false,
+      fallbackReason: binaryFormatRequested
+        ? observation.fallbackReason ?? "binary-artifact-unavailable"
+        : observation.fallbackReason,
+      responseBytes: cachedJsonResponse.bytes.byteLength,
+    });
   }
 
   if (shouldRequireStreamFallbackOnSnapshotMiss) {
@@ -481,14 +807,23 @@ export async function GET(
       "x-build-delivery-class": deliveryClass,
       "x-build-source": "artifact-redirect-miss",
     });
-    timing.end("total", requestStartedAt);
-    timing.apply(headers);
-    return NextResponse.json(
+    return finishResponse(
+      NextResponse.json(
+        {
+          error: "Full build artifact is still warming. Use stream fallback.",
+          retryVia: "stream",
+        },
+        { status: 503, headers },
+      ),
       {
-        error: "Full build artifact is still warming. Use stream fallback.",
-        retryVia: "stream",
+        source: "artifact-redirect-miss",
+        artifactOutcome:
+          observation.artifactOutcome === "not-attempted"
+            ? "redirect-miss"
+            : observation.artifactOutcome,
+        servedFormat: "json",
+        fallbackReason: observation.fallbackReason ?? "stream-fallback-required",
       },
-      { status: 503, headers },
     );
   }
 
@@ -499,14 +834,20 @@ export async function GET(
       "x-build-delivery-class": shellHints.deliveryClass,
       "x-build-source": "stream-required",
     });
-    timing.end("total", requestStartedAt);
-    timing.apply(headers);
-    return NextResponse.json(
+    return finishResponse(
+      NextResponse.json(
+        {
+          error: "Build must be loaded through the stream artifact endpoint.",
+          retryVia: "stream",
+        },
+        { status: 503, headers },
+      ),
       {
-        error: "Build must be loaded through the stream artifact endpoint.",
-        retryVia: "stream",
+        source: "stream-required",
+        artifactOutcome: "not-eligible",
+        servedFormat: "json",
+        fallbackReason: "stream-required",
       },
-      { status: 503, headers },
     );
   }
 
@@ -536,30 +877,55 @@ export async function GET(
     const prepareStartedAt = timing.start();
     try {
       if (!build) {
-        return NextResponse.json({ error: "Build not found" }, { status: 404 });
+        return finishResponse(NextResponse.json({ error: "Build not found" }, { status: 404 }), {
+          source: "live-prepare",
+          artifactOutcome: "not-found",
+          servedFormat: "json",
+        });
       }
-      prepared = await prepareArenaBuild(
-        { ...build, privateAccessOnly: buildMeta.privateAccessOnly },
-        { signal: request.signal },
+      prepared = await withServerSpan(
+        "arena.build.prepare",
+        {
+          "arena.access": observation.access,
+          "arena.variant": variant,
+          "arena.delivery_class": deliveryClass,
+        },
+        () =>
+          prepareArenaBuild(
+            { ...build, privateAccessOnly: buildMeta.privateAccessOnly },
+            { signal: request.signal },
+          ),
       );
     } catch (err) {
       const message =
         !buildAccess && err instanceof Error ? err.message : "Failed to load build payload";
-      return NextResponse.json({ error: message }, { status: 422 });
+      return finishResponse(NextResponse.json({ error: message }, { status: 422 }), {
+        source: "live-prepare",
+        artifactOutcome: "prepare-error",
+        servedFormat: "json",
+        fallbackReason: observation.fallbackReason ?? "live-prepare-error",
+      });
     }
     timing.end("prepare", prepareStartedAt);
   }
 
   if (expectedChecksum && expectedChecksum !== prepared.checksum) {
-    return NextResponse.json(
-      buildAccess
-        ? { error: "Build changed" }
-        : {
-            error: "Build checksum mismatch",
-            expectedChecksum,
-            actualChecksum: prepared.checksum,
-          },
-      { status: 409 },
+    return finishResponse(
+      NextResponse.json(
+        buildAccess
+          ? { error: "Build changed" }
+          : {
+              error: "Build checksum mismatch",
+              expectedChecksum,
+              actualChecksum: prepared.checksum,
+            },
+        { status: 409 },
+      ),
+      {
+        source: "live-prepare",
+        artifactOutcome: "checksum-mismatch",
+        servedFormat: "json",
+      },
     );
   }
 
@@ -581,17 +947,29 @@ export async function GET(
     if (!privateLoopbackAccess) await healArenaBuildSnapshotArtifactsOnce(prepared);
   });
 
-  const responseBytes = jsonBytes(
-    {
-      buildId: clientBuildId,
-      variant,
-      checksum: buildAccess ? null : prepared.checksum,
-      serverValidated: true,
-      buildLoadHints: prepared.hints,
-      voxelBuild,
-    },
-    shouldGzip,
-  );
+  const createResponseBytes = () =>
+    jsonBytes(
+      {
+        buildId: clientBuildId,
+        variant,
+        checksum: buildAccess ? null : prepared.checksum,
+        serverValidated: true,
+        buildLoadHints: prepared.hints,
+        voxelBuild,
+      },
+      shouldGzip,
+    );
+  const responseBytes = shouldGzip
+    ? measureStageSync(
+        "deflate",
+        "arena.response.deflate",
+        {
+          "arena.variant": variant,
+          "arena.format": "json",
+        },
+        createResponseBytes,
+      )
+    : createResponseBytes();
   if (!buildAccess) {
     rememberJsonResponse(
       prepared.buildId,
@@ -603,7 +981,6 @@ export async function GET(
       "live",
     );
   }
-  timing.end("total", requestStartedAt);
   const headers = createJsonHeaders({
     byteLength: responseBytes.byteLength,
     deliveryClass: variant === "preview" ? prepared.hints.initialDeliveryClass : prepared.hints.deliveryClass,
@@ -611,7 +988,15 @@ export async function GET(
     gzip: shouldGzip,
     privateAccess: Boolean(buildAccess),
   });
-  timing.apply(headers);
-
-  return new Response(Buffer.from(responseBytes), { headers });
+  return finishResponse(new Response(Buffer.from(responseBytes), { headers }), {
+    source: "live",
+    artifactOutcome:
+      observation.artifactOutcome === "not-attempted" ? "live" : observation.artifactOutcome,
+    servedFormat: "json",
+    optimizedDelivered: false,
+    fallbackReason: binaryFormatRequested
+      ? observation.fallbackReason ?? "binary-artifact-unavailable"
+      : observation.fallbackReason,
+    responseBytes: responseBytes.byteLength,
+  });
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata, Viewport } from "next";
 import { IBM_Plex_Mono, Spline_Sans, Unbounded } from "next/font/google";
 import { Analytics } from "@vercel/analytics/next";
+import { SpeedInsights } from "@vercel/speed-insights/next";
 import "./globals.css";
 import { OfflineBanner } from "@/components/OfflineBanner";
 import { SiteFooter } from "@/components/SiteFooter";
@@ -144,6 +145,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
           </div>
         </div>
         <Analytics />
+        <SpeedInsights />
       </body>
     </html>
   );

--- a/components/arena/Arena.tsx
+++ b/components/arena/Arena.tsx
@@ -157,32 +157,36 @@ async function readBuildVariantPayload(
 async function fetchMatchupOnce(promptId?: string, signal?: AbortSignal): Promise<ArenaMatchup> {
   const trace = createBrowserPerformanceTrace("matchup");
   trace.mark("fetch_start");
-  const url = new URL("/api/arena/matchup", window.location.origin);
-  if (promptId) url.searchParams.set("promptId", promptId);
-  // Adaptive mode keeps small builds instant while deferring large payloads.
-  url.searchParams.set("payload", "adaptive");
-  const res = await fetch(url, { method: "GET", credentials: "include", signal });
-  trace.mark("headers_received");
-  if (!res.ok) throw new Error(await readClientErrorResponse(res, "Failed to load matchup"));
-  const matchup = (await res.json()) as ArenaMatchup;
-  const packedMatchup = {
-    ...matchup,
-    a: { ...matchup.a, build: packDeliveredBuild(matchup.a.build) },
-    b: { ...matchup.b, build: packDeliveredBuild(matchup.b.build) },
-  };
-  trace.mark("matchup_received");
-  const totalMs = trace.measure("total", "fetch_start", "matchup_received") ?? 0;
-  trackEvent("arena_matchup_received", {
-    path: `${promptId ? "forced" : "random"}:adaptive`,
-    samplingLane: matchup.samplingLane ?? "unknown",
-    laneABlocks: getArenaBlockCountBucket(voxelBuildBlockCount(packedMatchup.a.build)),
-    laneBBlocks: getArenaBlockCountBucket(voxelBuildBlockCount(packedMatchup.b.build)),
-    headersMs: roundMetricMs(trace.measure("headers", "fetch_start", "headers_received")),
-    bodyMs: roundMetricMs(trace.measure("body", "headers_received", "matchup_received")),
-    totalMs: roundMetricMs(totalMs),
-    latency: getArenaLatencyBucket(totalMs),
-  });
-  return packedMatchup;
+  try {
+    const url = new URL("/api/arena/matchup", window.location.origin);
+    if (promptId) url.searchParams.set("promptId", promptId);
+    // Adaptive mode keeps small builds instant while deferring large payloads.
+    url.searchParams.set("payload", "adaptive");
+    const res = await fetch(url, { method: "GET", credentials: "include", signal });
+    trace.mark("headers_received");
+    if (!res.ok) throw new Error(await readClientErrorResponse(res, "Failed to load matchup"));
+    const matchup = (await res.json()) as ArenaMatchup;
+    const packedMatchup = {
+      ...matchup,
+      a: { ...matchup.a, build: packDeliveredBuild(matchup.a.build) },
+      b: { ...matchup.b, build: packDeliveredBuild(matchup.b.build) },
+    };
+    trace.mark("matchup_received");
+    const totalMs = trace.measure("total", "fetch_start", "matchup_received") ?? 0;
+    trackEvent("arena_matchup_received", {
+      path: `${promptId ? "forced" : "random"}:adaptive`,
+      samplingLane: matchup.samplingLane ?? "unknown",
+      laneABlocks: getArenaBlockCountBucket(voxelBuildBlockCount(packedMatchup.a.build)),
+      laneBBlocks: getArenaBlockCountBucket(voxelBuildBlockCount(packedMatchup.b.build)),
+      headersMs: roundMetricMs(trace.measure("headers", "fetch_start", "headers_received")),
+      bodyMs: roundMetricMs(trace.measure("body", "headers_received", "matchup_received")),
+      totalMs: roundMetricMs(totalMs),
+      latency: getArenaLatencyBucket(totalMs),
+    });
+    return packedMatchup;
+  } finally {
+    trace.clear();
+  }
 }
 
 async function fetchMatchup(
@@ -608,7 +612,11 @@ async function fetchBuildVariantSnapshot(
   ref: ArenaBuildRef,
   signal?: AbortSignal,
   timeoutMs = SNAPSHOT_FETCH_TIMEOUT_MS,
-  opts?: { redirect?: boolean; purpose?: BuildRequestPurpose },
+  opts?: {
+    redirect?: boolean;
+    purpose?: BuildRequestPurpose;
+    metrics?: BuildDeliveryMetrics;
+  },
 ): Promise<BuildVariantResponse> {
   const url = new URL(`/api/arena/builds/${encodeURIComponent(ref.buildId)}`, window.location.origin);
   url.searchParams.set("variant", ref.variant);
@@ -616,11 +624,10 @@ async function fetchBuildVariantSnapshot(
   const allowRedirect = opts?.redirect !== false && !snapshotStorageRedirectBlocked;
   if (!allowRedirect) url.searchParams.set("redirect", "0");
   if (BINARY_ARTIFACT_READS_ENABLED) url.searchParams.set("format", "v4");
-  const metrics = startBuildDeliveryMetrics(
-    ref,
-    opts?.purpose ?? "visible",
-    "snapshot",
-  );
+  const ownsMetrics = opts?.metrics == null;
+  const metrics =
+    opts?.metrics ??
+    startBuildDeliveryMetrics(ref, opts?.purpose ?? "visible", "snapshot");
   const timed = makeTimeoutSignal(signal, timeoutMs);
   try {
     let res: Response;
@@ -635,18 +642,20 @@ async function fetchBuildVariantSnapshot(
     } catch (err: unknown) {
       if (allowRedirect && !isAbortError(err)) {
         markStorageRedirectBlocked("snapshot");
-        return fetchBuildVariantSnapshot(ref, signal, timeoutMs, {
+        return await fetchBuildVariantSnapshot(ref, signal, timeoutMs, {
           redirect: false,
           purpose: opts?.purpose,
+          metrics,
         });
       }
       throw err;
     }
     if (!res.ok) {
       if (allowRedirect && shouldRetrySnapshotWithoutRedirect(res.status)) {
-        return fetchBuildVariantSnapshot(ref, signal, timeoutMs, {
+        return await fetchBuildVariantSnapshot(ref, signal, timeoutMs, {
           redirect: false,
           purpose: opts?.purpose,
+          metrics,
         });
       }
       const message = await readClientErrorResponse(res, "Couldn't load build");
@@ -667,12 +676,31 @@ async function fetchBuildVariantSnapshot(
     return result.payload;
   } finally {
     timed.cleanup();
+    if (ownsMetrics) metrics.trace.clear();
   }
 }
 
 async function fetchBuildVariantStreamOnce(
   ref: ArenaBuildRef,
   useArtifact: boolean,
+  opts?: FetchBuildVariantStreamOptions,
+): Promise<BuildVariantResponse> {
+  const metrics = startBuildDeliveryMetrics(
+    ref,
+    opts?.purpose ?? "visible",
+    useArtifact ? "stream-artifact" : "stream-live",
+  );
+  try {
+    return await fetchBuildVariantStreamOnceWithMetrics(ref, useArtifact, metrics, opts);
+  } finally {
+    metrics.trace.clear();
+  }
+}
+
+async function fetchBuildVariantStreamOnceWithMetrics(
+  ref: ArenaBuildRef,
+  useArtifact: boolean,
+  metrics: BuildDeliveryMetrics,
   opts?: FetchBuildVariantStreamOptions,
 ): Promise<BuildVariantResponse> {
   const url = new URL(
@@ -682,11 +710,6 @@ async function fetchBuildVariantStreamOnce(
   url.searchParams.set("variant", ref.variant);
   if (ref.checksum) url.searchParams.set("checksum", ref.checksum);
   if (!useArtifact) url.searchParams.set("artifact", "0");
-  const metrics = startBuildDeliveryMetrics(
-    ref,
-    opts?.purpose ?? "visible",
-    useArtifact ? "stream-artifact" : "stream-live",
-  );
 
   const requestTimed = makeTimeoutSignal(opts?.signal, STREAM_REQUEST_TIMEOUT_MS);
   let res: Response;

--- a/components/arena/Arena.tsx
+++ b/components/arena/Arena.tsx
@@ -16,6 +16,7 @@ import {
   IncompleteBuildStreamError,
   readBuildVariantArtifact,
   readBuildVariantStream,
+  type BuildVariantArtifactReadEvent,
   type BuildStreamProgress,
   type BuildVariantStreamResponse,
 } from "@/lib/arena/clientBuildResponse";
@@ -25,12 +26,22 @@ import {
   type RenderableVoxelBuild,
 } from "@/lib/voxel/packedBlocks";
 import { VoxelViewerCard } from "@/components/voxel/VoxelViewerCard";
+import type { VoxelViewerBuildMetrics } from "@/components/voxel/VoxelViewer";
 import { formatVoxelLoadingMessage } from "@/components/voxel/VoxelLoadingHud";
 import { VoteBar, type VoteConfirmTarget } from "@/components/arena/VoteBar";
 import { AnimatedPrompt } from "@/components/arena/AnimatedPrompt";
 import { ModelReveal } from "@/components/arena/ModelReveal";
 import { ErrorState } from "@/components/ErrorState";
 import { trackEvent } from "@/lib/analytics";
+import {
+  getArenaBlockCountBucket,
+  getArenaLatencyBucket,
+  roundMetricMs,
+} from "@/lib/observability/arenaMetrics";
+import {
+  createBrowserPerformanceTrace,
+  type BrowserPerformanceTrace,
+} from "@/lib/observability/browserPerformance";
 
 type ArenaState =
   | { kind: "loading" }
@@ -95,35 +106,83 @@ function packBuildVariantResponse(payload: BuildVariantResponse): BuildVariantRe
 
 // The binary artifact already carries its blocks as typed arrays, so it needs
 // no packing step and never becomes a string or per-block objects.
-async function readBuildVariantPayload(res: Response): Promise<BuildVariantResponse> {
-  const artifact = await readBuildVariantArtifact<BuildVariantResponse>(res);
-  if (artifact.kind === "json") return packBuildVariantResponse(artifact.value);
+type BuildVariantPayloadResult = {
+  payload: BuildVariantResponse;
+  servedFormat: "binary" | "json";
+  bodyBytes: number | null;
+  compressed: boolean;
+};
+
+async function readBuildVariantPayload(
+  res: Response,
+  onStage?: (event: BuildVariantArtifactReadEvent) => void,
+): Promise<BuildVariantPayloadResult> {
+  let bodyBytes: number | null = null;
+  let compressed = false;
+  const artifact = await readBuildVariantArtifact<BuildVariantResponse>(res, {
+    onStage(event) {
+      if (event.stage === "body_complete") bodyBytes = event.bytes;
+      if (event.stage === "inflate_complete") {
+        compressed = event.compressed;
+      }
+      onStage?.(event);
+    },
+  });
+  if (artifact.kind === "json") {
+    return {
+      payload: packBuildVariantResponse(artifact.value),
+      servedFormat: "json",
+      bodyBytes,
+      compressed,
+    };
+  }
   const envelope = artifact.envelope as Omit<BuildVariantResponse, "voxelBuild"> & {
     version?: string;
   };
   return {
-    buildId: envelope.buildId,
-    variant: envelope.variant,
-    checksum: envelope.checksum ?? null,
-    serverValidated: Boolean(envelope.serverValidated),
-    buildLoadHints: envelope.buildLoadHints,
-    voxelBuild: { version: "1.0", blocks: [], packed: artifact.blocks },
+    payload: {
+      buildId: envelope.buildId,
+      variant: envelope.variant,
+      checksum: envelope.checksum ?? null,
+      serverValidated: Boolean(envelope.serverValidated),
+      buildLoadHints: envelope.buildLoadHints,
+      voxelBuild: { version: "1.0", blocks: [], packed: artifact.blocks },
+    },
+    servedFormat: "binary",
+    bodyBytes,
+    compressed,
   };
 }
 
 async function fetchMatchupOnce(promptId?: string, signal?: AbortSignal): Promise<ArenaMatchup> {
+  const trace = createBrowserPerformanceTrace("matchup");
+  trace.mark("fetch_start");
   const url = new URL("/api/arena/matchup", window.location.origin);
   if (promptId) url.searchParams.set("promptId", promptId);
   // Adaptive mode keeps small builds instant while deferring large payloads.
   url.searchParams.set("payload", "adaptive");
   const res = await fetch(url, { method: "GET", credentials: "include", signal });
+  trace.mark("headers_received");
   if (!res.ok) throw new Error(await readClientErrorResponse(res, "Failed to load matchup"));
   const matchup = (await res.json()) as ArenaMatchup;
-  return {
+  const packedMatchup = {
     ...matchup,
     a: { ...matchup.a, build: packDeliveredBuild(matchup.a.build) },
     b: { ...matchup.b, build: packDeliveredBuild(matchup.b.build) },
   };
+  trace.mark("matchup_received");
+  const totalMs = trace.measure("total", "fetch_start", "matchup_received") ?? 0;
+  trackEvent("arena_matchup_received", {
+    path: `${promptId ? "forced" : "random"}:adaptive`,
+    samplingLane: matchup.samplingLane ?? "unknown",
+    laneABlocks: getArenaBlockCountBucket(voxelBuildBlockCount(packedMatchup.a.build)),
+    laneBBlocks: getArenaBlockCountBucket(voxelBuildBlockCount(packedMatchup.b.build)),
+    headersMs: roundMetricMs(trace.measure("headers", "fetch_start", "headers_received")),
+    bodyMs: roundMetricMs(trace.measure("body", "headers_received", "matchup_received")),
+    totalMs: roundMetricMs(totalMs),
+    latency: getArenaLatencyBucket(totalMs),
+  });
+  return packedMatchup;
 }
 
 async function fetchMatchup(
@@ -211,12 +270,156 @@ async function submitArenaAction(matchupId: string, action: ArenaAction): Promis
 }
 
 type BuildVariantResponse = BuildVariantStreamResponse;
+type BuildRequestPurpose = "visible" | "prefetch";
+type BuildTransport = "snapshot" | "stream-artifact" | "stream-live";
+
+type BuildDeliveryMetrics = {
+  trace: BrowserPerformanceTrace;
+  startStage: "preview_fetch_start" | "full_fetch_start";
+  purpose: BuildRequestPurpose;
+  transport: BuildTransport;
+};
+
+function startBuildDeliveryMetrics(
+  ref: ArenaBuildRef,
+  purpose: BuildRequestPurpose,
+  transport: BuildTransport,
+): BuildDeliveryMetrics {
+  const trace = createBrowserPerformanceTrace("build-delivery");
+  const startStage = ref.variant === "preview" ? "preview_fetch_start" : "full_fetch_start";
+  trace.mark(startStage);
+  return { trace, startStage, purpose, transport };
+}
+
+async function readMeasuredBuildVariantPayload(
+  response: Response,
+  metrics: BuildDeliveryMetrics,
+): Promise<BuildVariantPayloadResult> {
+  const result = await readBuildVariantPayload(response, (event) => {
+    if (event.stage === "body_complete") metrics.trace.mark("body_complete");
+    if (event.stage === "inflate_complete") metrics.trace.mark("inflate_complete");
+    if (
+      event.stage === "binary_decode_complete" ||
+      event.stage === "json_decode_complete"
+    ) {
+      metrics.trace.mark(event.stage);
+      metrics.trace.mark("decode_complete");
+    }
+  });
+  metrics.trace.mark("payload_ready");
+  return result;
+}
+
+function normalizeBuildSource(response: Response): string {
+  const source =
+    response.headers.get("x-build-source") ?? response.headers.get("x-build-stream-source");
+  if (source === "artifact") return "artifact";
+  if (source === "live") return "live";
+  if (source === "artifact-required") return "artifact-required";
+  if (source === "artifact-redirect") return "artifact-redirect";
+  if (source?.startsWith("response-cache:")) return "response-cache";
+  if (response.redirected) return "artifact-redirect";
+  return "unknown";
+}
+
+function normalizeBuildDeliveryClass(response: Response): ArenaBuildDeliveryClass | "unknown" {
+  const value = response.headers.get("x-build-delivery-class");
+  return value === "inline" ||
+    value === "snapshot" ||
+    value === "stream-live" ||
+    value === "stream-artifact"
+    ? value
+    : "unknown";
+}
+
+function reportBuildDeliveryMetrics(opts: {
+  metrics: BuildDeliveryMetrics;
+  ref: ArenaBuildRef;
+  response: Response;
+  requestedFormat: "v4" | "json" | "ndjson";
+  servedFormat: "binary" | "json" | "ndjson";
+  payload: BuildVariantResponse;
+  bodyBytes: number | null;
+  compressed: boolean;
+}) {
+  const { metrics } = opts;
+  const source = normalizeBuildSource(opts.response);
+  const deliveryClass = normalizeBuildDeliveryClass(opts.response);
+  const blockCountBucket = getArenaBlockCountBucket(
+    voxelBuildBlockCount(opts.payload.voxelBuild),
+  );
+  const path = `${metrics.purpose}:${opts.ref.variant}:${metrics.transport}`;
+  const totalMs =
+    metrics.trace.measure("total", metrics.startStage, "payload_ready") ?? 0;
+  const optimized =
+    opts.requestedFormat === "v4" &&
+    opts.servedFormat === "binary" &&
+    (source === "artifact" || source === "artifact-redirect");
+
+  // Web Analytics Plus accepts at most eight properties per custom event
+  trackEvent("arena_build_delivery", {
+    path,
+    requestedFormat: opts.requestedFormat,
+    servedFormat: opts.servedFormat,
+    source,
+    deliveryClass,
+    optimized,
+    blockCountBucket,
+    gzip: opts.compressed,
+  });
+  trackEvent("arena_build_delivery_timing", {
+    path: `${path}:${opts.servedFormat}`,
+    blockCountBucket,
+    headersMs: roundMetricMs(
+      metrics.trace.measure("headers", metrics.startStage, "headers_received"),
+    ),
+    bodyMs: roundMetricMs(
+      metrics.trace.measure("body", "headers_received", "body_complete"),
+    ),
+    inflateMs: roundMetricMs(
+      metrics.trace.measure("inflate", "body_complete", "inflate_complete"),
+    ),
+    decodeMs: roundMetricMs(
+      metrics.trace.measure("decode", "inflate_complete", "decode_complete"),
+    ),
+    totalMs: roundMetricMs(totalMs),
+    bodyBytes: opts.bodyBytes,
+  });
+}
+
+function reportBuildRenderMetrics(
+  variant: ArenaBuildVariant,
+  metrics: VoxelViewerBuildMetrics,
+) {
+  const path = `${variant}:${metrics.strategy}:${metrics.cacheStatus}`;
+  const blockCountBucket = getArenaBlockCountBucket(metrics.inputBlockCount);
+  trackEvent("arena_build_mesh_timing", {
+    path,
+    blockCountBucket,
+    queueMs: roundMetricMs(metrics.queueMs),
+    atlasMs: roundMetricMs(metrics.atlasMs),
+    payloadMs: roundMetricMs(metrics.payloadMs),
+    groupMs: roundMetricMs(metrics.groupMs),
+    meshMs: roundMetricMs(metrics.meshMs),
+    totalMs: roundMetricMs(metrics.totalMs),
+  });
+  trackEvent("arena_build_render_timing", {
+    path,
+    blockCountBucket,
+    renderedBlockCountBucket: getArenaBlockCountBucket(metrics.renderedBlockCount),
+    firstRenderMs: roundMetricMs(metrics.firstRenderMs),
+    revealMs: roundMetricMs(metrics.revealMs),
+    totalMs: roundMetricMs(metrics.totalMs),
+    animated: metrics.animated,
+  });
+}
 
 type FetchBuildVariantStreamOptions = {
   signal?: AbortSignal;
   onProgress?: (build: ArenaMatchup["a"]["build"], progress: BuildStreamProgress) => void;
   allowSnapshotFallback?: boolean;
   allowLiveFallback?: boolean;
+  purpose?: BuildRequestPurpose;
 };
 
 const SNAPSHOT_FETCH_TIMEOUT_MS = Number.parseInt(
@@ -405,7 +608,7 @@ async function fetchBuildVariantSnapshot(
   ref: ArenaBuildRef,
   signal?: AbortSignal,
   timeoutMs = SNAPSHOT_FETCH_TIMEOUT_MS,
-  opts?: { redirect?: boolean },
+  opts?: { redirect?: boolean; purpose?: BuildRequestPurpose },
 ): Promise<BuildVariantResponse> {
   const url = new URL(`/api/arena/builds/${encodeURIComponent(ref.buildId)}`, window.location.origin);
   url.searchParams.set("variant", ref.variant);
@@ -413,6 +616,11 @@ async function fetchBuildVariantSnapshot(
   const allowRedirect = opts?.redirect !== false && !snapshotStorageRedirectBlocked;
   if (!allowRedirect) url.searchParams.set("redirect", "0");
   if (BINARY_ARTIFACT_READS_ENABLED) url.searchParams.set("format", "v4");
+  const metrics = startBuildDeliveryMetrics(
+    ref,
+    opts?.purpose ?? "visible",
+    "snapshot",
+  );
   const timed = makeTimeoutSignal(signal, timeoutMs);
   try {
     let res: Response;
@@ -423,21 +631,40 @@ async function fetchBuildVariantSnapshot(
         signal: timed.signal,
         redirect: "follow",
       });
+      metrics.trace.mark("headers_received");
     } catch (err: unknown) {
       if (allowRedirect && !isAbortError(err)) {
         markStorageRedirectBlocked("snapshot");
-        return fetchBuildVariantSnapshot(ref, signal, timeoutMs, { redirect: false });
+        return fetchBuildVariantSnapshot(ref, signal, timeoutMs, {
+          redirect: false,
+          purpose: opts?.purpose,
+        });
       }
       throw err;
     }
     if (!res.ok) {
       if (allowRedirect && shouldRetrySnapshotWithoutRedirect(res.status)) {
-        return fetchBuildVariantSnapshot(ref, signal, timeoutMs, { redirect: false });
+        return fetchBuildVariantSnapshot(ref, signal, timeoutMs, {
+          redirect: false,
+          purpose: opts?.purpose,
+        });
       }
       const message = await readClientErrorResponse(res, "Couldn't load build");
       throw new Error(message);
     }
-    return await readBuildVariantPayload(res);
+    const result = await readMeasuredBuildVariantPayload(res, metrics);
+    reportBuildDeliveryMetrics({
+      metrics,
+      ref,
+      response: res,
+      requestedFormat: BINARY_ARTIFACT_READS_ENABLED ? "v4" : "json",
+      servedFormat: result.servedFormat,
+      payload: result.payload,
+      bodyBytes: result.bodyBytes,
+      compressed:
+        result.compressed || /\bgzip\b/i.test(res.headers.get("content-encoding") ?? ""),
+    });
+    return result.payload;
   } finally {
     timed.cleanup();
   }
@@ -455,6 +682,11 @@ async function fetchBuildVariantStreamOnce(
   url.searchParams.set("variant", ref.variant);
   if (ref.checksum) url.searchParams.set("checksum", ref.checksum);
   if (!useArtifact) url.searchParams.set("artifact", "0");
+  const metrics = startBuildDeliveryMetrics(
+    ref,
+    opts?.purpose ?? "visible",
+    useArtifact ? "stream-artifact" : "stream-live",
+  );
 
   const requestTimed = makeTimeoutSignal(opts?.signal, STREAM_REQUEST_TIMEOUT_MS);
   let res: Response;
@@ -464,6 +696,7 @@ async function fetchBuildVariantStreamOnce(
       credentials: "same-origin",
       signal: requestTimed.signal,
     });
+    metrics.trace.mark("headers_received");
   } catch (error) {
     if (useArtifact && !isAbortError(error)) markStorageRedirectBlocked("stream");
     throw error;
@@ -481,20 +714,56 @@ async function fetchBuildVariantStreamOnce(
 
   const contentType = res.headers.get("content-type") ?? "";
   if (!res.body || !contentType.includes("application/x-ndjson")) {
-    return readBuildVariantPayload(res);
+    const result = await readMeasuredBuildVariantPayload(res, metrics);
+    reportBuildDeliveryMetrics({
+      metrics,
+      ref,
+      response: res,
+      requestedFormat: "ndjson",
+      servedFormat: result.servedFormat,
+      payload: result.payload,
+      bodyBytes: result.bodyBytes,
+      compressed:
+        result.compressed || /\bgzip\b/i.test(res.headers.get("content-encoding") ?? ""),
+    });
+    return result.payload;
   }
 
   try {
-    return await readBuildVariantStream(res, {
+    const payload = await readBuildVariantStream(res, {
       signal: opts?.signal,
       onProgress: opts?.onProgress,
+      onStage(stage) {
+        if (stage === "body_complete") {
+          metrics.trace.mark("body_complete");
+          // Stream decompression and decoding happen incrementally while the body arrives.
+          metrics.trace.mark("inflate_complete");
+        } else {
+          metrics.trace.mark("decode_complete");
+        }
+      },
     });
+    metrics.trace.mark("payload_ready");
+    const contentLength = Number.parseInt(res.headers.get("content-length") ?? "", 10);
+    reportBuildDeliveryMetrics({
+      metrics,
+      ref,
+      response: res,
+      requestedFormat: "ndjson",
+      servedFormat: "ndjson",
+      payload,
+      bodyBytes: Number.isFinite(contentLength) && contentLength >= 0 ? contentLength : null,
+      compressed: /\bgzip\b/i.test(res.headers.get("content-encoding") ?? ""),
+    });
+    return payload;
   } catch (error) {
     if (
       error instanceof IncompleteBuildStreamError &&
       opts?.allowSnapshotFallback !== false
     ) {
-      return fetchBuildVariantSnapshot(ref, opts?.signal);
+      return fetchBuildVariantSnapshot(ref, opts?.signal, SNAPSHOT_FETCH_TIMEOUT_MS, {
+        purpose: opts?.purpose,
+      });
     }
     throw error;
   }
@@ -513,7 +782,11 @@ async function fetchBuildVariantStream(
     attempts.push(() => fetchBuildVariantStreamOnce(ref, false, opts));
   }
   if (opts?.allowSnapshotFallback !== false) {
-    attempts.push(() => fetchBuildVariantSnapshot(ref, opts?.signal));
+    attempts.push(() =>
+      fetchBuildVariantSnapshot(ref, opts?.signal, SNAPSHOT_FETCH_TIMEOUT_MS, {
+        purpose: opts?.purpose,
+      }),
+    );
   }
 
   for (const attempt of attempts) {
@@ -1726,11 +1999,14 @@ export function Arena() {
         const allowSnapshotFallback = shouldHydrateViaSnapshot(deliveryClass);
         const allowLiveFallback = deliveryClass !== "stream-artifact";
         const payload = shouldHydrateViaSnapshot(deliveryClass)
-          ? await fetchBuildVariantSnapshot(ref, controller.signal).catch(() =>
+          ? await fetchBuildVariantSnapshot(ref, controller.signal, SNAPSHOT_FETCH_TIMEOUT_MS, {
+              purpose: "prefetch",
+            }).catch(() =>
               fetchBuildVariantStream(ref, {
                 signal: controller.signal,
                 allowSnapshotFallback,
                 allowLiveFallback,
+                purpose: "prefetch",
                 onProgress: (_build, progress) => emitPrefetchProgress(progress),
               }),
             )
@@ -1738,6 +2014,7 @@ export function Arena() {
               signal: controller.signal,
               allowSnapshotFallback,
               allowLiveFallback,
+              purpose: "prefetch",
               onProgress: (_build, progress) => emitPrefetchProgress(progress),
             });
         const resolvedRef: ArenaBuildRef = {
@@ -2519,6 +2796,10 @@ export function Arena() {
                     return { ...prev, a: ready };
                   });
                 }}
+                onBuildMetrics={(metrics) => {
+                  if (!matchup) return;
+                  reportBuildRenderMetrics(getLaneHydratedVariant(matchup.a), metrics);
+                }}
                 isLoading={buildALoading}
                 loadingMode={buildALoadingMode}
                 loadingMessage={buildALoadingMessage}
@@ -2571,6 +2852,10 @@ export function Arena() {
                     if (prev.b === ready) return prev;
                     return { ...prev, b: ready };
                   });
+                }}
+                onBuildMetrics={(metrics) => {
+                  if (!matchup) return;
+                  reportBuildRenderMetrics(getLaneHydratedVariant(matchup.b), metrics);
                 }}
                 isLoading={buildBLoading}
                 loadingMode={buildBLoadingMode}

--- a/components/voxel/VoxelViewer.tsx
+++ b/components/voxel/VoxelViewer.tsx
@@ -5,7 +5,12 @@ import * as THREE from "three";
 import { OrbitControls } from "three/examples/jsm/controls/OrbitControls.js";
 import type { BlockDefinition } from "@/lib/blocks/palettes";
 import { getPalette } from "@/lib/blocks/palettes";
-import { createVoxelGroupAsync, VoxelGroup } from "@/lib/voxel/mesh";
+import {
+  createVoxelGroupAsync,
+  VoxelGroup,
+  type VoxelMeshCacheStatus,
+  type VoxelMeshStrategy,
+} from "@/lib/voxel/mesh";
 import {
   voxelBuildBlockCount,
   voxelBuildBlocksRef,
@@ -17,11 +22,28 @@ import {
   retargetDistanceForAspect,
   type RotatingBoundsFraming,
 } from "@/lib/voxel/framing";
+import { createBrowserPerformanceTrace } from "@/lib/observability/browserPerformance";
 
 export type VoxelViewerBuildProgress = {
   processedBlocks: number;
   totalBlocks: number;
   stageLabel?: string | null;
+};
+
+export type VoxelViewerBuildMetrics = {
+  inputBlockCount: number;
+  renderedBlockCount: number;
+  strategy: VoxelMeshStrategy;
+  cacheStatus: VoxelMeshCacheStatus;
+  animated: boolean;
+  queueMs: number | null;
+  atlasMs: number | null;
+  payloadMs: number | null;
+  groupMs: number | null;
+  meshMs: number | null;
+  firstRenderMs: number | null;
+  revealMs: number | null;
+  totalMs: number | null;
 };
 
 type ViewerProps = {
@@ -35,6 +57,7 @@ type ViewerProps = {
   onBuildReadyChange?: (ready: boolean) => void;
   onBuildProgressChange?: (progress: VoxelViewerBuildProgress | null) => void;
   onBuildErrorChange?: (message: string | null) => void;
+  onBuildMetrics?: (metrics: VoxelViewerBuildMetrics) => void;
 };
 
 export type VoxelViewerHandle = {
@@ -385,6 +408,7 @@ export const VoxelViewer = forwardRef<VoxelViewerHandle, ViewerProps>(function V
     onBuildReadyChange,
     onBuildProgressChange,
     onBuildErrorChange,
+    onBuildMetrics,
   },
   ref
 ) {
@@ -401,6 +425,13 @@ export const VoxelViewer = forwardRef<VoxelViewerHandle, ViewerProps>(function V
     undefined,
   );
   const onBuildErrorChangeRef = useRef<((message: string | null) => void) | undefined>(undefined);
+  const onBuildMetricsRef = useRef<((metrics: VoxelViewerBuildMetrics) => void) | undefined>(
+    undefined,
+  );
+  const pendingFirstRenderRef = useRef<{
+    group: THREE.Group;
+    report: () => void;
+  } | null>(null);
   const requestRenderRef = useRef<(() => void) | null>(null);
   const exportRendererRef = useRef<THREE.WebGLRenderer | null>(null);
   const tapStartRef = useRef<{ x: number; y: number; at: number } | null>(null);
@@ -494,6 +525,10 @@ export const VoxelViewer = forwardRef<VoxelViewerHandle, ViewerProps>(function V
     onBuildErrorChangeRef.current = onBuildErrorChange;
   }, [onBuildErrorChange]);
 
+  useEffect(() => {
+    onBuildMetricsRef.current = onBuildMetrics;
+  }, [onBuildMetrics]);
+
   const fitView = useCallback(() => {
     const three = threeRef.current;
     const vg = voxelGroupRef.current;
@@ -513,6 +548,9 @@ export const VoxelViewer = forwardRef<VoxelViewerHandle, ViewerProps>(function V
     }
 
     if (voxelGroupRef.current) {
+      if (pendingFirstRenderRef.current?.group === voxelGroupRef.current.group) {
+        pendingFirstRenderRef.current = null;
+      }
       three.scene.remove(voxelGroupRef.current.group);
       voxelGroupRef.current.dispose();
       voxelGroupRef.current = null;
@@ -625,9 +663,15 @@ export const VoxelViewer = forwardRef<VoxelViewerHandle, ViewerProps>(function V
     const buildSnapshot = latest.voxelBuild;
     const expectedSnapshot = latest.expectedBlockCount;
     const meshCacheKeySnapshot = latest.meshCacheKey;
+    const buildTrace = createBrowserPerformanceTrace("voxel-build");
+    buildTrace.mark("mesh_queued");
+    let meshStarted = false;
+    let meshStrategy: VoxelMeshStrategy = "local";
+    let meshCacheStatus: VoxelMeshCacheStatus = "not-used";
 
     try {
       const tex = await loadAtlasTexture();
+      buildTrace.mark("atlas_ready");
       if (controller.signal.aborted) return;
       if (!sameIdentity(identityRef.current, incomingIdentity)) return;
       if (!buildSnapshot) return;
@@ -637,6 +681,20 @@ export const VoxelViewer = forwardRef<VoxelViewerHandle, ViewerProps>(function V
         blockLimit,
         cacheKey: meshCacheKeySnapshot,
         yieldAfterMs: computeBuildYieldAfterMs(blockLimit),
+        onStage(event) {
+          meshStrategy = event.strategy;
+          if (event.cacheStatus) meshCacheStatus = event.cacheStatus;
+          if (event.stage === "mesh_started") {
+            if (!meshStarted) {
+              meshStarted = true;
+              buildTrace.mark("mesh_started");
+            }
+          } else if (event.stage === "mesh_payload_complete") {
+            buildTrace.mark("mesh_payload_complete");
+          } else {
+            buildTrace.mark("three_group_complete");
+          }
+        },
         onProgress(progress) {
           onBuildProgressChangeRef.current?.({
             processedBlocks: Math.max(0, Math.floor(progress.processedBlocks)),
@@ -681,6 +739,51 @@ export const VoxelViewer = forwardRef<VoxelViewerHandle, ViewerProps>(function V
       const expectedNow = normalizeExpectedBlockCount(expectedSnapshot);
       const desiredNow = Math.max(0, voxelBuildBlockCount(latestRef.current.voxelBuild));
       const requiredNow = expectedNow ?? desiredNow;
+      const buildReady = Boolean(
+        requiredNow <= 0 || (blockLimit >= requiredNow && desiredNow >= requiredNow),
+      );
+      let firstRenderComplete = false;
+      let revealComplete = false;
+      let metricsReported = false;
+      let revealAnimated = false;
+      const maybeReportBuildMetrics = () => {
+        if (
+          metricsReported ||
+          !buildReady ||
+          !firstRenderComplete ||
+          !revealComplete ||
+          controller.signal.aborted ||
+          !sameIdentity(identityRef.current, incomingIdentity) ||
+          voxelGroupRef.current?.group !== vg.group
+        ) {
+          return;
+        }
+        metricsReported = true;
+        buildTrace.mark("complete");
+        onBuildMetricsRef.current?.({
+          inputBlockCount: blockLimit,
+          renderedBlockCount: vg.stats.blockCount,
+          strategy: meshStrategy,
+          cacheStatus: meshCacheStatus,
+          animated: revealAnimated,
+          queueMs: buildTrace.duration("mesh_queued", "mesh_started"),
+          atlasMs: buildTrace.duration("mesh_queued", "atlas_ready"),
+          payloadMs: buildTrace.duration("mesh_started", "mesh_payload_complete"),
+          groupMs: buildTrace.duration("mesh_payload_complete", "three_group_complete"),
+          meshMs: buildTrace.duration("mesh_started", "three_group_complete"),
+          firstRenderMs: buildTrace.duration("three_group_complete", "first_render"),
+          revealMs: buildTrace.duration("three_group_complete", "reveal_complete"),
+          totalMs: buildTrace.duration("mesh_queued", "complete"),
+        });
+      };
+      pendingFirstRenderRef.current = {
+        group: vg.group,
+        report() {
+          buildTrace.mark("first_render");
+          firstRenderComplete = true;
+          maybeReportBuildMetrics();
+        },
+      };
       requestRenderRef.current?.();
 
       const revealFromFraction =
@@ -702,6 +805,7 @@ export const VoxelViewer = forwardRef<VoxelViewerHandle, ViewerProps>(function V
       if (shouldAnimateReveal) {
         const geometries = collectRevealGeometries(vg.group);
         if (geometries.length > 0) {
+          revealAnimated = true;
           applyRevealFraction(geometries, revealFromFraction);
           requestRenderRef.current?.();
 
@@ -745,9 +849,12 @@ export const VoxelViewer = forwardRef<VoxelViewerHandle, ViewerProps>(function V
         }
       }
 
+      buildTrace.mark("reveal_complete");
+      revealComplete = true;
+      maybeReportBuildMetrics();
       onBuildProgressChangeRef.current?.(null);
       onBuildErrorChangeRef.current?.(null);
-      reportReady(Boolean(requiredNow <= 0 || (blockLimit >= requiredNow && desiredNow >= requiredNow)));
+      reportReady(buildReady);
       requestRenderRef.current?.();
     } catch (err: unknown) {
       if (err instanceof DOMException && err.name === "AbortError") return;
@@ -1005,6 +1112,15 @@ export const VoxelViewer = forwardRef<VoxelViewerHandle, ViewerProps>(function V
           vg.group.rotation.y += dt * 0.25;
         }
         renderer.render(scene, camera);
+        const pendingFirstRender = pendingFirstRenderRef.current;
+        if (pendingFirstRender) {
+          if (pendingFirstRender.group === voxelGroupRef.current?.group) {
+            pendingFirstRenderRef.current = null;
+            pendingFirstRender.report();
+          } else {
+            pendingFirstRenderRef.current = null;
+          }
+        }
         needsFollowupFrame = Boolean(controlsChanged || shouldAutoRotate);
       } finally {
         rendering = false;
@@ -1099,6 +1215,7 @@ export const VoxelViewer = forwardRef<VoxelViewerHandle, ViewerProps>(function V
         voxelGroupRef.current.dispose();
         voxelGroupRef.current = null;
       }
+      pendingFirstRenderRef.current = null;
       boundsRef.current = null;
 
       scene.remove(grid);
@@ -1139,6 +1256,7 @@ export const VoxelViewer = forwardRef<VoxelViewerHandle, ViewerProps>(function V
       job.controller?.abort();
       job.controller = null;
       job.identity = null;
+      pendingFirstRenderRef.current = null;
     };
   }, []);
 

--- a/components/voxel/VoxelViewer.tsx
+++ b/components/voxel/VoxelViewer.tsx
@@ -431,6 +431,7 @@ export const VoxelViewer = forwardRef<VoxelViewerHandle, ViewerProps>(function V
   const pendingFirstRenderRef = useRef<{
     group: THREE.Group;
     report: () => void;
+    discard: () => void;
   } | null>(null);
   const requestRenderRef = useRef<(() => void) | null>(null);
   const exportRendererRef = useRef<THREE.WebGLRenderer | null>(null);
@@ -549,6 +550,7 @@ export const VoxelViewer = forwardRef<VoxelViewerHandle, ViewerProps>(function V
 
     if (voxelGroupRef.current) {
       if (pendingFirstRenderRef.current?.group === voxelGroupRef.current.group) {
+        pendingFirstRenderRef.current.discard();
         pendingFirstRenderRef.current = null;
       }
       three.scene.remove(voxelGroupRef.current.group);
@@ -668,6 +670,8 @@ export const VoxelViewer = forwardRef<VoxelViewerHandle, ViewerProps>(function V
     let meshStarted = false;
     let meshStrategy: VoxelMeshStrategy = "local";
     let meshCacheStatus: VoxelMeshCacheStatus = "not-used";
+    let traceRetainedForFirstRender = false;
+    let traceAbandoned = false;
 
     try {
       const tex = await loadAtlasTexture();
@@ -747,35 +751,43 @@ export const VoxelViewer = forwardRef<VoxelViewerHandle, ViewerProps>(function V
       let metricsReported = false;
       let revealAnimated = false;
       const maybeReportBuildMetrics = () => {
+        if (metricsReported) return;
         if (
-          metricsReported ||
+          traceAbandoned ||
           !buildReady ||
-          !firstRenderComplete ||
-          !revealComplete ||
           controller.signal.aborted ||
           !sameIdentity(identityRef.current, incomingIdentity) ||
           voxelGroupRef.current?.group !== vg.group
         ) {
+          buildTrace.clear();
+          return;
+        }
+        if (!firstRenderComplete || !revealComplete) {
           return;
         }
         metricsReported = true;
         buildTrace.mark("complete");
-        onBuildMetricsRef.current?.({
-          inputBlockCount: blockLimit,
-          renderedBlockCount: vg.stats.blockCount,
-          strategy: meshStrategy,
-          cacheStatus: meshCacheStatus,
-          animated: revealAnimated,
-          queueMs: buildTrace.duration("mesh_queued", "mesh_started"),
-          atlasMs: buildTrace.duration("mesh_queued", "atlas_ready"),
-          payloadMs: buildTrace.duration("mesh_started", "mesh_payload_complete"),
-          groupMs: buildTrace.duration("mesh_payload_complete", "three_group_complete"),
-          meshMs: buildTrace.duration("mesh_started", "three_group_complete"),
-          firstRenderMs: buildTrace.duration("three_group_complete", "first_render"),
-          revealMs: buildTrace.duration("three_group_complete", "reveal_complete"),
-          totalMs: buildTrace.duration("mesh_queued", "complete"),
-        });
+        try {
+          onBuildMetricsRef.current?.({
+            inputBlockCount: blockLimit,
+            renderedBlockCount: vg.stats.blockCount,
+            strategy: meshStrategy,
+            cacheStatus: meshCacheStatus,
+            animated: revealAnimated,
+            queueMs: buildTrace.duration("mesh_queued", "mesh_started"),
+            atlasMs: buildTrace.duration("mesh_queued", "atlas_ready"),
+            payloadMs: buildTrace.duration("mesh_started", "mesh_payload_complete"),
+            groupMs: buildTrace.duration("mesh_payload_complete", "three_group_complete"),
+            meshMs: buildTrace.duration("mesh_started", "three_group_complete"),
+            firstRenderMs: buildTrace.duration("three_group_complete", "first_render"),
+            revealMs: buildTrace.duration("three_group_complete", "reveal_complete"),
+            totalMs: buildTrace.duration("mesh_queued", "complete"),
+          });
+        } finally {
+          buildTrace.clear();
+        }
       };
+      pendingFirstRenderRef.current?.discard();
       pendingFirstRenderRef.current = {
         group: vg.group,
         report() {
@@ -783,7 +795,11 @@ export const VoxelViewer = forwardRef<VoxelViewerHandle, ViewerProps>(function V
           firstRenderComplete = true;
           maybeReportBuildMetrics();
         },
+        discard() {
+          buildTrace.clear();
+        },
       };
+      traceRetainedForFirstRender = true;
       requestRenderRef.current?.();
 
       const revealFromFraction =
@@ -857,6 +873,8 @@ export const VoxelViewer = forwardRef<VoxelViewerHandle, ViewerProps>(function V
       reportReady(buildReady);
       requestRenderRef.current?.();
     } catch (err: unknown) {
+      traceAbandoned = true;
+      buildTrace.clear();
       if (err instanceof DOMException && err.name === "AbortError") return;
       console.warn("VoxelViewer build failed", err);
       onBuildErrorChangeRef.current?.(
@@ -870,6 +888,7 @@ export const VoxelViewer = forwardRef<VoxelViewerHandle, ViewerProps>(function V
         activeJobRef.current.identity = null;
       }
       onBuildProgressChangeRef.current?.(null);
+      if (!traceRetainedForFirstRender) buildTrace.clear();
       if (buildPendingRef.current.dirty) scheduleKick();
     }
   }, [clearVoxelGroup, fitView, reportReady, scheduleKick]);
@@ -1119,6 +1138,7 @@ export const VoxelViewer = forwardRef<VoxelViewerHandle, ViewerProps>(function V
             pendingFirstRender.report();
           } else {
             pendingFirstRenderRef.current = null;
+            pendingFirstRender.discard();
           }
         }
         needsFollowupFrame = Boolean(controlsChanged || shouldAutoRotate);
@@ -1215,6 +1235,7 @@ export const VoxelViewer = forwardRef<VoxelViewerHandle, ViewerProps>(function V
         voxelGroupRef.current.dispose();
         voxelGroupRef.current = null;
       }
+      pendingFirstRenderRef.current?.discard();
       pendingFirstRenderRef.current = null;
       boundsRef.current = null;
 
@@ -1256,6 +1277,7 @@ export const VoxelViewer = forwardRef<VoxelViewerHandle, ViewerProps>(function V
       job.controller?.abort();
       job.controller = null;
       job.identity = null;
+      pendingFirstRenderRef.current?.discard();
       pendingFirstRenderRef.current = null;
     };
   }, []);

--- a/components/voxel/VoxelViewerCard.tsx
+++ b/components/voxel/VoxelViewerCard.tsx
@@ -8,6 +8,7 @@ import {
 } from "@/components/voxel/VoxelLoadingHud";
 import {
   VoxelViewer,
+  type VoxelViewerBuildMetrics,
   type VoxelViewerBuildProgress,
   type VoxelViewerHandle,
 } from "@/components/voxel/VoxelViewer";
@@ -33,6 +34,7 @@ export function VoxelViewerCard({
   autoRotate = true,
   animateIn,
   onBuildReadyChange,
+  onBuildMetrics,
   isLoading,
   loadingMode = "overlay",
   loadingProgress,
@@ -66,6 +68,7 @@ export function VoxelViewerCard({
   autoRotate?: boolean;
   animateIn?: boolean;
   onBuildReadyChange?: (ready: boolean) => void;
+  onBuildMetrics?: (metrics: VoxelViewerBuildMetrics) => void;
   isLoading?: boolean;
   loadingMode?: "overlay" | "silent";
   loadingProgress?: { receivedBlocks: number; totalBlocks: number | null };
@@ -369,6 +372,7 @@ export function VoxelViewerCard({
               // During progressive hydration, avoid restarting reveal animation on each chunk update.
               animateIn={Boolean(animateIn && !isLoading)}
               onBuildReadyChange={handleBuildReadyChange}
+              onBuildMetrics={onBuildMetrics}
               onBuildProgressChange={handleBuildProgressChange}
               onBuildErrorChange={handleBuildErrorChange}
             />

--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -1,0 +1,5 @@
+import { registerOTel } from "@vercel/otel";
+
+export function register() {
+  registerOTel({ serviceName: "minebench" });
+}

--- a/lib/arena/buildSnapshotArtifacts.ts
+++ b/lib/arena/buildSnapshotArtifacts.ts
@@ -13,6 +13,7 @@ import {
   type ArenaSnapshotArtifactFormat,
   uploadArenaBuildArtifact,
 } from "@/lib/arena/artifactOwnership";
+import { withServerSpanSync } from "@/lib/observability/serverTracing";
 import { gunzipSync, gzipSync } from "node:zlib";
 
 const ENCODER = new TextEncoder();
@@ -24,6 +25,19 @@ export function isBinarySnapshotArtifactEnabled(): boolean {
 export type ArenaSnapshotArtifactTarget = {
   variant: ArenaBuildVariant;
   format: ArenaSnapshotArtifactFormat;
+};
+
+export type ArenaSnapshotArtifactFetchMetrics = {
+  cacheStatus:
+    | "not-eligible"
+    | "negative-cache"
+    | "body-cache"
+    | "inflight"
+    | "miss"
+    | "bypass";
+  transferBytes?: number;
+  decodedBytes?: number;
+  inflateMs?: number;
 };
 
 const ARENA_SNAPSHOT_ARTIFACTS_ENABLED = readBoolEnv("ARENA_SNAPSHOT_ARTIFACTS_ENABLED", true);
@@ -290,9 +304,38 @@ export function expectedSnapshotArtifactTargets(
   return targets;
 }
 
-function maybeGunzipArtifactBytes(bytes: Uint8Array): Uint8Array {
-  if (bytes.length < 2 || bytes[0] !== 0x1f || bytes[1] !== 0x8b) return bytes;
-  return gunzipSync(Buffer.from(bytes.buffer as ArrayBuffer, bytes.byteOffset, bytes.byteLength));
+function maybeGunzipArtifactBytes(
+  bytes: Uint8Array,
+  variant: ArenaBuildVariant,
+  format: ArenaSnapshotArtifactFormat,
+  metrics?: ArenaSnapshotArtifactFetchMetrics,
+): Uint8Array {
+  if (bytes.length < 2 || bytes[0] !== 0x1f || bytes[1] !== 0x8b) {
+    if (metrics) metrics.decodedBytes = bytes.byteLength;
+    return bytes;
+  }
+
+  const startedAt = performance.now();
+  try {
+    const decoded = withServerSpanSync(
+      "arena.artifact.inflate",
+      { "arena.variant": variant, "arena.format": format },
+      (span) => {
+        const result = gunzipSync(
+          Buffer.from(bytes.buffer as ArrayBuffer, bytes.byteOffset, bytes.byteLength),
+        );
+        span.setAttributes({
+          "arena.transfer_bytes": bytes.byteLength,
+          "arena.decoded_bytes": result.byteLength,
+        });
+        return result;
+      },
+    );
+    if (metrics) metrics.decodedBytes = decoded.byteLength;
+    return decoded;
+  } finally {
+    if (metrics) metrics.inflateMs = performance.now() - startedAt;
+  }
 }
 
 async function uploadSnapshotArtifactVariant(
@@ -394,11 +437,15 @@ export async function fetchArenaBuildSnapshotArtifact(
     signal?: AbortSignal;
     format?: ArenaSnapshotArtifactFormat;
     cache?: "default" | "no-store";
+    metrics?: ArenaSnapshotArtifactFetchMetrics;
   },
 ): Promise<Uint8Array | null> {
   const format = opts?.format ?? "json";
   const ref = getSnapshotArtifactRef(buildId, variant, checksum, format);
-  if (!ref) return null;
+  if (!ref) {
+    if (opts?.metrics) opts.metrics.cacheStatus = "not-eligible";
+    return null;
+  }
 
   const useCache = opts?.cache !== "no-store";
   const cacheKey = getArtifactCacheKey(buildId, variant, checksum, format);
@@ -406,19 +453,29 @@ export async function fetchArenaBuildSnapshotArtifact(
   if (useCache) maybePruneArtifactCaches(now);
   if (useCache && hasFreshArtifactMiss(cacheKey)) {
     // recent miss means the db snapshot path should win immediately
+    if (opts?.metrics) opts.metrics.cacheStatus = "negative-cache";
     return null;
   }
 
   const cached = useCache ? getCachedSnapshotArtifactBody(cacheKey) : null;
   if (cached) {
+    if (opts?.metrics) {
+      opts.metrics.cacheStatus = "body-cache";
+      opts.metrics.decodedBytes = cached.byteLength;
+    }
     return cached;
   }
 
   const inflight = useCache ? artifactBodyInflight.get(cacheKey) : null;
   if (inflight) {
     // share supabase reads across concurrent requests
-    return inflight;
+    if (opts?.metrics) opts.metrics.cacheStatus = "inflight";
+    const bytes = await inflight;
+    if (opts?.metrics && bytes) opts.metrics.decodedBytes = bytes.byteLength;
+    return bytes;
   }
+
+  if (opts?.metrics) opts.metrics.cacheStatus = useCache ? "miss" : "bypass";
 
   const promise = (async () => {
     let config: ReturnType<typeof getSupabaseStorageConfig>;
@@ -441,7 +498,9 @@ export async function fetchArenaBuildSnapshotArtifact(
     });
 
     if (resp.ok) {
-      const bytes = maybeGunzipArtifactBytes(new Uint8Array(await resp.arrayBuffer()));
+      const transferred = new Uint8Array(await resp.arrayBuffer());
+      if (opts?.metrics) opts.metrics.transferBytes = transferred.byteLength;
+      const bytes = maybeGunzipArtifactBytes(transferred, variant, format, opts?.metrics);
       if (useCache) {
         clearSnapshotArtifactMiss(buildId, variant, checksum, format);
         setCachedSnapshotArtifactBody(cacheKey, bytes);

--- a/lib/arena/clientBuildResponse.ts
+++ b/lib/arena/clientBuildResponse.ts
@@ -73,14 +73,33 @@ export type BuildVariantArtifact<T> =
   | { kind: "json"; value: T }
   | { kind: "binary"; envelope: Record<string, unknown>; blocks: PackedVoxelBlocks };
 
-export async function readBuildVariantArtifact<T>(res: Response): Promise<BuildVariantArtifact<T>> {
+export type BuildVariantArtifactReadEvent =
+  | { stage: "body_complete"; bytes: number }
+  | { stage: "inflate_complete"; bytes: number; compressed: boolean }
+  | { stage: "binary_decode_complete"; blockCount: number }
+  | { stage: "json_decode_complete" };
+
+export async function readBuildVariantArtifact<T>(
+  res: Response,
+  options?: { onStage?: (event: BuildVariantArtifactReadEvent) => void },
+): Promise<BuildVariantArtifact<T>> {
   const bytes = new Uint8Array(await res.arrayBuffer());
-  const body = isGzipChunk(bytes) ? await gunzipBytes(bytes) : bytes;
+  options?.onStage?.({ stage: "body_complete", bytes: bytes.byteLength });
+  const compressed = isGzipChunk(bytes);
+  const body = compressed ? await gunzipBytes(bytes) : bytes;
+  options?.onStage?.({
+    stage: "inflate_complete",
+    bytes: body.byteLength,
+    compressed,
+  });
   if (isBinaryArtifact(body)) {
     const { envelope, blocks } = decodeBinaryArtifact(body);
+    options?.onStage?.({ stage: "binary_decode_complete", blockCount: blocks.count });
     return { kind: "binary", envelope, blocks };
   }
-  return { kind: "json", value: JSON.parse(new TextDecoder().decode(body)) as T };
+  const value = JSON.parse(new TextDecoder().decode(body)) as T;
+  options?.onStage?.({ stage: "json_decode_complete" });
+  return { kind: "json", value };
 }
 
 export type BuildVariantStreamResponse = {
@@ -254,6 +273,7 @@ export async function readBuildVariantStream(
   response: Response,
   options?: {
     signal?: AbortSignal;
+    onStage?: (stage: "body_complete" | "stream_decode_complete") => void;
     onProgress?: (
       build: RenderableVoxelBuild,
       progress: BuildStreamProgress,
@@ -418,6 +438,7 @@ export async function readBuildVariantStream(
       buffer = lines.pop() ?? "";
       for (const line of lines) processLine(line);
     }
+    options?.onStage?.("body_complete");
     buffer += decoder.decode();
     if (buffer.trim()) processLine(buffer);
 
@@ -427,6 +448,7 @@ export async function readBuildVariantStream(
     if (nextChunkIndex - 1 !== chunkCount) {
       throw new IncompleteBuildStreamError("Build stream ended before all chunks loaded");
     }
+    options?.onStage?.("stream_decode_complete");
     return {
       buildId,
       variant,

--- a/lib/observability/arenaMetrics.ts
+++ b/lib/observability/arenaMetrics.ts
@@ -1,0 +1,48 @@
+export type ArenaLatencyBucket =
+  | "under-100ms"
+  | "100-250ms"
+  | "250-500ms"
+  | "500-1000ms"
+  | "1-2.5s"
+  | "2.5-5s"
+  | "5-10s"
+  | "10s-plus";
+
+export type ArenaBlockCountBucket =
+  | "empty"
+  | "under-8k"
+  | "8k-50k"
+  | "50k-150k"
+  | "150k-300k"
+  | "300k-1m"
+  | "1m-plus"
+  | "unknown";
+
+export function roundMetricMs(value: number | null | undefined): number | null {
+  if (value == null || !Number.isFinite(value) || value < 0) return null;
+  return Math.round(value * 100) / 100;
+}
+
+export function getArenaLatencyBucket(durationMs: number): ArenaLatencyBucket {
+  if (durationMs < 100) return "under-100ms";
+  if (durationMs < 250) return "100-250ms";
+  if (durationMs < 500) return "250-500ms";
+  if (durationMs < 1_000) return "500-1000ms";
+  if (durationMs < 2_500) return "1-2.5s";
+  if (durationMs < 5_000) return "2.5-5s";
+  if (durationMs < 10_000) return "5-10s";
+  return "10s-plus";
+}
+
+export function getArenaBlockCountBucket(
+  blockCount: number | null | undefined,
+): ArenaBlockCountBucket {
+  if (blockCount == null || !Number.isFinite(blockCount) || blockCount < 0) return "unknown";
+  if (blockCount === 0) return "empty";
+  if (blockCount < 8_000) return "under-8k";
+  if (blockCount < 50_000) return "8k-50k";
+  if (blockCount < 150_000) return "50k-150k";
+  if (blockCount < 300_000) return "150k-300k";
+  if (blockCount < 1_000_000) return "300k-1m";
+  return "1m-plus";
+}

--- a/lib/observability/browserPerformance.ts
+++ b/lib/observability/browserPerformance.ts
@@ -1,0 +1,49 @@
+let traceSequence = 0;
+
+export type BrowserPerformanceTrace = {
+  mark: (stage: string) => number;
+  measure: (name: string, startStage: string, endStage: string) => number | null;
+  duration: (startStage: string, endStage: string) => number | null;
+};
+
+export function createBrowserPerformanceTrace(kind: string): BrowserPerformanceTrace {
+  traceSequence += 1;
+  const prefix = `minebench:arena:${kind}:${traceSequence}`;
+  const marks = new Map<string, number>();
+
+  const mark = (stage: string): number => {
+    const at = performance.now();
+    marks.set(stage, at);
+    try {
+      performance.mark(`${prefix}:${stage}`, { startTime: at });
+    } catch {
+      // Performance entries are diagnostic only
+    }
+    return at;
+  };
+
+  const duration = (startStage: string, endStage: string): number | null => {
+    const startedAt = marks.get(startStage);
+    const endedAt = marks.get(endStage);
+    if (startedAt == null || endedAt == null || endedAt < startedAt) return null;
+    return endedAt - startedAt;
+  };
+
+  return {
+    mark,
+    duration,
+    measure(name, startStage, endStage) {
+      const measured = duration(startStage, endStage);
+      if (measured == null) return null;
+      try {
+        performance.measure(`${prefix}:${name}`, {
+          start: `${prefix}:${startStage}`,
+          end: `${prefix}:${endStage}`,
+        });
+      } catch {
+        // Performance entries are diagnostic only
+      }
+      return measured;
+    },
+  };
+}

--- a/lib/observability/browserPerformance.ts
+++ b/lib/observability/browserPerformance.ts
@@ -4,12 +4,14 @@ export type BrowserPerformanceTrace = {
   mark: (stage: string) => number;
   measure: (name: string, startStage: string, endStage: string) => number | null;
   duration: (startStage: string, endStage: string) => number | null;
+  clear: () => void;
 };
 
 export function createBrowserPerformanceTrace(kind: string): BrowserPerformanceTrace {
   traceSequence += 1;
   const prefix = `minebench:arena:${kind}:${traceSequence}`;
   const marks = new Map<string, number>();
+  const measures = new Set<string>();
 
   const mark = (stage: string): number => {
     const at = performance.now();
@@ -35,6 +37,7 @@ export function createBrowserPerformanceTrace(kind: string): BrowserPerformanceT
     measure(name, startStage, endStage) {
       const measured = duration(startStage, endStage);
       if (measured == null) return null;
+      measures.add(name);
       try {
         performance.measure(`${prefix}:${name}`, {
           start: `${prefix}:${startStage}`,
@@ -44,6 +47,24 @@ export function createBrowserPerformanceTrace(kind: string): BrowserPerformanceT
         // Performance entries are diagnostic only
       }
       return measured;
+    },
+    clear() {
+      for (const stage of marks.keys()) {
+        try {
+          performance.clearMarks(`${prefix}:${stage}`);
+        } catch {
+          // Performance entries are diagnostic only
+        }
+      }
+      for (const name of measures) {
+        try {
+          performance.clearMeasures(`${prefix}:${name}`);
+        } catch {
+          // Performance entries are diagnostic only
+        }
+      }
+      marks.clear();
+      measures.clear();
     },
   };
 }

--- a/lib/observability/serverTracing.ts
+++ b/lib/observability/serverTracing.ts
@@ -1,0 +1,51 @@
+import {
+  SpanStatusCode,
+  trace,
+  type Attributes,
+  type Span,
+} from "@opentelemetry/api";
+
+const tracer = trace.getTracer("minebench.arena");
+
+export function setActiveServerSpanAttributes(attributes: Attributes) {
+  trace.getActiveSpan()?.setAttributes(attributes);
+}
+
+function recordSpanError(span: Span, error: unknown) {
+  span.recordException(error instanceof Error ? error : String(error));
+  span.setStatus({ code: SpanStatusCode.ERROR });
+}
+
+export function withServerSpan<T>(
+  name: string,
+  attributes: Attributes,
+  operation: (span: Span) => Promise<T>,
+): Promise<T> {
+  return tracer.startActiveSpan(name, { attributes }, async (span) => {
+    try {
+      return await operation(span);
+    } catch (error) {
+      recordSpanError(span, error);
+      throw error;
+    } finally {
+      span.end();
+    }
+  });
+}
+
+export function withServerSpanSync<T>(
+  name: string,
+  attributes: Attributes,
+  operation: (span: Span) => T,
+): T {
+  return tracer.startActiveSpan(name, { attributes }, (span) => {
+    try {
+      return operation(span);
+    } catch (error) {
+      recordSpanError(span, error);
+      throw error;
+    } finally {
+      span.end();
+    }
+  });
+}

--- a/lib/voxel/mesh.ts
+++ b/lib/voxel/mesh.ts
@@ -37,9 +37,19 @@ type BuildProgress = {
   stageLabel?: string;
 };
 
+export type VoxelMeshStrategy = "local" | "worker" | "worker-fallback";
+export type VoxelMeshCacheStatus = "hit" | "miss" | "disabled" | "not-used";
+export type VoxelMeshStageEvent = {
+  stage: "mesh_started" | "mesh_payload_complete" | "three_group_complete";
+  strategy: VoxelMeshStrategy;
+  cacheStatus?: VoxelMeshCacheStatus;
+  blockCount?: number;
+};
+
 type CreateVoxelGroupAsyncOpts = {
   signal?: AbortSignal;
   onProgress?: (progress: BuildProgress) => void;
+  onStage?: (event: VoxelMeshStageEvent) => void;
   // Yield to the main thread when we've spent about this many ms in a tight loop.
   yieldAfterMs?: number;
   // When set, only process the first N input blocks. Useful for progressive streaming without copying arrays.
@@ -1075,12 +1085,13 @@ async function createVoxelMeshPayloadInWorker(
   build: RenderableVoxelBuild,
   palette: BlockDefinition[],
   opts?: CreateVoxelGroupAsyncOpts,
-): Promise<VoxelMeshPayload> {
+): Promise<{ payload: VoxelMeshPayload; cacheStatus: VoxelMeshCacheStatus }> {
   const cacheKey = opts?.cacheKey?.trim();
   if (cacheKey) {
     const cached = await getCachedMeshPayload(cacheKey);
-    if (cached) return cached;
+    if (cached) return { payload: cached, cacheStatus: "hit" };
   }
+  const cacheStatus: VoxelMeshCacheStatus = cacheKey ? "miss" : "disabled";
 
   if (typeof Worker === "undefined") {
     throw new Error("Web Workers are unavailable in this environment");
@@ -1091,7 +1102,7 @@ async function createVoxelMeshPayloadInWorker(
     worker.terminate();
   };
 
-  return await new Promise<VoxelMeshPayload>((resolve, reject) => {
+  const payload = await new Promise<VoxelMeshPayload>((resolve, reject) => {
     let settled = false;
     let timeout: ReturnType<typeof setTimeout> | null =
       Number.isFinite(MESH_WORKER_TIMEOUT_MS) && MESH_WORKER_TIMEOUT_MS > 0
@@ -1170,6 +1181,7 @@ async function createVoxelMeshPayloadInWorker(
     };
     worker.postMessage(request, [blocks.positions.buffer, blocks.typeIds.buffer]);
   });
+  return { payload, cacheStatus };
 }
 
 export async function warmVoxelMeshPayload(
@@ -1192,6 +1204,7 @@ async function createVoxelGroupAsyncLocal(
   palette: BlockDefinition[],
   atlasTexture: THREE.Texture,
   opts?: CreateVoxelGroupAsyncOpts,
+  strategy: VoxelMeshStrategy = "local",
 ): Promise<VoxelGroup> {
   // Main-thread meshing walks block objects. This is the small-build path and
   // the worker-failure fallback, so materializing here costs no more than the
@@ -1237,6 +1250,12 @@ async function createVoxelGroupAsyncLocal(
   }
 
   const water = await buildWaterSurfaceBucketAsync(prepared, maybeYield);
+  opts?.onStage?.({
+    stage: "mesh_payload_complete",
+    strategy,
+    cacheStatus: "not-used",
+    blockCount: prepared.filteredBlockCount,
+  });
 
   const geometryStageCount = 5;
   const geometryStageTotal = prepared.filteredBlockCount + geometryStageCount;
@@ -1345,16 +1364,52 @@ export async function createVoxelGroupAsync(
     LOCAL_MESH_MAX_BLOCKS > 0 &&
     blockLimit <= LOCAL_MESH_MAX_BLOCKS
   ) {
-    return createVoxelGroupAsyncLocal(build, palette, atlasTexture, opts);
+    opts?.onStage?.({ stage: "mesh_started", strategy: "local" });
+    const group = await createVoxelGroupAsyncLocal(build, palette, atlasTexture, opts, "local");
+    opts?.onStage?.({
+      stage: "three_group_complete",
+      strategy: "local",
+      cacheStatus: "not-used",
+      blockCount: group.stats.blockCount,
+    });
+    return group;
   }
 
   try {
-    const payload = await createVoxelMeshPayloadInWorker(build, palette, opts);
+    opts?.onStage?.({ stage: "mesh_started", strategy: "worker" });
+    const { payload, cacheStatus } = await createVoxelMeshPayloadInWorker(build, palette, opts);
+    opts?.onStage?.({
+      stage: "mesh_payload_complete",
+      strategy: "worker",
+      cacheStatus,
+      blockCount: payload.filteredBlockCount,
+    });
     throwIfAborted(opts?.signal);
-    return createVoxelGroupFromMeshPayload(payload, atlasTexture);
+    const group = createVoxelGroupFromMeshPayload(payload, atlasTexture);
+    opts?.onStage?.({
+      stage: "three_group_complete",
+      strategy: "worker",
+      cacheStatus,
+      blockCount: group.stats.blockCount,
+    });
+    return group;
   } catch (err) {
     if (err instanceof DOMException && err.name === "AbortError") throw err;
     console.warn("Voxel mesh worker failed, falling back to main-thread meshing", err);
-    return createVoxelGroupAsyncLocal(build, palette, atlasTexture, opts);
+    opts?.onStage?.({ stage: "mesh_started", strategy: "worker-fallback" });
+    const group = await createVoxelGroupAsyncLocal(
+      build,
+      palette,
+      atlasTexture,
+      opts,
+      "worker-fallback",
+    );
+    opts?.onStage?.({
+      stage: "three_group_complete",
+      strategy: "worker-fallback",
+      cacheStatus: "not-used",
+      blockCount: group.stats.blockCount,
+    });
+    return group;
   }
 }

--- a/package.json
+++ b/package.json
@@ -60,10 +60,13 @@
     "stealth:eval": "tsx scripts/stealth-eval.ts"
   },
   "dependencies": {
+    "@opentelemetry/api": "^1.9.1",
     "@prisma/client": "^6.0.0",
     "@supabase/ssr": "0.12.4",
     "@supabase/supabase-js": "2.112.3",
     "@vercel/analytics": "^1.6.1",
+    "@vercel/otel": "^2.1.3",
+    "@vercel/speed-insights": "^2.0.0",
     "fflate": "^0.8.3",
     "gifenc": "^1.0.3",
     "gifsicle-wasm-browser": "^1.5.19",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,18 +8,27 @@ importers:
 
   .:
     dependencies:
+      '@opentelemetry/api':
+        specifier: ^1.9.1
+        version: 1.9.1
       '@prisma/client':
         specifier: ^6.0.0
         version: 6.19.1(prisma@6.19.1(typescript@5.9.3))(typescript@5.9.3)
       '@supabase/ssr':
         specifier: 0.12.4
-        version: 0.12.4(@supabase/supabase-js@2.112.3)
+        version: 0.12.4(@supabase/supabase-js@2.112.3(@opentelemetry/api@1.9.1))
       '@supabase/supabase-js':
         specifier: 2.112.3
-        version: 2.112.3
+        version: 2.112.3(@opentelemetry/api@1.9.1)
       '@vercel/analytics':
         specifier: ^1.6.1
-        version: 1.6.1(next@15.5.9(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)
+        version: 1.6.1(next@15.5.9(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)
+      '@vercel/otel':
+        specifier: ^2.1.3
+        version: 2.1.3(@opentelemetry/api-logs@0.221.0)(@opentelemetry/api@1.9.1)(@opentelemetry/instrumentation@0.221.0(@opentelemetry/api@1.9.1))(@opentelemetry/resources@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.221.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))
+      '@vercel/speed-insights':
+        specifier: ^2.0.0
+        version: 2.0.0(next@15.5.9(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)
       fflate:
         specifier: ^0.8.3
         version: 0.8.3
@@ -31,7 +40,7 @@ importers:
         version: 1.5.19
       next:
         specifier: ^15.0.0
-        version: 15.5.9(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        version: 15.5.9(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react:
         specifier: ^19.2.6
         version: 19.2.6
@@ -43,7 +52,7 @@ importers:
         version: 0.184.0
       workflow:
         specifier: 4.8.4
-        version: 4.8.4(@nestjs/common@11.2.1(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.2.1(@nestjs/common@11.2.1(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@swc/cli@0.8.1(@swc/core@1.15.3)(chokidar@5.0.0))(@swc/core@1.15.3)(next@15.5.9(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(typescript@5.9.3)
+        version: 4.8.4(@nestjs/common@11.2.1(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.2.1(@nestjs/common@11.2.1(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.1)(@swc/cli@0.8.1(@swc/core@1.15.3)(chokidar@5.0.0))(@swc/core@1.15.3)(next@15.5.9(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(typescript@5.9.3)
       zod:
         specifier: ^3.24.0
         version: 3.25.76
@@ -915,6 +924,60 @@ packages:
     resolution: {integrity: sha512-5N/X/FzlJaYfpaHwDC0YHzOzKDWa41s9t+4FpCDu4f9OMReds4JeNBaaWk9rlIzdKjh2M6AC5Q18ORfECRkHGA==}
     engines: {node: '>=18.0.0'}
 
+  '@opentelemetry/api-logs@0.221.0':
+    resolution: {integrity: sha512-OlanaW1vv7ufTqQ3/fPLI4arGt5ZoM+P8abOMki6uEYnpRazepSWDwDnnw+la7kE26SHVC18//SMccrDvLKOXQ==}
+    engines: {node: '>=8.0.0'}
+
+  '@opentelemetry/api@1.9.1':
+    resolution: {integrity: sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==}
+    engines: {node: '>=8.0.0'}
+
+  '@opentelemetry/core@2.10.0':
+    resolution: {integrity: sha512-/wNZ8twnEQQA4HoHu22+vcsdru6pWPWxW+7w+FlxT6Id7PE/WIbZmVKkte+PF72e0F2dnImFeHD2syyE1Mw6MQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/instrumentation@0.221.0':
+    resolution: {integrity: sha512-cCk80Z/iRDf/5gfsKMB4f74LqVA5yKETB/9ojPzVW/6/f70iu89nJvGxsFCxx4XfSohaOofkU19kiYm84AiAlw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/resources@2.10.0':
+    resolution: {integrity: sha512-q6MMm2zhggzsHVNbabYwut+a6nbuQQe3URUoxaojM/8K1IBfwwPzvxIjNi2/lI1TFe+fMHMW9MWhrtDLEXEnkA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/sdk-logs@0.221.0':
+    resolution: {integrity: sha512-FaDcazjyMp7TZZZAsqbo4IkovP0UegoCu0EBkiNt+qCqvUf7FPAsfcrZ3+ZEkKgXZ/jHafop+JoGPDk3A0SmLg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.4.0 <1.10.0'
+
+  '@opentelemetry/sdk-metrics@2.10.0':
+    resolution: {integrity: sha512-t6r1VSvXNtSDnPXU1FbZeetJb7yyovHmgu0wRSoftxtE0g2rSNhQZQUy69sRUCL+iioJpX8SN/S6wq6ZtvLySQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.9.0 <1.10.0'
+
+  '@opentelemetry/sdk-trace-base@2.10.0':
+    resolution: {integrity: sha512-GuYQQT7QD2EeO8lcZLRQzcbOyhqAzL+6WWTKTU9mSUBYBazkEDl+VrQcXQhbB08OWM9anD1aHleVadzulpOaUQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/sdk-trace@2.10.0':
+    resolution: {integrity: sha512-MfQGq3GRmTh5fM/y+OjaO0vj6+luCB1XO2gfXCalKCfgKw0eHL++sm75DNweC6ohlp+aFvACqeE0fYayqdRaoQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/semantic-conventions@1.43.0':
+    resolution: {integrity: sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg==}
+    engines: {node: '>=14'}
+
   '@prisma/client@6.19.1':
     resolution: {integrity: sha512-4SXj4Oo6HyQkLUWT8Ke5R0PTAfVOKip5Roo+6+b2EDTkFg5be0FnBWiuRJc0BC0sRQIWGMLKW1XguhVfW/z3/A==}
     engines: {node: '>=18.18'}
@@ -1376,9 +1439,47 @@ packages:
     resolution: {integrity: sha512-RwXYtnt6za+5UO4IaLywN/6B95AlLqynPRUWRJxeJ/qufwkcLUbZNUxYtzT0uMpuraWhlNcGqPNGkTnZr4BGBw==}
     engines: {node: '>= 20'}
 
+  '@vercel/otel@2.1.3':
+    resolution: {integrity: sha512-Ofvzs9qhftRD1YMLuPnhbXjQZG6IKrJ9AmEKmRHRGfoWlV89ed2gAOkvddkFiZDFZJm2rrFNdeZKRVxoCdnWiw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.9.0 <2.0.0'
+      '@opentelemetry/api-logs': '>=0.200.0 <0.300.0'
+      '@opentelemetry/instrumentation': '>=0.200.0 <0.300.0'
+      '@opentelemetry/resources': '>=2.0.0 <3.0.0'
+      '@opentelemetry/sdk-logs': '>=0.200.0 <0.300.0'
+      '@opentelemetry/sdk-metrics': '>=2.0.0 <3.0.0'
+      '@opentelemetry/sdk-trace-base': '>=2.0.0 <3.0.0'
+
   '@vercel/queue@0.3.1':
     resolution: {integrity: sha512-6pjdXyNfdCQnj1nyeB1rPtll/XUhmciyeZJD0rpIUUwmcIfR+utDl6+iFvlHvsBdqAVT8UC6ydObT0v+xldfUQ==}
     engines: {node: '>=20.0.0'}
+
+  '@vercel/speed-insights@2.0.0':
+    resolution: {integrity: sha512-jwkNcrTeafWxjmWq4AHBaptSqZiJkYU5adLC9QBSqeim0GcqDMgN5Ievh8OG1rJ6W3A4l1oiP7qr9CWxGuzu3w==}
+    peerDependencies:
+      '@sveltejs/kit': ^1 || ^2
+      next: '>= 13'
+      nuxt: '>= 3'
+      react: ^18 || ^19 || ^19.0.0-rc
+      svelte: '>= 4'
+      vue: ^3
+      vue-router: ^4
+    peerDependenciesMeta:
+      '@sveltejs/kit':
+        optional: true
+      next:
+        optional: true
+      nuxt:
+        optional: true
+      react:
+        optional: true
+      svelte:
+        optional: true
+      vue:
+        optional: true
+      vue-router:
+        optional: true
 
   '@workflow/astro@4.0.19':
     resolution: {integrity: sha512-Ep1jLR061wOFfTHHP+LvrWR9XQHpi7coXjIDw+161fFBd4SVpc/UXXNdqdlBdhI5EJgy7WtcHE4QytvvXJjzQA==}
@@ -1808,6 +1909,9 @@ packages:
   citty@0.1.6:
     resolution: {integrity: sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ==}
 
+  cjs-module-lexer@2.2.1:
+    resolution: {integrity: sha512-Ca8swihM+/4yKecYHY52kgJd300hi2lADU/a1RxNTRe+RJ9jvqQlESpbz9DnG9mowez8qwXHB8qYdIUw9e+F5Q==}
+
   clean-stack@3.0.1:
     resolution: {integrity: sha512-lR9wNiMRcVQjSB3a7xXGLuz4cr4wJuuXlaAEbRutGowQTmlp7R72/DOgN21e8jdwblMWl9UOJMJXarX94pzKdg==}
     engines: {node: '>=10'}
@@ -2082,6 +2186,9 @@ packages:
   es-iterator-helpers@1.2.2:
     resolution: {integrity: sha512-BrUQ0cPTB/IwXj23HtwHjS9n7O4h9FX94b4xc5zlTHxeLgTAdzYUDyy6KdExAl9lbN5rtfe44xpjpmj9grxs5w==}
     engines: {node: '>= 0.4'}
+
+  es-module-lexer@2.3.2:
+    resolution: {integrity: sha512-poHGpORABojJJucnV9KbOavETW8lBVnphkW77ER5/BQ5Fz7oXSoCNek7IH3vR5nRjdsEz926ibFYX8KtLQmdyw==}
 
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
@@ -2563,6 +2670,10 @@ packages:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
     engines: {node: '>=6'}
 
+  import-in-the-middle@3.3.3:
+    resolution: {integrity: sha512-AiohS3H80sXO6owEltjGX+glb7qXaDhBoJb9XcQVH4UI207xu/bDLUcadVKp7Qe576reg9yr/PXZjV5qx8gfbA==}
+    engines: {node: '>=18'}
+
   imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
@@ -2974,6 +3085,9 @@ packages:
 
   mlly@1.8.2:
     resolution: {integrity: sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==}
+
+  module-details-from-path@1.0.4:
+    resolution: {integrity: sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==}
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -3396,6 +3510,10 @@ packages:
   regexp.prototype.flags@1.5.4:
     resolution: {integrity: sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==}
     engines: {node: '>= 0.4'}
+
+  require-in-the-middle@8.0.1:
+    resolution: {integrity: sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ==}
+    engines: {node: '>=9.3.0 || >=8.10.0 <9.0.0'}
 
   resolve-alpn@1.2.1:
     resolution: {integrity: sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==}
@@ -4629,6 +4747,63 @@ snapshots:
     dependencies:
       '@oclif/core': 4.11.4
 
+  '@opentelemetry/api-logs@0.221.0':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+
+  '@opentelemetry/api@1.9.1': {}
+
+  '@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/semantic-conventions': 1.43.0
+
+  '@opentelemetry/instrumentation@0.221.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.221.0
+      import-in-the-middle: 3.3.3
+      require-in-the-middle: 8.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/resources@2.10.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.43.0
+
+  '@opentelemetry/sdk-logs@0.221.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.221.0
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.43.0
+
+  '@opentelemetry/sdk-metrics@2.10.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.10.0(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.43.0
+
+  '@opentelemetry/sdk-trace@2.10.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.43.0
+
+  '@opentelemetry/semantic-conventions@1.43.0': {}
+
   '@prisma/client@6.19.1(prisma@6.19.1(typescript@5.9.3))(typescript@5.9.3)':
     optionalDependencies:
       prisma: 6.19.1(typescript@5.9.3)
@@ -4724,9 +4899,9 @@ snapshots:
       '@supabase/phoenix': 0.4.5
       tslib: 2.8.1
 
-  '@supabase/ssr@0.12.4(@supabase/supabase-js@2.112.3)':
+  '@supabase/ssr@0.12.4(@supabase/supabase-js@2.112.3(@opentelemetry/api@1.9.1))':
     dependencies:
-      '@supabase/supabase-js': 2.112.3
+      '@supabase/supabase-js': 2.112.3(@opentelemetry/api@1.9.1)
       cookie: 1.1.1
 
   '@supabase/storage-js@2.112.3':
@@ -4734,13 +4909,15 @@ snapshots:
       iceberg-js: 0.8.1
       tslib: 2.8.1
 
-  '@supabase/supabase-js@2.112.3':
+  '@supabase/supabase-js@2.112.3(@opentelemetry/api@1.9.1)':
     dependencies:
       '@supabase/auth-js': 2.112.3
       '@supabase/functions-js': 2.112.3
       '@supabase/postgrest-js': 2.112.3
       '@supabase/realtime-js': 2.112.3
       '@supabase/storage-js': 2.112.3
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.1
 
   '@sveltejs/load-config@0.2.3': {}
 
@@ -4752,10 +4929,10 @@ snapshots:
       commander: 8.3.0
       minimatch: 9.0.5
       piscina: 4.9.3
-      semver: 7.7.3
+      semver: 7.8.5
       slash: 3.0.0
       source-map: 0.7.6
-      tinyglobby: 0.2.15
+      tinyglobby: 0.2.17
     optionalDependencies:
       chokidar: 5.0.0
     transitivePeerDependencies:
@@ -5020,9 +5197,9 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
     optional: true
 
-  '@vercel/analytics@1.6.1(next@15.5.9(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)':
+  '@vercel/analytics@1.6.1(next@15.5.9(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)':
     optionalDependencies:
-      next: 15.5.9(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      next: 15.5.9(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react: 19.2.6
 
   '@vercel/cli-auth@0.0.1':
@@ -5055,6 +5232,16 @@ snapshots:
       '@vercel/cli-exec': 1.0.1
       jose: 5.10.0
 
+  '@vercel/otel@2.1.3(@opentelemetry/api-logs@0.221.0)(@opentelemetry/api@1.9.1)(@opentelemetry/instrumentation@0.221.0(@opentelemetry/api@1.9.1))(@opentelemetry/resources@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.221.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.221.0
+      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-logs': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-metrics': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.10.0(@opentelemetry/api@1.9.1)
+
   '@vercel/queue@0.3.1':
     dependencies:
       '@vercel/oidc': 3.2.0
@@ -5062,13 +5249,18 @@ snapshots:
       mixpart: 0.0.6
       picocolors: 1.1.1
 
-  '@workflow/astro@4.0.19':
+  '@vercel/speed-insights@2.0.0(next@15.5.9(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)':
+    optionalDependencies:
+      next: 15.5.9(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      react: 19.2.6
+
+  '@workflow/astro@4.0.19(@opentelemetry/api@1.9.1)':
     dependencies:
       '@swc/core': 1.15.3
-      '@workflow/builders': 4.1.9
-      '@workflow/rollup': 4.0.19
+      '@workflow/builders': 4.1.9(@opentelemetry/api@1.9.1)
+      '@workflow/rollup': 4.0.19(@opentelemetry/api@1.9.1)
       '@workflow/swc-plugin': 4.1.2(@swc/core@1.15.3)
-      '@workflow/vite': 4.0.19
+      '@workflow/vite': 4.0.19(@opentelemetry/api@1.9.1)
       exsolve: 1.0.8
       pathe: 2.0.3
     transitivePeerDependencies:
@@ -5077,10 +5269,10 @@ snapshots:
       - supports-color
       - ws
 
-  '@workflow/builders@4.1.9':
+  '@workflow/builders@4.1.9(@opentelemetry/api@1.9.1)':
     dependencies:
       '@swc/core': 1.15.3
-      '@workflow/core': 4.8.4
+      '@workflow/core': 4.8.4(@opentelemetry/api@1.9.1)
       '@workflow/errors': 4.2.1
       '@workflow/swc-plugin': 4.1.2(@swc/core@1.15.3)
       '@workflow/utils': 4.1.4
@@ -5097,21 +5289,21 @@ snapshots:
       - supports-color
       - ws
 
-  '@workflow/cli@4.3.8':
+  '@workflow/cli@4.3.8(@opentelemetry/api@1.9.1)':
     dependencies:
       '@oclif/core': 4.11.4
       '@oclif/plugin-help': 6.2.37
       '@swc/core': 1.15.3
       '@vercel/cli-auth': 0.0.1
-      '@workflow/builders': 4.1.9
-      '@workflow/core': 4.8.4
+      '@workflow/builders': 4.1.9(@opentelemetry/api@1.9.1)
+      '@workflow/core': 4.8.4(@opentelemetry/api@1.9.1)
       '@workflow/errors': 4.2.1
       '@workflow/swc-plugin': 4.1.2(@swc/core@1.15.3)
       '@workflow/utils': 4.1.4
       '@workflow/web': 4.1.20
       '@workflow/world': 4.4.0
-      '@workflow/world-local': 4.3.0
-      '@workflow/world-vercel': 4.7.0
+      '@workflow/world-local': 4.3.0(@opentelemetry/api@1.9.1)
+      '@workflow/world-vercel': 4.7.0(@opentelemetry/api@1.9.1)
       boxen: 8.0.1
       builtin-modules: 5.0.0
       chalk: 5.6.2
@@ -5135,7 +5327,7 @@ snapshots:
       - supports-color
       - ws
 
-  '@workflow/core@4.8.4':
+  '@workflow/core@4.8.4(@opentelemetry/api@1.9.1)':
     dependencies:
       '@aws-sdk/credential-provider-web-identity': 3.972.49
       '@jridgewell/trace-mapping': 0.3.31
@@ -5146,8 +5338,8 @@ snapshots:
       '@workflow/serde': 4.1.2
       '@workflow/utils': 4.1.4
       '@workflow/world': 4.4.0
-      '@workflow/world-local': 4.3.0
-      '@workflow/world-vercel': 4.7.0
+      '@workflow/world-local': 4.3.0(@opentelemetry/api@1.9.1)
+      '@workflow/world-vercel': 4.7.0(@opentelemetry/api@1.9.1)
       debug: 4.4.3(supports-color@8.1.1)
       devalue: 5.8.1
       ms: 2.1.3
@@ -5156,6 +5348,8 @@ snapshots:
       semver: 7.7.4
       ulid: 3.0.2
       zod: 4.3.6
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.1
     transitivePeerDependencies:
       - supports-color
       - ws
@@ -5165,13 +5359,13 @@ snapshots:
       '@workflow/utils': 4.1.4
       ms: 2.1.3
 
-  '@workflow/nest@4.0.20(@nestjs/common@11.2.1(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.2.1(@nestjs/common@11.2.1(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@swc/cli@0.8.1(@swc/core@1.15.3)(chokidar@5.0.0))(@swc/core@1.15.3)':
+  '@workflow/nest@4.0.20(@nestjs/common@11.2.1(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.2.1(@nestjs/common@11.2.1(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.1)(@swc/cli@0.8.1(@swc/core@1.15.3)(chokidar@5.0.0))(@swc/core@1.15.3)':
     dependencies:
       '@nestjs/common': 11.2.1(reflect-metadata@0.2.2)(rxjs@7.8.2)
       '@nestjs/core': 11.2.1(@nestjs/common@11.2.1(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2)
       '@swc/cli': 0.8.1(@swc/core@1.15.3)(chokidar@5.0.0)
       '@swc/core': 1.15.3
-      '@workflow/builders': 4.1.9
+      '@workflow/builders': 4.1.9(@opentelemetry/api@1.9.1)
       '@workflow/swc-plugin': 4.1.2(@swc/core@1.15.3)
       pathe: 2.0.3
     transitivePeerDependencies:
@@ -5180,30 +5374,30 @@ snapshots:
       - supports-color
       - ws
 
-  '@workflow/next@4.1.8(next@15.5.9(react-dom@19.2.6(react@19.2.6))(react@19.2.6))':
+  '@workflow/next@4.1.8(@opentelemetry/api@1.9.1)(next@15.5.9(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))':
     dependencies:
       '@swc/core': 1.15.3
-      '@workflow/builders': 4.1.9
-      '@workflow/core': 4.8.4
+      '@workflow/builders': 4.1.9(@opentelemetry/api@1.9.1)
+      '@workflow/core': 4.8.4(@opentelemetry/api@1.9.1)
       '@workflow/swc-plugin': 4.1.2(@swc/core@1.15.3)
       semver: 7.7.4
       watchpack: 2.5.1
     optionalDependencies:
-      next: 15.5.9(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      next: 15.5.9(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
     transitivePeerDependencies:
       - '@opentelemetry/api'
       - '@swc/helpers'
       - supports-color
       - ws
 
-  '@workflow/nitro@4.1.10':
+  '@workflow/nitro@4.1.10(@opentelemetry/api@1.9.1)':
     dependencies:
       '@swc/core': 1.15.3
-      '@workflow/builders': 4.1.9
-      '@workflow/core': 4.8.4
-      '@workflow/rollup': 4.0.19
+      '@workflow/builders': 4.1.9(@opentelemetry/api@1.9.1)
+      '@workflow/core': 4.8.4(@opentelemetry/api@1.9.1)
+      '@workflow/rollup': 4.0.19(@opentelemetry/api@1.9.1)
       '@workflow/swc-plugin': 4.1.2(@swc/core@1.15.3)
-      '@workflow/vite': 4.0.19
+      '@workflow/vite': 4.0.19(@opentelemetry/api@1.9.1)
       '@workflow/web': 4.1.20
       exsolve: 1.0.8
       pathe: 2.0.3
@@ -5213,10 +5407,10 @@ snapshots:
       - supports-color
       - ws
 
-  '@workflow/nuxt@4.0.20':
+  '@workflow/nuxt@4.0.20(@opentelemetry/api@1.9.1)':
     dependencies:
       '@nuxt/kit': 4.4.8
-      '@workflow/nitro': 4.1.10
+      '@workflow/nitro': 4.1.10(@opentelemetry/api@1.9.1)
     transitivePeerDependencies:
       - '@opentelemetry/api'
       - '@swc/helpers'
@@ -5224,10 +5418,10 @@ snapshots:
       - supports-color
       - ws
 
-  '@workflow/rollup@4.0.19':
+  '@workflow/rollup@4.0.19(@opentelemetry/api@1.9.1)':
     dependencies:
       '@swc/core': 1.15.3
-      '@workflow/builders': 4.1.9
+      '@workflow/builders': 4.1.9(@opentelemetry/api@1.9.1)
       '@workflow/swc-plugin': 4.1.2(@swc/core@1.15.3)
       exsolve: 1.0.7
     transitivePeerDependencies:
@@ -5238,14 +5432,14 @@ snapshots:
 
   '@workflow/serde@4.1.2': {}
 
-  '@workflow/sveltekit@4.0.19':
+  '@workflow/sveltekit@4.0.19(@opentelemetry/api@1.9.1)':
     dependencies:
       '@sveltejs/load-config': 0.2.3
       '@swc/core': 1.15.3
-      '@workflow/builders': 4.1.9
-      '@workflow/rollup': 4.0.19
+      '@workflow/builders': 4.1.9(@opentelemetry/api@1.9.1)
+      '@workflow/rollup': 4.0.19(@opentelemetry/api@1.9.1)
       '@workflow/swc-plugin': 4.1.2(@swc/core@1.15.3)
-      '@workflow/vite': 4.0.19
+      '@workflow/vite': 4.0.19(@opentelemetry/api@1.9.1)
       exsolve: 1.0.8
       fs-extra: 11.4.0
       pathe: 2.0.3
@@ -5267,9 +5461,9 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
-  '@workflow/vite@4.0.19':
+  '@workflow/vite@4.0.19(@opentelemetry/api@1.9.1)':
     dependencies:
-      '@workflow/builders': 4.1.9
+      '@workflow/builders': 4.1.9(@opentelemetry/api@1.9.1)
     transitivePeerDependencies:
       - '@opentelemetry/api'
       - '@swc/helpers'
@@ -5282,7 +5476,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@workflow/world-local@4.3.0':
+  '@workflow/world-local@4.3.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@vercel/queue': 0.3.1
       '@workflow/errors': 4.2.1
@@ -5292,8 +5486,10 @@ snapshots:
       ulid: 3.0.2
       undici: 7.28.0
       zod: 4.3.6
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.1
 
-  '@workflow/world-vercel@4.7.0':
+  '@workflow/world-vercel@4.7.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@vercel/oidc': 3.2.0
       '@vercel/queue': 0.3.1
@@ -5302,6 +5498,8 @@ snapshots:
       cbor-x: 1.6.0
       undici: 7.28.0
       zod: 4.3.6
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.1
 
   '@workflow/world@4.4.0':
     dependencies:
@@ -5565,7 +5763,7 @@ snapshots:
   binary-version-check@6.1.0:
     dependencies:
       binary-version: 7.1.0
-      semver: 7.7.3
+      semver: 7.8.5
       semver-truncate: 3.0.0
 
   binary-version@7.1.0:
@@ -5745,6 +5943,8 @@ snapshots:
   citty@0.1.6:
     dependencies:
       consola: 3.4.2
+
+  cjs-module-lexer@2.2.1: {}
 
   clean-stack@3.0.1:
     dependencies:
@@ -6024,6 +6224,8 @@ snapshots:
       internal-slot: 1.1.0
       iterator.prototype: 1.1.5
       safe-array-concat: 1.1.3
+
+  es-module-lexer@2.3.2: {}
 
   es-object-atoms@1.1.1:
     dependencies:
@@ -6700,6 +6902,12 @@ snapshots:
       parent-module: 1.0.1
       resolve-from: 4.0.0
 
+  import-in-the-middle@3.3.3:
+    dependencies:
+      cjs-module-lexer: 2.2.1
+      es-module-lexer: 2.3.2
+      module-details-from-path: 1.0.4
+
   imurmurhash@0.1.4: {}
 
   indent-string@4.0.0: {}
@@ -7058,6 +7266,8 @@ snapshots:
       pkg-types: 1.3.1
       ufo: 1.6.4
 
+  module-details-from-path@1.0.4: {}
+
   ms@2.1.3: {}
 
   mz@2.7.0:
@@ -7078,7 +7288,7 @@ snapshots:
     dependencies:
       content-type: 2.1.0
 
-  next@15.5.9(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
+  next@15.5.9(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
     dependencies:
       '@next/env': 15.5.9
       '@swc/helpers': 0.5.15
@@ -7096,6 +7306,7 @@ snapshots:
       '@next/swc-linux-x64-musl': 15.5.7
       '@next/swc-win32-arm64-msvc': 15.5.7
       '@next/swc-win32-x64-msvc': 15.5.7
+      '@opentelemetry/api': 1.9.1
       sharp: 0.34.5
     transitivePeerDependencies:
       - '@babel/core'
@@ -7474,6 +7685,13 @@ snapshots:
       gopd: 1.2.0
       set-function-name: 2.0.2
 
+  require-in-the-middle@8.0.1:
+    dependencies:
+      debug: 4.4.3(supports-color@8.1.1)
+      module-details-from-path: 1.0.4
+    transitivePeerDependencies:
+      - supports-color
+
   resolve-alpn@1.2.1: {}
 
   resolve-from@4.0.0: {}
@@ -7558,7 +7776,7 @@ snapshots:
 
   semver-truncate@3.0.0:
     dependencies:
-      semver: 7.7.3
+      semver: 7.8.5
 
   semver@6.3.1: {}
 
@@ -8181,21 +8399,23 @@ snapshots:
 
   wordwrap@1.0.0: {}
 
-  workflow@4.8.4(@nestjs/common@11.2.1(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.2.1(@nestjs/common@11.2.1(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@swc/cli@0.8.1(@swc/core@1.15.3)(chokidar@5.0.0))(@swc/core@1.15.3)(next@15.5.9(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(typescript@5.9.3):
+  workflow@4.8.4(@nestjs/common@11.2.1(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.2.1(@nestjs/common@11.2.1(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.1)(@swc/cli@0.8.1(@swc/core@1.15.3)(chokidar@5.0.0))(@swc/core@1.15.3)(next@15.5.9(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(typescript@5.9.3):
     dependencies:
-      '@workflow/astro': 4.0.19
-      '@workflow/cli': 4.3.8
-      '@workflow/core': 4.8.4
+      '@workflow/astro': 4.0.19(@opentelemetry/api@1.9.1)
+      '@workflow/cli': 4.3.8(@opentelemetry/api@1.9.1)
+      '@workflow/core': 4.8.4(@opentelemetry/api@1.9.1)
       '@workflow/errors': 4.2.1
-      '@workflow/nest': 4.0.20(@nestjs/common@11.2.1(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.2.1(@nestjs/common@11.2.1(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@swc/cli@0.8.1(@swc/core@1.15.3)(chokidar@5.0.0))(@swc/core@1.15.3)
-      '@workflow/next': 4.1.8(next@15.5.9(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
-      '@workflow/nitro': 4.1.10
-      '@workflow/nuxt': 4.0.20
-      '@workflow/rollup': 4.0.19
-      '@workflow/sveltekit': 4.0.19
+      '@workflow/nest': 4.0.20(@nestjs/common@11.2.1(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.2.1(@nestjs/common@11.2.1(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.1)(@swc/cli@0.8.1(@swc/core@1.15.3)(chokidar@5.0.0))(@swc/core@1.15.3)
+      '@workflow/next': 4.1.8(@opentelemetry/api@1.9.1)(next@15.5.9(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
+      '@workflow/nitro': 4.1.10(@opentelemetry/api@1.9.1)
+      '@workflow/nuxt': 4.0.20(@opentelemetry/api@1.9.1)
+      '@workflow/rollup': 4.0.19(@opentelemetry/api@1.9.1)
+      '@workflow/sveltekit': 4.0.19(@opentelemetry/api@1.9.1)
       '@workflow/typescript-plugin': 4.0.3(typescript@5.9.3)
       '@workflow/utils': 4.1.4
       ms: 2.1.3
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.1
     transitivePeerDependencies:
       - '@nestjs/common'
       - '@nestjs/core'

--- a/tests/unit/arena/client-build-response.test.ts
+++ b/tests/unit/arena/client-build-response.test.ts
@@ -76,6 +76,7 @@ async function main() {
     IncompleteBuildStreamError,
     isGzipChunk,
     isGzipStreamPrefix,
+    readBuildVariantArtifact,
     readBuildVariantJson,
     readBuildVariantStream,
     streamFromInitialChunks,
@@ -95,8 +96,48 @@ async function main() {
   const decodedJson = await readBuildVariantJson<typeof payload>(new Response(gzippedJson));
   assert.deepEqual(decodedJson, payload);
 
+  const jsonArtifactStages: string[] = [];
+  const jsonArtifact = await readBuildVariantArtifact<typeof payload>(new Response(gzippedJson), {
+    onStage(event) {
+      jsonArtifactStages.push(event.stage);
+    },
+  });
+  assert.equal(jsonArtifact.kind, "json");
+  assert.deepEqual(jsonArtifactStages, [
+    "body_complete",
+    "inflate_complete",
+    "json_decode_complete",
+  ]);
+
+  const { encodeBinaryArtifact } = await import("../../../lib/arena/binaryArtifact");
+  const binaryArtifactStages: string[] = [];
+  const encodedBinaryArtifact = encodeBinaryArtifact(
+    { buildId: "test-build", variant: "preview", serverValidated: true },
+    payload.voxelBuild.blocks,
+  );
+  const binaryArtifact = await readBuildVariantArtifact(
+    new Response(
+      encodedBinaryArtifact.buffer.slice(
+        encodedBinaryArtifact.byteOffset,
+        encodedBinaryArtifact.byteOffset + encodedBinaryArtifact.byteLength,
+      ) as ArrayBuffer,
+    ),
+    {
+      onStage(event) {
+        binaryArtifactStages.push(event.stage);
+      },
+    },
+  );
+  assert.equal(binaryArtifact.kind, "binary");
+  assert.deepEqual(binaryArtifactStages, [
+    "body_complete",
+    "inflate_complete",
+    "binary_decode_complete",
+  ]);
+
   const { blocks, events } = successfulEvents();
   const progressBuilds: object[] = [];
+  const streamStages: string[] = [];
   const progress: Array<{
     receivedBlocks: number;
     totalBlocks: number | null;
@@ -105,6 +146,9 @@ async function main() {
   }> = [];
   const plainResponse = responseFromChunks([ndjson(...events)]);
   const decoded = await readBuildVariantStream(plainResponse, {
+    onStage(stage) {
+      streamStages.push(stage);
+    },
     onProgress(build, value) {
       progressBuilds.push(build);
       progress.push(value);
@@ -127,6 +171,7 @@ async function main() {
   assert.equal(progress.at(-1)?.chunkIndex, 2);
   assert.equal(progress.at(-1)?.chunkCount, 2);
   assert.equal(plainResponse.body?.locked, false);
+  assert.deepEqual(streamStages, ["body_complete", "stream_decode_complete"]);
 
   const repeatedHello = await readBuildVariantStream(
     responseFromChunks([

--- a/tests/unit/arena/snapshot-artifact-format-cache.test.ts
+++ b/tests/unit/arena/snapshot-artifact-format-cache.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { gzipSync } from "node:zlib";
 
 const originalFetch = globalThis.fetch;
 const originalEnv = {
@@ -31,24 +32,43 @@ async function main() {
       return new Response("missing", { status: 404 });
     }
     if (url.endsWith(".json")) {
-      return new Response('{"ok":true}', { status: 200 });
+      return new Response(new Uint8Array(gzipSync(Buffer.from('{"ok":true}'))), { status: 200 });
     }
     throw new Error(`Unexpected URL: ${url}`);
   }) as typeof fetch;
 
   const buildId = "format-cache-build";
   const checksum = "a".repeat(64);
+  const binaryMetrics = { cacheStatus: "miss" as const };
   const binary = await fetchArenaBuildSnapshotArtifact(buildId, "full", checksum, {
     format: "binary",
+    metrics: binaryMetrics,
   });
   assert.equal(binary, null);
+  assert.equal(binaryMetrics.cacheStatus, "miss");
 
+  const jsonMetrics = { cacheStatus: "miss" as const, transferBytes: 0, decodedBytes: 0, inflateMs: 0 };
   const json = await fetchArenaBuildSnapshotArtifact(buildId, "full", checksum, {
     format: "json",
+    metrics: jsonMetrics,
   });
   assert.ok(json);
   assert.equal(new TextDecoder().decode(json), '{"ok":true}');
+  assert.equal(jsonMetrics.cacheStatus, "miss");
+  assert.ok(jsonMetrics.transferBytes > jsonMetrics.decodedBytes);
+  assert.equal(jsonMetrics.decodedBytes, json.byteLength);
+  assert.ok(jsonMetrics.inflateMs >= 0);
   assert.equal(requests.length, 2, "a binary miss must not suppress the JSON request");
+
+  const cachedMetrics = { cacheStatus: "miss" as const, decodedBytes: 0 };
+  const cachedJson = await fetchArenaBuildSnapshotArtifact(buildId, "full", checksum, {
+    format: "json",
+    metrics: cachedMetrics,
+  });
+  assert.ok(cachedJson);
+  assert.equal(cachedMetrics.cacheStatus, "body-cache");
+  assert.equal(cachedMetrics.decodedBytes, cachedJson.byteLength);
+  assert.equal(requests.length, 2, "a body cache hit must not fetch storage again");
 
   const privateBuildId = "private-format-cache-build";
   await fetchArenaBuildSnapshotArtifact(privateBuildId, "full", checksum, {

--- a/tests/unit/observability/arena-metrics.test.ts
+++ b/tests/unit/observability/arena-metrics.test.ts
@@ -29,6 +29,21 @@ async function main() {
   assert.ok((trace.duration("start", "end") ?? -1) >= 0);
   assert.ok((trace.measure("total", "start", "end") ?? -1) >= 0);
   assert.equal(trace.duration("missing", "end"), null);
+  assert.equal(
+    performance
+      .getEntries()
+      .some((entry) => entry.name.startsWith("minebench:arena:test:")),
+    true,
+  );
+  trace.clear();
+  assert.equal(trace.duration("start", "end"), null);
+  assert.equal(
+    performance
+      .getEntries()
+      .some((entry) => entry.name.startsWith("minebench:arena:test:")),
+    false,
+  );
+  trace.clear();
 
   console.log("arena observability metric checks passed");
 }

--- a/tests/unit/observability/arena-metrics.test.ts
+++ b/tests/unit/observability/arena-metrics.test.ts
@@ -1,0 +1,39 @@
+import assert from "node:assert/strict";
+import {
+  getArenaBlockCountBucket,
+  getArenaLatencyBucket,
+  roundMetricMs,
+} from "../../../lib/observability/arenaMetrics";
+import { createBrowserPerformanceTrace } from "../../../lib/observability/browserPerformance";
+
+async function main() {
+  assert.equal(getArenaLatencyBucket(99.99), "under-100ms");
+  assert.equal(getArenaLatencyBucket(100), "100-250ms");
+  assert.equal(getArenaLatencyBucket(999.99), "500-1000ms");
+  assert.equal(getArenaLatencyBucket(10_000), "10s-plus");
+
+  assert.equal(getArenaBlockCountBucket(null), "unknown");
+  assert.equal(getArenaBlockCountBucket(0), "empty");
+  assert.equal(getArenaBlockCountBucket(7_999), "under-8k");
+  assert.equal(getArenaBlockCountBucket(8_000), "8k-50k");
+  assert.equal(getArenaBlockCountBucket(299_999), "150k-300k");
+  assert.equal(getArenaBlockCountBucket(1_000_000), "1m-plus");
+
+  assert.equal(roundMetricMs(12.345), 12.35);
+  assert.equal(roundMetricMs(Number.NaN), null);
+  assert.equal(roundMetricMs(-1), null);
+
+  const trace = createBrowserPerformanceTrace("test");
+  trace.mark("start");
+  trace.mark("end");
+  assert.ok((trace.duration("start", "end") ?? -1) >= 0);
+  assert.ok((trace.measure("total", "start", "end") ?? -1) >= 0);
+  assert.equal(trace.duration("missing", "end"), null);
+
+  console.log("arena observability metric checks passed");
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/tests/unit/stealth/privacy-contract.test.ts
+++ b/tests/unit/stealth/privacy-contract.test.ts
@@ -32,6 +32,18 @@ const arenaBuildRoute = read("app/api/arena/builds/[buildId]/route.ts");
 assert.match(arenaBuildRoute, /cache: buildAccess \? "no-store"/);
 assert.match(arenaBuildRoute, /const binaryFormatRequested = url\.searchParams\.get\("format"\) === "v4"/);
 assert.match(arenaBuildRoute, /rewriteBlindBinaryArtifactIdentity\(artifactBytes, clientBuildId\)/);
+const serverDeliveryTelemetry = arenaBuildRoute.slice(
+  arenaBuildRoute.indexOf("function logArenaBuildDelivery"),
+  arenaBuildRoute.indexOf("// short process cache"),
+);
+assert.doesNotMatch(serverDeliveryTelemetry, /buildId|checksum|requestedBuildId|clientBuildId/);
+
+const arenaClient = read("components/arena/Arena.tsx");
+const clientDeliveryTelemetry = arenaClient.slice(
+  arenaClient.indexOf("function reportBuildDeliveryMetrics"),
+  arenaClient.indexOf("type FetchBuildVariantStreamOptions"),
+);
+assert.doesNotMatch(clientDeliveryTelemetry, /buildId|checksum|requestedBuildId|clientBuildId/);
 assert.match(read("app/api/arena/matchup/route.ts"), /cache: privateAccessOnly \? "no-store"/);
 
 const generation = read("lib/stealth/generation.ts");

--- a/tests/unit/voxel/mesh-atlas-cache.test.ts
+++ b/tests/unit/voxel/mesh-atlas-cache.test.ts
@@ -1,6 +1,11 @@
 import assert from "node:assert/strict";
 import * as THREE from "three";
-import { configureAtlasTexture } from "../../../lib/voxel/mesh";
+import { getPalette } from "../../../lib/blocks/palettes";
+import {
+  configureAtlasTexture,
+  createVoxelGroupAsync,
+  type VoxelMeshStageEvent,
+} from "../../../lib/voxel/mesh";
 import {
   CACHE_VERSION,
   buildPersistentMeshCacheKey,
@@ -65,6 +70,31 @@ async function main() {
     assert.equal(table.get(0, 0, 513), -1);
     assert.equal(table.get(-1, 0, 0), -1);
     assert.equal(table.get(1024, 0, 0), -1);
+  }
+
+  {
+    const stages: VoxelMeshStageEvent[] = [];
+    const group = await createVoxelGroupAsync(
+      {
+        version: "1.0",
+        blocks: [{ x: 0, y: 0, z: 0, type: "stone" }],
+      },
+      getPalette("simple"),
+      new THREE.Texture(),
+      {
+        yieldAfterMs: Number.POSITIVE_INFINITY,
+        onStage(event) {
+          stages.push(event);
+        },
+      },
+    );
+    assert.deepEqual(
+      stages.map((event) => event.stage),
+      ["mesh_started", "mesh_payload_complete", "three_group_complete"],
+    );
+    assert.ok(stages.every((event) => event.strategy === "local"));
+    assert.equal(stages.at(-1)?.cacheStatus, "not-used");
+    group.dispose();
   }
 
   console.log("mesh atlas cache and texture configuration checks passed");


### PR DESCRIPTION
## Summary

- register Vercel OpenTelemetry and Speed Insights for the web application
- add complete build-route timing for token validation, artifact resolution and fetch, inflate, blind identity rewrite, deflate, body readiness, and total preparation
- annotate traces and emit structured delivery logs with bounded artifact, cache, format, source, fallback, and block-count dimensions
- measure matchup receipt, preview/full delivery, headers, body completion, binary or JSON decode, atlas readiness, meshing, Three.js assembly, first render, and reveal completion in the browser
- emit v4 requested-versus-served coverage events so optimized artifact misses and fallback paths are directly filterable
- keep blind telemetry free of build IDs, checksums, tokens, prompts, model identity, and Storage paths

## Validation

- `pnpm exec tsc --noEmit`
- `pnpm lint`
- `pnpm test:unit` — 61 test files passed
- `pnpm build`
- focused decoder, artifact-cache, mesh-stage, metric-boundary, and blind-privacy regressions

The two lint warnings are pre-existing generated Workflow route directives.

*(PR written by Codex)*