### PR TITLE
(fix) lab: polish checkpoint action alignment, clear edit state on save, and clarify draft workflow

### DIFF
--- a/app/lab/[orgSlug]/actions.ts
+++ b/app/lab/[orgSlug]/actions.ts
@@ -152,6 +152,7 @@ export async function configureEndpointAction(
     },
   });
   revalidateEvaluation(orgSlug, experimentId);
+  redirect(`/lab/${orgSlug}/experiments/${experimentId}/settings`);
 }
 
 export async function uploadCohortAction(

--- a/app/lab/[orgSlug]/experiments/[experimentId]/builds/page.tsx
+++ b/app/lab/[orgSlug]/experiments/[experimentId]/builds/page.tsx
@@ -146,12 +146,14 @@ export default async function EvaluationBuildsPage({
                           <span className="min-w-0 break-words">
                             <span className="font-medium">Error:</span> {checkpoint.lastGenerationError}
                           </span>
-                          <Link
-                            href={`/lab/${orgSlug}/experiments/${experimentId}/settings?checkpoint=${encodeURIComponent(checkpoint.id)}`}
-                            className="shrink-0 font-medium text-fg underline hover:text-accent"
-                          >
-                            Edit endpoint settings
-                          </Link>
+                          {checkpoint.status === "DRAFT" && checkpoint.source === "ENDPOINT" ? (
+                            <Link
+                              href={`/lab/${orgSlug}/experiments/${experimentId}/settings?checkpoint=${encodeURIComponent(checkpoint.id)}`}
+                              className="shrink-0 font-medium text-fg underline hover:text-accent"
+                            >
+                              Edit endpoint settings
+                            </Link>
+                          ) : null}
                         </div>
                       ) : null}
                     </article>

--- a/app/lab/[orgSlug]/experiments/[experimentId]/builds/page.tsx
+++ b/app/lab/[orgSlug]/experiments/[experimentId]/builds/page.tsx
@@ -142,8 +142,16 @@ export default async function EvaluationBuildsPage({
                         <span className="hidden w-24 sm:block" />
                       )}
                       {checkpoint.lastGenerationError ? (
-                        <div className="col-span-full border-t border-border/40 pt-2 text-xs text-danger break-words">
-                          <span className="font-medium">Error:</span> {checkpoint.lastGenerationError}
+                        <div className="col-span-full flex flex-wrap items-center justify-between gap-2 border-t border-border/40 pt-2 text-xs text-danger">
+                          <span className="min-w-0 break-words">
+                            <span className="font-medium">Error:</span> {checkpoint.lastGenerationError}
+                          </span>
+                          <Link
+                            href={`/lab/${orgSlug}/experiments/${experimentId}/settings?checkpoint=${encodeURIComponent(checkpoint.id)}`}
+                            className="shrink-0 font-medium text-fg underline hover:text-accent"
+                          >
+                            Edit endpoint settings
+                          </Link>
                         </div>
                       ) : null}
                     </article>

--- a/app/lab/[orgSlug]/experiments/[experimentId]/overview/page.tsx
+++ b/app/lab/[orgSlug]/experiments/[experimentId]/overview/page.tsx
@@ -161,9 +161,20 @@ export default async function EvaluationOverviewPage({
                   ) : null}
                 </div>
                 {checkpoint.lastGenerationError ? (
-                  <p role="alert" className="text-xs text-danger md:col-span-3">
-                    {checkpoint.lastGenerationError}
-                  </p>
+                  <div
+                    role="alert"
+                    className="flex flex-wrap items-center justify-between gap-2 text-xs text-danger md:col-span-3"
+                  >
+                    <span className="min-w-0 break-words">{checkpoint.lastGenerationError}</span>
+                    {checkpoint.status === "DRAFT" && checkpoint.source === "ENDPOINT" ? (
+                      <Link
+                        href={`${basePath}/settings?checkpoint=${encodeURIComponent(checkpoint.id)}`}
+                        className="shrink-0 font-medium text-fg underline hover:text-accent"
+                      >
+                        Edit endpoint settings
+                      </Link>
+                    ) : null}
+                  </div>
                 ) : null}
               </article>
             ))}

--- a/app/lab/[orgSlug]/experiments/[experimentId]/settings/page.tsx
+++ b/app/lab/[orgSlug]/experiments/[experimentId]/settings/page.tsx
@@ -3,6 +3,7 @@ import { EvaluationStatus } from "@/components/lab/EvaluationStatus";
 import { CohortUploadForm } from "@/components/lab/CohortUploadForm";
 import { formatDate, titleCase } from "@/components/lab/format";
 import { LabDisclosure } from "@/components/lab/LabDisclosure";
