### PR TITLE
fix(observability): restore generation health metrics

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -163,6 +163,10 @@ NEXT_PUBLIC_VOXEL_LOCAL_MESH_MAX_BLOCKS=8000
 NEXT_PUBLIC_VOXEL_REVEAL_ANIMATION_MIN_BLOCKS=12000
 NEXT_PUBLIC_VOXEL_MESH_WORKER_TIMEOUT_MS=45000
 
+# Production-only Vercel OIDC role for generation metrics; leave unset locally and in previews.
+MINEBENCH_CLOUDWATCH_ROLE_ARN=
+MINEBENCH_CLOUDWATCH_REGION=us-east-1
+
 # Alpha staging (lives in .env.staging.local, never in .env)
 # - STAGING_DIRECT_URL: direct Postgres connection of the alpha Supabase branch
 # - STAGING_SUPABASE_URL / STAGING_SUPABASE_SERVICE_ROLE_KEY: alpha branch API

--- a/app/api/generate/route.ts
+++ b/app/api/generate/route.ts
@@ -1,10 +1,11 @@
 import { z } from "zod";
 import { NextResponse } from "next/server";
+import { waitUntil } from "@vercel/functions";
 import { generateVoxelBuild } from "@/lib/ai/generateVoxelBuild";
 import { getModelByKey, ModelKey } from "@/lib/ai/modelCatalog";
 import { assertSafeCustomApiUrl } from "@/lib/ai/providers/customApiGuard";
 import type { GenerateEvent, GenerateModelRequest, GenerateRequest } from "@/lib/ai/types";
-import { recordGenerationError, recordGenerationSuccess } from "@/lib/observability/cloudwatch";
+import { publishGenerationError, publishGenerationSuccess } from "@/lib/observability/cloudwatch";
 
 export const runtime = "nodejs";
 
