### PR TITLE
feat(observability): emit Vercel custom metrics

### DIFF
--- a/app/api/arena/builds/[buildId]/route.ts
+++ b/app/api/arena/builds/[buildId]/route.ts
@@ -31,6 +31,11 @@ import {
   roundMetricMs,
 } from "@/lib/observability/arenaMetrics";
 import {
+  emitArenaBuildCustomMetrics,
+  type ArenaBuildMetricObservation,
+  type ArenaBuildMetricStage,
+} from "@/lib/observability/customMetrics";
+import {
   setActiveServerSpanAttributes,
   withServerSpan,
   withServerSpanSync,
@@ -74,38 +79,15 @@ type CachedJsonResponse = {
   touchedAt: number;
 };
 
-type ArenaBuildTimingStage =
-  | "token_validate"
-  | "artifact_resolve"
-  | "artifact_fetch"
-  | "inflate"
-  | "identity_rewrite"
-  | "deflate"
-  | "body_ready"
-  | "total";
-
-type ArenaBuildDeliveryObservation = {
-  access: "blind" | "public";
-  variant: ArenaBuildVariant;
-  requestedFormat: "v4" | "legacy";
-  servedFormat: "binary" | "json" | "ndjson" | "none";
-  deliveryClass: string;
-  source: string;
-  artifactOutcome: string;
+type ArenaBuildDeliveryObservation = ArenaBuildMetricObservation & {
   artifactCacheStatus: string;
   fallbackReason: string | null;
-  blockCount: number | null;
-  responseBytes: number | null;
-  transferBytes: number | null;
-  decodedBytes: number | null;
   gzip: boolean;
-  optimizedExpected: boolean;
-  optimizedDelivered: boolean;
 };
 
 function logArenaBuildDelivery(
   observation: ArenaBuildDeliveryObservation,
-  stages: Partial<Record<ArenaBuildTimingStage, number>>,
+  stages: Partial<Record<ArenaBuildMetricStage, number>>,
   status: number,
 ) {
   const blockCountBucket = getArenaBlockCountBucket(observation.blockCount);
@@ -136,6 +118,7 @@ function logArenaBuildDelivery(
       ...roundedStages,
     }),
   );
+  emitArenaBuildCustomMetrics(observation, stages, status);
 
   // Web Analytics Plus accepts at most eight properties per custom event
   after(async () => {
@@ -327,7 +310,7 @@ export async function GET(
 ) {
   const timing = new ServerTiming();
   const requestStartedAt = timing.start();
-  const stages: Partial<Record<ArenaBuildTimingStage, number>> = {};
+  const stages: Partial<Record<ArenaBuildMetricStage, number>> = {};
   const url = new URL(request.url);
   const variant = parseVariant(url.searchParams.get("variant"));
   const binaryFormatRequested = url.searchParams.get("format") === "v4";
@@ -351,13 +334,13 @@ export async function GET(
     optimizedDelivered: false,
   };
 
-  const recordStage = (stage: ArenaBuildTimingStage, durationMs: number) => {
+  const recordStage = (stage: ArenaBuildMetricStage, durationMs: number) => {
     if (!Number.isFinite(durationMs) || durationMs < 0) return;
     stages[stage] = (stages[stage] ?? 0) + durationMs;
     timing.add(stage, durationMs);
   };
   const measureStageSync = <T,>(
-    stage: ArenaBuildTimingStage,
+    stage: ArenaBuildMetricStage,
     spanName: string,
     attributes: Record<string, string | number | boolean>,
     operation: () => T,
@@ -370,7 +353,7 @@ export async function GET(
     }
   };
   const measureStage = async <T,>(
-    stage: ArenaBuildTimingStage,
+    stage: ArenaBuildMetricStage,
     spanName: string,
     attributes: Record<string, string | number | boolean>,
     operation: () => Promise<T>,

--- a/app/api/observability/client-metrics/route.ts
+++ b/app/api/observability/client-metrics/route.ts
@@ -1,0 +1,61 @@
+import { NextResponse } from "next/server";
+import {
+  clientMetricBatchSchema,
+  emitClientCustomMetrics,
+} from "@/lib/observability/customMetrics";
+
+export const runtime = "nodejs";
+
+const MAX_BODY_BYTES = 64 * 1024;
+
+function isSameOriginRequest(request: Request): boolean {
+  const candidate = request.headers.get("origin") ?? request.headers.get("referer");
+  if (!candidate) return false;
+
+  try {
+    return new URL(candidate).origin === new URL(request.url).origin;
+  } catch {
+    return false;
+  }
+}
+
+export async function POST(request: Request) {
+  if (process.env.NODE_ENV === "production") {
+    const fetchSite = request.headers.get("sec-fetch-site");
+    if (
+      !isSameOriginRequest(request) ||
+      (fetchSite && fetchSite !== "same-origin" && fetchSite !== "same-site")
+    ) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+  }
+
+  const contentLength = Number.parseInt(request.headers.get("content-length") ?? "", 10);
+  if (Number.isFinite(contentLength) && contentLength > MAX_BODY_BYTES) {
+    return NextResponse.json({ error: "Payload too large" }, { status: 413 });
+  }
+
+  let raw: string;
+  try {
+    raw = await request.text();
+  } catch {
+    return NextResponse.json({ error: "Invalid metrics payload" }, { status: 400 });
+  }
+  if (Buffer.byteLength(raw) > MAX_BODY_BYTES) {
+    return NextResponse.json({ error: "Payload too large" }, { status: 413 });
+  }
+
+  let payload: unknown;
+  try {
+    payload = JSON.parse(raw) as unknown;
+  } catch {
+    return NextResponse.json({ error: "Invalid metrics payload" }, { status: 400 });
+  }
+  const parsed = clientMetricBatchSchema.safeParse(payload);
+  if (!parsed.success) {
+    return NextResponse.json({ error: "Invalid metrics payload" }, { status: 400 });
+  }
+
+  emitClientCustomMetrics(parsed.data.samples);
+  return new Response(null, { status: 204 });
+}

--- a/components/arena/Arena.tsx
+++ b/components/arena/Arena.tsx
@@ -42,6 +42,10 @@ import {
   createBrowserPerformanceTrace,
   type BrowserPerformanceTrace,
 } from "@/lib/observability/browserPerformance";
+import {
+  enqueueClientMetric,
+  enqueueVoxelMetric,
+} from "@/lib/observability/clientMetrics";
 
 type ArenaState =
   | { kind: "loading" }
@@ -173,15 +177,32 @@ async function fetchMatchupOnce(promptId?: string, signal?: AbortSignal): Promis
     };
     trace.mark("matchup_received");
     const totalMs = trace.measure("total", "fetch_start", "matchup_received") ?? 0;
+    const headersMs = roundMetricMs(
+      trace.measure("headers", "fetch_start", "headers_received"),
+    );
+    const bodyMs = roundMetricMs(
+      trace.measure("body", "headers_received", "matchup_received"),
+    );
+    const laneABlocks = getArenaBlockCountBucket(voxelBuildBlockCount(packedMatchup.a.build));
+    const laneBBlocks = getArenaBlockCountBucket(voxelBuildBlockCount(packedMatchup.b.build));
     trackEvent("arena_matchup_received", {
       path: `${promptId ? "forced" : "random"}:adaptive`,
       samplingLane: matchup.samplingLane ?? "unknown",
-      laneABlocks: getArenaBlockCountBucket(voxelBuildBlockCount(packedMatchup.a.build)),
-      laneBBlocks: getArenaBlockCountBucket(voxelBuildBlockCount(packedMatchup.b.build)),
-      headersMs: roundMetricMs(trace.measure("headers", "fetch_start", "headers_received")),
-      bodyMs: roundMetricMs(trace.measure("body", "headers_received", "matchup_received")),
+      laneABlocks,
+      laneBBlocks,
+      headersMs,
+      bodyMs,
       totalMs: roundMetricMs(totalMs),
       latency: getArenaLatencyBucket(totalMs),
+    });
+    enqueueClientMetric({
+      kind: "matchup",
+      mode: promptId ? "forced" : "random",
+      laneABlocks,
+      laneBBlocks,
+      headersMs,
+      bodyMs,
+      totalMs: roundMetricMs(totalMs),
     });
     return packedMatchup;
   } finally {
@@ -314,7 +335,15 @@ async function readMeasuredBuildVariantPayload(
   return result;
 }
 
-function normalizeBuildSource(response: Response): string {
+type BuildMetricSource =
+  | "artifact"
+  | "live"
+  | "artifact-required"
+  | "artifact-redirect"
+  | "response-cache"
+  | "unknown";
+
+function normalizeBuildSource(response: Response): BuildMetricSource {
   const source =
     response.headers.get("x-build-source") ?? response.headers.get("x-build-stream-source");
   if (source === "artifact") return "artifact";
@@ -359,6 +388,18 @@ function reportBuildDeliveryMetrics(opts: {
     opts.requestedFormat === "v4" &&
     opts.servedFormat === "binary" &&
     (source === "artifact" || source === "artifact-redirect");
+  const headersMs = roundMetricMs(
+    metrics.trace.measure("headers", metrics.startStage, "headers_received"),
+  );
+  const bodyMs = roundMetricMs(
+    metrics.trace.measure("body", "headers_received", "body_complete"),
+  );
+  const inflateMs = roundMetricMs(
+    metrics.trace.measure("inflate", "body_complete", "inflate_complete"),
+  );
+  const decodeMs = roundMetricMs(
+    metrics.trace.measure("decode", "inflate_complete", "decode_complete"),
+  );
 
   // Web Analytics Plus accepts at most eight properties per custom event
   trackEvent("arena_build_delivery", {
@@ -374,18 +415,28 @@ function reportBuildDeliveryMetrics(opts: {
   trackEvent("arena_build_delivery_timing", {
     path: `${path}:${opts.servedFormat}`,
     blockCountBucket,
-    headersMs: roundMetricMs(
-      metrics.trace.measure("headers", metrics.startStage, "headers_received"),
-    ),
-    bodyMs: roundMetricMs(
-      metrics.trace.measure("body", "headers_received", "body_complete"),
-    ),
-    inflateMs: roundMetricMs(
-      metrics.trace.measure("inflate", "body_complete", "inflate_complete"),
-    ),
-    decodeMs: roundMetricMs(
-      metrics.trace.measure("decode", "inflate_complete", "decode_complete"),
-    ),
+    headersMs,
+    bodyMs,
+    inflateMs,
+    decodeMs,
+    totalMs: roundMetricMs(totalMs),
+    bodyBytes: opts.bodyBytes,
+  });
+  enqueueClientMetric({
+    kind: "delivery",
+    purpose: metrics.purpose,
+    variant: opts.ref.variant,
+    transport: metrics.transport,
+    requestedFormat: opts.requestedFormat,
+    servedFormat: opts.servedFormat,
+    source,
+    blockCountBucket,
+    compressed: opts.compressed,
+    optimized,
+    headersMs,
+    bodyMs,
+    inflateMs,
+    decodeMs,
     totalMs: roundMetricMs(totalMs),
     bodyBytes: opts.bodyBytes,
   });
@@ -416,6 +467,7 @@ function reportBuildRenderMetrics(
     totalMs: roundMetricMs(metrics.totalMs),
     animated: metrics.animated,
   });
+  enqueueVoxelMetric("arena", variant, metrics);
 }
 
 type FetchBuildVariantStreamOptions = {

--- a/components/sandbox/SandboxBenchmark.tsx
+++ b/components/sandbox/SandboxBenchmark.tsx
@@ -44,6 +44,7 @@ import {
   parseSandboxComparisonDeepLink,
 } from "@/lib/deepLinks";
 import type { RenderableVoxelBuild } from "@/lib/voxel/packedBlocks";
+import { enqueueVoxelMetric } from "@/lib/observability/clientMetrics";
 
 type Palette = "simple" | "advanced";
 type GridSize = 64 | 256 | 512;
@@ -1009,6 +1010,11 @@ export function SandboxBenchmark() {
             loadingMessage={loadingMessage}
             loadingProgress={isHydrating ? laneState.progress ?? undefined : undefined}
             viewerRef={viewerRef}
+            onBuildMetrics={
+              laneState.phase === "ready"
+                ? (metrics) => enqueueVoxelMetric("sandbox", "full", metrics)
+                : undefined
+            }
             enableBuildExport={hasRenderableBuild && laneState.phase === "ready" && Boolean(build && model)}
             exportLabel={title}
             exportPrompt={selectedPromptText}

--- a/components/sandbox/SandboxLive.tsx
+++ b/components/sandbox/SandboxLive.tsx
@@ -14,6 +14,7 @@ import { readClientErrorResponse } from "@/lib/clientErrorResponse";
 import type { VoxelBuild } from "@/lib/voxel/types";
 import { parseVoxelBuildSpec, validateVoxelBuild } from "@/lib/voxel/validate";
 import { getPalette } from "@/lib/blocks/palettes";
+import { enqueueVoxelMetric } from "@/lib/observability/clientMetrics";
 
 type Palette = "simple" | "advanced";
 type GridSize = 64 | 256 | 512;
@@ -893,6 +894,11 @@ export function SandboxLive({ initialPrompt }: { initialPrompt?: string }) {
         jsonText={r?.rawText}
         palette={palette}
         viewerRef={viewerRef}
+        onBuildMetrics={
+          r?.status === "success"
+            ? (metrics) => enqueueVoxelMetric("sandbox", "full", metrics)
+            : undefined
+        }
         enableBuildJsonToggle
         enableBuildExport={r?.status === "success"}
         exportLabel={modelName}

--- a/lib/observability/clientMetrics.ts
+++ b/lib/observability/clientMetrics.ts
@@ -1,0 +1,65 @@
+import type { ArenaBuildVariant } from "@/lib/arena/types";
+import type { VoxelViewerBuildMetrics } from "@/components/voxel/VoxelViewer";
+import type { ClientMetricSample } from "@/lib/observability/customMetrics";
+import {
+  getArenaBlockCountBucket,
+  roundMetricMs,
+} from "@/lib/observability/arenaMetrics";
+
+const MAX_BATCH_SIZE = 50;
+const FLUSH_DELAY_MS = 1_000;
+const pendingSamples: ClientMetricSample[] = [];
+let flushTimer: ReturnType<typeof setTimeout> | null = null;
+
+function flushClientMetrics() {
+  if (flushTimer) clearTimeout(flushTimer);
+  flushTimer = null;
+  const samples = pendingSamples.splice(0, MAX_BATCH_SIZE);
+  if (samples.length === 0) return;
+
+  void fetch("/api/observability/client-metrics", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ samples }),
+    keepalive: true,
+  }).catch(() => undefined);
+
+  if (pendingSamples.length > 0) {
+    flushTimer = setTimeout(flushClientMetrics, FLUSH_DELAY_MS);
+  }
+}
+
+export function enqueueClientMetric(sample: ClientMetricSample) {
+  if (typeof window === "undefined") return;
+  pendingSamples.push(sample);
+  if (pendingSamples.length >= MAX_BATCH_SIZE) {
+    flushClientMetrics();
+  } else if (!flushTimer) {
+    flushTimer = setTimeout(flushClientMetrics, FLUSH_DELAY_MS);
+  }
+}
+
+export function enqueueVoxelMetric(
+  surface: "arena" | "sandbox",
+  variant: ArenaBuildVariant,
+  metrics: VoxelViewerBuildMetrics,
+) {
+  enqueueClientMetric({
+    kind: "voxel",
+    surface,
+    variant,
+    strategy: metrics.strategy,
+    cacheStatus: metrics.cacheStatus,
+    blockCountBucket: getArenaBlockCountBucket(metrics.inputBlockCount),
+    renderedBlockCountBucket: getArenaBlockCountBucket(metrics.renderedBlockCount),
+    animated: metrics.animated,
+    queueMs: roundMetricMs(metrics.queueMs),
+    atlasMs: roundMetricMs(metrics.atlasMs),
+    payloadMs: roundMetricMs(metrics.payloadMs),
+    groupMs: roundMetricMs(metrics.groupMs),
+    meshMs: roundMetricMs(metrics.meshMs),
+    firstRenderMs: roundMetricMs(metrics.firstRenderMs),
+    revealMs: roundMetricMs(metrics.revealMs),
+    totalMs: roundMetricMs(metrics.totalMs),
+  });
+}

--- a/lib/observability/customMetrics.ts
+++ b/lib/observability/customMetrics.ts
@@ -1,0 +1,321 @@
+import { metric } from "@vercel/functions";
+import { z } from "zod";
+import type { ArenaBuildVariant } from "@/lib/arena/types";
+import {
+  getArenaBlockCountBucket,
+  roundMetricMs,
+} from "@/lib/observability/arenaMetrics";
+
+const durationSchema = z.number().finite().nonnegative().nullable();
+const blockCountBucketSchema = z.enum([
+  "empty",
+  "under-8k",
+  "8k-50k",
+  "50k-150k",
+  "150k-300k",
+  "300k-1m",
+  "1m-plus",
+  "unknown",
+]);
+
+const matchupMetricSchema = z
+  .object({
+    kind: z.literal("matchup"),
+    mode: z.enum(["random", "forced"]),
+    laneABlocks: blockCountBucketSchema,
+    laneBBlocks: blockCountBucketSchema,
+    headersMs: durationSchema,
+    bodyMs: durationSchema,
+    totalMs: durationSchema,
+  })
+  .strict();
+
+const deliveryMetricSchema = z
+  .object({
+    kind: z.literal("delivery"),
+    purpose: z.enum(["visible", "prefetch"]),
+    variant: z.enum(["preview", "full"]),
+    transport: z.enum(["snapshot", "stream-artifact", "stream-live"]),
+    requestedFormat: z.enum(["v4", "json", "ndjson"]),
+    servedFormat: z.enum(["binary", "json", "ndjson"]),
+    source: z.enum([
+      "artifact",
+      "live",
+      "artifact-required",
+      "artifact-redirect",
+      "response-cache",
+      "unknown",
+    ]),
+    blockCountBucket: blockCountBucketSchema,
+    compressed: z.boolean(),
+    optimized: z.boolean(),
+    headersMs: durationSchema,
+    bodyMs: durationSchema,
+    inflateMs: durationSchema,
+    decodeMs: durationSchema,
+    totalMs: durationSchema,
+    bodyBytes: z.number().int().nonnegative().nullable(),
+  })
+  .strict();
+
+const voxelMetricSchema = z
+  .object({
+    kind: z.literal("voxel"),
+    surface: z.enum(["arena", "sandbox"]),
+    variant: z.enum(["preview", "full"]),
+    strategy: z.enum(["local", "worker", "worker-fallback"]),
+    cacheStatus: z.enum(["hit", "miss", "disabled", "not-used"]),
+    blockCountBucket: blockCountBucketSchema,
+    renderedBlockCountBucket: blockCountBucketSchema,
+    animated: z.boolean(),
+    queueMs: durationSchema,
+    atlasMs: durationSchema,
+    payloadMs: durationSchema,
+    groupMs: durationSchema,
+    meshMs: durationSchema,
+    firstRenderMs: durationSchema,
+    revealMs: durationSchema,
+    totalMs: durationSchema,
+  })
+  .strict();
+
+export const clientMetricBatchSchema = z
+  .object({
+    samples: z
+      .array(
+        z.discriminatedUnion("kind", [
+          matchupMetricSchema,
+          deliveryMetricSchema,
+          voxelMetricSchema,
+        ]),
+      )
+      .min(1)
+      .max(50),
+  })
+  .strict();
+
+export type ClientMetricSample = z.infer<
+  typeof clientMetricBatchSchema
+>["samples"][number];
+
+export type ArenaBuildMetricStage =
+  | "token_validate"
+  | "artifact_resolve"
+  | "artifact_fetch"
+  | "inflate"
+  | "identity_rewrite"
+  | "deflate"
+  | "body_ready"
+  | "total";
+
+export type ArenaBuildMetricObservation = {
+  access: "blind" | "public";
+  variant: ArenaBuildVariant;
+  requestedFormat: "v4" | "legacy";
+  servedFormat: "binary" | "json" | "ndjson" | "none";
+  deliveryClass: string;
+  source: string;
+  artifactOutcome: string;
+  blockCount: number | null;
+  responseBytes: number | null;
+  transferBytes: number | null;
+  decodedBytes: number | null;
+  optimizedExpected: boolean;
+  optimizedDelivered: boolean;
+};
+
+export type CustomMetricEmitter = (
+  name: string,
+  value: number,
+  tags?: Record<string, string>,
+) => void;
+
+function emitMetric(
+  emit: CustomMetricEmitter,
+  name: string,
+  value: number | null | undefined,
+  tags: Record<string, string>,
+) {
+  if (value == null || !Number.isFinite(value) || value < 0) return;
+  try {
+    emit(name, value, tags);
+  } catch {
+    // Metrics must never affect the request they describe
+  }
+}
+
+function normalizeServerSource(value: string): string {
+  if (value.startsWith("response-cache:")) return "response-cache";
+  return [
+    "unknown",
+    "rejected",
+    "metadata-miss",
+    "artifact-redirect",
+    "artifact",
+    "artifact-redirect-miss",
+    "stream-required",
+    "live-prepare",
+    "live",
+  ].includes(value)
+    ? value
+    : "unknown";
+}
+
+function normalizeArtifactOutcome(value: string): string {
+  return [
+    "not-attempted",
+    "invalid-token",
+    "checksum-mismatch",
+    "not-found",
+    "private",
+    "redirect",
+    "hit",
+    "miss",
+    "response-cache",
+    "redirect-miss",
+    "not-eligible",
+    "prepare-error",
+    "live",
+  ].includes(value)
+    ? value
+    : "unknown";
+}
+
+function normalizeDeliveryClass(value: string): string {
+  return ["inline", "snapshot", "stream-live", "stream-artifact"].includes(value)
+    ? value
+    : "unknown";
+}
+
+function getStatusClass(status: number): string {
+  if (status < 300) return "success";
+  if (status < 400) return "redirect";
+  if (status < 500) return "client-error";
+  return "server-error";
+}
+
+export function emitArenaBuildCustomMetrics(
+  observation: ArenaBuildMetricObservation,
+  stages: Partial<Record<ArenaBuildMetricStage, number>>,
+  status: number,
+  emit: CustomMetricEmitter = metric,
+) {
+  const tags = {
+    access: observation.access,
+    variant: observation.variant,
+    format: `${observation.requestedFormat}-${observation.servedFormat}`,
+    source: normalizeServerSource(observation.source),
+    outcome: normalizeArtifactOutcome(observation.artifactOutcome),
+    delivery_class: normalizeDeliveryClass(observation.deliveryClass),
+    block_bucket: getArenaBlockCountBucket(observation.blockCount),
+  };
+
+  for (const [stage, value] of Object.entries(stages)) {
+    emitMetric(emit, "minebench.arena.build.stage_ms", roundMetricMs(value), {
+      ...tags,
+      stage,
+    });
+  }
+
+  for (const [kind, value] of [
+    ["response", observation.responseBytes],
+    ["transfer", observation.transferBytes],
+    ["decoded", observation.decodedBytes],
+  ] as const) {
+    emitMetric(emit, "minebench.arena.build.bytes", value, { ...tags, kind });
+  }
+
+  emitMetric(emit, "minebench.arena.build.request", 1, {
+    ...tags,
+    status: getStatusClass(status),
+  });
+
+  if (status >= 200 && status < 400) {
+    emitMetric(emit, "minebench.arena.build.delivery", 1, {
+      ...tags,
+      optimized: String(observation.optimizedDelivered),
+    });
+    if (observation.optimizedExpected && !observation.optimizedDelivered) {
+      emitMetric(emit, "minebench.arena.build.optimized_miss", 1, tags);
+    }
+  }
+}
+
+function emitStages(
+  emit: CustomMetricEmitter,
+  name: string,
+  tags: Record<string, string>,
+  stages: Record<string, number | null>,
+) {
+  for (const [stage, value] of Object.entries(stages)) {
+    emitMetric(emit, name, value, { ...tags, stage });
+  }
+}
+
+export function emitClientCustomMetrics(
+  samples: readonly ClientMetricSample[],
+  emit: CustomMetricEmitter = metric,
+) {
+  for (const sample of samples) {
+    if (sample.kind === "matchup") {
+      const tags = {
+        mode: sample.mode,
+        lane_a_blocks: sample.laneABlocks,
+        lane_b_blocks: sample.laneBBlocks,
+      };
+      emitStages(emit, "minebench.arena.matchup.stage_ms", tags, {
+        headers: sample.headersMs,
+        body: sample.bodyMs,
+        total: sample.totalMs,
+      });
+      emitMetric(emit, "minebench.arena.matchup.complete", 1, tags);
+      continue;
+    }
+
+    if (sample.kind === "delivery") {
+      const tags = {
+        purpose: sample.purpose,
+        variant: sample.variant,
+        transport: sample.transport,
+        format: `${sample.requestedFormat}-${sample.servedFormat}`,
+        source: sample.source,
+        block_bucket: sample.blockCountBucket,
+        encoding: sample.compressed ? "gzip" : "identity",
+      };
+      emitStages(emit, "minebench.arena.delivery.stage_ms", tags, {
+        headers: sample.headersMs,
+        body: sample.bodyMs,
+        inflate: sample.inflateMs,
+        decode: sample.decodeMs,
+        total: sample.totalMs,
+      });
+      emitMetric(emit, "minebench.arena.delivery.body_bytes", sample.bodyBytes, tags);
+      emitMetric(emit, "minebench.arena.delivery.complete", 1, {
+        ...tags,
+        optimized: String(sample.optimized),
+      });
+      continue;
+    }
+
+    const tags = {
+      surface: sample.surface,
+      variant: sample.variant,
+      strategy: sample.strategy,
+      cache: sample.cacheStatus,
+      block_bucket: sample.blockCountBucket,
+      rendered_bucket: sample.renderedBlockCountBucket,
+      animated: String(sample.animated),
+    };
+    emitStages(emit, "minebench.voxel.stage_ms", tags, {
+      queue: sample.queueMs,
+      atlas: sample.atlasMs,
+      payload: sample.payloadMs,
+      group: sample.groupMs,
+      mesh: sample.meshMs,
+      first_render: sample.firstRenderMs,
+      reveal: sample.revealMs,
+      total: sample.totalMs,
+    });
+    emitMetric(emit, "minebench.voxel.build", 1, tags);
+  }
+}

--- a/lib/observability/customMetrics.ts
+++ b/lib/observability/customMetrics.ts
@@ -171,6 +171,7 @@ function normalizeArtifactOutcome(value: string): string {
     "redirect",
     "hit",
     "miss",
+    "error",
     "response-cache",
     "redirect-miss",
     "not-eligible",

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "@supabase/ssr": "0.12.4",
     "@supabase/supabase-js": "2.112.3",
     "@vercel/analytics": "^1.6.1",
+    "@vercel/functions": "^3.9.5",
     "@vercel/otel": "^2.1.3",
     "@vercel/speed-insights": "^2.0.0",
     "fflate": "^0.8.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       '@vercel/analytics':
         specifier: ^1.6.1
         version: 1.6.1(next@15.5.9(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)
+      '@vercel/functions':
+        specifier: ^3.9.5
+        version: 3.9.5(@aws-sdk/credential-provider-web-identity@3.972.49)
       '@vercel/otel':
         specifier: ^2.1.3
         version: 2.1.3(@opentelemetry/api-logs@0.221.0)(@opentelemetry/api@1.9.1)(@opentelemetry/instrumentation@0.221.0(@opentelemetry/api@1.9.1))(@opentelemetry/resources@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.221.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))

--- a/tests/unit/observability/custom-metrics.test.ts
+++ b/tests/unit/observability/custom-metrics.test.ts
@@ -102,6 +102,32 @@ async function main() {
     false,
   );
 
+  const errorEmissions: Emission[] = [];
+  emitArenaBuildCustomMetrics(
+    {
+      access: "blind",
+      variant: "full",
+      requestedFormat: "v4",
+      servedFormat: "json",
+      deliveryClass: "snapshot",
+      source: "live",
+      artifactOutcome: "error",
+      blockCount: 10_000,
+      responseBytes: 2_000,
+      transferBytes: 1_000,
+      decodedBytes: 4_000,
+      optimizedExpected: true,
+      optimizedDelivered: false,
+    },
+    { artifact_fetch: 50, total: 100 },
+    200,
+    (name, value, tags = {}) => errorEmissions.push({ name, value, tags }),
+  );
+  assert.equal(
+    errorEmissions.find((entry) => entry.name === "minebench.arena.build.request")?.tags.outcome,
+    "error",
+  );
+
   const parsed = clientMetricBatchSchema.safeParse({ samples: [validMatchupSample] });
   assert.equal(parsed.success, true);
   assert.equal(

--- a/tests/unit/observability/custom-metrics.test.ts
+++ b/tests/unit/observability/custom-metrics.test.ts
@@ -1,0 +1,199 @@
+import assert from "node:assert/strict";
+import {
+  clientMetricBatchSchema,
+  emitArenaBuildCustomMetrics,
+  emitClientCustomMetrics,
+  type CustomMetricEmitter,
+} from "../../../lib/observability/customMetrics";
+import { POST } from "../../../app/api/observability/client-metrics/route";
+
+type Emission = {
+  name: string;
+  value: number;
+  tags: Record<string, string>;
+};
+
+const validMatchupSample = {
+  kind: "matchup" as const,
+  mode: "random" as const,
+  laneABlocks: "under-8k" as const,
+  laneBBlocks: "150k-300k" as const,
+  headersMs: 18.2,
+  bodyMs: 4.1,
+  totalMs: 22.3,
+};
+
+async function main() {
+  const emissions: Emission[] = [];
+  const emit: CustomMetricEmitter = (name, value, tags = {}) => {
+    emissions.push({ name, value, tags });
+  };
+
+  emitArenaBuildCustomMetrics(
+    {
+      access: "blind",
+      variant: "full",
+      requestedFormat: "v4",
+      servedFormat: "json",
+      deliveryClass: "snapshot",
+      source: "live",
+      artifactOutcome: "miss",
+      blockCount: 155_553,
+      responseBytes: 2_000,
+      transferBytes: 1_000,
+      decodedBytes: 4_000,
+      optimizedExpected: true,
+      optimizedDelivered: false,
+    },
+    {
+      token_validate: 1.234,
+      artifact_resolve: 4.5,
+      artifact_fetch: 80,
+      total: 100,
+    },
+    200,
+    emit,
+  );
+
+  assert.equal(
+    emissions.filter((entry) => entry.name === "minebench.arena.build.stage_ms").length,
+    4,
+  );
+  assert.equal(
+    emissions.some((entry) => entry.name === "minebench.arena.build.optimized_miss"),
+    true,
+  );
+  assert.equal(
+    emissions.find(
+      (entry) =>
+        entry.name === "minebench.arena.build.stage_ms" &&
+        entry.tags.stage === "token_validate",
+    )?.value,
+    1.23,
+  );
+  assert.equal(
+    emissions.every((entry) => Object.keys(entry.tags).length <= 8),
+    true,
+  );
+
+  const rejectedEmissions: Emission[] = [];
+  emitArenaBuildCustomMetrics(
+    {
+      access: "blind",
+      variant: "preview",
+      requestedFormat: "v4",
+      servedFormat: "json",
+      deliveryClass: "unknown",
+      source: "rejected",
+      artifactOutcome: "invalid-token",
+      blockCount: null,
+      responseBytes: null,
+      transferBytes: null,
+      decodedBytes: null,
+      optimizedExpected: true,
+      optimizedDelivered: false,
+    },
+    { token_validate: 0.5, total: 1 },
+    404,
+    (name, value, tags = {}) => rejectedEmissions.push({ name, value, tags }),
+  );
+  assert.equal(
+    rejectedEmissions.some((entry) => entry.name === "minebench.arena.build.optimized_miss"),
+    false,
+  );
+
+  const parsed = clientMetricBatchSchema.safeParse({ samples: [validMatchupSample] });
+  assert.equal(parsed.success, true);
+  assert.equal(
+    clientMetricBatchSchema.safeParse({
+      samples: [{ ...validMatchupSample, buildId: "secret-build-id" }],
+    }).success,
+    false,
+  );
+
+  const clientEmissions: Emission[] = [];
+  emitClientCustomMetrics(
+    [
+      validMatchupSample,
+      {
+        kind: "voxel",
+        surface: "sandbox",
+        variant: "full",
+        strategy: "worker",
+        cacheStatus: "miss",
+        blockCountBucket: "150k-300k",
+        renderedBlockCountBucket: "150k-300k",
+        animated: false,
+        queueMs: 1,
+        atlasMs: 2,
+        payloadMs: 300,
+        groupMs: 30,
+        meshMs: 330,
+        firstRenderMs: 16,
+        revealMs: 0,
+        totalMs: 350,
+      },
+    ],
+    (name, value, tags = {}) => clientEmissions.push({ name, value, tags }),
+  );
+  assert.equal(
+    clientEmissions.some(
+      (entry) =>
+        entry.name === "minebench.voxel.stage_ms" && entry.tags.stage === "first_render",
+    ),
+    true,
+  );
+  assert.equal(
+    clientEmissions.every((entry) => Object.keys(entry.tags).length <= 8),
+    true,
+  );
+
+  const mutableEnv = process.env as Record<string, string | undefined>;
+  const originalNodeEnv = mutableEnv.NODE_ENV;
+  mutableEnv.NODE_ENV = "production";
+  try {
+    const endpoint = "https://minebench.ai/api/observability/client-metrics";
+    const crossOrigin = await POST(
+      new Request(endpoint, {
+        method: "POST",
+        headers: { "Content-Type": "application/json", Origin: "https://example.com" },
+        body: JSON.stringify({ samples: [validMatchupSample] }),
+      }),
+    );
+    assert.equal(crossOrigin.status, 403);
+
+    const accepted = await POST(
+      new Request(endpoint, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Origin: "https://minebench.ai",
+          "Sec-Fetch-Site": "same-origin",
+        },
+        body: JSON.stringify({ samples: [validMatchupSample] }),
+      }),
+    );
+    assert.equal(accepted.status, 204);
+
+    const invalid = await POST(
+      new Request(endpoint, {
+        method: "POST",
+        headers: { "Content-Type": "application/json", Origin: "https://minebench.ai" },
+        body: JSON.stringify({
+          samples: [{ ...validMatchupSample, laneABlocks: "build-123" }],
+        }),
+      }),
+    );
+    assert.equal(invalid.status, 400);
+  } finally {
+    if (originalNodeEnv === undefined) delete mutableEnv.NODE_ENV;
+    else mutableEnv.NODE_ENV = originalNodeEnv;
+  }
+
+  console.log("custom metric contract checks passed");
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

- export Arena build stages, byte sizes, delivery outcomes, and optimized-delivery misses as numeric Vercel Custom Metrics
- batch strict same-origin client samples for matchup, delivery, mesh, first-render, and reveal distributions
- include completed Sandbox voxel builds while excluding transient streamed previews
- retain the existing Server-Timing, structured logs, OpenTelemetry spans, Web Analytics events, and Speed Insights signals

## Safety

- metric names are selected server-side
- attributes are bounded to eight categorical dimensions
- client payloads reject identifiers, tokens, prompts, model names, storage paths, and unknown fields
- telemetry remains best-effort and cannot fail the observed request

## Validation

- `pnpm exec tsc --noEmit`
- `pnpm lint`
- `pnpm test:unit` (63 files)
- `pnpm build`

*(PR written by Codex)*