### PR TITLE
(feat) add GLM 5.3 Flash benchmark support

### DIFF
--- a/lib/ai/modelBenchmarkMetrics.generated.json
+++ b/lib/ai/modelBenchmarkMetrics.generated.json
@@ -587,6 +587,23 @@
       "interruptedRunCount": 0,
       "providerCallTrackingJobCount": 15,
       "completedAttemptTrackingJobCount": 15
+    },
+    "zai_glm_5_3_flash": {
+      "inferenceSampleCount": 15,
+      "expectedBuildCount": 15,
+      "finalizedBuildCount": 15,
+      "promptCohortId": "prompts-v1:bd8c28367f8a97f2",
+      "averageJsonSizeBytes": 27273756,
+      "configurationSampleCount": 15,
+      "configurationIsConsistent": false,
+      "outputCapSampleCount": 15,
+      "outputCapIsConsistent": true,
+      "outputCapTokens": 131072,
+      "providerCallCount": 97,
+      "failedAttemptCount": 55,
+      "failedRunCount": 36,
+      "interruptedRunCount": 20,
+      "providerCallTrackingJobCount": 15
     }
   }
 }

--- a/lib/ai/modelBenchmarkProfiles.ts
+++ b/lib/ai/modelBenchmarkProfiles.ts
@@ -197,6 +197,10 @@ const MODEL_RUN_PARAMETERS = {
   ],
   xai_grok_4_20: [{ label: "Reasoning", value: "Thinking enabled" }],
   zai_glm_5_3: [{ label: "Reasoning effort", value: "Max" }],
+  zai_glm_5_3_flash: [
+    { label: "Reasoning effort", value: "Max" },
+    { label: "Sampling", value: "Temperature 1 · Top P 0.95" },
+  ],
   zai_glm_5_2: [
     { label: "Reasoning effort", value: "XHigh → High" },
   ],

