### PR TITLE
perf(arena): prioritize visible mesh work

### DIFF
--- a/components/arena/Arena.tsx
+++ b/components/arena/Arena.tsx
@@ -31,6 +31,7 @@ import {
   createVoxelMeshPayloadInWorker,
   type VoxelMeshPayload,
 } from "@/lib/voxel/mesh";
+import { claimArenaPremesh, type ArenaPremeshEntry } from "@/lib/arena/premesh";
 import { VoxelViewerCard } from "@/components/voxel/VoxelViewerCard";
 import type { VoxelViewerBuildMetrics } from "@/components/voxel/VoxelViewer";
 import { formatVoxelLoadingMessage } from "@/components/voxel/VoxelLoadingHud";
@@ -1185,12 +1186,6 @@ function getArenaPremeshedMeshKey(
   return `${matchupId}:${side}:${variant}`;
 }
 
-type PremeshedMeshEntry = {
-  matchupId: string;
-  promise: Promise<VoxelMeshPayload>;
-  controller: AbortController;
-};
-
 export function Arena() {
   const [state, setState] = useState<ArenaState>({ kind: "loading" });
   const [reloadToken, setReloadToken] = useState(0);
@@ -1226,7 +1221,7 @@ export function Arena() {
   const hydratedBuildCacheWeightsRef = useRef(new Map<string, number>());
   const hydratedBuildCacheBytesRef = useRef(0);
   const fullBuildPrefetchRef = useRef(new Map<string, FullBuildPrefetch>());
-  const premeshedFullMeshRef = useRef<Map<string, PremeshedMeshEntry>>(new Map());
+  const premeshedFullMeshRef = useRef<Map<string, ArenaPremeshEntry>>(new Map());
   const inFlightWarmPromiseRef = useRef<Promise<void>>(Promise.resolve());
   const matchupStagesRef = useRef<{
     matchupId: string;
@@ -1730,7 +1725,7 @@ export function Arena() {
     (matchupId: string, side: "a" | "b", lane: ArenaMatchupLane): Promise<VoxelMeshPayload> | null => {
       if (!lane.build || getLaneHydratedVariant(lane) !== "full") return null;
       const key = getArenaPremeshedMeshKey(matchupId, side, "full");
-      return premeshedFullMeshRef.current.get(key)?.promise ?? null;
+      return claimArenaPremesh(premeshedFullMeshRef.current, key);
     },
     [],
   );
@@ -2100,6 +2095,11 @@ export function Arena() {
           if (!premeshedFullMeshRef.current.has(warmKey)) {
             const warmController = new AbortController();
             const startWarm = async (): Promise<VoxelMeshPayload> => {
+              const warmEntry = premeshedFullMeshRef.current.get(warmKey);
+              if (!warmEntry || warmController.signal.aborted) {
+                throw new DOMException("Aborted", "AbortError");
+              }
+              warmEntry.started = true;
               const { payload: meshPayload } = await createVoxelMeshPayloadInWorker(
                 payload.voxelBuild!,
                 getPalette("simple"),
@@ -2117,6 +2117,7 @@ export function Arena() {
               matchupId: matchupValue.id,
               promise: sequencedPromise,
               controller: warmController,
+              started: false,
             });
           }
         }
@@ -2943,8 +2944,10 @@ export function Arena() {
                 voxelBuild={matchup?.a.build ?? null}
                 expectedBlockCount={matchup ? getExpectedBlocksForLane(matchup.a) : undefined}
                 meshCacheKey={matchup ? getLaneMeshCacheKey(matchup.a) : null}
-                premeshedPayloadPromise={
-                  matchup ? getLanePremeshedPayloadPromise(matchup.id, "a", matchup.a) : null
+                getPremeshedPayloadPromise={
+                  matchup
+                    ? () => getLanePremeshedPayloadPromise(matchup.id, "a", matchup.a)
+                    : undefined
                 }
                 onPremeshedPayloadConsumed={
                   matchup
@@ -3008,8 +3011,10 @@ export function Arena() {
                 voxelBuild={matchup?.b.build ?? null}
                 expectedBlockCount={matchup ? getExpectedBlocksForLane(matchup.b) : undefined}
                 meshCacheKey={matchup ? getLaneMeshCacheKey(matchup.b) : null}
-                premeshedPayloadPromise={
-                  matchup ? getLanePremeshedPayloadPromise(matchup.id, "b", matchup.b) : null
+                getPremeshedPayloadPromise={
+                  matchup
+                    ? () => getLanePremeshedPayloadPromise(matchup.id, "b", matchup.b)
+                    : undefined
                 }
                 onPremeshedPayloadConsumed={
                   matchup

--- a/components/voxel/VoxelViewer.tsx
+++ b/components/voxel/VoxelViewer.tsx
@@ -52,7 +52,7 @@ type ViewerProps = {
   palette: "simple" | "advanced";
   expectedBlockCount?: number;
   meshCacheKey?: string | null;
-  premeshedPayloadPromise?: Promise<VoxelMeshPayload> | null;
+  getPremeshedPayloadPromise?: () => Promise<VoxelMeshPayload> | null;
   onPremeshedPayloadConsumed?: (promise: Promise<VoxelMeshPayload>) => void;
   autoRotate?: boolean;
   animateIn?: boolean;
@@ -411,7 +411,7 @@ export const VoxelViewer = forwardRef<VoxelViewerHandle, ViewerProps>(function V
     palette,
     expectedBlockCount,
     meshCacheKey,
-    premeshedPayloadPromise,
+    getPremeshedPayloadPromise,
     onPremeshedPayloadConsumed,
     autoRotate,
     animateIn,
@@ -474,7 +474,7 @@ export const VoxelViewer = forwardRef<VoxelViewerHandle, ViewerProps>(function V
     animateIn: boolean;
     expectedBlockCount: number | null;
     meshCacheKey: string | null;
-    premeshedPayloadPromise: Promise<VoxelMeshPayload> | null;
+    getPremeshedPayloadPromise: (() => Promise<VoxelMeshPayload> | null) | null;
     onPremeshedPayloadConsumed: ((promise: Promise<VoxelMeshPayload>) => void) | null;
   }>({
     voxelBuild: null,
@@ -483,7 +483,7 @@ export const VoxelViewer = forwardRef<VoxelViewerHandle, ViewerProps>(function V
     animateIn: Boolean(animateIn),
     expectedBlockCount: normalizeExpectedBlockCount(expectedBlockCount),
     meshCacheKey: meshCacheKey?.trim() || null,
-    premeshedPayloadPromise: premeshedPayloadPromise ?? null,
+    getPremeshedPayloadPromise: getPremeshedPayloadPromise ?? null,
     onPremeshedPayloadConsumed: onPremeshedPayloadConsumed ?? null,
   });
   latestRef.current = {
@@ -493,7 +493,7 @@ export const VoxelViewer = forwardRef<VoxelViewerHandle, ViewerProps>(function V
     animateIn: Boolean(animateIn),
     expectedBlockCount: normalizeExpectedBlockCount(expectedBlockCount),
     meshCacheKey: meshCacheKey?.trim() || null,
-    premeshedPayloadPromise: premeshedPayloadPromise ?? null,
+    getPremeshedPayloadPromise: getPremeshedPayloadPromise ?? null,
     onPremeshedPayloadConsumed: onPremeshedPayloadConsumed ?? null,
   };
 
@@ -710,6 +710,7 @@ export const VoxelViewer = forwardRef<VoxelViewerHandle, ViewerProps>(function V
     let meshCacheStatus: VoxelMeshCacheStatus = "not-used";
     let traceRetainedForFirstRender = false;
     let traceAbandoned = false;
+    const premeshedPayloadPromise = latest.getPremeshedPayloadPromise?.() ?? null;
 
     try {
       const tex = await loadAtlasTexture();
@@ -722,7 +723,7 @@ export const VoxelViewer = forwardRef<VoxelViewerHandle, ViewerProps>(function V
         signal: controller.signal,
         blockLimit,
         cacheKey: meshCacheKeySnapshot,
-        premeshedPayloadPromise: latest.premeshedPayloadPromise,
+        premeshedPayloadPromise,
         onPremeshedPayloadConsumed: latest.onPremeshedPayloadConsumed ?? undefined,
         yieldAfterMs: computeBuildYieldAfterMs(blockLimit),
         onStage(event) {

--- a/components/voxel/VoxelViewerCard.tsx
+++ b/components/voxel/VoxelViewerCard.tsx
@@ -31,7 +31,7 @@ export function VoxelViewerCard({
   voxelBuild,
   expectedBlockCount,
   meshCacheKey,
-  premeshedPayloadPromise,
+  getPremeshedPayloadPromise,
   onPremeshedPayloadConsumed,
   gridSize = 256,
   autoRotate = true,
@@ -69,7 +69,7 @@ export function VoxelViewerCard({
   voxelBuild: unknown | null;
   expectedBlockCount?: number;
   meshCacheKey?: string | null;
-  premeshedPayloadPromise?: Promise<VoxelMeshPayload> | null;
+  getPremeshedPayloadPromise?: () => Promise<VoxelMeshPayload> | null;
   onPremeshedPayloadConsumed?: (promise: Promise<VoxelMeshPayload>) => void;
   gridSize?: 64 | 256 | 512;
   autoRotate?: boolean;
@@ -397,7 +397,7 @@ export function VoxelViewerCard({
               palette={palette}
               expectedBlockCount={expectedBlockCount}
               meshCacheKey={meshCacheKey}
-              premeshedPayloadPromise={premeshedPayloadPromise}
+              getPremeshedPayloadPromise={getPremeshedPayloadPromise}
               onPremeshedPayloadConsumed={onPremeshedPayloadConsumed}
               autoRotate={autoRotate}
               // During progressive hydration, avoid restarting reveal animation on each chunk update.

--- a/lib/arena/premesh.ts
+++ b/lib/arena/premesh.ts
@@ -1,0 +1,21 @@
+import type { VoxelMeshPayload } from "@/lib/voxel/mesh";
+
+export type ArenaPremeshEntry = {
+  matchupId: string;
+  promise: Promise<VoxelMeshPayload>;
+  controller: AbortController;
+  started: boolean;
+};
+
+export function claimArenaPremesh(
+  entries: Map<string, ArenaPremeshEntry>,
+  key: string,
+): Promise<VoxelMeshPayload> | null {
+  const entry = entries.get(key);
+  if (!entry) return null;
+  if (entry.started) return entry.promise;
+
+  entry.controller.abort();
+  entries.delete(key);
+  return null;
+}

--- a/lib/voxel/mesh.worker.ts
+++ b/lib/voxel/mesh.worker.ts
@@ -9,10 +9,9 @@ import type {
 } from "@/lib/voxel/mesh";
 import { appendQuad, makeBucket, serializeBucket, type MeshBucket } from "@/lib/voxel/meshBuckets";
 import {
-  canBlockEmitAnyFace,
-  computeFaceAO,
   DIRS,
   SpatialBlockTable,
+  type CornerOffset,
   type Direction,
 } from "@/lib/voxel/ambientOcclusion";
 
@@ -39,8 +38,8 @@ type PreparedMeshData = {
   table: SpatialBlockTable;
   materialOccluding: Uint8Array;
   typeNames: string[];
-  typeIdsByName: Map<string, number>;
   blocks: TransferableVoxelBlocks;
+  visibleFaceMasks: Uint8Array;
   nonWaterBlockIndices: Int32Array;
   nonWaterCount: number;
   waterBlockIndices: Int32Array;
@@ -67,6 +66,16 @@ type PreResolvedFaceTable = {
   isEmissive: Uint8Array;
   tints: Array<FaceTint | null>;
   uvs: Array<FaceUv | null>;
+};
+
+type NeighborhoodCache = {
+  table: SpatialBlockTable;
+  materialOccluding: Uint8Array;
+  x: number;
+  y: number;
+  z: number;
+  knownMask: number;
+  occludingMask: number;
 };
 
 const workerScope = (typeof self !== "undefined" ? self : globalThis) as unknown as typeof globalThis & {
@@ -192,6 +201,85 @@ function postProgress(processedBlocks: number, totalBlocks: number, stageLabel: 
   workerScope.postMessage(message);
 }
 
+function computeVisibleFaceMask(
+  x: number,
+  y: number,
+  z: number,
+  typeId: number,
+  table: SpatialBlockTable,
+  materialOccluding: Uint8Array,
+): number {
+  let mask = 0;
+  for (let dIdx = 0; dIdx < 6; dIdx += 1) {
+    const d = DIRS[dIdx];
+    const neighborTypeId = table.get(x + d.dx, y + d.dy, z + d.dz);
+    if (
+      neighborTypeId === -1 ||
+      (neighborTypeId !== typeId && materialOccluding[neighborTypeId] !== 1)
+    ) {
+      mask |= 1 << dIdx;
+    }
+  }
+  return mask;
+}
+
+function isOccludingInNeighborhood(
+  cache: NeighborhoodCache,
+  dx: number,
+  dy: number,
+  dz: number,
+): boolean {
+  const bit = 1 << ((dx + 1) * 9 + (dy + 1) * 3 + dz + 1);
+  if ((cache.knownMask & bit) === 0) {
+    const typeId = cache.table.get(cache.x + dx, cache.y + dy, cache.z + dz);
+    cache.knownMask |= bit;
+    if (typeId !== -1 && cache.materialOccluding[typeId] === 1) {
+      cache.occludingMask |= bit;
+    }
+  }
+  return (cache.occludingMask & bit) !== 0;
+}
+
+function cachedCornerFactor(
+  corner: CornerOffset,
+  direction: Direction,
+  cache: NeighborhoodCache,
+): number {
+  const sideA = isOccludingInNeighborhood(
+    cache,
+    direction.dx + corner.sideA[0],
+    direction.dy + corner.sideA[1],
+    direction.dz + corner.sideA[2],
+  );
+  const sideB = isOccludingInNeighborhood(
+    cache,
+    direction.dx + corner.sideB[0],
+    direction.dy + corner.sideB[1],
+    direction.dz + corner.sideB[2],
+  );
+  if (sideA && sideB) return 0.58;
+  const diagonal = isOccludingInNeighborhood(
+    cache,
+    direction.dx + corner.diag[0],
+    direction.dy + corner.diag[1],
+    direction.dz + corner.diag[2],
+  );
+  const level = 3 - ((sideA ? 1 : 0) + (sideB ? 1 : 0) + (diagonal ? 1 : 0));
+  return 0.58 + (level / 3) * 0.42;
+}
+
+function computeFaceAOWithCache(
+  direction: Direction,
+  cache: NeighborhoodCache,
+): readonly [number, number, number, number] {
+  return [
+    cachedCornerFactor(direction.corners[0], direction, cache),
+    cachedCornerFactor(direction.corners[1], direction, cache),
+    cachedCornerFactor(direction.corners[2], direction, cache),
+    cachedCornerFactor(direction.corners[3], direction, cache),
+  ];
+}
+
 function prepareMeshData(
   blocks: TransferableVoxelBlocks,
   allowedBlockIds: string[],
@@ -209,14 +297,13 @@ function prepareMeshData(
 
   const table = new SpatialBlockTable(maxInputBlocks);
   const materialOccluding = new Uint8Array(typeNames.length);
-  const typeIdsByName = new Map<string, number>();
 
   for (let i = 0; i < typeNames.length; i += 1) {
     const name = typeNames[i];
-    typeIdsByName.set(name, i);
     materialOccluding[i] = isVoxelOccluder(name) ? 1 : 0;
   }
 
+  const visibleFaceMasks = new Uint8Array(maxInputBlocks);
   const nonWaterBlockIndices = new Int32Array(maxInputBlocks);
   const waterBlockIndices = new Int32Array(maxInputBlocks);
   let nonWaterCount = 0;
@@ -256,7 +343,9 @@ function prepareMeshData(
     const y = positions[i * 3 + 1];
     const z = positions[i * 3 + 2];
 
-    if (!canBlockEmitAnyFace(x, y, z, typeId, table, materialOccluding)) continue;
+    const visibleFaceMask = computeVisibleFaceMask(x, y, z, typeId, table, materialOccluding);
+    visibleFaceMasks[i] = visibleFaceMask;
+    if (visibleFaceMask === 0) continue;
 
     if (type === WATER_BLOCK_ID) {
       waterBlockIndices[waterCount] = i;
@@ -281,8 +370,8 @@ function prepareMeshData(
     table,
     materialOccluding,
     typeNames,
-    typeIdsByName,
     blocks,
+    visibleFaceMasks,
     nonWaterBlockIndices,
     nonWaterCount,
     waterBlockIndices,
@@ -306,6 +395,7 @@ function appendStandardFaces(
   prepared: PreparedMeshData,
   faceTable: PreResolvedFaceTable,
   bucketList: [MeshBucket, MeshBucket, MeshBucket, MeshBucket],
+  neighborhoodCache: NeighborhoodCache,
 ) {
   const { positions, typeIds } = prepared.blocks;
   const typeId = typeIds[blockIdx];
@@ -315,17 +405,18 @@ function appendStandardFaces(
   const bx = x - prepared.cx;
   const by = y - prepared.cy;
   const bz = z - prepared.cz;
+  const visibleFaceMask = prepared.visibleFaceMasks[blockIdx];
+  neighborhoodCache.x = x;
+  neighborhoodCache.y = y;
+  neighborhoodCache.z = z;
+  neighborhoodCache.knownMask = 0;
+  neighborhoodCache.occludingMask = 0;
 
   const baseFaceIdx = typeId * 6;
 
   for (let dIdx = 0; dIdx < 6; dIdx += 1) {
+    if ((visibleFaceMask & (1 << dIdx)) === 0) continue;
     const d = DIRS[dIdx];
-    const neighborTypeId = prepared.table.get(x + d.dx, y + d.dy, z + d.dz);
-    if (neighborTypeId !== -1) {
-      if (neighborTypeId === typeId) continue;
-      if (prepared.materialOccluding[neighborTypeId] === 1) continue;
-    }
-
     const faceIdx = baseFaceIdx + dIdx;
     if (faceTable.valid[faceIdx] === 0) continue;
 
@@ -334,7 +425,7 @@ function appendStandardFaces(
     const uv = faceTable.uvs[faceIdx]!;
     const ao = faceTable.isEmissive[faceIdx] === 1
       ? undefined
-      : computeFaceAO(d, x, y, z, prepared.table, prepared.materialOccluding);
+      : computeFaceAOWithCache(d, neighborhoodCache);
 
     appendQuad(
       bucket,
@@ -507,7 +598,6 @@ function buildWaterSurfaceBucket(prepared: PreparedMeshData): MeshBucket {
   const bucket = makeBucket({ repeatingUvs: true });
   const planes = new Map<string, { face: Face; plane: number; cells: Set<number> }>();
   if (!prepared.allowed.has(WATER_BLOCK_ID) || prepared.waterCount === 0) return bucket;
-  const waterTypeId = prepared.typeIdsByName.get(WATER_BLOCK_ID) ?? -1;
   const { positions } = prepared.blocks;
 
   for (let i = 0; i < prepared.waterCount; i += 1) {
@@ -515,18 +605,11 @@ function buildWaterSurfaceBucket(prepared: PreparedMeshData): MeshBucket {
     const x = positions[blockIdx * 3];
     const y = positions[blockIdx * 3 + 1];
     const z = positions[blockIdx * 3 + 2];
+    const visibleFaceMask = prepared.visibleFaceMasks[blockIdx];
 
-    for (const d of DIRS) {
-      const neighborTypeId = prepared.table.get(
-        x + d.dx,
-        y + d.dy,
-        z + d.dz,
-      );
-      if (neighborTypeId !== -1) {
-        if (neighborTypeId === waterTypeId) continue;
-        if (prepared.materialOccluding[neighborTypeId] === 1) continue;
-      }
-
+    for (let dIdx = 0; dIdx < 6; dIdx += 1) {
+      if ((visibleFaceMask & (1 << dIdx)) === 0) continue;
+      const d = DIRS[dIdx];
       switch (d.face) {
         case "east":
           getOrCreatePlane(planes, d.face, x + 1).cells.add(packPlaneCell(y, z));
@@ -584,10 +667,19 @@ export function buildMeshPayload(
     transparent,
     emissive,
   ];
+  const neighborhoodCache: NeighborhoodCache = {
+    table: prepared.table,
+    materialOccluding: prepared.materialOccluding,
+    x: 0,
+    y: 0,
+    z: 0,
+    knownMask: 0,
+    occludingMask: 0,
+  };
 
   for (let i = 0; i < prepared.nonWaterCount; i += 1) {
     const blockIdx = prepared.nonWaterBlockIndices[i];
-    appendStandardFaces(blockIdx, prepared, faceTable, bucketList);
+    appendStandardFaces(blockIdx, prepared, faceTable, bucketList, neighborhoodCache);
     if ((i & (PROGRESS_EVERY - 1)) === 0) {
       postProgress(i, Math.max(1, prepared.nonWaterCount), "Meshing blocks");
     }

--- a/tests/unit/arena/arena-premesh.test.ts
+++ b/tests/unit/arena/arena-premesh.test.ts
@@ -7,6 +7,10 @@ import {
 import type { VoxelBuild } from "../../../lib/voxel/types";
 import { getPalette } from "../../../lib/blocks/palettes";
 import { clientMetricBatchSchema } from "../../../lib/observability/customMetrics";
+import {
+  claimArenaPremesh,
+  type ArenaPremeshEntry,
+} from "../../../lib/arena/premesh";
 
 function makeFakeTexture(): THREE.Texture {
   const texture = new THREE.Texture();
@@ -155,12 +159,7 @@ function testMatchupStageMetricsValidation() {
 }
 
 function testArenaPremeshMapLifecycle() {
-  type PremeshEntry = {
-    matchupId: string;
-    controller: AbortController;
-    promise: Promise<VoxelMeshPayload>;
-  };
-  const premeshMap = new Map<string, PremeshEntry>();
+  const premeshMap = new Map<string, ArenaPremeshEntry>();
 
   const ARENA_PREMESH_MAX_BLOCK_COUNT = 150_000;
 
@@ -174,18 +173,34 @@ function testArenaPremeshMapLifecycle() {
   assert.equal(shouldAdmitPremesh(150_000), true);
   assert.equal(shouldAdmitPremesh(150_001), false);
 
-  // 2. Duplicate avoidance & in-flight joining
-  const ctrl1 = new AbortController();
+  // 2. Queued work yields to the visible lane instead of delaying it
   const fakePayload = makeFakeMeshPayload(10);
   const promise1 = Promise.resolve(fakePayload);
-  premeshMap.set("build-1", { matchupId: "matchup-1", controller: ctrl1, promise: promise1 });
+  const queuedController = new AbortController();
+  premeshMap.set("queued", {
+    matchupId: "matchup-1",
+    controller: queuedController,
+    promise: promise1,
+    started: false,
+  });
 
-  // Adding existing key does nothing
-  const existing = premeshMap.get("build-1");
-  assert.ok(existing);
-  assert.equal(existing.promise, promise1);
+  assert.equal(claimArenaPremesh(premeshMap, "queued"), null);
+  assert.equal(queuedController.signal.aborted, true);
+  assert.equal(premeshMap.has("queued"), false);
 
-  // 3. Entry consumption
+  // 3. Started work is reused rather than duplicated
+  const startedController = new AbortController();
+  premeshMap.set("started", {
+    matchupId: "matchup-1",
+    controller: startedController,
+    promise: promise1,
+    started: true,
+  });
+  assert.equal(claimArenaPremesh(premeshMap, "started"), promise1);
+  assert.equal(startedController.signal.aborted, false);
+  assert.equal(premeshMap.has("started"), true);
+
+  // 4. Entry consumption
   function consumePremesh(key: string): Promise<VoxelMeshPayload> | null {
     const entry = premeshMap.get(key);
     if (!entry) return null;
@@ -193,16 +208,26 @@ function testArenaPremeshMapLifecycle() {
     return entry.promise;
   }
 
-  const consumed = consumePremesh("build-1");
+  const consumed = consumePremesh("started");
   assert.equal(consumed, promise1);
-  assert.equal(premeshMap.has("build-1"), false);
-  assert.equal(consumePremesh("build-1"), null);
+  assert.equal(premeshMap.has("started"), false);
+  assert.equal(consumePremesh("started"), null);
 
-  // 4. Aborting on matchup advance
+  // 5. Aborting on matchup advance
   const ctrlA = new AbortController();
   const ctrlB = new AbortController();
-  premeshMap.set("b-1", { matchupId: "m-1", controller: ctrlA, promise: promise1 });
-  premeshMap.set("b-2", { matchupId: "m-2", controller: ctrlB, promise: promise1 });
+  premeshMap.set("b-1", {
+    matchupId: "m-1",
+    controller: ctrlA,
+    promise: promise1,
+    started: true,
+  });
+  premeshMap.set("b-2", {
+    matchupId: "m-2",
+    controller: ctrlB,
+    promise: promise1,
+    started: false,
+  });
 
   function abortPremeshedMeshes(matchupId?: string) {
     for (const [key, entry] of premeshMap) {
@@ -218,7 +243,7 @@ function testArenaPremeshMapLifecycle() {
   assert.equal(premeshMap.has("b-1"), false);
   assert.equal(premeshMap.has("b-2"), true);
 
-  // 5. Unmount cleanup (aborts all remaining)
+  // 6. Unmount cleanup (aborts all remaining)
   abortPremeshedMeshes();
   assert.equal(ctrlB.signal.aborted, true);
   assert.equal(premeshMap.size, 0);


### PR DESCRIPTION
## Summary

- let visible Arena lanes bypass background pre-mesh jobs that are still queued while continuing to reuse jobs that have already started
- compute each worker block's visible-face mask once and reuse it for standard and water meshing
- lazily reuse repeated ambient-occlusion neighborhood lookups within each block
- cover queued-versus-started pre-mesh consumption while preserving the existing frozen mesh payload hashes

## Alpha results

Across 191 post-deploy vote-ready samples versus 157 samples on the closest prior Alpha baseline:

| Metric | Before | After | Change |
| --- | ---: | ---: | ---: |
| Average time to vote | 868 ms | 619 ms | -29% |
| p50 time to vote | 464 ms | 331 ms | -29% |
| p75 time to vote | 1,271 ms | 981 ms | -23% |
| p95 time to vote | 3,149 ms | 2,143 ms | -32% |

Worker mesh time also improved:

- 150k-300k blocks: p50 `1,120 ms -> 741 ms`; p95 `2,963 ms -> 1,675 ms`
- 300k-1m blocks: p50 `2,137 ms -> 1,221 ms`

The Alpha deployment produced no runtime errors or 4xx/5xx responses during the measured window.

## Validation

- `pnpm exec tsx tests/unit/arena/arena-premesh.test.ts`
- `pnpm exec tsx tests/unit/voxel/mesh-worker-hot-loop.test.ts`
- `pnpm exec tsx tests/unit/voxel/mesh-buckets.test.ts`
- `pnpm exec tsc --noEmit`
- `pnpm lint` — zero errors; two existing generated-workflow warnings
- `pnpm build`
- `pnpm test` — changed-area tests pass; the local full suite stops at `tests/unit/scripts/model-publish.test.ts` because the configured Supabase Auth, Storage, and Database URLs target different project references

*(PR written by Codex)*
