### PR TITLE
feat(delivery): shared public v4 normalization and delivery observability

### DIFF
--- a/components/arena/Arena.tsx
+++ b/components/arena/Arena.tsx
@@ -14,14 +14,14 @@ import {
 import { readClientErrorResponse } from "@/lib/clientErrorResponse";
 import {
   IncompleteBuildStreamError,
-  readBuildVariantArtifact,
+  packDeliveredBuild,
+  readBuildVariantPayload,
   readBuildVariantStream,
-  type BuildVariantArtifactReadEvent,
+  type BuildVariantPayloadResult,
   type BuildStreamProgress,
   type BuildVariantStreamResponse,
 } from "@/lib/arena/clientBuildResponse";
 import {
-  packVoxelBlocks,
   voxelBuildBlockCount,
   type RenderableVoxelBuild,
 } from "@/lib/voxel/packedBlocks";
@@ -45,6 +45,7 @@ import {
 import {
   enqueueClientMetric,
   enqueueVoxelMetric,
+  normalizeDeliverySource,
 } from "@/lib/observability/clientMetrics";
 
 type ArenaState =
@@ -91,72 +92,6 @@ const PREFETCH_INITIAL_MAX_BYTES = Number.parseInt(
 );
 let snapshotStorageRedirectBlocked = false;
 let streamStorageRedirectBlocked = false;
-
-// Parsing JSON produces one object per block. Packing at the delivery boundary
-// lets that array go instead of keeping it alive for as long as a lane holds
-// the build, which on a matchup means two of them at once.
-function packDeliveredBuild(
-  build: ArenaMatchup["a"]["build"],
-): ArenaMatchup["a"]["build"] {
-  if (!build || build.packed || build.blocks.length === 0) return build;
-  return { ...build, blocks: [], packed: packVoxelBlocks(build.blocks) };
-}
-
-function packBuildVariantResponse(payload: BuildVariantResponse): BuildVariantResponse {
-  const packedBuild = packDeliveredBuild(payload.voxelBuild);
-  if (!packedBuild) return payload;
-  return packedBuild === payload.voxelBuild ? payload : { ...payload, voxelBuild: packedBuild };
-}
-
-// The binary artifact already carries its blocks as typed arrays, so it needs
-// no packing step and never becomes a string or per-block objects.
-type BuildVariantPayloadResult = {
-  payload: BuildVariantResponse;
-  servedFormat: "binary" | "json";
-  bodyBytes: number | null;
-  compressed: boolean;
-};
-
-async function readBuildVariantPayload(
-  res: Response,
-  onStage?: (event: BuildVariantArtifactReadEvent) => void,
-): Promise<BuildVariantPayloadResult> {
-  let bodyBytes: number | null = null;
-  let compressed = false;
-  const artifact = await readBuildVariantArtifact<BuildVariantResponse>(res, {
-    onStage(event) {
-      if (event.stage === "body_complete") bodyBytes = event.bytes;
-      if (event.stage === "inflate_complete") {
-        compressed = event.compressed;
-      }
-      onStage?.(event);
-    },
-  });
-  if (artifact.kind === "json") {
-    return {
-      payload: packBuildVariantResponse(artifact.value),
-      servedFormat: "json",
-      bodyBytes,
-      compressed,
-    };
-  }
-  const envelope = artifact.envelope as Omit<BuildVariantResponse, "voxelBuild"> & {
-    version?: string;
-  };
-  return {
-    payload: {
-      buildId: envelope.buildId,
-      variant: envelope.variant,
-      checksum: envelope.checksum ?? null,
-      serverValidated: Boolean(envelope.serverValidated),
-      buildLoadHints: envelope.buildLoadHints,
-      voxelBuild: { version: "1.0", blocks: [], packed: artifact.blocks },
-    },
-    servedFormat: "binary",
-    bodyBytes,
-    compressed,
-  };
-}
 
 async function fetchMatchupOnce(promptId?: string, signal?: AbortSignal): Promise<ArenaMatchup> {
   const trace = createBrowserPerformanceTrace("matchup");
@@ -335,26 +270,6 @@ async function readMeasuredBuildVariantPayload(
   return result;
 }
 
-type BuildMetricSource =
-  | "artifact"
-  | "live"
-  | "artifact-required"
-  | "artifact-redirect"
-  | "response-cache"
-  | "unknown";
-
-function normalizeBuildSource(response: Response): BuildMetricSource {
-  const source =
-    response.headers.get("x-build-source") ?? response.headers.get("x-build-stream-source");
-  if (source === "artifact") return "artifact";
-  if (source === "live") return "live";
-  if (source === "artifact-required") return "artifact-required";
-  if (source === "artifact-redirect") return "artifact-redirect";
-  if (source?.startsWith("response-cache:")) return "response-cache";
-  if (response.redirected) return "artifact-redirect";
-  return "unknown";
-}
-
 function normalizeBuildDeliveryClass(response: Response): ArenaBuildDeliveryClass | "unknown" {
   const value = response.headers.get("x-build-delivery-class");
   return value === "inline" ||
@@ -376,7 +291,7 @@ function reportBuildDeliveryMetrics(opts: {
   compressed: boolean;
 }) {
   const { metrics } = opts;
-  const source = normalizeBuildSource(opts.response);
+  const source = normalizeDeliverySource(opts.response);
   const deliveryClass = normalizeBuildDeliveryClass(opts.response);
   const blockCountBucket = getArenaBlockCountBucket(
     voxelBuildBlockCount(opts.payload.voxelBuild),
@@ -424,12 +339,13 @@ function reportBuildDeliveryMetrics(opts: {
   });
   enqueueClientMetric({
     kind: "delivery",
+    surface: "arena",
     purpose: metrics.purpose,
     variant: opts.ref.variant,
     transport: metrics.transport,
     requestedFormat: opts.requestedFormat,
     servedFormat: opts.servedFormat,
-    source,
+    delivery_source: source,
     blockCountBucket,
     compressed: opts.compressed,
     optimized,

--- a/components/leaderboard/ModelDetail.tsx
+++ b/components/leaderboard/ModelDetail.tsx
@@ -16,7 +16,7 @@ import type {
 } from "@/lib/arena/types";
 import {
   IncompleteBuildStreamError,
-  readBuildVariantJson,
+  readBuildVariantPayload,
   readBuildVariantStream,
   type BuildStreamProgress,
   type BuildVariantStreamResponse,
@@ -36,6 +36,7 @@ import {
   voxelBuildBlockCount,
   type RenderableVoxelBuild,
 } from "@/lib/voxel/packedBlocks";
+import { enqueueDeliveryMetric } from "@/lib/observability/clientMetrics";
 import { ModelLateralNav, PromptLateralNav } from "@/components/leaderboard/LateralNav";
 import {
   SandboxGifExportButton,
@@ -120,6 +121,7 @@ type LoadedPromptBuild = {
   gridSize: number;
   palette: "simple" | "advanced";
   mode: string;
+  checksum?: string | null;
   blockCount: number;
 };
 
@@ -180,15 +182,18 @@ async function fetchBuildVariantSnapshot(
 ): Promise<BuildVariantResponse> {
   const url = new URL(`/api/arena/builds/${encodeURIComponent(ref.buildId)}`, window.location.origin);
   url.searchParams.set("variant", ref.variant);
+  url.searchParams.set("format", "v4");
   if (ref.checksum) url.searchParams.set("checksum", ref.checksum);
   const allowRedirect = opts?.redirect !== false && !snapshotStorageRedirectBlocked;
   if (!allowRedirect) url.searchParams.set("redirect", "0");
   const timed = makeTimeoutSignal(signal, timeoutMs);
+  const startedAt = performance.now();
   try {
     let res: Response;
     try {
       res = await fetch(url, {
         method: "GET",
+        headers: { accept: "application/octet-stream, application/json;q=0.9" },
         credentials: "same-origin",
         signal: timed.signal,
         redirect: "follow",
@@ -207,7 +212,21 @@ async function fetchBuildVariantSnapshot(
       throw new Error(await readClientErrorResponse(res, "Failed to load build"));
     }
     try {
-      return await readBuildVariantJson<BuildVariantResponse>(res);
+      const result = await readBuildVariantPayload(res, { fallbackIdentity: ref });
+      const totalMs = performance.now() - startedAt;
+      enqueueDeliveryMetric({
+        surface: "leaderboard",
+        variant: ref.variant,
+        transport: "snapshot",
+        requestedFormat: "v4",
+        servedFormat: result.servedFormat,
+        response: res,
+        blockCount: voxelBuildBlockCount(result.payload.voxelBuild),
+        totalMs,
+        bodyBytes: result.bodyBytes,
+        compressed: result.compressed,
+      });
+      return result.payload;
     } catch (err: unknown) {
       if (allowRedirect && !isAbortError(err)) {
         snapshotStorageRedirectBlocked = true;
@@ -248,7 +267,20 @@ async function fetchBuildVariantStreamOnce(
 
   const contentType = res.headers.get("content-type") ?? "";
   if (!res.body || !contentType.includes("application/x-ndjson")) {
-    return readBuildVariantJson<BuildVariantResponse>(res);
+    const result = await readBuildVariantPayload(res, { fallbackIdentity: ref });
+    enqueueDeliveryMetric({
+      surface: "leaderboard",
+      variant: ref.variant,
+      transport: useArtifact ? "stream-artifact" : "stream-live",
+      requestedFormat: "ndjson",
+      servedFormat: result.servedFormat,
+      response: res,
+      blockCount: voxelBuildBlockCount(result.payload.voxelBuild),
+      totalMs: null,
+      bodyBytes: result.bodyBytes,
+      compressed: result.compressed,
+    });
+    return result.payload;
   }
 
   try {
@@ -1109,6 +1141,7 @@ export function ModelDetail({ data }: { data: ModelDetailStats }) {
         gridSize: activeBuildMeta.gridSize,
         palette: activeBuildMeta.palette,
         mode: activeBuildMeta.mode,
+        checksum: payload.checksum ?? activeBuildMeta.checksum ?? null,
         blockCount:
           payload.variant === "full"
             ? Math.max(activeBuildMeta.blockCount, receivedBlockCount)

--- a/components/leaderboard/ModelDetail.tsx
+++ b/components/leaderboard/ModelDetail.tsx
@@ -284,10 +284,24 @@ async function fetchBuildVariantStreamOnce(
   }
 
   try {
-    return await readBuildVariantStream(res, {
+    const startedAt = performance.now();
+    const payload = await readBuildVariantStream(res, {
       signal: opts?.signal,
       onProgress: opts?.onProgress,
     });
+    enqueueDeliveryMetric({
+      surface: "leaderboard",
+      variant: ref.variant,
+      transport: useArtifact ? "stream-artifact" : "stream-live",
+      requestedFormat: "ndjson",
+      servedFormat: "ndjson",
+      response: res,
+      blockCount: voxelBuildBlockCount(payload.voxelBuild),
+      totalMs: performance.now() - startedAt,
+      bodyBytes: null,
+      compressed: res.headers.get("content-encoding")?.includes("gzip") || false,
+    });
+    return payload;
   } catch (error) {
     if (error instanceof IncompleteBuildStreamError) {
       return fetchBuildVariantSnapshot(ref, opts?.signal);

--- a/components/sandbox/SandboxBenchmark.tsx
+++ b/components/sandbox/SandboxBenchmark.tsx
@@ -394,10 +394,24 @@ async function fetchBuildVariantStreamOnce(
   }
 
   try {
-    return await readBuildVariantStream(res, {
+    const startedAt = performance.now();
+    const payload = await readBuildVariantStream(res, {
       signal: opts?.signal,
       onProgress: opts?.onProgress,
     });
+    enqueueDeliveryMetric({
+      surface: "sandbox",
+      variant: ref.variant,
+      transport: useArtifact ? "stream-artifact" : "stream-live",
+      requestedFormat: "ndjson",
+      servedFormat: "ndjson",
+      response: res,
+      blockCount: voxelBuildBlockCount(payload.voxelBuild),
+      totalMs: performance.now() - startedAt,
+      bodyBytes: null,
+      compressed: res.headers.get("content-encoding")?.includes("gzip") || false,
+    });
+    return payload;
   } catch (error) {
     if (
       error instanceof IncompleteBuildStreamError &&

--- a/components/sandbox/SandboxBenchmark.tsx
+++ b/components/sandbox/SandboxBenchmark.tsx
@@ -26,7 +26,7 @@ import type {
 } from "@/lib/arena/types";
 import {
   IncompleteBuildStreamError,
-  readBuildVariantJson,
+  readBuildVariantPayload,
   readBuildVariantStream,
   type BuildStreamProgress,
   type BuildVariantStreamResponse,
@@ -43,8 +43,14 @@ import {
   buildSandboxComparisonPath,
   parseSandboxComparisonDeepLink,
 } from "@/lib/deepLinks";
-import type { RenderableVoxelBuild } from "@/lib/voxel/packedBlocks";
-import { enqueueVoxelMetric } from "@/lib/observability/clientMetrics";
+import {
+  voxelBuildBlockCount,
+  type RenderableVoxelBuild,
+} from "@/lib/voxel/packedBlocks";
+import {
+  enqueueDeliveryMetric,
+  enqueueVoxelMetric,
+} from "@/lib/observability/clientMetrics";
 
 type Palette = "simple" | "advanced";
 type GridSize = 64 | 256 | 512;
@@ -314,15 +320,31 @@ async function fetchBuildVariantSnapshot(
 ): Promise<BuildVariantResponse> {
   const url = new URL(`/api/arena/builds/${encodeURIComponent(ref.buildId)}`, window.location.origin);
   url.searchParams.set("variant", ref.variant);
+  url.searchParams.set("format", "v4");
   if (ref.checksum) url.searchParams.set("checksum", ref.checksum);
   const timed = makeTimeoutSignal(signal, timeoutMs);
+  const startedAt = performance.now();
   try {
     const res = await fetch(url, {
       method: "GET",
       signal: timed.signal,
     });
     if (!res.ok) throw new Error(await readClientErrorResponse(res, "Failed to load build"));
-    return await readBuildVariantJson<BuildVariantResponse>(res);
+    const result = await readBuildVariantPayload(res, { fallbackIdentity: ref });
+    const totalMs = performance.now() - startedAt;
+    enqueueDeliveryMetric({
+      surface: "sandbox",
+      variant: ref.variant,
+      transport: "snapshot",
+      requestedFormat: "v4",
+      servedFormat: result.servedFormat,
+      response: res,
+      blockCount: voxelBuildBlockCount(result.payload.voxelBuild),
+      totalMs,
+      bodyBytes: result.bodyBytes,
+      compressed: result.compressed,
+    });
+    return result.payload;
   } finally {
     timed.cleanup();
   }
@@ -355,7 +377,20 @@ async function fetchBuildVariantStreamOnce(
 
   const contentType = res.headers.get("content-type") ?? "";
   if (!res.body || !contentType.includes("application/x-ndjson")) {
-    return readBuildVariantJson<BuildVariantResponse>(res);
+    const result = await readBuildVariantPayload(res, { fallbackIdentity: ref });
+    enqueueDeliveryMetric({
+      surface: "sandbox",
+      variant: ref.variant,
+      transport: useArtifact ? "stream-artifact" : "stream-live",
+      requestedFormat: "ndjson",
+      servedFormat: result.servedFormat,
+      response: res,
+      blockCount: voxelBuildBlockCount(result.payload.voxelBuild),
+      totalMs: null,
+      bodyBytes: result.bodyBytes,
+      compressed: result.compressed,
+    });
+    return result.payload;
   }
 
   try {

--- a/lib/arena/clientBuildResponse.ts
+++ b/lib/arena/clientBuildResponse.ts
@@ -7,6 +7,7 @@ import type {
 import {
   appendPackedVoxelBlocks,
   createPackedVoxelBlocks,
+  packVoxelBlocks,
   reservePackedVoxelBlocks,
   type PackedVoxelBlocks,
   type RenderableVoxelBuild,
@@ -162,6 +163,151 @@ function isBuildLoadHints(value: unknown): value is ArenaBuildLoadHints {
     (value.initialEstimatedBytes === null || isNonNegativeInt(value.initialEstimatedBytes)) &&
     (value.fullEstimatedBytes === null || isNonNegativeInt(value.fullEstimatedBytes))
   );
+}
+
+// Parsing JSON produces one object per block. Packing at the delivery boundary
+// lets that array go instead of keeping it alive for as long as a lane holds
+// the build, which on a matchup means two of them at once.
+export function packDeliveredBuild(
+  build: RenderableVoxelBuild,
+): RenderableVoxelBuild;
+export function packDeliveredBuild(
+  build: RenderableVoxelBuild | null,
+): RenderableVoxelBuild | null;
+export function packDeliveredBuild(
+  build: RenderableVoxelBuild | null | undefined,
+): RenderableVoxelBuild | null | undefined;
+export function packDeliveredBuild(
+  build: RenderableVoxelBuild | null | undefined,
+): RenderableVoxelBuild | null | undefined {
+  if (!build) return build;
+  if (build.packed || !Array.isArray(build.blocks) || build.blocks.length === 0) {
+    return build;
+  }
+  return { ...build, blocks: [], packed: packVoxelBlocks(build.blocks) };
+}
+
+export type BuildVariantPayloadResult = {
+  payload: BuildVariantStreamResponse;
+  servedFormat: "binary" | "json";
+  bodyBytes: number | null;
+  compressed: boolean;
+};
+
+export type ReadBuildVariantPayloadOptions = {
+  fallbackIdentity?: {
+    buildId?: string;
+    variant?: ArenaBuildVariant;
+    checksum?: string | null;
+  };
+  onStage?: (event: BuildVariantArtifactReadEvent) => void;
+};
+
+export async function readBuildVariantPayload(
+  res: Response,
+  optionsOrOnStage?:
+    | ReadBuildVariantPayloadOptions
+    | ((event: BuildVariantArtifactReadEvent) => void),
+): Promise<BuildVariantPayloadResult> {
+  const options: ReadBuildVariantPayloadOptions =
+    typeof optionsOrOnStage === "function"
+      ? { onStage: optionsOrOnStage }
+      : optionsOrOnStage ?? {};
+
+  let bodyBytes: number | null = null;
+  let compressed = false;
+  const artifact = await readBuildVariantArtifact<BuildVariantStreamResponse>(res, {
+    onStage(event) {
+      if (event.stage === "body_complete") bodyBytes = event.bytes;
+      if (event.stage === "inflate_complete") {
+        compressed = event.compressed;
+      }
+      options.onStage?.(event);
+    },
+  });
+
+  if (artifact.kind === "json") {
+    const raw = artifact.value;
+    if (!isRecord(raw)) throw new Error("Malformed build response JSON");
+    const rawVariant = typeof raw.variant === "string" ? raw.variant : undefined;
+    if (rawVariant && options.fallbackIdentity?.variant && rawVariant !== options.fallbackIdentity.variant) {
+      throw new Error("Contradictory variant in build response");
+    }
+    const variant = (isVariant(rawVariant) ? rawVariant : options.fallbackIdentity?.variant) as ArenaBuildVariant;
+    if (!isVariant(variant)) {
+      throw new Error("Invalid or missing variant in build response");
+    }
+    const buildId =
+      typeof raw.buildId === "string" && raw.buildId.length > 0
+        ? raw.buildId
+        : (options.fallbackIdentity?.buildId ?? "");
+    const checksum =
+      typeof raw.checksum === "string"
+        ? raw.checksum
+        : (raw.checksum === null ? null : (options.fallbackIdentity?.checksum ?? null));
+    const serverValidated = typeof raw.serverValidated === "boolean" ? raw.serverValidated : false;
+    const buildLoadHints = isBuildLoadHints(raw.buildLoadHints) ? raw.buildLoadHints : undefined;
+
+    const voxelBuild = (isRecord(raw.voxelBuild) ? raw.voxelBuild : raw) as RenderableVoxelBuild;
+    const packedVoxelBuild = packDeliveredBuild(voxelBuild) ?? {
+      version: "1.0",
+      blocks: [],
+      packed: createPackedVoxelBlocks(0),
+    };
+
+    return {
+      payload: {
+        buildId,
+        variant,
+        checksum,
+        serverValidated,
+        buildLoadHints,
+        voxelBuild: packedVoxelBuild,
+      },
+      servedFormat: "json",
+      bodyBytes,
+      compressed,
+    };
+  }
+
+  const envelope = (artifact.envelope ?? {}) as Partial<BuildVariantStreamResponse> & {
+    version?: string;
+  };
+  const expectedVariant = options.fallbackIdentity?.variant;
+  if (envelope.variant && expectedVariant && envelope.variant !== expectedVariant) {
+    throw new Error("Contradictory variant in build response");
+  }
+
+  const resolvedVariant = (envelope.variant ?? expectedVariant) as ArenaBuildVariant;
+  if (!isVariant(resolvedVariant)) {
+    throw new Error("Invalid or missing variant in build response");
+  }
+
+  const buildId =
+    typeof envelope.buildId === "string" && envelope.buildId.length > 0
+      ? envelope.buildId
+      : (options.fallbackIdentity?.buildId ?? "");
+
+  const checksum =
+    typeof envelope.checksum === "string"
+      ? envelope.checksum
+      : (envelope.checksum === null ? null : (options.fallbackIdentity?.checksum ?? null));
+
+  return {
+    payload: {
+      buildId,
+      variant: resolvedVariant,
+      checksum,
+      serverValidated: Boolean(envelope.serverValidated),
+      buildLoadHints: isBuildLoadHints(envelope.buildLoadHints)
+        ? envelope.buildLoadHints
+        : undefined,
+      voxelBuild: { version: "1.0", blocks: [], packed: artifact.blocks },
+    },
+    servedFormat: "binary",
+    bodyBytes,
+    compressed,
+  };
 }
 
 function isVoxelBlock(value: unknown): boolean {

--- a/lib/observability/clientMetrics.ts
+++ b/lib/observability/clientMetrics.ts
@@ -40,7 +40,7 @@ export function enqueueClientMetric(sample: ClientMetricSample) {
 }
 
 export function enqueueVoxelMetric(
-  surface: "arena" | "sandbox",
+  surface: "arena" | "sandbox" | "leaderboard",
   variant: ArenaBuildVariant,
   metrics: VoxelViewerBuildMetrics,
 ) {
@@ -61,5 +61,62 @@ export function enqueueVoxelMetric(
     firstRenderMs: roundMetricMs(metrics.firstRenderMs),
     revealMs: roundMetricMs(metrics.revealMs),
     totalMs: roundMetricMs(metrics.totalMs),
+  });
+}
+
+export function normalizeDeliverySource(
+  response: Response,
+): "artifact" | "live" | "artifact-required" | "artifact-redirect" | "response-cache" | "unknown" {
+  const source =
+    response.headers.get("x-build-source") ?? response.headers.get("x-build-stream-source");
+  if (source === "artifact") return "artifact";
+  if (source === "live") return "live";
+  if (source === "artifact-required") return "artifact-required";
+  if (source === "artifact-redirect") return "artifact-redirect";
+  if (source?.startsWith("response-cache:")) return "response-cache";
+  if (response.redirected) return "artifact-redirect";
+  return "unknown";
+}
+
+export function enqueueDeliveryMetric(params: {
+  surface: "arena" | "sandbox" | "leaderboard";
+  purpose?: "visible" | "prefetch";
+  variant: ArenaBuildVariant;
+  transport: "snapshot" | "stream-artifact" | "stream-live";
+  requestedFormat: "v4" | "json" | "ndjson";
+  servedFormat: "binary" | "json" | "ndjson";
+  response: Response;
+  blockCount: number;
+  totalMs: number | null;
+  headersMs?: number | null;
+  bodyMs?: number | null;
+  inflateMs?: number | null;
+  decodeMs?: number | null;
+  bodyBytes?: number | null;
+  compressed?: boolean;
+}) {
+  const source = normalizeDeliverySource(params.response);
+  const optimized =
+    params.requestedFormat === "v4" &&
+    params.servedFormat === "binary" &&
+    (source === "artifact" || source === "artifact-redirect");
+  enqueueClientMetric({
+    kind: "delivery",
+    surface: params.surface,
+    purpose: params.purpose ?? "visible",
+    variant: params.variant,
+    transport: params.transport,
+    requestedFormat: params.requestedFormat,
+    servedFormat: params.servedFormat,
+    delivery_source: source,
+    blockCountBucket: getArenaBlockCountBucket(params.blockCount),
+    compressed: Boolean(params.compressed),
+    optimized,
+    headersMs: roundMetricMs(params.headersMs),
+    bodyMs: roundMetricMs(params.bodyMs),
+    inflateMs: roundMetricMs(params.inflateMs),
+    decodeMs: roundMetricMs(params.decodeMs),
+    totalMs: roundMetricMs(params.totalMs),
+    bodyBytes: params.bodyBytes ?? null,
   });
 }

--- a/lib/observability/clientMetrics.ts
+++ b/lib/observability/clientMetrics.ts
@@ -96,6 +96,13 @@ export function enqueueDeliveryMetric(params: {
   compressed?: boolean;
 }) {
   const source = normalizeDeliverySource(params.response);
+  const encoding = (
+    params.response.headers.get("content-encoding") ??
+    params.response.headers.get("x-build-content-encoding") ??
+    ""
+  ).toLowerCase();
+  const isGzip = encoding.includes("gzip");
+  const compressed = Boolean(params.compressed || isGzip);
   const optimized =
     params.requestedFormat === "v4" &&
     params.servedFormat === "binary" &&
@@ -110,7 +117,7 @@ export function enqueueDeliveryMetric(params: {
     servedFormat: params.servedFormat,
     delivery_source: source,
     blockCountBucket: getArenaBlockCountBucket(params.blockCount),
-    compressed: Boolean(params.compressed),
+    compressed,
     optimized,
     headersMs: roundMetricMs(params.headersMs),
     bodyMs: roundMetricMs(params.bodyMs),

--- a/lib/observability/customMetrics.ts
+++ b/lib/observability/customMetrics.ts
@@ -33,12 +33,13 @@ const matchupMetricSchema = z
 const deliveryMetricSchema = z
   .object({
     kind: z.literal("delivery"),
+    surface: z.enum(["arena", "sandbox", "leaderboard"]),
     purpose: z.enum(["visible", "prefetch"]),
     variant: z.enum(["preview", "full"]),
     transport: z.enum(["snapshot", "stream-artifact", "stream-live"]),
     requestedFormat: z.enum(["v4", "json", "ndjson"]),
     servedFormat: z.enum(["binary", "json", "ndjson"]),
-    source: z.enum([
+    delivery_source: z.enum([
       "artifact",
       "live",
       "artifact-required",
@@ -61,7 +62,7 @@ const deliveryMetricSchema = z
 const voxelMetricSchema = z
   .object({
     kind: z.literal("voxel"),
-    surface: z.enum(["arena", "sandbox"]),
+    surface: z.enum(["arena", "sandbox", "leaderboard"]),
     variant: z.enum(["preview", "full"]),
     strategy: z.enum(["local", "worker", "worker-fallback"]),
     cacheStatus: z.enum(["hit", "miss", "disabled", "not-used"]),
@@ -205,7 +206,7 @@ export function emitArenaBuildCustomMetrics(
     access: observation.access,
     variant: observation.variant,
     format: `${observation.requestedFormat}-${observation.servedFormat}`,
-    source: normalizeServerSource(observation.source),
+    delivery_source: normalizeServerSource(observation.source),
     outcome: normalizeArtifactOutcome(observation.artifactOutcome),
     delivery_class: normalizeDeliveryClass(observation.deliveryClass),
     block_bucket: getArenaBlockCountBucket(observation.blockCount),
@@ -275,11 +276,12 @@ export function emitClientCustomMetrics(
 
     if (sample.kind === "delivery") {
       const tags = {
+        surface: sample.surface,
         purpose: sample.purpose,
         variant: sample.variant,
         transport: sample.transport,
         format: `${sample.requestedFormat}-${sample.servedFormat}`,
-        source: sample.source,
+        delivery_source: sample.delivery_source,
         block_bucket: sample.blockCountBucket,
         encoding: sample.compressed ? "gzip" : "identity",
       };

--- a/tests/unit/arena/client-build-response.test.ts
+++ b/tests/unit/arena/client-build-response.test.ts
@@ -78,6 +78,7 @@ async function main() {
     isGzipStreamPrefix,
     readBuildVariantArtifact,
     readBuildVariantJson,
+    readBuildVariantPayload,
     readBuildVariantStream,
     streamFromInitialChunks,
   } = await import("../../../lib/arena/clientBuildResponse");
@@ -368,6 +369,107 @@ async function main() {
   );
   await assert.rejects(readBuildVariantStream(sourceFailureResponse), /source failed/);
   assert.equal(sourceFailureResponse.body?.locked, false);
+
+  // readBuildVariantPayload tests
+  const testBlocks = [
+    { x: 10, y: 20, z: 30, type: "oak_planks" },
+    { x: 11, y: 20, z: 30, type: "stone" },
+    { x: 12, y: 20, z: 30, type: "glass" },
+  ];
+  const fullJsonPayload = {
+    buildId: "bench-build-1",
+    variant: "full",
+    checksum: "sha256-abc",
+    serverValidated: true,
+    voxelBuild: {
+      version: "1.0",
+      blocks: testBlocks,
+    },
+  };
+  const gzippedJsonPayload = gzipSync(Buffer.from(JSON.stringify(fullJsonPayload)));
+  const jsonStages: string[] = [];
+  const payloadFromJson = await readBuildVariantPayload(new Response(gzippedJsonPayload), {
+    onStage: (event) => jsonStages.push(event.stage),
+  });
+  assert.equal(payloadFromJson.servedFormat, "json");
+  assert.equal(payloadFromJson.compressed, true);
+  assert.equal(payloadFromJson.payload.buildId, "bench-build-1");
+  assert.equal(payloadFromJson.payload.variant, "full");
+  assert.equal(payloadFromJson.payload.checksum, "sha256-abc");
+  assert.equal(payloadFromJson.payload.voxelBuild.packed?.count, 3);
+  assert.equal(payloadFromJson.payload.voxelBuild.blocks.length, 0); // packed at delivery boundary
+  assert.deepEqual(jsonStages, [
+    "body_complete",
+    "inflate_complete",
+    "json_decode_complete",
+  ]);
+
+  // Binary payload
+  const binaryBytes = encodeBinaryArtifact(
+    { buildId: "bench-build-1", variant: "full", checksum: "sha256-abc", serverValidated: true },
+    testBlocks,
+  );
+  const gzippedBinary = gzipSync(Buffer.from(binaryBytes));
+  const binaryStages: string[] = [];
+  const payloadFromBinary = await readBuildVariantPayload(new Response(gzippedBinary), {
+    onStage: (event) => binaryStages.push(event.stage),
+  });
+  assert.equal(payloadFromBinary.servedFormat, "binary");
+  assert.equal(payloadFromBinary.compressed, true);
+  assert.equal(payloadFromBinary.payload.buildId, "bench-build-1");
+  assert.equal(payloadFromBinary.payload.variant, "full");
+  assert.equal(payloadFromBinary.payload.checksum, "sha256-abc");
+  assert.equal(payloadFromBinary.payload.voxelBuild.packed?.count, 3);
+  assert.deepEqual(binaryStages, [
+    "body_complete",
+    "inflate_complete",
+    "binary_decode_complete",
+  ]);
+
+  // Equivalence between binary and JSON delivery
+  assert.equal(
+    payloadFromBinary.payload.voxelBuild.packed?.count,
+    payloadFromJson.payload.voxelBuild.packed?.count,
+  );
+  assert.deepEqual(
+    payloadFromBinary.payload.voxelBuild.packed?.positions.slice(0, 9),
+    payloadFromJson.payload.voxelBuild.packed?.positions.slice(0, 9),
+  );
+  assert.deepEqual(
+    payloadFromBinary.payload.voxelBuild.packed?.typeNames,
+    payloadFromJson.payload.voxelBuild.packed?.typeNames,
+  );
+
+  // Fallback identity when binary envelope has missing fields
+  const strippedBinaryBytes = encodeBinaryArtifact(
+    { serverValidated: true }, // missing buildId, variant, checksum
+    testBlocks,
+  );
+  const fallbackResult = await readBuildVariantPayload(
+    new Response(Buffer.from(strippedBinaryBytes)),
+    {
+      fallbackIdentity: {
+        buildId: "fallback-id",
+        variant: "preview",
+        checksum: "fallback-checksum",
+      },
+    },
+  );
+  assert.equal(fallbackResult.payload.buildId, "fallback-id");
+  assert.equal(fallbackResult.payload.variant, "preview");
+  assert.equal(fallbackResult.payload.checksum, "fallback-checksum");
+
+  // Contradictory variant rejection
+  const previewBinaryBytes = encodeBinaryArtifact(
+    { buildId: "test", variant: "preview" },
+    testBlocks,
+  );
+  await assert.rejects(
+    readBuildVariantPayload(new Response(Buffer.from(previewBinaryBytes)), {
+      fallbackIdentity: { variant: "full" },
+    }),
+    /Contradictory variant in build response/,
+  );
 }
 
 main().catch((error) => {

--- a/tests/unit/observability/custom-metrics.test.ts
+++ b/tests/unit/observability/custom-metrics.test.ts
@@ -128,11 +128,38 @@ async function main() {
     "error",
   );
 
-  const parsed = clientMetricBatchSchema.safeParse({ samples: [validMatchupSample] });
+  const validDeliverySample = {
+    kind: "delivery" as const,
+    surface: "sandbox" as const,
+    purpose: "visible" as const,
+    variant: "full" as const,
+    transport: "snapshot" as const,
+    requestedFormat: "v4" as const,
+    servedFormat: "binary" as const,
+    delivery_source: "artifact" as const,
+    blockCountBucket: "50k-150k" as const,
+    compressed: true,
+    optimized: true,
+    headersMs: 15.0,
+    bodyMs: 25.0,
+    inflateMs: 2.0,
+    decodeMs: 0.5,
+    totalMs: 42.5,
+    bodyBytes: 120_000,
+  };
+
+  const parsed = clientMetricBatchSchema.safeParse({ samples: [validMatchupSample, validDeliverySample] });
   assert.equal(parsed.success, true);
   assert.equal(
     clientMetricBatchSchema.safeParse({
       samples: [{ ...validMatchupSample, buildId: "secret-build-id" }],
+    }).success,
+    false,
+  );
+  // Rejects old `source` on delivery metric (must use delivery_source)
+  assert.equal(
+    clientMetricBatchSchema.safeParse({
+      samples: [{ ...validDeliverySample, source: "artifact", delivery_source: undefined }],
     }).success,
     false,
   );
@@ -141,6 +168,7 @@ async function main() {
   emitClientCustomMetrics(
     [
       validMatchupSample,
+      validDeliverySample,
       {
         kind: "voxel",
         surface: "sandbox",
@@ -170,7 +198,17 @@ async function main() {
     true,
   );
   assert.equal(
-    clientEmissions.every((entry) => Object.keys(entry.tags).length <= 8),
+    clientEmissions.some(
+      (entry) =>
+        entry.name === "minebench.arena.delivery.stage_ms" &&
+        entry.tags.delivery_source === "artifact" &&
+        entry.tags.surface === "sandbox" &&
+        !("source" in entry.tags),
+    ),
+    true,
+  );
+  assert.equal(
+    clientEmissions.every((entry) => Object.keys(entry.tags).length <= 9),
     true,
   );
 


### PR DESCRIPTION
### Summary

- Unifies build payload normalization across Arena, Sandbox, and Leaderboard via `packDeliveredBuild` and `readBuildVariantPayload`.
- Requests `format=v4` binary snapshot payloads on public endpoints (Sandbox and Leaderboard) when fetching pre-generated build artifacts.
- Emits structured client delivery telemetry for Sandbox and Leaderboard build fetches, recording transport, served format, payload size, and transfer timings.
- Standardizes delivery source resolution using a shared helper across client metrics and Arena instrumentation.

*(PR written by Codex)*