--- a/lib/ai/modelCatalog.ts
+++ b/lib/ai/modelCatalog.ts
@@ -480,6 +480,15 @@ const CATALOG = [
     openRouterModelId: "z-ai/glm-5.3",
   },
   {
+    key: "zai_glm_5_3_flash",
+    slug: "glm-5-3-flash",
+    provider: "zai",
+    modelId: "glm-5.3-flash",
+    displayName: "Z.AI GLM 5.3 Flash",
+    enabled: true,
+    openRouterModelId: "z-ai/glm-5.3-flash",
+  },
+  {
     key: "zai_glm_5_2",
     slug: "glm-5-2",
     provider: "zai",

--- a/lib/ai/modelRequestProfiles.ts
+++ b/lib/ai/modelRequestProfiles.ts
@@ -32,7 +32,7 @@ const OUTPUT_CEILINGS: readonly { tokens: number; ids: readonly string[] }[] = [
   // MiniMax M2.7 rejects the larger MineBench default on its OpenAI-compatible route
   {
     tokens: 131_072,
-    ids: ["glm-5.3", "glm-5.2", "glm-5.1", "glm-5", "minimax-m2.7", "muse-spark-1.2"],
+    ids: ["glm-5.3", "glm-5.3-flash", "glm-5.2", "glm-5.1", "glm-5", "minimax-m2.7", "muse-spark-1.2"],
   },
   {
     tokens: 65_536,
@@ -75,6 +75,10 @@ const DEFAULT_SAMPLING_IDS: readonly string[] = [
 
 const DEFAULT_SAMPLING_PREFIXES: readonly string[] = ["gpt-5.6", "openai/gpt-5.6"];
 
+const RECOMMENDED_TOP_P: readonly { topP: number; ids: readonly string[] }[] = [
+  { topP: 0.95, ids: ["glm-5.3-flash"] },
+];
+
 // Returns the catalogued counterpart IDs for a model ID, so a fact declared
 // under one route's ID also resolves from the other
 function counterpartIds(normalized: string): string[] {
@@ -108,4 +112,13 @@ export function modelUsesDefaultSampling(modelId: string): boolean {
     ) ||
     DEFAULT_SAMPLING_PREFIXES.some((prefix) => normalized.startsWith(prefix))
   );
+}
+
+export function modelRecommendedTopP(modelId: string): number | undefined {
+  const normalized = modelId.toLowerCase();
+  for (const id of [normalized, ...counterpartIds(normalized)]) {
+    const match = RECOMMENDED_TOP_P.find(({ ids }) => ids.includes(id));
+    if (match) return match.topP;
+  }
+  return undefined;
 }

--- a/lib/ai/providers/openrouter.ts
+++ b/lib/ai/providers/openrouter.ts
@@ -1,5 +1,8 @@
 import { withMaxOutputTokens } from "@/lib/ai/providers/shared";
-import { modelUsesDefaultSampling } from "@/lib/ai/modelRequestProfiles";
+import {
+  modelRecommendedTopP,
+  modelUsesDefaultSampling,
+} from "@/lib/ai/modelRequestProfiles";
 import { attachAbortSignal } from "@/lib/ai/providers/abort";
 import { consumeSseStream } from "@/lib/ai/providers/sse";
 import { tokenBudgetCandidates } from "@/lib/ai/tokenBudgets";
@@ -142,6 +145,10 @@ function openRouterTemperaturePayload(modelId: string, temperature?: number): { 
   return { temperature: temperature ?? 0.2 };
 }
 
+function openRouterTopPPayload(topP?: number): { top_p?: number } {
+  return topP === undefined ? {} : { top_p: topP };
+}
+
 async function fetchWithRetry(
   url: string,
   init: RequestInit,
@@ -201,7 +208,7 @@ export async function openrouterGenerateText(params: {
   const maxTokens = params.maxOutputTokens ?? 8192;
   const responseFormat = !params.jsonSchema
     ? undefined
-    : params.modelId === "z-ai/glm-5.3"
+    : params.modelId === "z-ai/glm-5.3" || params.modelId === "z-ai/glm-5.3-flash"
       ? { type: "json_object" }
       : {
           type: "json_schema",
@@ -285,6 +292,7 @@ export async function openrouterGenerateText(params: {
                   : {}),
                 stream: Boolean(params.onDelta),
                 ...openRouterTemperaturePayload(params.modelId, params.temperature),
+                ...openRouterTopPPayload(modelRecommendedTopP(params.modelId)),
                 max_tokens: tok,
                 reasoning: reasoningConfig,
                 ...(textVerbosity ? { text: { verbosity: textVerbosity } } : {}),

--- a/lib/ai/providers/zai.ts
+++ b/lib/ai/providers/zai.ts
@@ -3,6 +3,7 @@ import {
   postChatCompletionWithTokenBudgetRetry,
   withMaxOutputTokens,
 } from "@/lib/ai/providers/shared";
+import { modelRecommendedTopP } from "@/lib/ai/modelRequestProfiles";
 import { consumeSseStream } from "@/lib/ai/providers/sse";
 import type { ProviderTelemetryCallbacks } from "@/lib/ai/types";
 
@@ -62,6 +63,12 @@ export async function zaiGenerateText(params: {
     ? params.reasoningEffortAttempts
     : [undefined];
   const useJsonOutput = Boolean(params.jsonSchema);
+  const stream = Boolean(params.onDelta) || params.modelId === "glm-5.3-flash";
+  const topP = modelRecommendedTopP(params.modelId);
+  const thinking =
+    params.modelId === "glm-5.3-flash"
+      ? { type: "enabled", clear_thinking: false }
+      : { type: "enabled" };
 
   let reasoningEffort: string | undefined;
   let response: Awaited<ReturnType<typeof postChatCompletionWithTokenBudgetRetry>> | null = null;
@@ -72,7 +79,7 @@ export async function zaiGenerateText(params: {
         url,
         apiKey,
         maxOutputTokens: maxTokens,
-        stream: Boolean(params.onDelta),
+        stream,
         looksLikeTokenLimitError,
         signal: params.signal,
         onProviderRequest: params.onProviderRequest,
@@ -82,10 +89,11 @@ export async function zaiGenerateText(params: {
             { role: "system", content: params.system },
             { role: "user", content: params.user },
           ],
-          stream: Boolean(params.onDelta),
+          stream,
           max_tokens: tok,
-          thinking: { type: "enabled" },
+          thinking,
           ...(params.temperature === undefined ? {} : { temperature: params.temperature }),
+          ...(topP === undefined ? {} : { top_p: topP }),
           ...(effort ? { reasoning_effort: effort } : {}),
           ...(useJsonOutput ? { response_format: { type: "json_object" } } : {}),
         }),
@@ -121,7 +129,7 @@ export async function zaiGenerateText(params: {
     ),
   );
 
-  if (params.onDelta) {
+  if (stream) {
     let text = "";
     await consumeSseStream(res, (evt) => {
       if (evt.data === "[DONE]") return;

--- a/lib/ai/reasoningProfiles.ts
+++ b/lib/ai/reasoningProfiles.ts
@@ -126,7 +126,7 @@ const EFFORT_LADDER_RULES: readonly EffortLadderRule[] = [
   },
   { ids: ["moonshotai/kimi-k3"], ladder: ["max"] },
   {
-    ids: ["glm-5.3", "z-ai/glm-5.3"],
+    ids: ["glm-5.3", "z-ai/glm-5.3", "glm-5.3-flash", "z-ai/glm-5.3-flash"],
     ladder: ["max", "high", "low"],
     aliases: { xhigh: null },
     supported: "max, xhigh, high, low",
@@ -230,6 +230,8 @@ export function modelRequiresReasoning(modelId: string): boolean {
     normalized === "x-ai/grok-4.6" ||
     normalized === "glm-5.3" ||
     normalized === "z-ai/glm-5.3" ||
+    normalized === "glm-5.3-flash" ||
+    normalized === "z-ai/glm-5.3-flash" ||
     normalized === "google/gemini-3.7-flash" ||
     normalized === "muse-spark-1.2" ||
     normalized === "meta/muse-spark-1.2"

--- a/tests/unit/providers/zai-family.test.ts
+++ b/tests/unit/providers/zai-family.test.ts
@@ -11,6 +11,7 @@ import {
   assertTraceLine,
   runGeneration,
   runProviderConfigTest,
+  validBuildJson,
 } from "../../helpers/providerConfigHarness";
 
 runProviderConfigTest("zai family", {
@@ -157,6 +158,73 @@ runProviderConfigTest("zai family", {
     "OpenRouter trace should report the 131072-token cap and the GLM 5.3 effort ladder",
     ["disabled"],
   );
+
+  const flash = assertCatalogEntry({
+    key: "zai_glm_5_3_flash",
+    provider: "zai",
+    modelId: "glm-5.3-flash",
+    displayName: "Z.AI GLM 5.3 Flash",
+    openRouterModelId: "z-ai/glm-5.3-flash",
+    slug: "glm-5-3-flash",
+  });
+  assert.equal(modelRequiresReasoning(flash.modelId), true);
+  assert.equal(modelRequiresReasoning(flash.openRouterModelId!), true);
+  assert.deepEqual(zaiReasoningEffortAttempts(flash.modelId), ["max", "high", "low"]);
+  assert.deepEqual(openRouterReasoningEffortAttempts(flash.openRouterModelId!), [
+    "max",
+    "high",
+    "low",
+  ]);
+  assert.deepEqual(getModelBenchmarkProfile(flash.key)?.parameters, [
+    { label: "Reasoning effort", value: "Max" },
+    { label: "Sampling", value: "Temperature 1 · Top P 0.95" },
+  ]);
+
+  capture.respondWith((request) => {
+    if (request.body.model !== flash.modelId || request.body.stream !== true) return null;
+    return new Response(
+      `data: ${JSON.stringify({ choices: [{ delta: { content: validBuildJson() } }] })}\n\ndata: [DONE]\n\n`,
+      { headers: { "Content-Type": "text/event-stream" } },
+    );
+  });
+  const flashDirect = await runGeneration(capture, {
+    modelKey: flash.key,
+    providerKeys: {},
+    allowServerKeys: true,
+  });
+  capture.respondWith(null);
+  const flashDirectRequest = flashDirect.requests.find((request) =>
+    request.url.includes("zai.test"),
+  );
+  assert.ok(flashDirectRequest, "Direct GLM 5.3 Flash request should be captured");
+  assert.equal(flashDirectRequest.body.model, "glm-5.3-flash");
+  assert.equal(flashDirectRequest.body.max_tokens, 131_072);
+  assert.equal(flashDirectRequest.body.temperature, 1);
+  assert.equal(flashDirectRequest.body.top_p, 0.95);
+  assert.equal(flashDirectRequest.body.stream, true);
+  assert.equal(flashDirectRequest.headers.accept, "text/event-stream");
+  assert.equal(flashDirectRequest.body.reasoning_effort, "max");
+  assert.deepEqual(flashDirectRequest.body.thinking, {
+    type: "enabled",
+    clear_thinking: false,
+  });
+  assert.deepEqual(flashDirectRequest.body.response_format, { type: "json_object" });
+
+  const flashOpenRouter = await runGeneration(capture, {
+    modelKey: flash.key,
+    providerKeys: { openrouter: "test-openrouter-key" },
+    preferOpenRouter: true,
+  });
+  const flashOpenRouterRequest = flashOpenRouter.requests.find((request) =>
+    request.url.includes("openrouter.test"),
+  )?.body;
+  assert.ok(flashOpenRouterRequest, "OpenRouter GLM 5.3 Flash request should be captured");
+  assert.equal(flashOpenRouterRequest.model, "z-ai/glm-5.3-flash");
+  assert.equal(flashOpenRouterRequest.max_tokens, 131_072);
+  assert.equal(flashOpenRouterRequest.temperature, 1);
+  assert.equal(flashOpenRouterRequest.top_p, 0.95);
+  assert.deepEqual(flashOpenRouterRequest.reasoning, { effort: "max" });
+  assert.deepEqual(flashOpenRouterRequest.response_format, { type: "json_object" });
 
   const glm52 = assertCatalogEntry({
     key: "zai_glm_5_2",


### PR DESCRIPTION
## Summary

- add GLM 5.3 Flash to the existing direct Z.ai and OpenRouter routes
- configure the documented 131,072-token output cap, max reasoning, temperature 1, top P 0.95, and persistent thinking
- extend the existing Z.ai family contract coverage for both routes

## Validation

- pnpm exec tsc --noEmit
- pnpm test
- pnpm lint
- pnpm build

*(PR written by Codex)*