### PR TITLE
fix(ai): sanitize Gemini schemas through OpenRouter

### DIFF
--- a/lib/ai/providers/gemini.ts
+++ b/lib/ai/providers/gemini.ts
@@ -31,7 +31,7 @@ const GEMINI_SUPPORTED_JSON_SCHEMA_KEYS = new Set([
   "propertyOrdering",
 ]);
 
-function sanitizeGeminiJsonSchema(value: unknown): unknown {
+export function sanitizeGeminiJsonSchema(value: unknown): unknown {
   if (Array.isArray(value)) return value.map(sanitizeGeminiJsonSchema);
   if (!value || typeof value !== "object") return value;
 

--- a/lib/ai/providers/openrouter.ts
+++ b/lib/ai/providers/openrouter.ts
@@ -207,7 +207,9 @@ export async function openrouterGenerateText(params: {
 
   const baseUrl = process.env.OPENROUTER_BASE_URL ?? "https://openrouter.ai/api";
   const maxTokens = params.maxOutputTokens ?? 8192;
-  const jsonSchema = params.modelId.startsWith("google/gemini-")
+  const usesGeminiSchema =
+    params.modelId.startsWith("google/gemini-") || params.modelId.startsWith("google/gemma-");
+  const jsonSchema = usesGeminiSchema
     ? (sanitizeGeminiJsonSchema(params.jsonSchema) as Record<string, unknown> | undefined)
     : params.jsonSchema;
   const responseFormat = !jsonSchema

--- a/lib/ai/providers/openrouter.ts
+++ b/lib/ai/providers/openrouter.ts
@@ -4,6 +4,7 @@ import {
   modelUsesDefaultSampling,
 } from "@/lib/ai/modelRequestProfiles";
 import { attachAbortSignal } from "@/lib/ai/providers/abort";
+import { sanitizeGeminiJsonSchema } from "@/lib/ai/providers/gemini";
 import { consumeSseStream } from "@/lib/ai/providers/sse";
 import { tokenBudgetCandidates } from "@/lib/ai/tokenBudgets";
 import type { ProviderTelemetryCallbacks } from "@/lib/ai/types";
@@ -206,7 +207,10 @@ export async function openrouterGenerateText(params: {
 
   const baseUrl = process.env.OPENROUTER_BASE_URL ?? "https://openrouter.ai/api";
   const maxTokens = params.maxOutputTokens ?? 8192;
-  const responseFormat = !params.jsonSchema
+  const jsonSchema = params.modelId.startsWith("google/gemini-")
+    ? (sanitizeGeminiJsonSchema(params.jsonSchema) as Record<string, unknown> | undefined)
+    : params.jsonSchema;
+  const responseFormat = !jsonSchema
     ? undefined
     : params.modelId === "z-ai/glm-5.3" || params.modelId === "z-ai/glm-5.3-flash"
       ? { type: "json_object" }
@@ -215,7 +219,7 @@ export async function openrouterGenerateText(params: {
           json_schema: {
             name: VOXEL_BUILD_JSON_SCHEMA_NAME,
             strict: true,
-            schema: params.jsonSchema,
+            schema: jsonSchema,
           },
         };
   const reasoningAttempts = reasoningConfigFallbacks({

--- a/tests/unit/providers/gemini-family.test.ts
+++ b/tests/unit/providers/gemini-family.test.ts
@@ -214,19 +214,27 @@ runProviderConfigTest("gemini family", {}, async (capture) => {
     "Gemini schema sanitization should not mutate the shared tool schema",
   );
 
-  for (const expected of EXPECTATIONS) {
+  const openRouterToolModels = [
+    ...EXPECTATIONS.map((expected) => expected.catalog),
+    {
+      key: "gemma_4_31b" as const,
+      displayName: "Gemma 4 31B",
+      openRouterModelId: "google/gemma-4-31b-it",
+    },
+  ];
+  for (const model of openRouterToolModels) {
     const openRouterTool = await runGeneration(capture, {
-      modelKey: expected.catalog.key,
+      modelKey: model.key,
       maxAttempts: 1,
       enableTools: true,
       providerKeys: { openrouter: "test-openrouter-key" },
     });
     const openRouterToolRequest = openRouterTool.requests.find(
-      (request) => request.body.model === expected.catalog.openRouterModelId,
+      (request) => request.body.model === model.openRouterModelId,
     )?.body;
     assert.ok(
       openRouterToolRequest,
-      `OpenRouter ${expected.catalog.displayName} tool-schema request should be captured`,
+      `OpenRouter ${model.displayName} tool-schema request should be captured`,
     );
     const openRouterToolFormat = openRouterToolRequest.response_format as {
       json_schema?: { schema?: unknown };
@@ -234,7 +242,7 @@ runProviderConfigTest("gemini family", {}, async (capture) => {
     assert.deepEqual(
       openRouterToolFormat.json_schema?.schema,
       toolGenerationConfig.responseJsonSchema,
-      `OpenRouter ${expected.catalog.displayName} should receive the direct Gemini schema`,
+      `OpenRouter ${model.displayName} should receive the direct Gemini schema`,
     );
   }
   assert.equal(

--- a/tests/unit/providers/gemini-family.test.ts
+++ b/tests/unit/providers/gemini-family.test.ts
@@ -214,6 +214,35 @@ runProviderConfigTest("gemini family", {}, async (capture) => {
     "Gemini schema sanitization should not mutate the shared tool schema",
   );
 
+  for (const expected of EXPECTATIONS) {
+    const openRouterTool = await runGeneration(capture, {
+      modelKey: expected.catalog.key,
+      maxAttempts: 1,
+      enableTools: true,
+      providerKeys: { openrouter: "test-openrouter-key" },
+    });
+    const openRouterToolRequest = openRouterTool.requests.find(
+      (request) => request.body.model === expected.catalog.openRouterModelId,
+    )?.body;
+    assert.ok(
+      openRouterToolRequest,
+      `OpenRouter ${expected.catalog.displayName} tool-schema request should be captured`,
+    );
+    const openRouterToolFormat = openRouterToolRequest.response_format as {
+      json_schema?: { schema?: unknown };
+    };
+    assert.deepEqual(
+      openRouterToolFormat.json_schema?.schema,
+      toolGenerationConfig.responseJsonSchema,
+      `OpenRouter ${expected.catalog.displayName} should receive the direct Gemini schema`,
+    );
+  }
+  assert.equal(
+    schemaContainsKey(toolSchema, "minLength"),
+    true,
+    "OpenRouter Gemini schema sanitization should not mutate the shared tool schema",
+  );
+
   // A terminal schema rejection is not retried and never drops the schema
   capture.respondWith((request) =>
     request.url.includes("generativelanguage.googleapis.com")


### PR DESCRIPTION
## Summary

- sanitize structured-output schemas for Gemini and Gemma requests sent through OpenRouter
- reuse the same compatibility sanitizer as the native Gemini provider
- cover tool-enabled OpenRouter requests with provider regression tests

## Validation

- `pnpm exec tsx tests/run.ts tests/unit/providers`
- `pnpm exec tsc --noEmit`
- `pnpm exec eslint lib/ai/providers/gemini.ts lib/ai/providers/openrouter.ts tests/unit/providers/gemini-family.test.ts`
- `git diff --check origin/master...HEAD`

*(PR written by Codex)*