### PR TITLE
feat(observability): add CloudWatch EMF generation metrics and queue health monitoring

### DIFF
--- a/app/api/generate/route.ts
+++ b/app/api/generate/route.ts
@@ -4,6 +4,7 @@ import { generateVoxelBuild } from "@/lib/ai/generateVoxelBuild";
 import { getModelByKey, ModelKey } from "@/lib/ai/modelCatalog";
 import { assertSafeCustomApiUrl } from "@/lib/ai/providers/customApiGuard";
 import type { GenerateEvent, GenerateModelRequest, GenerateRequest } from "@/lib/ai/types";
+import { recordGenerationError, recordGenerationSuccess } from "@/lib/observability/cloudwatch";
 
 export const runtime = "nodejs";
 
@@ -240,6 +241,11 @@ export async function POST(req: Request) {
         )
           .then((r) => {
             if (r.ok) {
+              recordGenerationSuccess({
+                jobType: "stream",
+                model: requestModelKey,
+                durationMs: r.generationTimeMs ?? 0,
+              });
               send({
                 type: "result",
                 modelKey: requestModelKey,
@@ -251,6 +257,11 @@ export async function POST(req: Request) {
                 },
               });
             } else {
+              recordGenerationError({
+                jobType: "stream",
+                model: requestModelKey,
+                errorType: r.error || "generation_error",
+              });
               send({
                 type: "error",
                 modelKey: requestModelKey,
@@ -260,10 +271,16 @@ export async function POST(req: Request) {
             }
           })
           .catch((err: unknown) => {
+            const message = err instanceof Error ? err.message : "Generation failed";
+            recordGenerationError({
+              jobType: "stream",
+              model: requestModelKey,
+              errorType: message,
+            });
             send({
               type: "error",
               modelKey: requestModelKey,
-              message: err instanceof Error ? err.message : "Generation failed",
+              message,
             });
           })
           .finally(() => {

--- a/docs/cloudwatch-monitoring.md
+++ b/docs/cloudwatch-monitoring.md
@@ -1,0 +1,36 @@
+# CloudWatch Metrics & Architecture
+
+MineBench publishes asynchronous telemetry to Amazon CloudWatch to monitor generation workloads, throughput, latency distributions, worker health, and queue latency.
+
+```mermaid
+flowchart LR
+    subgraph Compute["Generation Compute (AWS Lightsail)"]
+        Worker["Worker Process"] -->|EMF JSON| Stdout["stdout / Logs"]
+        Agent["CloudWatch Agent"] -->|Tail & Parse| Stdout
+        Agent -->|OS Telemetry| OS["RAM & CPU Stats"]
+    end
+
+    subgraph CloudWatch["Amazon CloudWatch"]
+        Agent -->|Async Flush| Metrics["Metrics Engine<br/>(MineBench/Production)"]
+        Metrics --> Dashboards["Unified Dashboard"]
+        Metrics --> Alarms["CloudWatch Alarms"]
+    end
+
+    Alarms -->|Trigger| SNS["Amazon SNS Topic"]
+```
+
+## Metrics Specification
+
+All telemetry is emitted under the `MineBench/Production` namespace.
+
+| Metric | Unit | Description |
+| :--- | :--- | :--- |
+| `GenerationsCount` | Count | Aggregate successful generation volume (Sum). |
+| `GenerationDuration` | Milliseconds | Generation latency distribution (p50, p90, p95, p99, Min, Max). |
+| `ActiveGenerations` | Count | In-flight generation concurrency gauge. |
+| `QueuedJobsCount` | Count | Count of generation jobs waiting in the queue. |
+| `OldestQueuedJobAgeSeconds` | Seconds | Age of the oldest waiting job in queue. |
+| `GenerationErrors` | Count | Count of failed generation attempts, tagged by error classification. |
+| `mem_used_percent` | Percent | Host memory utilization percentage. |
+| `disk_used_percent` | Percent | Host disk space utilization percentage. |
+| `cpu_usage_idle` | Percent | Host idle CPU percentage. |

--- a/lib/custom-builds/generateJob.ts
+++ b/lib/custom-builds/generateJob.ts
@@ -4,6 +4,7 @@ import { generateVoxelBuild, type GenerateVoxelBuildParams } from "@/lib/ai/gene
 import { MAX_BLOCKS_BY_GRID, type GridSize } from "@/lib/ai/limits";
 import type { ProviderApiKeys } from "@/lib/ai/types";
 import { encodeBinaryArtifact } from "@/lib/arena/binaryArtifact";
+import { recordGenerationError, recordGenerationSuccess } from "@/lib/observability/cloudwatch";
 import { ARENA_MESH_FACTS_MIN_BLOCKS } from "@/lib/arena/types";
 import { getPalette } from "@/lib/blocks/palettes";
 import {
@@ -584,6 +585,11 @@ export async function runCustomBuildGenerateJob(
     throwIfCustomBuildLeaseLost(opts.signal);
     throwIfCustomBuildLeaseLost(opts.signal);
     emitCustomBuildEvent(customBuild.id, "complete", { stage: "complete" });
+    recordGenerationSuccess({
+      jobType: "worker",
+      model: customBuild.modelKey || customBuild.modelDisplayName || customBuild.modelId,
+      durationMs: generated.generationTimeMs ?? (Date.now() - (customBuild.startedAt?.getTime() ?? Date.now())),
+    });
   } catch (error) {
     if (isCustomBuildLeaseLostError(error)) throw error;
     const effectiveError =
@@ -591,6 +597,11 @@ export async function runCustomBuildGenerateJob(
         ? new CustomBuildArtifactBookkeepingError(error)
         : error;
     const message = redactSensitiveText(effectiveError);
+    recordGenerationError({
+      jobType: "worker",
+      model: customBuild.modelKey || customBuild.modelDisplayName || customBuild.modelId,
+      errorType: message,
+    });
     const manuallyRetryable =
       effectiveError instanceof CustomBuildGenerationFailedError &&
       !isTerminalCustomBuildGenerateError(message);

--- a/lib/custom-builds/worker.ts
+++ b/lib/custom-builds/worker.ts
@@ -19,6 +19,7 @@ import {
   throwIfCustomBuildLeaseLost,
 } from "@/lib/custom-builds/lease";
 import { redactSensitiveText } from "@/lib/custom-builds/sanitize";
+import { recordQueueHeartbeat, startActiveGenerationsHeartbeat } from "@/lib/observability/cloudwatch";
 import { prisma } from "@/lib/prisma";
 
 function readIntEnv(name: string, fallback: number, min: number, max: number): number {
@@ -234,40 +235,69 @@ export async function runCustomBuildWorkerOnce(workerId = getCustomBuildWorkerId
   return processClaimedJob(job, workerId, createCustomBuildProcessingGate());
 }
 
+async function checkAndReportQueueHealth(): Promise<void> {
+  try {
+    const oldest = await prisma.customBuildJob.findFirst({
+      where: { status: "queued", runAfter: { lte: new Date() } },
+      orderBy: { runAfter: "asc" },
+      select: { runAfter: true },
+    });
+    const queuedCount = await prisma.customBuildJob.count({
+      where: { status: "queued", runAfter: { lte: new Date() } },
+    });
+    const oldestAgeSeconds = oldest
+      ? Math.max(0, (Date.now() - oldest.runAfter.getTime()) / 1000)
+      : 0;
+    recordQueueHeartbeat({ queuedCount, oldestAgeSeconds });
+  } catch {
+    // Non-blocking telemetry
+  }
+}
+
 export async function runCustomBuildWorkerLoop(workerId = getCustomBuildWorkerId()): Promise<void> {
   let shutdownRequested = false;
   const concurrency = getCustomBuildWorkerConcurrency();
   const processingGate = createCustomBuildProcessingGate();
   const activeJobs = new Set<Promise<unknown>>();
+  const heartbeat = startActiveGenerationsHeartbeat(() => activeJobs.size, 30_000, "worker");
+  let lastQueueReport = 0;
   const stop = () => {
     shutdownRequested = true;
   };
   process.once("SIGINT", stop);
   process.once("SIGTERM", stop);
 
-  while (!shutdownRequested) {
-    await recoverStaleCustomBuildJobLeases();
-    let claimed = false;
-    while (!shutdownRequested && activeJobs.size < concurrency) {
-      const job = await claimNextCustomBuildJob(workerId);
-      if (!job) break;
-      claimed = true;
-      const active = processClaimedJob(job, workerId, processingGate);
-      activeJobs.add(active);
-      void active.then(
-        () => activeJobs.delete(active),
-        () => activeJobs.delete(active),
-      );
+  try {
+    while (!shutdownRequested) {
+      if (Date.now() - lastQueueReport >= 30_000) {
+        lastQueueReport = Date.now();
+        void checkAndReportQueueHealth();
+      }
+      await recoverStaleCustomBuildJobLeases();
+      let claimed = false;
+      while (!shutdownRequested && activeJobs.size < concurrency) {
+        const job = await claimNextCustomBuildJob(workerId);
+        if (!job) break;
+        claimed = true;
+        const active = processClaimedJob(job, workerId, processingGate);
+        activeJobs.add(active);
+        void active.then(
+          () => activeJobs.delete(active),
+          () => activeJobs.delete(active),
+        );
+      }
+
+      if (shutdownRequested) break;
+      if (activeJobs.size >= concurrency) {
+        await Promise.race(activeJobs);
+      } else if (!claimed) {
+        await Promise.race([sleep(getCustomBuildWorkerPollMs()), ...activeJobs]);
+      }
     }
 
-    if (shutdownRequested) break;
-    if (activeJobs.size >= concurrency) {
-      await Promise.race(activeJobs);
-    } else if (!claimed) {
-      await Promise.race([sleep(getCustomBuildWorkerPollMs()), ...activeJobs]);
-    }
+    await Promise.all(activeJobs);
+  } finally {
+    clearInterval(heartbeat);
+    await prisma.$disconnect();
   }
-
-  await Promise.all(activeJobs);
-  await prisma.$disconnect();
 }

--- a/lib/observability/cloudwatch.ts
+++ b/lib/observability/cloudwatch.ts
@@ -92,19 +92,76 @@ export function recordGenerationSuccess(
 }
 
 /**
+ * Maps raw error messages to a bounded set of stable classification dimensions
+ * to prevent high cardinality / unique dimension series in CloudWatch.
+ */
+export function normalizeErrorClassification(rawError: string | undefined): string {
+  if (!rawError) return "unknown_error";
+  const lower = rawError.toLowerCase();
+
+  if (lower.includes("timeout") || lower.includes("aborted") || lower.includes("etimedout")) {
+    return "timeout";
+  }
+  if (lower.includes("rate_limit") || lower.includes("too many requests") || lower.includes("429")) {
+    return "rate_limit";
+  }
+  if (
+    lower.includes("provider_key_expired") ||
+    lower.includes("unauthorized") ||
+    lower.includes("invalid_api_key") ||
+    lower.includes("invalid key") ||
+    lower.includes("401") ||
+    lower.includes("403")
+  ) {
+    return "auth_failed";
+  }
+  if (
+    lower.includes("context_length") ||
+    lower.includes("context length") ||
+    lower.includes("context_window") ||
+    lower.includes("context window") ||
+    lower.includes("maximum context") ||
+    lower.includes("too long")
+  ) {
+    return "context_length_exceeded";
+  }
+  if (lower.includes("content_filter") || lower.includes("moderation") || lower.includes("safety")) {
+    return "content_filter";
+  }
+  if (lower.includes("lease") || lower.includes("lease_lost")) {
+    return "lease_lost";
+  }
+  if (lower.includes("persistence_failed") || lower.includes("storage")) {
+    return "persistence_failed";
+  }
+  if (lower.includes("bookkeeping_failed")) {
+    return "bookkeeping_failed";
+  }
+  if (lower.includes("format") || lower.includes("json") || lower.includes("syntax") || lower.includes("parse")) {
+    return "format_invalid";
+  }
+  if (lower.includes("unavailable") || lower.includes("503") || lower.includes("502") || lower.includes("500")) {
+    return "provider_unavailable";
+  }
+  return "other_error";
+}
+
+/**
  * Record a failed generation attempt
  */
 export function recordGenerationError(
   event: GenerationErrorEvent,
   writer?: MetricLogWriter,
 ): void {
+  const classification = normalizeErrorClassification(event.errorType);
   emitEmf(
     [["Environment", "JobType", "Model", "ErrorType"]],
     [{ Name: "GenerationErrors", Unit: "Count" }],
     {
       JobType: event.jobType,
       Model: event.model || "unknown",
-      ErrorType: (event.errorType || "unknown_error").slice(0, 100),
+      ErrorType: classification,
+      RawError: (event.errorType || "").slice(0, 1000),
       GenerationErrors: 1,
     },
     writer,

--- a/lib/observability/cloudwatch.ts
+++ b/lib/observability/cloudwatch.ts
@@ -1,0 +1,173 @@
+/**
+ * CloudWatch Embedded Metric Format (EMF) Telemetry
+ * Emits structured metric logs to stdout, which the Amazon CloudWatch Agent
+ * automatically parses and flushes to AWS CloudWatch Metrics asynchronously with zero network latency.
+ */
+
+export type JobType = "worker" | "stream";
+
+export interface GenerationSuccessEvent {
+  jobType: JobType;
+  model: string;
+  durationMs: number;
+}
+
+export interface GenerationErrorEvent {
+  jobType: JobType;
+  model: string;
+  errorType: string;
+}
+
+const CLOUDWATCH_NAMESPACE = process.env.CLOUDWATCH_NAMESPACE || "MineBench/Production";
+const ENVIRONMENT = "production";
+
+export type MetricLogWriter = (line: string) => void;
+
+let defaultWriter: MetricLogWriter = (line: string) => {
+  process.stdout.write(line + "\n");
+};
+
+export function setMetricLogWriter(writer: MetricLogWriter): void {
+  defaultWriter = writer;
+}
+
+export function resetMetricLogWriter(): void {
+  defaultWriter = (line: string) => {
+    process.stdout.write(line + "\n");
+  };
+}
+
+/**
+ * Format and emit an EMF JSON line
+ */
+export function emitEmf(
+  dimensions: string[][],
+  metrics: Array<{ Name: string; Unit: string }>,
+  properties: Record<string, string | number>,
+  writer: MetricLogWriter = defaultWriter,
+): void {
+  const payload = {
+    _aws: {
+      Timestamp: Date.now(),
+      CloudWatchMetrics: [
+        {
+          Namespace: CLOUDWATCH_NAMESPACE,
+          Dimensions: dimensions,
+          Metrics: metrics,
+        },
+      ],
+    },
+    Environment: ENVIRONMENT,
+    ...properties,
+  };
+
+  try {
+    writer(JSON.stringify(payload));
+  } catch {
+    // Telemetry must never crash runtime requests
+  }
+}
+
+/**
+ * Record a successful generation and its latency
+ */
+export function recordGenerationSuccess(
+  event: GenerationSuccessEvent,
+  writer?: MetricLogWriter,
+): void {
+  emitEmf(
+    [["Environment", "JobType", "Model"]],
+    [
+      { Name: "GenerationsCount", Unit: "Count" },
+      { Name: "GenerationDuration", Unit: "Milliseconds" },
+    ],
+    {
+      JobType: event.jobType,
+      Model: event.model || "unknown",
+      GenerationsCount: 1,
+      GenerationDuration: Math.max(0, Math.round(event.durationMs)),
+    },
+    writer,
+  );
+}
+
+/**
+ * Record a failed generation attempt
+ */
+export function recordGenerationError(
+  event: GenerationErrorEvent,
+  writer?: MetricLogWriter,
+): void {
+  emitEmf(
+    [["Environment", "JobType", "Model", "ErrorType"]],
+    [{ Name: "GenerationErrors", Unit: "Count" }],
+    {
+      JobType: event.jobType,
+      Model: event.model || "unknown",
+      ErrorType: (event.errorType || "unknown_error").slice(0, 100),
+      GenerationErrors: 1,
+    },
+    writer,
+  );
+}
+
+/**
+ * Record the current number of in-flight active generations (Gauge)
+ */
+export function recordActiveGenerations(
+  count: number,
+  jobType: JobType = "worker",
+  writer?: MetricLogWriter,
+): void {
+  emitEmf(
+    [["Environment", "JobType"]],
+    [{ Name: "ActiveGenerations", Unit: "Count" }],
+    {
+      JobType: jobType,
+      ActiveGenerations: Math.max(0, count),
+    },
+    writer,
+  );
+}
+
+/**
+ * Record queue health (queued job count and oldest job age)
+ */
+export interface QueueHeartbeatEvent {
+  queuedCount: number;
+  oldestAgeSeconds: number;
+}
+
+export function recordQueueHeartbeat(
+  event: QueueHeartbeatEvent,
+  writer?: MetricLogWriter,
+): void {
+  emitEmf(
+    [["Environment", "JobType"]],
+    [
+      { Name: "QueuedJobsCount", Unit: "Count" },
+      { Name: "OldestQueuedJobAgeSeconds", Unit: "Seconds" },
+    ],
+    {
+      JobType: "worker",
+      QueuedJobsCount: Math.max(0, event.queuedCount),
+      OldestQueuedJobAgeSeconds: Math.max(0, Math.round(event.oldestAgeSeconds)),
+    },
+    writer,
+  );
+}
+
+/**
+ * Start a periodic heartbeat reporting active in-flight generations
+ */
+export function startActiveGenerationsHeartbeat(
+  getActiveCount: () => number,
+  intervalMs = 30_000,
+  jobType: JobType = "worker",
+  writer?: MetricLogWriter,
+): NodeJS.Timeout {
+  return setInterval(() => {
+    recordActiveGenerations(getActiveCount(), jobType, writer);
+  }, intervalMs);
+}
+

--- a/tests/unit/observability/cloudwatch-metrics.test.ts
+++ b/tests/unit/observability/cloudwatch-metrics.test.ts
@@ -5,6 +5,7 @@ import {
   recordActiveGenerations,
   recordQueueHeartbeat,
   startActiveGenerationsHeartbeat,
+  normalizeErrorClassification,
 } from "../../../lib/observability/cloudwatch";
 
 async function main() {
@@ -45,7 +46,7 @@ async function main() {
     {
       jobType: "stream",
       model: "claude-opus-5",
-      errorType: "rate_limit_exceeded",
+      errorType: "rate_limit_exceeded (request_id: req_12345)",
     },
     mockWriter,
   );
@@ -55,7 +56,8 @@ async function main() {
   assert.equal(errorParsed.Environment, "production");
   assert.equal(errorParsed.JobType, "stream");
   assert.equal(errorParsed.Model, "claude-opus-5");
-  assert.equal(errorParsed.ErrorType, "rate_limit_exceeded");
+  assert.equal(errorParsed.ErrorType, "rate_limit");
+  assert.equal(errorParsed.RawError, "rate_limit_exceeded (request_id: req_12345)");
   assert.equal(errorParsed.GenerationErrors, 1);
   assert.deepEqual(errorParsed._aws.CloudWatchMetrics[0].Dimensions, [
     ["Environment", "JobType", "Model", "ErrorType"],
@@ -109,6 +111,14 @@ async function main() {
   assert.ok(lines.length >= 2);
   const heartbeatParsed = JSON.parse(lines[0]);
   assert.equal(heartbeatParsed.ActiveGenerations, 2);
+
+  // 6. Test normalizeErrorClassification
+  assert.equal(normalizeErrorClassification("ETIMEDOUT connection failed"), "timeout");
+  assert.equal(normalizeErrorClassification("Rate limit exceeded: 429 Too Many Requests"), "rate_limit");
+  assert.equal(normalizeErrorClassification("provider_key_expired: key 12345 expired"), "auth_failed");
+  assert.equal(normalizeErrorClassification("Request exceeds context length 128000"), "context_length_exceeded");
+  assert.equal(normalizeErrorClassification("Custom build lease lost for job"), "lease_lost");
+  assert.equal(normalizeErrorClassification(undefined), "unknown_error");
 
   console.log("cloudwatch metrics unit tests passed");
 }

--- a/tests/unit/observability/cloudwatch-metrics.test.ts
+++ b/tests/unit/observability/cloudwatch-metrics.test.ts
@@ -1,0 +1,119 @@
+import assert from "node:assert/strict";
+import {
+  recordGenerationSuccess,
+  recordGenerationError,
+  recordActiveGenerations,
+  recordQueueHeartbeat,
+  startActiveGenerationsHeartbeat,
+} from "../../../lib/observability/cloudwatch";
+
+async function main() {
+  const lines: string[] = [];
+  const mockWriter = (line: string) => {
+    lines.push(line);
+  };
+
+  // 1. Test recordGenerationSuccess
+  recordGenerationSuccess(
+    {
+      jobType: "worker",
+      model: "gpt-5-2-pro",
+      durationMs: 12450.6,
+    },
+    mockWriter,
+  );
+
+  assert.equal(lines.length, 1);
+  const successParsed = JSON.parse(lines[0]);
+  assert.equal(successParsed.Environment, "production");
+  assert.equal(successParsed.JobType, "worker");
+  assert.equal(successParsed.Model, "gpt-5-2-pro");
+  assert.equal(successParsed.GenerationsCount, 1);
+  assert.equal(successParsed.GenerationDuration, 12451);
+  assert.equal(successParsed._aws.CloudWatchMetrics[0].Namespace, "MineBench/Production");
+  assert.deepEqual(successParsed._aws.CloudWatchMetrics[0].Dimensions, [
+    ["Environment", "JobType", "Model"],
+  ]);
+  assert.deepEqual(successParsed._aws.CloudWatchMetrics[0].Metrics, [
+    { Name: "GenerationsCount", Unit: "Count" },
+    { Name: "GenerationDuration", Unit: "Milliseconds" },
+  ]);
+
+  // 2. Test recordGenerationError
+  lines.length = 0;
+  recordGenerationError(
+    {
+      jobType: "stream",
+      model: "claude-opus-5",
+      errorType: "rate_limit_exceeded",
+    },
+    mockWriter,
+  );
+
+  assert.equal(lines.length, 1);
+  const errorParsed = JSON.parse(lines[0]);
+  assert.equal(errorParsed.Environment, "production");
+  assert.equal(errorParsed.JobType, "stream");
+  assert.equal(errorParsed.Model, "claude-opus-5");
+  assert.equal(errorParsed.ErrorType, "rate_limit_exceeded");
+  assert.equal(errorParsed.GenerationErrors, 1);
+  assert.deepEqual(errorParsed._aws.CloudWatchMetrics[0].Dimensions, [
+    ["Environment", "JobType", "Model", "ErrorType"],
+  ]);
+  assert.deepEqual(errorParsed._aws.CloudWatchMetrics[0].Metrics, [
+    { Name: "GenerationErrors", Unit: "Count" },
+  ]);
+
+  // 3. Test recordActiveGenerations (Gauge)
+  lines.length = 0;
+  recordActiveGenerations(4, "worker", mockWriter);
+
+  assert.equal(lines.length, 1);
+  const activeParsed = JSON.parse(lines[0]);
+  assert.equal(activeParsed.Environment, "production");
+  assert.equal(activeParsed.JobType, "worker");
+  assert.equal(activeParsed.ActiveGenerations, 4);
+  assert.deepEqual(activeParsed._aws.CloudWatchMetrics[0].Dimensions, [
+    ["Environment", "JobType"],
+  ]);
+
+  // 4. Test recordQueueHeartbeat
+  lines.length = 0;
+  recordQueueHeartbeat(
+    {
+      queuedCount: 3,
+      oldestAgeSeconds: 125,
+    },
+    mockWriter,
+  );
+
+  assert.equal(lines.length, 1);
+  const queueParsed = JSON.parse(lines[0]);
+  assert.equal(queueParsed.Environment, "production");
+  assert.equal(queueParsed.JobType, "worker");
+  assert.equal(queueParsed.QueuedJobsCount, 3);
+  assert.equal(queueParsed.OldestQueuedJobAgeSeconds, 125);
+  assert.deepEqual(queueParsed._aws.CloudWatchMetrics[0].Metrics, [
+    { Name: "QueuedJobsCount", Unit: "Count" },
+    { Name: "OldestQueuedJobAgeSeconds", Unit: "Seconds" },
+  ]);
+
+  // 5. Test Heartbeat interval
+  lines.length = 0;
+  let currentCount = 2;
+  const heartbeat = startActiveGenerationsHeartbeat(() => currentCount, 50, "worker", mockWriter);
+
+  await new Promise((resolve) => setTimeout(resolve, 130));
+  clearInterval(heartbeat);
+
+  assert.ok(lines.length >= 2);
+  const heartbeatParsed = JSON.parse(lines[0]);
+  assert.equal(heartbeatParsed.ActiveGenerations, 2);
+
+  console.log("cloudwatch metrics unit tests passed");
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- Adds high-performance, zero-overhead CloudWatch Embedded Metric Format (EMF) telemetry to generation workloads.
- Emits `GenerationsCount`, `GenerationDuration` distributions, `ActiveGenerations` concurrency gauge, and `GenerationErrors` tagged by model and error reason.
- Implements background queue health tracking (`QueuedJobsCount` and `OldestQueuedJobAgeSeconds`) on worker loops to detect queue latency or stalled workers.
- Adds comprehensive unit test coverage in `tests/unit/observability/cloudwatch-metrics.test.ts`.
- Adds high-level architectural documentation in `docs/cloudwatch-monitoring.md`.

*(PR written by Codex)*