+import { LifecycleActionButton } from "@/components/lab/LifecycleActionButton";
 import {
   closeEvaluationAction,
   configureEndpointAction,
@@ -36,6 +37,7 @@ export default async function EvaluationSettingsPage({
   searchParams: Promise<{ checkpoint?: string }>;
 }) {
   const { orgSlug, experimentId } = await params;
+  const basePath = `/lab/${orgSlug}/experiments/${experimentId}`;
   const { checkpoint: refreshCheckpointId } = await searchParams;
   const { workspace } = await loadEvaluationWorkspace(orgSlug, experimentId);
   const selectedCheckpoint = workspace.checkpoints.find(
@@ -178,7 +180,7 @@ export default async function EvaluationSettingsPage({
                     : ""}
                 </div>
               </div>
-              <div className="flex flex-wrap items-center justify-end gap-3">
+              <div className="flex items-center justify-end gap-3 shrink-0">
                 <EvaluationStatus
                   status={
                     checkpoint.lastGenerationError && checkpoint.status === "DRAFT"
@@ -186,13 +188,21 @@ export default async function EvaluationSettingsPage({
                       : checkpoint.status
                   }
                 />
+                {checkpoint.status === "DRAFT" && checkpoint.credentialConfigured ? (
+                  <Link
+                    href={`${basePath}/builds`}
+                    className="inline-flex items-center text-xs font-medium text-accent hover:underline"
+                  >
+                    Generate builds &rarr;
+                  </Link>
+                ) : null}
                 {mutable &&
                 checkpoint.source === "ENDPOINT" &&
                 (checkpoint.status === "DRAFT" ||
                   (checkpoint.status === "READY" && !checkpoint.promptCohortCurrent)) ? (
                   <Link
                     href={`?checkpoint=${encodeURIComponent(checkpoint.id)}`}
-                    className="min-h-11 px-2 py-3 text-xs text-muted hover:text-fg"
+                    className="inline-flex items-center text-xs font-medium text-muted transition hover:text-fg"
                   >
                     {checkpoint.status === "READY" ? "Refresh" : "Edit"}
                   </Link>
@@ -205,8 +215,12 @@ export default async function EvaluationSettingsPage({
                       experimentId,
                       checkpoint.id,
                     )}
+                    className="inline-flex items-center"
                   >
-                    <button type="submit" className="min-h-11 px-2 text-xs text-muted hover:text-danger">
+                    <button
+                      type="submit"
+                      className="inline-flex items-center text-xs font-medium text-muted transition hover:text-danger"
+                    >
                       Disable
                     </button>
                   </form>
@@ -325,10 +339,26 @@ export default async function EvaluationSettingsPage({
                 </label>
               </fieldset>
             </div>
-            <div className="flex justify-end">
-              <button type="submit" className="mb-btn mb-btn-primary min-h-11 px-5 text-sm">
-                {refreshEndpoint ? "Save & refresh" : "Add checkpoint"}
-              </button>
+            <div className="flex items-center justify-end gap-3">
+              {refreshEndpoint ? (
+                <Link
+                  href={`${basePath}/settings`}
+                  className="mb-btn mb-btn-ghost min-h-11 px-4 text-sm"
+                >
+                  Cancel
+                </Link>
+              ) : null}
+              <LifecycleActionButton
+                label={
+                  refreshEndpoint
+                    ? refreshEndpoint.status === "READY"
+                      ? "Save & refresh"
+                      : "Save changes"
+                    : "Add checkpoint"
+                }
+                pendingLabel="Saving…"
+                tone="primary"
+              />
             </div>
           </form>
             </LabDisclosure>


### PR DESCRIPTION
## Summary
- **Visual Baseline Alignment**: Replaces uneven box padding with unified flex centering (`inline-flex items-center text-xs font-medium`) so status pills, edit links, disable actions, and next steps line up on the exact same horizontal baseline and vertical center.
- **Form State & Confirmations**: Redirects back to `/settings` after saving checkpoint configuration to automatically clear query params and collapse the disclosure. Adds `LifecycleActionButton` with active saving indicator and a `Cancel` button.
- **Clear Draft Next Steps**: Changes the button label to `"Save changes"` when editing draft endpoints and adds a direct `Generate builds →` link next to configured draft checkpoints.

*(PR written by Codex)*