### PR TITLE
feat(voxel): add MBF1 mesh facts codec

### DIFF
--- a/lib/observability/customMetrics.ts
+++ b/lib/observability/customMetrics.ts
@@ -75,7 +75,7 @@ const voxelMetricSchema = z
     kind: z.literal("voxel"),
     surface: z.enum(["arena", "sandbox", "leaderboard"]),
     variant: z.enum(["preview", "full"]),
-    strategy: z.enum(["local", "worker", "worker-fallback"]),
+    strategy: z.enum(["local", "worker", "worker-facts", "worker-fallback"]),
     cacheStatus: z.enum(["hit", "miss", "disabled", "not-used", "prewarm-hit"]),
     blockCountBucket: blockCountBucketSchema,
     renderedBlockCountBucket: blockCountBucketSchema,

--- a/lib/voxel/ambientOcclusion.ts
+++ b/lib/voxel/ambientOcclusion.ts
@@ -197,6 +197,32 @@ export function isOccludingAt(
   return tid !== -1 && materialOccluding[tid] === 1;
 }
 
+export function computeVisibleFaceMask(
+  x: number,
+  y: number,
+  z: number,
+  typeId: number,
+  table: SpatialBlockTable,
+  materialOccluding: Uint8Array,
+): number {
+  let mask = 0;
+  for (let dIdx = 0; dIdx < DIRS.length; dIdx += 1) {
+    const direction = DIRS[dIdx];
+    const neighborTypeId = table.get(
+      x + direction.dx,
+      y + direction.dy,
+      z + direction.dz,
+    );
+    if (
+      neighborTypeId === -1 ||
+      (neighborTypeId !== typeId && materialOccluding[neighborTypeId] !== 1)
+    ) {
+      mask |= 1 << dIdx;
+    }
+  }
+  return mask;
+}
+
 function cornerFactor(
   corner: CornerOffset,
   ox: number,

--- a/lib/voxel/mesh.ts
+++ b/lib/voxel/mesh.ts
@@ -28,6 +28,10 @@ import {
   SpatialBlockTable,
   type Direction,
 } from "@/lib/voxel/ambientOcclusion";
+import {
+  copyVoxelMeshFacts,
+  type VoxelMeshFacts,
+} from "@/lib/voxel/meshFacts";
 
 export type { SerializedMeshBucket } from "@/lib/voxel/meshBuckets";
 
@@ -37,7 +41,7 @@ type BuildProgress = {
   stageLabel?: string;
 };
 
-export type VoxelMeshStrategy = "local" | "worker" | "worker-fallback";
+export type VoxelMeshStrategy = "local" | "worker" | "worker-facts" | "worker-fallback";
 export type VoxelMeshCacheStatus = "hit" | "miss" | "disabled" | "not-used" | "prewarm-hit";
 export type VoxelMeshStageEvent = {
   stage: "mesh_started" | "mesh_payload_complete" | "three_group_complete";
@@ -1008,17 +1012,32 @@ export function encodeTransferableVoxelBlocks(
   return packVoxelBlocks(blocks);
 }
 
-type MeshWorkerRequest = {
-  type: "build";
-  blocks: TransferableVoxelBlocks;
-  allowedBlockIds: string[];
-  blockLimit?: number;
-};
+type MeshWorkerRequest =
+  | {
+      type: "build";
+      blocks: TransferableVoxelBlocks;
+      allowedBlockIds: string[];
+      blockLimit?: number;
+    }
+  | {
+      type: "mesh-facts";
+      facts: VoxelMeshFacts;
+      allowedBlockIds: string[];
+    };
 
 type MeshWorkerResponse =
   | { type: "progress"; progress: BuildProgress }
   | { type: "complete"; payload: VoxelMeshPayload }
   | { type: "error"; message: string };
+
+function getUsableMeshFacts(
+  build: RenderableVoxelBuild,
+  blockLimit?: number,
+): VoxelMeshFacts | null {
+  const facts = build.meshFacts;
+  if (!facts) return null;
+  return blockLimit == null || blockLimit >= facts.blocks.count ? facts : null;
+}
 
 export function createVoxelGroupFromMeshPayload(
   payload: VoxelMeshPayload,
@@ -1168,6 +1187,23 @@ export async function createVoxelMeshPayloadInWorker(
       return;
     }
     opts?.signal?.addEventListener("abort", onAbort, { once: true });
+
+    const usableMeshFacts = getUsableMeshFacts(build, opts?.blockLimit);
+    if (usableMeshFacts) {
+      const facts = copyVoxelMeshFacts(usableMeshFacts);
+      const request: MeshWorkerRequest = {
+        type: "mesh-facts",
+        facts,
+        allowedBlockIds: palette.map((entry) => entry.id),
+      };
+      worker.postMessage(request, [
+        facts.blocks.positions.buffer,
+        facts.blocks.typeIds.buffer,
+        facts.visibilityMasks.buffer,
+        facts.ambientOcclusion.buffer,
+      ]);
+      return;
+    }
 
     // A packed build is still being hydrated in place, so the worker gets a
     // trimmed copy: transferring the live arrays would detach them.
@@ -1407,11 +1443,14 @@ export async function createVoxelGroupAsync(
   }
 
   try {
-    opts?.onStage?.({ stage: "mesh_started", strategy: "worker" });
+    const workerStrategy: VoxelMeshStrategy = getUsableMeshFacts(build, blockLimit)
+      ? "worker-facts"
+      : "worker";
+    opts?.onStage?.({ stage: "mesh_started", strategy: workerStrategy });
     const { payload, cacheStatus } = await createVoxelMeshPayloadInWorker(build, palette, opts);
     opts?.onStage?.({
       stage: "mesh_payload_complete",
-      strategy: "worker",
+      strategy: workerStrategy,
       cacheStatus,
       blockCount: payload.filteredBlockCount,
     });
@@ -1419,7 +1458,7 @@ export async function createVoxelGroupAsync(
     const group = createVoxelGroupFromMeshPayload(payload, atlasTexture);
     opts?.onStage?.({
       stage: "three_group_complete",
-      strategy: "worker",
+      strategy: workerStrategy,
       cacheStatus,
       blockCount: group.stats.blockCount,
     });

--- a/lib/voxel/mesh.worker.ts
+++ b/lib/voxel/mesh.worker.ts
@@ -816,6 +816,10 @@ export function buildMeshPayloadFromFacts(
   facts: VoxelMeshFacts,
   allowedBlockIds: string[],
 ): VoxelMeshPayload {
+  const allowed = new Set(allowedBlockIds);
+  if (facts.blocks.typeNames.some((type) => !allowed.has(type))) {
+    return buildMeshPayload(facts.blocks, allowedBlockIds);
+  }
   const prepared = prepareMeshDataFromFacts(facts, allowedBlockIds);
   const faceTable = buildFaceTable(prepared.typeNames, prepared.allowed);
   const opaque = makeBucket();

--- a/lib/voxel/mesh.worker.ts
+++ b/lib/voxel/mesh.worker.ts
@@ -9,11 +9,13 @@ import type {
 } from "@/lib/voxel/mesh";
 import { appendQuad, makeBucket, serializeBucket, type MeshBucket } from "@/lib/voxel/meshBuckets";
 import {
+  computeVisibleFaceMask,
   DIRS,
   SpatialBlockTable,
   type CornerOffset,
   type Direction,
 } from "@/lib/voxel/ambientOcclusion";
+import type { VoxelMeshFacts } from "@/lib/voxel/meshFacts";
 
 type BuildProgress = {
   processedBlocks: number;
@@ -21,12 +23,18 @@ type BuildProgress = {
   stageLabel?: string;
 };
 
-type WorkerRequest = {
-  type: "build";
-  blocks: TransferableVoxelBlocks;
-  allowedBlockIds: string[];
-  blockLimit?: number;
-};
+type WorkerRequest =
+  | {
+      type: "build";
+      blocks: TransferableVoxelBlocks;
+      allowedBlockIds: string[];
+      blockLimit?: number;
+    }
+  | {
+      type: "mesh-facts";
+      facts: VoxelMeshFacts;
+      allowedBlockIds: string[];
+    };
 
 type WorkerResponse =
   | { type: "progress"; progress: BuildProgress }
@@ -86,6 +94,13 @@ const POSITION_BITS = 10;
 const POSITION_MASK = (1 << POSITION_BITS) - 1;
 const WATER_BLOCK_ID = "water";
 const PROGRESS_EVERY = 4096;
+const AO_FACTORS = [0.58, 0.72, 0.86, 1] as const;
+const AMBIENT_OCCLUSION_BY_BYTE = Array.from({ length: 256 }, (_, packed) => [
+  AO_FACTORS[packed & 0x03],
+  AO_FACTORS[(packed >> 2) & 0x03],
+  AO_FACTORS[(packed >> 4) & 0x03],
+  AO_FACTORS[(packed >> 6) & 0x03],
+] as const);
 
 function packPlaneCell(u: number, v: number): number {
   return u | (v << POSITION_BITS);
@@ -148,15 +163,15 @@ function buildFaceTable(
     for (let dIdx = 0; dIdx < 6; dIdx += 1) {
       const d = DIRS[dIdx];
       const texKey = getTextureKey(typeName, d.face);
+      const faceIdx = typeId * 6 + dIdx;
+      isEmissive[faceIdx] = emissive;
       if (!hasAtlasKey(texKey)) continue;
 
       const uv = getAtlasUv(texKey);
       const tint = faceTint(typeName, d.face);
-      const faceIdx = typeId * 6 + dIdx;
 
       valid[faceIdx] = 1;
       bucketIndex[faceIdx] = bIndex;
-      isEmissive[faceIdx] = emissive;
       tints[faceIdx] = tint;
       uvs[faceIdx] = [uv.u0, uv.v0, uv.u0, uv.v1, uv.u1, uv.v1, uv.u1, uv.v0];
     }
@@ -199,28 +214,6 @@ function postProgress(processedBlocks: number, totalBlocks: number, stageLabel: 
     },
   };
   workerScope.postMessage(message);
-}
-
-function computeVisibleFaceMask(
-  x: number,
-  y: number,
-  z: number,
-  typeId: number,
-  table: SpatialBlockTable,
-  materialOccluding: Uint8Array,
-): number {
-  let mask = 0;
-  for (let dIdx = 0; dIdx < 6; dIdx += 1) {
-    const d = DIRS[dIdx];
-    const neighborTypeId = table.get(x + d.dx, y + d.dy, z + d.dz);
-    if (
-      neighborTypeId === -1 ||
-      (neighborTypeId !== typeId && materialOccluding[neighborTypeId] !== 1)
-    ) {
-      mask |= 1 << dIdx;
-    }
-  }
-  return mask;
 }
 
 function isOccludingInNeighborhood(
@@ -390,6 +383,83 @@ function prepareMeshData(
   };
 }
 
+function prepareMeshDataFromFacts(
+  facts: VoxelMeshFacts,
+  allowedBlockIds: string[],
+): PreparedMeshData {
+  const allowed = new Set(allowedBlockIds);
+  const blocks = facts.blocks;
+  if (facts.visibilityMasks.length !== blocks.count) {
+    throw new Error("Mesh facts visibility masks do not match block count");
+  }
+
+  const nonWaterBlockIndices = new Int32Array(blocks.count);
+  const waterBlockIndices = new Int32Array(blocks.count);
+  let nonWaterCount = 0;
+  let waterCount = 0;
+  let minX = Infinity;
+  let minY = Infinity;
+  let minZ = Infinity;
+  let maxX = -Infinity;
+  let maxY = -Infinity;
+  let maxZ = -Infinity;
+
+  for (let i = 0; i < blocks.count; i += 1) {
+    const type = blocks.typeNames[blocks.typeIds[i]];
+    if (!type || !allowed.has(type)) continue;
+    const x = blocks.positions[i * 3];
+    const y = blocks.positions[i * 3 + 1];
+    const z = blocks.positions[i * 3 + 2];
+    minX = Math.min(minX, x);
+    minY = Math.min(minY, y);
+    minZ = Math.min(minZ, z);
+    maxX = Math.max(maxX, x);
+    maxY = Math.max(maxY, y);
+    maxZ = Math.max(maxZ, z);
+    if (facts.visibilityMasks[i] !== 0) {
+      if (type === WATER_BLOCK_ID) {
+        waterBlockIndices[waterCount] = i;
+        waterCount += 1;
+      } else {
+        nonWaterBlockIndices[nonWaterCount] = i;
+        nonWaterCount += 1;
+      }
+    }
+    if ((i & (PROGRESS_EVERY - 1)) === 0) {
+      postProgress(i, Math.max(1, blocks.count), "Loading mesh facts");
+    }
+  }
+
+  if (!Number.isFinite(minX)) {
+    minX = minY = minZ = 0;
+    maxX = maxY = maxZ = 0;
+  }
+
+  return {
+    allowed,
+    table: new SpatialBlockTable(0),
+    materialOccluding: new Uint8Array(0),
+    typeNames: blocks.typeNames,
+    blocks,
+    visibleFaceMasks: facts.visibilityMasks,
+    nonWaterBlockIndices,
+    nonWaterCount,
+    waterBlockIndices,
+    waterCount,
+    filteredBlockCount: nonWaterCount + waterCount,
+    maxInputBlocks: blocks.count,
+    minX,
+    minY,
+    minZ,
+    maxX,
+    maxY,
+    maxZ,
+    cx: (minX + maxX + 1) / 2,
+    cy: minY,
+    cz: (minZ + maxZ + 1) / 2,
+  };
+}
+
 function appendStandardFaces(
   blockIdx: number,
   prepared: PreparedMeshData,
@@ -433,6 +503,49 @@ function appendStandardFaces(
       d,
       tint,
       uv,
+      ao,
+    );
+  }
+}
+
+function appendStandardFacesFromFacts(
+  blockIdx: number,
+  prepared: PreparedMeshData,
+  faceTable: PreResolvedFaceTable,
+  bucketList: [MeshBucket, MeshBucket, MeshBucket, MeshBucket],
+  ambientOcclusion: Uint8Array,
+  ambientOcclusionCursor: { value: number },
+) {
+  const { positions, typeIds } = prepared.blocks;
+  const typeId = typeIds[blockIdx];
+  const x = positions[blockIdx * 3];
+  const y = positions[blockIdx * 3 + 1];
+  const z = positions[blockIdx * 3 + 2];
+  const bx = x - prepared.cx;
+  const by = y - prepared.cy;
+  const bz = z - prepared.cz;
+  const visibleFaceMask = prepared.visibleFaceMasks[blockIdx];
+  const baseFaceIdx = typeId * 6;
+
+  for (let dIdx = 0; dIdx < 6; dIdx += 1) {
+    if ((visibleFaceMask & (1 << dIdx)) === 0) continue;
+    const faceIdx = baseFaceIdx + dIdx;
+    let ao: readonly [number, number, number, number] | undefined;
+    if (faceTable.isEmissive[faceIdx] === 0) {
+      if (ambientOcclusionCursor.value >= ambientOcclusion.length) {
+        throw new Error("Mesh facts ambient occlusion data is truncated");
+      }
+      ao = AMBIENT_OCCLUSION_BY_BYTE[ambientOcclusion[ambientOcclusionCursor.value]];
+      ambientOcclusionCursor.value += 1;
+    }
+    if (faceTable.valid[faceIdx] === 0) continue;
+
+    appendQuad(
+      bucketList[faceTable.bucketIndex[faceIdx]],
+      DIRS[dIdx].quad(bx, by, bz),
+      DIRS[dIdx],
+      faceTable.tints[faceIdx]!,
+      faceTable.uvs[faceIdx]!,
       ao,
     );
   }
@@ -699,6 +812,54 @@ export function buildMeshPayload(
   };
 }
 
+export function buildMeshPayloadFromFacts(
+  facts: VoxelMeshFacts,
+  allowedBlockIds: string[],
+): VoxelMeshPayload {
+  const prepared = prepareMeshDataFromFacts(facts, allowedBlockIds);
+  const faceTable = buildFaceTable(prepared.typeNames, prepared.allowed);
+  const opaque = makeBucket();
+  const cutout = makeBucket();
+  const transparent = makeBucket();
+  const emissive = makeBucket();
+  const bucketList: [MeshBucket, MeshBucket, MeshBucket, MeshBucket] = [
+    opaque,
+    cutout,
+    transparent,
+    emissive,
+  ];
+  const ambientOcclusionCursor = { value: 0 };
+
+  for (let i = 0; i < prepared.nonWaterCount; i += 1) {
+    appendStandardFacesFromFacts(
+      prepared.nonWaterBlockIndices[i],
+      prepared,
+      faceTable,
+      bucketList,
+      facts.ambientOcclusion,
+      ambientOcclusionCursor,
+    );
+    if ((i & (PROGRESS_EVERY - 1)) === 0) {
+      postProgress(i, Math.max(1, prepared.nonWaterCount), "Expanding mesh facts");
+    }
+  }
+  if (ambientOcclusionCursor.value !== facts.ambientOcclusion.length) {
+    throw new Error("Mesh facts ambient occlusion data has trailing bytes");
+  }
+
+  const water = buildWaterSurfaceBucket(prepared);
+  postProgress(prepared.filteredBlockCount, Math.max(1, prepared.filteredBlockCount), "Finalizing geometry");
+  return {
+    opaque: serializeBucket(opaque),
+    cutout: serializeBucket(cutout),
+    transparent: serializeBucket(transparent),
+    water: serializeBucket(water),
+    emissive: serializeBucket(emissive),
+    bounds: serializeBounds(prepared),
+    filteredBlockCount: prepared.filteredBlockCount,
+  };
+}
+
 function collectTransferables(payload: VoxelMeshPayload): Transferable[] {
   const transferables: Transferable[] = [];
   for (const bucket of [
@@ -723,10 +884,12 @@ function collectTransferables(payload: VoxelMeshPayload): Transferable[] {
 if (typeof self !== "undefined") {
   workerScope.onmessage = (event: MessageEvent<WorkerRequest>) => {
     const message = event.data;
-    if (!message || message.type !== "build") return;
+    if (!message) return;
 
     try {
-      const payload = buildMeshPayload(message.blocks, message.allowedBlockIds, message.blockLimit);
+      const payload = message.type === "mesh-facts"
+        ? buildMeshPayloadFromFacts(message.facts, message.allowedBlockIds)
+        : buildMeshPayload(message.blocks, message.allowedBlockIds, message.blockLimit);
       const response: WorkerResponse = { type: "complete", payload };
       workerScope.postMessage?.(response, collectTransferables(payload));
     } catch (err) {

--- a/lib/voxel/meshFacts.ts
+++ b/lib/voxel/meshFacts.ts
@@ -1,0 +1,289 @@
+import { getRenderKind } from "@/lib/blocks/registry";
+import {
+  computeFaceAO,
+  computeVisibleFaceMask,
+  DIRS,
+  SpatialBlockTable,
+} from "@/lib/voxel/ambientOcclusion";
+import {
+  decodeBinaryVoxelBuild,
+  encodeBinaryVoxelBuild,
+  readBinaryVoxelBuildHeader,
+} from "@/lib/voxel/binaryBuild";
+import {
+  copyPackedVoxelBlocks,
+  type PackedVoxelBlocks,
+} from "@/lib/voxel/packedBlocks";
+import { isVoxelOccluder } from "@/lib/voxel/renderVisibility";
+
+export const MESH_FACTS_MAGIC = 0x4d424631;
+export const MESH_FACTS_VERSION = 1;
+export const MESH_FACTS_HEADER_BYTES = 24;
+
+const MAX_UINT32 = 0xffff_ffff;
+const WATER_BLOCK_ID = "water";
+const FACE_COUNT_BY_MASK = new Uint8Array(64);
+for (let mask = 0; mask < FACE_COUNT_BY_MASK.length; mask += 1) {
+  let value = mask;
+  let count = 0;
+  while (value !== 0) {
+    count += value & 1;
+    value >>>= 1;
+  }
+  FACE_COUNT_BY_MASK[mask] = count;
+}
+
+export type VoxelMeshFacts = {
+  blocks: PackedVoxelBlocks;
+  visibilityMasks: Uint8Array;
+  ambientOcclusion: Uint8Array;
+  visibleFaceCount: number;
+  filteredBlockCount: number;
+};
+
+export type VoxelMeshFactsHeader = {
+  version: number;
+  flags: number;
+  blockPayloadBytes: number;
+  visibleFaceCount: number;
+  ambientOcclusionFaceCount: number;
+  filteredBlockCount: number;
+};
+
+export class VoxelMeshFactsFormatError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "VoxelMeshFactsFormatError";
+  }
+}
+
+function faceCount(mask: number): number {
+  return FACE_COUNT_BY_MASK[mask & 0x3f];
+}
+
+function encodeAmbientOcclusion(
+  factors: readonly [number, number, number, number],
+): number {
+  let packed = 0;
+  for (let i = 0; i < 4; i += 1) {
+    const level = Math.max(0, Math.min(3, Math.round(((factors[i] - 0.58) / 0.42) * 3)));
+    packed |= level << (i * 2);
+  }
+  return packed;
+}
+
+function validatePackedBlocks(blocks: PackedVoxelBlocks): void {
+  if (!Number.isInteger(blocks.count) || blocks.count < 0) {
+    throw new VoxelMeshFactsFormatError("Mesh facts block count is invalid");
+  }
+  if (blocks.positions.length < blocks.count * 3 || blocks.typeIds.length < blocks.count) {
+    throw new VoxelMeshFactsFormatError("Mesh facts block arrays are truncated");
+  }
+  for (let i = 0; i < blocks.count; i += 1) {
+    if (blocks.typeIds[i] >= blocks.typeNames.length) {
+      throw new VoxelMeshFactsFormatError(
+        `Block ${i} references palette entry ${blocks.typeIds[i]}`,
+      );
+    }
+  }
+}
+
+export function createVoxelMeshFacts(blocks: PackedVoxelBlocks): VoxelMeshFacts {
+  validatePackedBlocks(blocks);
+  const table = new SpatialBlockTable(blocks.count);
+  const materialOccluding = new Uint8Array(blocks.typeNames.length);
+  for (let typeId = 0; typeId < blocks.typeNames.length; typeId += 1) {
+    materialOccluding[typeId] = isVoxelOccluder(blocks.typeNames[typeId]) ? 1 : 0;
+  }
+
+  for (let i = 0; i < blocks.count; i += 1) {
+    table.set(
+      blocks.positions[i * 3],
+      blocks.positions[i * 3 + 1],
+      blocks.positions[i * 3 + 2],
+      blocks.typeIds[i],
+    );
+  }
+
+  const visibilityMasks = new Uint8Array(blocks.count);
+  let visibleFaceCount = 0;
+  let filteredBlockCount = 0;
+  for (let i = 0; i < blocks.count; i += 1) {
+    const mask = computeVisibleFaceMask(
+      blocks.positions[i * 3],
+      blocks.positions[i * 3 + 1],
+      blocks.positions[i * 3 + 2],
+      blocks.typeIds[i],
+      table,
+      materialOccluding,
+    );
+    visibilityMasks[i] = mask;
+    if (mask !== 0) filteredBlockCount += 1;
+    visibleFaceCount += faceCount(mask);
+  }
+
+  const ambientOcclusion = new Uint8Array(visibleFaceCount);
+  let ambientOcclusionFaceCount = 0;
+  for (let i = 0; i < blocks.count; i += 1) {
+    const mask = visibilityMasks[i];
+    if (mask === 0) continue;
+    const type = blocks.typeNames[blocks.typeIds[i]];
+    if (type === WATER_BLOCK_ID || getRenderKind(type) === "emissive") continue;
+    const x = blocks.positions[i * 3];
+    const y = blocks.positions[i * 3 + 1];
+    const z = blocks.positions[i * 3 + 2];
+    for (let dIdx = 0; dIdx < DIRS.length; dIdx += 1) {
+      if ((mask & (1 << dIdx)) === 0) continue;
+      ambientOcclusion[ambientOcclusionFaceCount] = encodeAmbientOcclusion(
+        computeFaceAO(DIRS[dIdx], x, y, z, table, materialOccluding),
+      );
+      ambientOcclusionFaceCount += 1;
+    }
+  }
+
+  return {
+    blocks,
+    visibilityMasks,
+    ambientOcclusion: ambientOcclusion.slice(0, ambientOcclusionFaceCount),
+    visibleFaceCount,
+    filteredBlockCount,
+  };
+}
+
+export function encodeVoxelMeshFacts(facts: VoxelMeshFacts): Uint8Array {
+  validatePackedBlocks(facts.blocks);
+  if (facts.visibilityMasks.length !== facts.blocks.count) {
+    throw new VoxelMeshFactsFormatError("Mesh facts visibility masks do not match block count");
+  }
+  const blockPayload = encodeBinaryVoxelBuild(facts.blocks, null);
+  const fields = [
+    blockPayload.byteLength,
+    facts.visibleFaceCount,
+    facts.ambientOcclusion.byteLength,
+    facts.filteredBlockCount,
+  ];
+  if (fields.some((value) => !Number.isInteger(value) || value < 0 || value > MAX_UINT32)) {
+    throw new VoxelMeshFactsFormatError("Mesh facts header value exceeds its field");
+  }
+  const total = MESH_FACTS_HEADER_BYTES + blockPayload.byteLength +
+    facts.visibilityMasks.byteLength + facts.ambientOcclusion.byteLength;
+  const bytes = new Uint8Array(total);
+  const view = new DataView(bytes.buffer);
+  view.setUint32(0, MESH_FACTS_MAGIC, false);
+  view.setUint8(4, MESH_FACTS_VERSION);
+  view.setUint8(5, 0);
+  view.setUint16(6, MESH_FACTS_HEADER_BYTES, false);
+  view.setUint32(8, blockPayload.byteLength, false);
+  view.setUint32(12, facts.visibleFaceCount, false);
+  view.setUint32(16, facts.ambientOcclusion.byteLength, false);
+  view.setUint32(20, facts.filteredBlockCount, false);
+  bytes.set(blockPayload, MESH_FACTS_HEADER_BYTES);
+  bytes.set(facts.visibilityMasks, MESH_FACTS_HEADER_BYTES + blockPayload.byteLength);
+  bytes.set(
+    facts.ambientOcclusion,
+    MESH_FACTS_HEADER_BYTES + blockPayload.byteLength + facts.visibilityMasks.byteLength,
+  );
+  return bytes;
+}
+
+export function isVoxelMeshFacts(bytes: Uint8Array): boolean {
+  return bytes.length >= MESH_FACTS_HEADER_BYTES &&
+    bytes[0] === 0x4d && bytes[1] === 0x42 && bytes[2] === 0x46 && bytes[3] === 0x31;
+}
+
+export function readVoxelMeshFactsHeader(bytes: Uint8Array): VoxelMeshFactsHeader {
+  if (!isVoxelMeshFacts(bytes)) {
+    throw new VoxelMeshFactsFormatError("Not an MBF1 mesh facts payload");
+  }
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  const version = view.getUint8(4);
+  if (version !== MESH_FACTS_VERSION) {
+    throw new VoxelMeshFactsFormatError(`Unsupported mesh facts version ${version}`);
+  }
+  const headerBytes = view.getUint16(6, false);
+  if (headerBytes !== MESH_FACTS_HEADER_BYTES) {
+    throw new VoxelMeshFactsFormatError(`Unsupported mesh facts header length ${headerBytes}`);
+  }
+  return {
+    version,
+    flags: view.getUint8(5),
+    blockPayloadBytes: view.getUint32(8, false),
+    visibleFaceCount: view.getUint32(12, false),
+    ambientOcclusionFaceCount: view.getUint32(16, false),
+    filteredBlockCount: view.getUint32(20, false),
+  };
+}
+
+export function decodeVoxelMeshFacts(bytes: Uint8Array): VoxelMeshFacts {
+  const header = readVoxelMeshFactsHeader(bytes);
+  const blockPayloadEnd = MESH_FACTS_HEADER_BYTES + header.blockPayloadBytes;
+  if (blockPayloadEnd > bytes.byteLength) {
+    throw new VoxelMeshFactsFormatError("Mesh facts block payload is truncated");
+  }
+  const blockPayload = bytes.subarray(MESH_FACTS_HEADER_BYTES, blockPayloadEnd);
+  let nestedHeader;
+  try {
+    nestedHeader = readBinaryVoxelBuildHeader(blockPayload);
+  } catch (error) {
+    throw new VoxelMeshFactsFormatError(
+      error instanceof Error ? error.message : "Mesh facts block payload is invalid",
+    );
+  }
+  if (nestedHeader.checksumPrefix !== 0) {
+    throw new VoxelMeshFactsFormatError("Mesh facts block payload contains a content identity");
+  }
+  const expectedLength = blockPayloadEnd + nestedHeader.blockCount +
+    header.ambientOcclusionFaceCount;
+  if (bytes.byteLength !== expectedLength) {
+    throw new VoxelMeshFactsFormatError(
+      `Mesh facts length ${bytes.byteLength} does not match the declared ${expectedLength}`,
+    );
+  }
+
+  const blocks = decodeBinaryVoxelBuild(blockPayload);
+  const visibilityMasks = bytes.slice(blockPayloadEnd, blockPayloadEnd + blocks.count);
+  const ambientOcclusion = bytes.slice(blockPayloadEnd + blocks.count);
+  let visibleFaceCount = 0;
+  let filteredBlockCount = 0;
+  let ambientOcclusionFaceCount = 0;
+  for (let i = 0; i < blocks.count; i += 1) {
+    const mask = visibilityMasks[i];
+    if ((mask & 0xc0) !== 0) {
+      throw new VoxelMeshFactsFormatError(`Block ${i} has an invalid visibility mask`);
+    }
+    if (mask !== 0) filteredBlockCount += 1;
+    const faces = faceCount(mask);
+    visibleFaceCount += faces;
+    const type = blocks.typeNames[blocks.typeIds[i]];
+    if (type !== WATER_BLOCK_ID && getRenderKind(type) !== "emissive") {
+      ambientOcclusionFaceCount += faces;
+    }
+  }
+  if (visibleFaceCount !== header.visibleFaceCount) {
+    throw new VoxelMeshFactsFormatError("Mesh facts visible face count is inconsistent");
+  }
+  if (filteredBlockCount !== header.filteredBlockCount) {
+    throw new VoxelMeshFactsFormatError("Mesh facts filtered block count is inconsistent");
+  }
+  if (ambientOcclusionFaceCount !== header.ambientOcclusionFaceCount) {
+    throw new VoxelMeshFactsFormatError("Mesh facts ambient occlusion count is inconsistent");
+  }
+
+  return {
+    blocks,
+    visibilityMasks,
+    ambientOcclusion,
+    visibleFaceCount,
+    filteredBlockCount,
+  };
+}
+
+export function copyVoxelMeshFacts(facts: VoxelMeshFacts): VoxelMeshFacts {
+  return {
+    blocks: copyPackedVoxelBlocks(facts.blocks),
+    visibilityMasks: facts.visibilityMasks.slice(),
+    ambientOcclusion: facts.ambientOcclusion.slice(),
+    visibleFaceCount: facts.visibleFaceCount,
+    filteredBlockCount: facts.filteredBlockCount,
+  };
+}

--- a/lib/voxel/packedBlocks.ts
+++ b/lib/voxel/packedBlocks.ts
@@ -1,4 +1,5 @@
 import type { VoxelBlock, VoxelBuild } from "./types";
+import type { VoxelMeshFacts } from "./meshFacts";
 
 // Blocks cost roughly 80 bytes each as JS objects and 8 bytes each in typed
 // arrays, plus one shared palette. Stream chunks are written directly into
@@ -16,7 +17,10 @@ export type PackedVoxelBlocks = {
 // A build whose blocks may live in packed form. Server-side builds and anything
 // coming out of validation stay object-backed, so both shapes flow through the
 // same viewer and mesh entry points.
-export type RenderableVoxelBuild = VoxelBuild & { packed?: PackedVoxelBlocks };
+export type RenderableVoxelBuild = VoxelBuild & {
+  packed?: PackedVoxelBlocks;
+  meshFacts?: VoxelMeshFacts;
+};
 
 const MIN_PACKED_CAPACITY = 1024;
 

--- a/tests/unit/voxel/mesh-facts.test.ts
+++ b/tests/unit/voxel/mesh-facts.test.ts
@@ -1,0 +1,56 @@
+import assert from "node:assert/strict";
+import {
+  decodeVoxelMeshFacts,
+  encodeVoxelMeshFacts,
+  isVoxelMeshFacts,
+  MESH_FACTS_HEADER_BYTES,
+  readVoxelMeshFactsHeader,
+  createVoxelMeshFacts,
+  VoxelMeshFactsFormatError,
+} from "../../../lib/voxel/meshFacts";
+import { readBinaryVoxelBuildHeader } from "../../../lib/voxel/binaryBuild";
+import { packVoxelBlocks } from "../../../lib/voxel/packedBlocks";
+
+const packed = packVoxelBlocks([
+  { x: 0, y: 0, z: 0, type: "stone" },
+  { x: 1, y: 0, z: 0, type: "stone" },
+  { x: 0, y: 1, z: 0, type: "grass_block" },
+  { x: 1, y: 1, z: 0, type: "glass" },
+  { x: 2, y: 0, z: 0, type: "water" },
+  { x: 3, y: 0, z: 0, type: "glowstone" },
+]);
+
+const facts = createVoxelMeshFacts(packed);
+const encoded = encodeVoxelMeshFacts(facts);
+assert.equal(isVoxelMeshFacts(encoded), true);
+
+const header = readVoxelMeshFactsHeader(encoded);
+assert.equal(header.filteredBlockCount, facts.filteredBlockCount);
+assert.equal(header.visibleFaceCount, facts.visibleFaceCount);
+assert.equal(header.ambientOcclusionFaceCount, facts.ambientOcclusion.length);
+
+const nested = encoded.subarray(
+  MESH_FACTS_HEADER_BYTES,
+  MESH_FACTS_HEADER_BYTES + header.blockPayloadBytes,
+);
+assert.equal(readBinaryVoxelBuildHeader(nested).checksumPrefix, 0);
+
+const decoded = decodeVoxelMeshFacts(encoded);
+assert.deepEqual(decoded.blocks.typeNames, facts.blocks.typeNames);
+assert.deepEqual(decoded.blocks.positions, facts.blocks.positions);
+assert.deepEqual(decoded.blocks.typeIds, facts.blocks.typeIds);
+assert.deepEqual(decoded.visibilityMasks, facts.visibilityMasks);
+assert.deepEqual(decoded.ambientOcclusion, facts.ambientOcclusion);
+assert.equal(decoded.visibleFaceCount, facts.visibleFaceCount);
+assert.equal(decoded.filteredBlockCount, facts.filteredBlockCount);
+
+assert.throws(
+  () => decodeVoxelMeshFacts(encoded.subarray(0, encoded.length - 1)),
+  VoxelMeshFactsFormatError,
+);
+
+const invalidMask = encoded.slice();
+invalidMask[MESH_FACTS_HEADER_BYTES + header.blockPayloadBytes] = 0x80;
+assert.throws(() => decodeVoxelMeshFacts(invalidMask), /invalid visibility mask/);
+
+console.log("mesh facts codec unit tests passed");

--- a/tests/unit/voxel/mesh-worker-hot-loop.test.ts
+++ b/tests/unit/voxel/mesh-worker-hot-loop.test.ts
@@ -1,7 +1,11 @@
 import assert from "node:assert/strict";
 import { createHash } from "node:crypto";
-import { buildMeshPayload } from "../../../lib/voxel/mesh.worker";
+import {
+  buildMeshPayload,
+  buildMeshPayloadFromFacts,
+} from "../../../lib/voxel/mesh.worker";
 import { packVoxelBlocks } from "../../../lib/voxel/packedBlocks";
+import { createVoxelMeshFacts } from "../../../lib/voxel/meshFacts";
 import { getPalette } from "../../../lib/blocks/palettes";
 import type { SerializedMeshBucket } from "../../../lib/voxel/mesh";
 
@@ -20,6 +24,7 @@ function testWorkerMeshingVariousMaterials() {
   ]);
 
   const payload = buildMeshPayload(build, allowed);
+  assert.deepEqual(buildMeshPayloadFromFacts(createVoxelMeshFacts(build), allowed), payload);
 
   assert.equal(payload.filteredBlockCount, 7);
   assert.ok(payload.opaque != null, "should have opaque geometry");
@@ -51,6 +56,7 @@ function testWorkerMeshingOcclusionCulling() {
 
   const build = packVoxelBlocks(blocks);
   const payload = buildMeshPayload(build, allowed);
+  assert.deepEqual(buildMeshPayloadFromFacts(createVoxelMeshFacts(build), allowed), payload);
 
   // 26 outer blocks remain visible, 1 center block culled
   assert.equal(payload.filteredBlockCount, 26);
@@ -63,6 +69,7 @@ function testWorkerMeshingEmptyBuild() {
 
   const build = packVoxelBlocks([]);
   const payload = buildMeshPayload(build, allowed);
+  assert.deepEqual(buildMeshPayloadFromFacts(createVoxelMeshFacts(build), allowed), payload);
 
   assert.equal(payload.filteredBlockCount, 0);
   assert.equal(payload.opaque, null);
@@ -97,6 +104,7 @@ function testGoldenFixtureParity() {
     { x: 5, y: 0, z: 0, type: "glowstone" },
   ]);
   const payload = buildMeshPayload(packed, allowed);
+  assert.deepEqual(buildMeshPayloadFromFacts(createVoxelMeshFacts(packed), allowed), payload);
 
   // frozen from the preoptimization mesher so byte changes require deliberate review
   assert.deepEqual(

--- a/tests/unit/voxel/mesh-worker-hot-loop.test.ts
+++ b/tests/unit/voxel/mesh-worker-hot-loop.test.ts
@@ -63,6 +63,19 @@ function testWorkerMeshingOcclusionCulling() {
   assert.ok(payload.opaque != null);
 }
 
+function testMeshFactsFallbackWhenPaletteFiltersBlocks() {
+  const allowed = ["stone"];
+  const build = packVoxelBlocks([
+    { x: 0, y: 0, z: 0, type: "stone" },
+    { x: 1, y: 0, z: 0, type: "bricks" },
+  ]);
+
+  assert.deepEqual(
+    buildMeshPayloadFromFacts(createVoxelMeshFacts(build), allowed),
+    buildMeshPayload(build, allowed),
+  );
+}
+
 function testWorkerMeshingEmptyBuild() {
   const palette = getPalette("simple");
   const allowed = palette.map((p) => p.id);
@@ -139,6 +152,7 @@ function testGoldenFixtureParity() {
 function main() {
   testWorkerMeshingVariousMaterials();
   testWorkerMeshingOcclusionCulling();
+  testMeshFactsFallbackWhenPaletteFiltersBlocks();
   testWorkerMeshingEmptyBuild();
   testGoldenFixtureParity();
   console.log("worker hot loop optimization unit tests passed");


### PR DESCRIPTION
## Summary

- add the identity-free MBF1 codec using packed MBV4 blocks, per-block visibility masks, and packed ambient-occlusion levels
- expand MBF1 facts through the existing worker and serialized mesh payload contract
- retain the established packed-build worker path when mesh facts are unavailable
- verify geometry, materials, water, bounds, culling, and ambient-occlusion parity against the existing mesher

## Validation

- `pnpm exec tsc --noEmit --pretty false --incremental false`
- `pnpm lint`
- `pnpm exec tsx tests/run.ts tests/unit/voxel/mesh-facts.test.ts tests/unit/voxel/mesh-worker-hot-loop.test.ts`
- `pnpm build`

Stacked on #110.

*(PR written by Codex)*
