### PR TITLE
docs(architecture): document personal rankings

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -122,6 +122,7 @@ erDiagram
     Model ||--o{ Matchup : competes
     Build ||--o{ Matchup : renders
     Matchup ||--o{ Vote : receives
+    User o|--o{ Vote : owns
     Vote ||--o{ ArenaVoteJob : queues
     Model ||--o{ ModelRankSnapshot : records
 
@@ -148,8 +149,12 @@ erDiagram
         string buildBId FK
         string samplingLane
     }
+    User {
+        string id PK
+    }
     Vote {
         string matchupId FK
+        string userId FK
         string sessionId
         string choice
     }
@@ -160,3 +165,9 @@ artifacts. Supabase Storage contains the source JSON and derived binary objects.
 Vercel route handlers own sampling, blind-token validation, artifact resolution,
 and response observability; the browser owns decoding, geometry construction,
 and rendering.
+
+Public votes remain valid without an account and use the browser session as their
+duplicate-vote boundary. A signed-in vote can also have an optional `User` owner;
+sign-in claims unowned public votes from the same session. Private-evaluation
+votes are never assigned to public accounts. Deleting an account clears vote
+ownership while retaining the aggregate vote history.

--- a/docs/arena-ranking-system.md
+++ b/docs/arena-ranking-system.md
@@ -77,6 +77,18 @@ The operational state is not the published score. The leaderboard and model deta
 
 For private matchups, the public model is a read-only anchor. Only the private `StealthVariant` rating and counters change.
 
+## Personal rankings
+
+Personal rankings are a per-account view of public Arena evidence. The fit uses
+only that account's eligible `A`, `B`, and `TIE` votes, follows the public model
+and prompt eligibility rules, and uses global Bradley-Terry abilities to anchor
+disconnected personal comparison components.
+
+This calculation is read-only: it does not update public ratings, counters,
+coverage, snapshots, or matchmaking state. Anonymous public votes from the same
+browser session are linked when sign-in completes. Private-evaluation votes are
+excluded and are never linked to public accounts.
+
 ## Matchmaking
 
 Each matchup request samples a lane and falls back to the others if the selected lane cannot produce a valid pair.
@@ -128,5 +140,6 @@ The consistency estimator is documented separately in [Consistency Metric](./con
 - Vote processing: `lib/arena/voteJobs.ts`
 - Eligible prompt universe: `lib/arena/eligibility.ts`
 - Leaderboard API: `app/api/leaderboard/route.ts`
+- Personal ranking: `lib/account/personalRanking.ts`
 - Rank snapshots: `app/api/admin/rank-snapshots/capture/route.ts`
 - Rating replay: `scripts/recompute-elo.ts`


### PR DESCRIPTION
## Summary
- document optional account ownership for public Arena votes
- explain anonymous-session vote claiming and account deletion behavior
- define personal Bradley-Terry inputs and preserve the public/private ranking boundary

## Validation
- `pnpm exec tsx tests/unit/account/personal-ranking.test.ts`
- `pnpm exec tsx tests/unit/auth/public-auth-contract.test.ts`
- `pnpm exec tsx tests/unit/stealth/privacy-contract.test.ts`
- `git diff --check`

*(PR written by Codex)*