### PR TITLE
(fix) openrouter: fall back when provider parameter requirements return 404

### DIFF
--- a/lib/ai/providers/openrouter.ts
+++ b/lib/ai/providers/openrouter.ts
@@ -240,6 +240,7 @@ export async function openrouterGenerateText(params: {
     let selectedReasoningMaxTokens: number | undefined;
     let selectedReasoningTokenBudget: number | null = null;
     const tokenBudgets = tokenBudgetCandidates(maxTokens);
+    let requireParameters = params.requireParameterSupport !== false;
     for (const [tokIdx, tok] of tokenBudgets.entries()) {
       let tryLowerTokenBudget = false;
       for (const [cfgIdx, cfg] of reasoningAttempts.entries()) {
@@ -274,7 +275,7 @@ export async function openrouterGenerateText(params: {
                   { role: "system", content: params.system },
                   { role: "user", content: params.user },
                 ],
-                ...(params.jsonSchema && params.requireParameterSupport !== false
+                ...(params.jsonSchema && requireParameters
                   ? {
                       provider: {
                         require_parameters: true,
@@ -310,6 +311,13 @@ export async function openrouterGenerateText(params: {
             break;
           }
           lastBody = await res.text().catch(() => "");
+          if (res.status === 404 && requireParameters && lastBody.toLowerCase().includes("no endpoints found")) {
+            requireParameters = false;
+            params.onTrace?.(
+              `OpenRouter rejected parameter requirements (HTTP 404); retrying without require_parameters.`,
+            );
+            continue;
+          }
           if (res.status === 400 && looksLikeTokenLimitError(lastBody)) {
             tryLowerTokenBudget = true;
             const nextBudget = tokenBudgets[tokIdx + 1];

--- a/lib/ai/providers/openrouter.ts
+++ b/lib/ai/providers/openrouter.ts
@@ -240,7 +240,8 @@ export async function openrouterGenerateText(params: {
     let selectedReasoningMaxTokens: number | undefined;
     let selectedReasoningTokenBudget: number | null = null;
     const tokenBudgets = tokenBudgetCandidates(maxTokens);
-    let requireParameters = params.requireParameterSupport !== false;
+    let requireParameters =
+      Boolean(params.jsonSchema) && params.requireParameterSupport !== false;
     for (const [tokIdx, tok] of tokenBudgets.entries()) {
       let tryLowerTokenBudget = false;
       for (const [cfgIdx, cfg] of reasoningAttempts.entries()) {
@@ -275,7 +276,7 @@ export async function openrouterGenerateText(params: {
                   { role: "system", content: params.system },
                   { role: "user", content: params.user },
                 ],
-                ...(params.jsonSchema && requireParameters
+                ...(requireParameters
                   ? {
                       provider: {
                         require_parameters: true,
@@ -311,7 +312,11 @@ export async function openrouterGenerateText(params: {
             break;
           }
           lastBody = await res.text().catch(() => "");
-          if (res.status === 404 && requireParameters && lastBody.toLowerCase().includes("no endpoints found")) {
+          if (
+            res.status === 404 &&
+            requireParameters &&
+            lastBody.toLowerCase().includes("requested parameters")
+          ) {
             requireParameters = false;
             params.onTrace?.(
               `OpenRouter rejected parameter requirements (HTTP 404); retrying without require_parameters.`,

--- a/tests/unit/providers/openrouter-opus-request.test.ts
+++ b/tests/unit/providers/openrouter-opus-request.test.ts
@@ -9,13 +9,16 @@ type CapturedRequest = {
 const capturedRequests: CapturedRequest[] = [];
 const originalFetch = globalThis.fetch;
 let failWithBadRequest = false;
+let failWithParameter404 = false;
+let failWithGeneric404 = false;
 
 globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
   assert.ok(init?.body, "OpenRouter request should include a JSON body");
   assert.equal(typeof init.body, "string", "OpenRouter request body should be serialized JSON");
+  const parsedBody = JSON.parse(init.body as string) as Record<string, unknown>;
   capturedRequests.push({
     url: String(input),
-    body: JSON.parse(init.body as string) as Record<string, unknown>,
+    body: parsedBody,
   });
 
   if (failWithBadRequest) {
@@ -23,6 +26,36 @@ globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit): Promis
       status: 400,
       headers: { "Content-Type": "application/json" },
     });
+  }
+
+  if (failWithParameter404 && parsedBody.provider) {
+    return new Response(
+      JSON.stringify({
+        error: {
+          message: "No endpoints found that can handle the requested parameters.",
+          code: 404,
+        },
+      }),
+      {
+        status: 404,
+        headers: { "Content-Type": "application/json" },
+      },
+    );
+  }
+
+  if (failWithGeneric404) {
+    return new Response(
+      JSON.stringify({
+        error: {
+          message: "No endpoints found",
+          code: 404,
+        },
+      }),
+      {
+        status: 404,
+        headers: { "Content-Type": "application/json" },
+      },
+    );
   }
 
   return new Response(
@@ -146,6 +179,57 @@ async function main() {
     )?.json_schema?.strict,
     true,
   );
+  failWithBadRequest = false;
+
+  // Verify that parameter 404 retries without provider.require_parameters
+  failWithParameter404 = true;
+  const paramRetryIndex = capturedRequests.length;
+  await openrouterGenerateText({
+    modelId: "stealth/ox-alpha",
+    apiKey: "test-openrouter-key",
+    system: "Return valid JSON.",
+    user: "Build a small test shape.",
+    maxOutputTokens: 512,
+    jsonSchema: {
+      type: "object",
+      additionalProperties: false,
+      properties: { ok: { type: "boolean" } },
+      required: ["ok"],
+    },
+  });
+  assert.equal(
+    capturedRequests.length,
+    paramRetryIndex + 2,
+    "A parameter 404 must retry exactly once without provider.require_parameters",
+  );
+  assert.deepEqual(capturedRequests[paramRetryIndex]?.body.provider, { require_parameters: true });
+  assert.equal(capturedRequests[paramRetryIndex + 1]?.body.provider, undefined);
+  failWithParameter404 = false;
+
+  // Verify that an unstructured request with a generic 404 fails immediately without retrying
+  failWithGeneric404 = true;
+  const generic404Index = capturedRequests.length;
+  try {
+    console.error = () => {};
+    await assert.rejects(
+      openrouterGenerateText({
+        modelId: "openai/nonexistent-model",
+        apiKey: "test-openrouter-key",
+        system: "Return text.",
+        user: "Say ok.",
+        maxOutputTokens: 512,
+      }),
+      /OpenRouter error 404/,
+    );
+  } finally {
+    console.error = originalConsoleError;
+  }
+  assert.equal(
+    capturedRequests.length,
+    generic404Index + 1,
+    "A generic 404 on an unstructured request must not retry",
+  );
+  failWithGeneric404 = false;
 
   console.log("openrouter request checks passed");
 }


### PR DESCRIPTION
## Summary
- Automatically catches HTTP 404 `"No endpoints found that can handle the requested parameters"` when strict parameter requirements (`provider: { require_parameters: true }`) are rejected by OpenRouter for private, stealth, or unindexed provider endpoints.
- Retries seamlessly without `require_parameters` so models such as `stealth/ox-alpha` route properly.

*(PR written by Codex)*