@@ -241,11 +242,11 @@ export async function POST(req: Request) {
         )
           .then((r) => {
             if (r.ok) {
-              recordGenerationSuccess({
+              waitUntil(publishGenerationSuccess({
                 jobType: "stream",
                 model: requestModelKey,
                 durationMs: r.generationTimeMs ?? 0,
-              });
+              }));
               send({
                 type: "result",
                 modelKey: requestModelKey,
@@ -257,11 +258,11 @@ export async function POST(req: Request) {
                 },
               });
             } else {
-              recordGenerationError({
+              waitUntil(publishGenerationError({
                 jobType: "stream",
                 model: requestModelKey,
                 errorType: r.error || "generation_error",
-              });
+              }));
               send({
                 type: "error",
                 modelKey: requestModelKey,
@@ -272,11 +273,11 @@ export async function POST(req: Request) {
           })
           .catch((err: unknown) => {
             const message = err instanceof Error ? err.message : "Generation failed";
-            recordGenerationError({
+            waitUntil(publishGenerationError({
               jobType: "stream",
               model: requestModelKey,
               errorType: message,
-            });
+            }));
             send({
               type: "error",
               modelKey: requestModelKey,

--- a/docs/cloudwatch-monitoring.md
+++ b/docs/cloudwatch-monitoring.md
@@ -6,8 +6,12 @@ MineBench publishes asynchronous telemetry to Amazon CloudWatch to monitor gener
 flowchart LR
     subgraph Compute["Generation Compute (AWS Lightsail)"]
         Worker["Worker Process"] -->|EMF JSON| Stdout["stdout / Logs"]
-        Agent["CloudWatch Agent"] -->|Tail & Parse| Stdout
+        Stdout -->|Tail & Parse| Agent["CloudWatch Agent"]
         Agent -->|OS Telemetry| OS["RAM & CPU Stats"]
+    end
+
+    subgraph Web["Streaming Generation (Vercel)"]
+        Route["Generate Route"] -->|OIDC + PutMetricData| Metrics
     end
 
     subgraph CloudWatch["Amazon CloudWatch"]
@@ -28,9 +32,20 @@ All telemetry is emitted under the `MineBench/Production` namespace.
 | `GenerationsCount` | Count | Aggregate successful generation volume (Sum). |
 | `GenerationDuration` | Milliseconds | Generation latency distribution (p50, p90, p95, p99, Min, Max). |
 | `ActiveGenerations` | Count | In-flight generation concurrency gauge. |
+| `WorkerAcceptingJobs` | Count | `1` while the worker accepts jobs and `0` while it drains. |
 | `QueuedJobsCount` | Count | Count of generation jobs waiting in the queue. |
 | `OldestQueuedJobAgeSeconds` | Seconds | Age of the oldest waiting job in queue. |
 | `GenerationErrors` | Count | Count of failed generation attempts, tagged by error classification. |
 | `mem_used_percent` | Percent | Host memory utilization percentage. |
 | `disk_used_percent` | Percent | Host disk space utilization percentage. |
 | `cpu_usage_idle` | Percent | Host idle CPU percentage. |
+
+Worker heartbeats and queue health are emitted immediately at startup and every 30 seconds. They continue while active work drains after shutdown begins, so deploys remain visible. Missing `WorkerAcceptingJobs` data is an alarm condition rather than a healthy state.
+
+Success, duration, and error events publish both an `Environment` aggregate for alarms and detailed model dimensions for dashboards. CloudWatch does not aggregate custom metrics across dimension sets automatically, so alarms must use the aggregate series.
+
+## Vercel publishing
+
+Production Vercel Functions can publish through a narrowly scoped AWS OIDC role. No long-lived AWS credentials are stored in Vercel. Publishing is disabled unless `MINEBENCH_CLOUDWATCH_ROLE_ARN` is present in the production environment. `MINEBENCH_CLOUDWATCH_REGION` defaults to `us-east-1`.
+
+The IAM role may only call `cloudwatch:PutMetricData` when `cloudwatch:namespace` is `MineBench/Production`. Preview and development deployments never publish production metrics.

--- a/lib/custom-builds/worker.ts
+++ b/lib/custom-builds/worker.ts
@@ -19,7 +19,11 @@ import {
   throwIfCustomBuildLeaseLost,
 } from "@/lib/custom-builds/lease";
 import { redactSensitiveText } from "@/lib/custom-builds/sanitize";
-import { recordQueueHeartbeat, startActiveGenerationsHeartbeat } from "@/lib/observability/cloudwatch";
+import {
+  recordActiveGenerations,
+  recordQueueHeartbeat,
+  startActiveGenerationsHeartbeat,
+} from "@/lib/observability/cloudwatch";
 import { prisma } from "@/lib/prisma";
 
 function readIntEnv(name: string, fallback: number, min: number, max: number): number {
@@ -276,7 +280,9 @@ export async function runCustomBuildWorkerLoop(workerId = getCustomBuildWorkerId
     void checkAndReportQueueHealth();
   }, 30_000);
   const stop = () => {
+    if (shutdownRequested) return;
     shutdownRequested = true;
+    recordActiveGenerations(activeJobs.size, "worker", undefined, false);
   };
   process.once("SIGINT", stop);
   process.once("SIGTERM", stop);

--- a/lib/custom-builds/worker.ts
+++ b/lib/custom-builds/worker.ts
@@ -208,10 +208,7 @@ async function processClaimedJob(
       return { processed: true, jobId: job.id, jobType: job.type };
     }
     const message = redactSensitiveText(error);
-    const forceTerminal = job.type === "generate" && (
-      isTerminalCustomBuildGenerateError(message) ||
-      ["artifact_persistence_failed", "artifact_bookkeeping_failed", "provider_rejected"].includes(message)
-    );
+    const forceTerminal = job.type === "generate" && isTerminalCustomBuildJobFailure(message);
     await failCustomBuildJob(job.id, workerId, {
       code: message === "provider_key_expired" ? "provider_key_expired" : "worker_failed",
       message,
@@ -222,6 +219,15 @@ async function processClaimedJob(
   } finally {
     clearInterval(heartbeat);
   }
+}
+
+export function isTerminalCustomBuildJobFailure(message: string): boolean {
+  return isTerminalCustomBuildGenerateError(message) || [
+    "artifact_persistence_failed",
+    "artifact_bookkeeping_failed",
+    "generation_failed",
+    "provider_rejected",
+  ].includes(message);
 }
 
 export async function runCustomBuildWorkerOnce(workerId = getCustomBuildWorkerId()): Promise<{
@@ -259,8 +265,16 @@ export async function runCustomBuildWorkerLoop(workerId = getCustomBuildWorkerId
   const concurrency = getCustomBuildWorkerConcurrency();
   const processingGate = createCustomBuildProcessingGate();
   const activeJobs = new Set<Promise<unknown>>();
-  const heartbeat = startActiveGenerationsHeartbeat(() => activeJobs.size, 30_000, "worker");
-  let lastQueueReport = 0;
+  const heartbeat = startActiveGenerationsHeartbeat(
+    () => activeJobs.size,
+    () => !shutdownRequested,
+    30_000,
+    "worker",
+  );
+  void checkAndReportQueueHealth();
+  const queueHeartbeat = setInterval(() => {
+    void checkAndReportQueueHealth();
+  }, 30_000);
   const stop = () => {
     shutdownRequested = true;
   };
@@ -269,10 +283,6 @@ export async function runCustomBuildWorkerLoop(workerId = getCustomBuildWorkerId
 
   try {
     while (!shutdownRequested) {
-      if (Date.now() - lastQueueReport >= 30_000) {
-        lastQueueReport = Date.now();
-        void checkAndReportQueueHealth();
-      }
       await recoverStaleCustomBuildJobLeases();
       let claimed = false;
       while (!shutdownRequested && activeJobs.size < concurrency) {
@@ -298,6 +308,7 @@ export async function runCustomBuildWorkerLoop(workerId = getCustomBuildWorkerId
     await Promise.all(activeJobs);
   } finally {
     clearInterval(heartbeat);
+    clearInterval(queueHeartbeat);
     await prisma.$disconnect();
   }
 }

--- a/lib/observability/cloudwatch.ts
+++ b/lib/observability/cloudwatch.ts
@@ -4,6 +4,8 @@
  * automatically parses and flushes to AWS CloudWatch Metrics asynchronously with zero network latency.
  */
 
+import type { MetricDatum } from "@aws-sdk/client-cloudwatch";
+
 export type JobType = "worker" | "stream";
 
 export interface GenerationSuccessEvent {
@@ -18,8 +20,13 @@ export interface GenerationErrorEvent {
   errorType: string;
 }
 
-const CLOUDWATCH_NAMESPACE = process.env.CLOUDWATCH_NAMESPACE || "MineBench/Production";
-const ENVIRONMENT = "production";
+function cloudWatchNamespace(): string {
+  return process.env.CLOUDWATCH_NAMESPACE?.trim() || "MineBench/Production";
+}
+
+function metricEnvironment(): string {
+  return process.env.MINEBENCH_ENVIRONMENT?.trim() || process.env.VERCEL_ENV?.trim() || "production";
+}
 
 export type MetricLogWriter = (line: string) => void;
 
@@ -51,13 +58,13 @@ export function emitEmf(
       Timestamp: Date.now(),
       CloudWatchMetrics: [
         {
-          Namespace: CLOUDWATCH_NAMESPACE,
+          Namespace: cloudWatchNamespace(),
           Dimensions: dimensions,
           Metrics: metrics,
         },
       ],
     },
-    Environment: ENVIRONMENT,
+    Environment: metricEnvironment(),
     ...properties,
   };
 
@@ -76,7 +83,7 @@ export function recordGenerationSuccess(
   writer?: MetricLogWriter,
 ): void {
   emitEmf(
-    [["Environment", "JobType", "Model"]],
+    [["Environment"], ["Environment", "JobType", "Model"]],
     [
       { Name: "GenerationsCount", Unit: "Count" },
       { Name: "GenerationDuration", Unit: "Milliseconds" },
@@ -99,6 +106,9 @@ export function normalizeErrorClassification(rawError: string | undefined): stri
   if (!rawError) return "unknown_error";
   const lower = rawError.toLowerCase();
 
+  if (lower.includes("insufficient credits") || lower.includes("error 402")) {
+    return "insufficient_credits";
+  }
   if (lower.includes("timeout") || lower.includes("aborted") || lower.includes("etimedout")) {
     return "timeout";
   }
@@ -155,7 +165,7 @@ export function recordGenerationError(
 ): void {
   const classification = normalizeErrorClassification(event.errorType);
   emitEmf(
-    [["Environment", "JobType", "Model", "ErrorType"]],
+    [["Environment"], ["Environment", "JobType", "Model", "ErrorType"]],
     [{ Name: "GenerationErrors", Unit: "Count" }],
     {
       JobType: event.jobType,
@@ -175,13 +185,18 @@ export function recordActiveGenerations(
   count: number,
   jobType: JobType = "worker",
   writer?: MetricLogWriter,
+  acceptingJobs = true,
 ): void {
   emitEmf(
     [["Environment", "JobType"]],
-    [{ Name: "ActiveGenerations", Unit: "Count" }],
+    [
+      { Name: "ActiveGenerations", Unit: "Count" },
+      { Name: "WorkerAcceptingJobs", Unit: "Count" },
+    ],
     {
       JobType: jobType,
       ActiveGenerations: Math.max(0, count),
+      WorkerAcceptingJobs: acceptingJobs ? 1 : 0,
     },
     writer,
   );
@@ -219,12 +234,96 @@ export function recordQueueHeartbeat(
  */
 export function startActiveGenerationsHeartbeat(
   getActiveCount: () => number,
+  getAcceptingJobs: () => boolean,
   intervalMs = 30_000,
   jobType: JobType = "worker",
   writer?: MetricLogWriter,
 ): NodeJS.Timeout {
-  return setInterval(() => {
-    recordActiveGenerations(getActiveCount(), jobType, writer);
-  }, intervalMs);
+  const report = () => {
+    recordActiveGenerations(getActiveCount(), jobType, writer, getAcceptingJobs());
+  };
+  report();
+  return setInterval(report, intervalMs);
 }
 
+function dimensions(values: Record<string, string>): NonNullable<MetricDatum["Dimensions"]> {
+  return Object.entries(values).map(([Name, Value]) => ({ Name, Value }));
+}
+
+export function generationSuccessMetricData(event: GenerationSuccessEvent): MetricDatum[] {
+  const environment = metricEnvironment();
+  const model = event.model || "unknown";
+  const duration = Math.max(0, Math.round(event.durationMs));
+  const aggregate = dimensions({ Environment: environment });
+  const detailed = dimensions({ Environment: environment, JobType: event.jobType, Model: model });
+  return [
+    { MetricName: "GenerationsCount", Unit: "Count", Value: 1, Dimensions: aggregate },
+    { MetricName: "GenerationDuration", Unit: "Milliseconds", Value: duration, Dimensions: aggregate },
+    { MetricName: "GenerationsCount", Unit: "Count", Value: 1, Dimensions: detailed },
+    { MetricName: "GenerationDuration", Unit: "Milliseconds", Value: duration, Dimensions: detailed },
+  ];
+}
+
+export function generationErrorMetricData(event: GenerationErrorEvent): MetricDatum[] {
+  const environment = metricEnvironment();
+  const model = event.model || "unknown";
+  const classification = normalizeErrorClassification(event.errorType);
+  return [
+    {
+      MetricName: "GenerationErrors",
+      Unit: "Count",
+      Value: 1,
+      Dimensions: dimensions({ Environment: environment }),
+    },
+    {
+      MetricName: "GenerationErrors",
+      Unit: "Count",
+      Value: 1,
+      Dimensions: dimensions({
+        Environment: environment,
+        JobType: event.jobType,
+        Model: model,
+        ErrorType: classification,
+      }),
+    },
+  ];
+}
+
+let cloudWatchClientPromise: Promise<import("@aws-sdk/client-cloudwatch").CloudWatchClient> | undefined;
+
+async function publishMetricData(metricData: MetricDatum[]): Promise<void> {
+  const roleArn = process.env.MINEBENCH_CLOUDWATCH_ROLE_ARN?.trim();
+  if (process.env.VERCEL_ENV !== "production" || !roleArn) return;
+
+  try {
+    cloudWatchClientPromise ??= Promise.all([
+      import("@aws-sdk/client-cloudwatch"),
+      import("@vercel/oidc-aws-credentials-provider"),
+    ]).then(([{ CloudWatchClient }, { awsCredentialsProvider }]) => {
+      const region = process.env.MINEBENCH_CLOUDWATCH_REGION?.trim() || "us-east-1";
+      return new CloudWatchClient({
+        region,
+        credentials: awsCredentialsProvider({ roleArn, clientConfig: { region } }),
+      });
+    });
+    const [{ PutMetricDataCommand }, client] = await Promise.all([
+      import("@aws-sdk/client-cloudwatch"),
+      cloudWatchClientPromise,
+    ]);
+    await client.send(new PutMetricDataCommand({
+      Namespace: cloudWatchNamespace(),
+      MetricData: metricData,
+    }));
+  } catch {
+    cloudWatchClientPromise = undefined;
+    console.warn("CloudWatch metric publish failed");
+  }
+}
+
+export function publishGenerationSuccess(event: GenerationSuccessEvent): Promise<void> {
+  return publishMetricData(generationSuccessMetricData(event));
+}
+
+export function publishGenerationError(event: GenerationErrorEvent): Promise<void> {
+  return publishMetricData(generationErrorMetricData(event));
+}

--- a/package.json
+++ b/package.json
@@ -63,12 +63,14 @@
     "generations:artifacts:audit": "tsx scripts/audit-saved-generation-artifacts.ts"
   },
   "dependencies": {
+    "@aws-sdk/client-cloudwatch": "^3.1119.0",
     "@opentelemetry/api": "^1.9.1",
     "@prisma/client": "^6.0.0",
     "@supabase/ssr": "0.12.4",
     "@supabase/supabase-js": "2.112.3",
     "@vercel/analytics": "^1.6.1",
     "@vercel/functions": "^3.9.5",
+    "@vercel/oidc-aws-credentials-provider": "^3.3.5",
     "@vercel/otel": "^2.1.3",
     "@vercel/speed-insights": "^2.0.0",
     "fflate": "^0.8.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@aws-sdk/client-cloudwatch':
+        specifier: ^3.1119.0
+        version: 3.1119.0
       '@opentelemetry/api':
         specifier: ^1.9.1
         version: 1.9.1
@@ -26,6 +29,9 @@ importers:
       '@vercel/functions':
         specifier: ^3.9.5
         version: 3.9.5(@aws-sdk/credential-provider-web-identity@3.972.49)
+      '@vercel/oidc-aws-credentials-provider':
+        specifier: ^3.3.5
+        version: 3.3.5
       '@vercel/otel':
         specifier: ^2.1.3
         version: 2.1.3(@opentelemetry/api-logs@0.221.0)(@opentelemetry/api@1.9.1)(@opentelemetry/instrumentation@0.221.0(@opentelemetry/api@1.9.1))(@opentelemetry/resources@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.221.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))
@@ -115,12 +121,48 @@ packages:
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
 
+  '@aws-sdk/client-cloudwatch@3.1119.0':
+    resolution: {integrity: sha512-xcT0jRQVL3XyaW/QGWXg4cqA500BcTFsZ9dgGm9XWeO25EI5uTsAWy2ol0MiDrXIg/og/jjesyuWP4eIkUj5Uw==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/core@3.977.9':
     resolution: {integrity: sha512-reqPFEQrZxDZpeGj4PFMepBeR5LGYHRqq/L0motTzgFkCRBA4rFdaVXDSLYyGHhxVz7sT2PDnPN9CluGSfgyJA==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-env@3.972.70':
+    resolution: {integrity: sha512-H404B7dJl2mCrBqahDEYsanB0xhdDp6tXnXcTUnXmmpy2Q3J0Ho0bUajZ2jr/RdwzCyS59Gi8xXIFwPLGBl6Uw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-http@3.972.72':
+    resolution: {integrity: sha512-X98zYOrVOeuosCX+6ktf29FC2N2GHPLia7qv6mzPzTc+RPAuHWCDS++Z6JK7eGYqb/v6uaW7bAXaOvDBfol+0w==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-ini@3.973.15':
+    resolution: {integrity: sha512-Rykg6s5ceBuynMOGWgoowO4N+27JfnqXAnVaSunZl0hOO1XodSrxGNz6sCEbnmS0lAfQZDKyb3fbr46gSuv6Sg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-login@3.972.77':
+    resolution: {integrity: sha512-Jb59xfEISoN5mmbnA+HYqdtrSX3CgCtJoof+V5D8/TgUI56W63GEEd5Y58WijU3Ou6+WEgaLD1feVzaRXV5IDQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-node@3.972.81':
+    resolution: {integrity: sha512-Rml+WitoFvXmv6JZ18U/xGdGDGGvB/mOin0ya0lTnTrdC0Z1lrVxTYh7iNklZBcvcRMrs4DoEf6xy1KWyrLQQw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-process@3.972.70':
+    resolution: {integrity: sha512-2ry03fGRJr4sV3jI+ocjj5JqALnFD6ymM5KiNCDZMvq8bX2GSbE0vji4aM43TVCl2nXqqLRZaUxdq/KeWRAY4Q==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-sso@3.973.14':
+    resolution: {integrity: sha512-jkhg/8ocAAoc0RFyLMhCw+/zZh7gystQgd4F4hznNa8P4Cc501PQmxd+jGLiMHodPJ+7Zv/3znM62gZojyasmA==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-web-identity@3.972.49':
     resolution: {integrity: sha512-IYx1lN38MnnPXv+NBLpuATu0cZakbZ321TAfjW+aVkw7HIJF38YnEwdeEO55MSl3pl7hIX1IvvnD6EmnAzmAJw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-web-identity@3.972.76':
+    resolution: {integrity: sha512-d3AGyVu759PGr35mEB2s22xxlNEA5rpdxtSPJthfPFJvoQ8dt357iVPECqWfUxXp1toJAvKmbtcIYVGigaGsCA==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/nested-clients@3.997.44':
@@ -129,6 +171,10 @@ packages:
 
   '@aws-sdk/signature-v4-multi-region@3.996.46':
     resolution: {integrity: sha512-L+2xZTye/2T96f3lwCws0Zw6GG2JHZW9e8FpVgGBeeExSKyeoZ6CWRpBml/7DNiK/O26jrgPM9F+Ay8VkgzUWQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/token-providers@3.1116.0':
+    resolution: {integrity: sha512-ygIivKqh8aHzNkucOCXHyIBgBpLPfrSI0mCqXF+vLBsPTUKqj0VSqAY0GFPe7lQl4HntjOcQ+KSyS7oUV2C54Q==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/types@3.974.5':
@@ -1041,8 +1087,16 @@ packages:
     resolution: {integrity: sha512-CsOeKq/9kA3y6VJHt+/+VTCtBaxJ4OTFpgrjIUhPpDIKxBci1k2bJaQASF2h/ELWrulGp+t97DZ0mevfAD8idg==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/credential-provider-imds@4.5.2':
+    resolution: {integrity: sha512-A9uSdn72ozbRUSit0eib0TW7nXuNPlaeM0zcGkJ+nE6tFcSDbnmtwoxbTCFBukVQcszDAyvsd7+rTduPTXpygg==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/fetch-http-handler@5.7.2':
     resolution: {integrity: sha512-nZyWTmSpJEXl6VtWVMBJve/7x12DZu6sIX1z1a+ZMaHlQQRs9Zpu6NbTe/gmxYXVRpkjxyDYpZ5gx2IM6f/Wkw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/middleware-compression@4.6.2':
+    resolution: {integrity: sha512-Q9d+luiRjyHT6kCL/9NyGpdZJgodh4vtvfHC6H8SqoVKrV2k9RoyI9/IloVfdCYks3/2DIi7BsYYLcda5KZS0A==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/node-http-handler@4.11.3':
@@ -1445,6 +1499,10 @@ packages:
         optional: true
       ws:
         optional: true
+
+  '@vercel/oidc-aws-credentials-provider@3.3.5':
+    resolution: {integrity: sha512-l03pONDI2r255W6SjBg5I6vvetUqYdXSheKyJgDMmCGOLIQFWOwLq5E1Ypltn9r+pgapaK6dZotMR4zYf8Tq7g==}
+    engines: {node: '>= 20'}
 
   '@vercel/oidc@3.2.0':
     resolution: {integrity: sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==}
@@ -4154,6 +4212,18 @@ snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
 
+  '@aws-sdk/client-cloudwatch@3.1119.0':
+    dependencies:
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/credential-provider-node': 3.972.81
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/fetch-http-handler': 5.7.2
+      '@smithy/middleware-compression': 4.6.2
+      '@smithy/node-http-handler': 4.11.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
   '@aws-sdk/core@3.977.9':
     dependencies:
       '@aws-sdk/types': 3.974.5
@@ -4165,7 +4235,91 @@ snapshots:
       bowser: 2.14.1
       tslib: 2.8.1
 
+  '@aws-sdk/credential-provider-env@3.972.70':
+    dependencies:
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-http@3.972.72':
+    dependencies:
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/fetch-http-handler': 5.7.2
+      '@smithy/node-http-handler': 4.11.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-ini@3.973.15':
+    dependencies:
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/credential-provider-env': 3.972.70
+      '@aws-sdk/credential-provider-http': 3.972.72
+      '@aws-sdk/credential-provider-login': 3.972.77
+      '@aws-sdk/credential-provider-process': 3.972.70
+      '@aws-sdk/credential-provider-sso': 3.973.14
+      '@aws-sdk/credential-provider-web-identity': 3.972.76
+      '@aws-sdk/nested-clients': 3.997.44
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/credential-provider-imds': 4.5.2
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-login@3.972.77':
+    dependencies:
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/nested-clients': 3.997.44
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-node@3.972.81':
+    dependencies:
+      '@aws-sdk/credential-provider-env': 3.972.70
+      '@aws-sdk/credential-provider-http': 3.972.72
+      '@aws-sdk/credential-provider-ini': 3.973.15
+      '@aws-sdk/credential-provider-process': 3.972.70
+      '@aws-sdk/credential-provider-sso': 3.973.14
+      '@aws-sdk/credential-provider-web-identity': 3.972.76
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/credential-provider-imds': 4.5.2
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-process@3.972.70':
+    dependencies:
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-sso@3.973.14':
+    dependencies:
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/nested-clients': 3.997.44
+      '@aws-sdk/token-providers': 3.1116.0
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-web-identity@3.972.49':
+    dependencies:
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/nested-clients': 3.997.44
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-web-identity@3.972.76':
     dependencies:
       '@aws-sdk/core': 3.977.9
       '@aws-sdk/nested-clients': 3.997.44
@@ -4189,6 +4343,15 @@ snapshots:
     dependencies:
       '@aws-sdk/types': 3.974.5
       '@smithy/signature-v4': 5.7.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/token-providers@3.1116.0':
+    dependencies:
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/nested-clients': 3.997.44
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
       '@smithy/types': 4.17.2
       tslib: 2.8.1
 
@@ -4877,10 +5040,23 @@ snapshots:
       '@smithy/types': 4.17.2
       tslib: 2.8.1
 
+  '@smithy/credential-provider-imds@4.5.2':
+    dependencies:
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
   '@smithy/fetch-http-handler@5.7.2':
     dependencies:
       '@smithy/core': 3.33.3
       '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@smithy/middleware-compression@4.6.2':
+    dependencies:
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
+      fflate: 0.8.3
       tslib: 2.8.1
 
   '@smithy/node-http-handler@4.11.3':
@@ -5250,6 +5426,11 @@ snapshots:
       '@vercel/oidc': 3.8.5
     optionalDependencies:
       '@aws-sdk/credential-provider-web-identity': 3.972.49
+
+  '@vercel/oidc-aws-credentials-provider@3.3.5':
+    dependencies:
+      '@aws-sdk/credential-provider-web-identity': 3.972.76
+      '@vercel/oidc': 3.8.5
 
   '@vercel/oidc@3.2.0': {}
 

--- a/tests/unit/custom-builds/worker.test.ts
+++ b/tests/unit/custom-builds/worker.test.ts
@@ -141,6 +141,10 @@ async function main() {
       workerSource.includes("clearInterval(queueHeartbeat)"),
     "queue health reporting should continue while the worker drains active jobs",
   );
+  assert.ok(
+    workerSource.includes('recordActiveGenerations(activeJobs.size, "worker", undefined, false);'),
+    "shutdown should report the non-accepting state before a short drain can finish",
+  );
   const callbackIndex = exportJobSource.indexOf("await opts.beforeSynchronousExport?.()");
   const downloadIndex = exportJobSource.indexOf("const bytes = await downloadCustomBuildArtifactBytes");
   assert.ok(

--- a/tests/unit/custom-builds/worker.test.ts
+++ b/tests/unit/custom-builds/worker.test.ts
@@ -18,7 +18,14 @@ async function main() {
     getCustomBuildWorkerConcurrency,
     getCustomBuildWorkerHeartbeatMs,
     getCustomBuildWorkerId,
+    isTerminalCustomBuildJobFailure,
   } = await import("../../../lib/custom-builds/worker");
+
+  assert.equal(
+    isTerminalCustomBuildJobFailure("generation_failed"),
+    true,
+    "a terminally failed build must not leave its job runnable",
+  );
 
   assert.equal(
     getCustomBuildWorkerConcurrency(),
@@ -128,6 +135,11 @@ async function main() {
     workerSource.includes("isCustomBuildLeaseLostError(error)") &&
       workerSource.includes("return { processed: true, jobId: job.id, jobType: job.type };"),
     "lost leases should stop the worker path without failing a job it may no longer own",
+  );
+  assert.ok(
+    workerSource.includes("const queueHeartbeat = setInterval") &&
+      workerSource.includes("clearInterval(queueHeartbeat)"),
+    "queue health reporting should continue while the worker drains active jobs",
   );
   const callbackIndex = exportJobSource.indexOf("await opts.beforeSynchronousExport?.()");
   const downloadIndex = exportJobSource.indexOf("const bytes = await downloadCustomBuildArtifactBytes");

--- a/tests/unit/observability/cloudwatch-metrics.test.ts
+++ b/tests/unit/observability/cloudwatch-metrics.test.ts
@@ -1,5 +1,7 @@
 import assert from "node:assert/strict";
 import {
+  generationErrorMetricData,
+  generationSuccessMetricData,
   recordGenerationSuccess,
   recordGenerationError,
   recordActiveGenerations,
@@ -33,11 +35,24 @@ async function main() {
   assert.equal(successParsed.GenerationDuration, 12451);
   assert.equal(successParsed._aws.CloudWatchMetrics[0].Namespace, "MineBench/Production");
   assert.deepEqual(successParsed._aws.CloudWatchMetrics[0].Dimensions, [
+    ["Environment"],
     ["Environment", "JobType", "Model"],
   ]);
   assert.deepEqual(successParsed._aws.CloudWatchMetrics[0].Metrics, [
     { Name: "GenerationsCount", Unit: "Count" },
     { Name: "GenerationDuration", Unit: "Milliseconds" },
+  ]);
+  const successMetricData = generationSuccessMetricData({
+    jobType: "stream",
+    model: "gpt-test",
+    durationMs: 3210,
+  });
+  assert.equal(successMetricData.length, 4);
+  assert.deepEqual(successMetricData[0]?.Dimensions, [{ Name: "Environment", Value: "production" }]);
+  assert.deepEqual(successMetricData[2]?.Dimensions, [
+    { Name: "Environment", Value: "production" },
+    { Name: "JobType", Value: "stream" },
+    { Name: "Model", Value: "gpt-test" },
   ]);
 
   // 2. Test recordGenerationError
@@ -60,10 +75,23 @@ async function main() {
   assert.equal(errorParsed.RawError, "rate_limit_exceeded (request_id: req_12345)");
   assert.equal(errorParsed.GenerationErrors, 1);
   assert.deepEqual(errorParsed._aws.CloudWatchMetrics[0].Dimensions, [
+    ["Environment"],
     ["Environment", "JobType", "Model", "ErrorType"],
   ]);
   assert.deepEqual(errorParsed._aws.CloudWatchMetrics[0].Metrics, [
     { Name: "GenerationErrors", Unit: "Count" },
+  ]);
+  const errorMetricData = generationErrorMetricData({
+    jobType: "stream",
+    model: "gpt-test",
+    errorType: "OpenRouter error 402: Insufficient credits",
+  });
+  assert.equal(errorMetricData.length, 2);
+  assert.deepEqual(errorMetricData[1]?.Dimensions, [
+    { Name: "Environment", Value: "production" },
+    { Name: "JobType", Value: "stream" },
+    { Name: "Model", Value: "gpt-test" },
+    { Name: "ErrorType", Value: "insufficient_credits" },
   ]);
 
   // 3. Test recordActiveGenerations (Gauge)
@@ -75,8 +103,13 @@ async function main() {
   assert.equal(activeParsed.Environment, "production");
   assert.equal(activeParsed.JobType, "worker");
   assert.equal(activeParsed.ActiveGenerations, 4);
+  assert.equal(activeParsed.WorkerAcceptingJobs, 1);
   assert.deepEqual(activeParsed._aws.CloudWatchMetrics[0].Dimensions, [
     ["Environment", "JobType"],
+  ]);
+  assert.deepEqual(activeParsed._aws.CloudWatchMetrics[0].Metrics, [
+    { Name: "ActiveGenerations", Unit: "Count" },
+    { Name: "WorkerAcceptingJobs", Unit: "Count" },
   ]);
 
   // 4. Test recordQueueHeartbeat
@@ -103,14 +136,27 @@ async function main() {
   // 5. Test Heartbeat interval
   lines.length = 0;
   let currentCount = 2;
-  const heartbeat = startActiveGenerationsHeartbeat(() => currentCount, 50, "worker", mockWriter);
+  let acceptingJobs = true;
+  const heartbeat = startActiveGenerationsHeartbeat(
+    () => currentCount,
+    () => acceptingJobs,
+    50,
+    "worker",
+    mockWriter,
+  );
+
+  assert.equal(lines.length, 1, "worker heartbeats should emit immediately on startup");
+  assert.equal(JSON.parse(lines[0]).WorkerAcceptingJobs, 1);
+
+  acceptingJobs = false;
 
   await new Promise((resolve) => setTimeout(resolve, 130));
   clearInterval(heartbeat);
 
-  assert.ok(lines.length >= 2);
-  const heartbeatParsed = JSON.parse(lines[0]);
+  assert.ok(lines.length >= 3);
+  const heartbeatParsed = JSON.parse(lines[1]);
   assert.equal(heartbeatParsed.ActiveGenerations, 2);
+  assert.equal(heartbeatParsed.WorkerAcceptingJobs, 0);
 
   // 6. Test normalizeErrorClassification
   assert.equal(normalizeErrorClassification("ETIMEDOUT connection failed"), "timeout");
@@ -118,6 +164,7 @@ async function main() {
   assert.equal(normalizeErrorClassification("provider_key_expired: key 12345 expired"), "auth_failed");
   assert.equal(normalizeErrorClassification("Request exceeds context length 128000"), "context_length_exceeded");
   assert.equal(normalizeErrorClassification("Custom build lease lost for job"), "lease_lost");
+  assert.equal(normalizeErrorClassification("OpenRouter error 402: Insufficient credits"), "insufficient_credits");
   assert.equal(normalizeErrorClassification(undefined), "unknown_error");
 
   console.log("cloudwatch metrics unit tests passed");


### PR DESCRIPTION
## Summary
- keep worker availability and queue heartbeats live during startup and graceful drains
- emit aggregate alarm series alongside detailed dashboard series and classify insufficient-credit failures
- publish streaming-generation metrics through an optional production-only Vercel OIDC role
- prevent terminally failed builds from leaving runnable jobs

## Production incident
An automatic worker restart waited on a long-running provider request. The old process stopped claiming jobs before the new telemetry code could start, while missing CloudWatch data was treated as healthy.

## Validation
- `pnpm lint`
- `pnpm exec tsc --noEmit`
- `npm run build`
- `pnpm exec tsx tests/unit/observability/cloudwatch-metrics.test.ts`
- `pnpm exec tsx tests/unit/custom-builds/worker.test.ts`

*(PR written by Codex)*