### PR TITLE
fix(ai): use JSON mode for OpenRouter Gemini

### DIFF
--- a/lib/ai/providers/openrouter.ts
+++ b/lib/ai/providers/openrouter.ts
@@ -214,7 +214,9 @@ export async function openrouterGenerateText(params: {
     : params.jsonSchema;
   const responseFormat = !jsonSchema
     ? undefined
-    : params.modelId === "z-ai/glm-5.3" || params.modelId === "z-ai/glm-5.3-flash"
+    : params.modelId.startsWith("google/gemini-") ||
+        params.modelId === "z-ai/glm-5.3" ||
+        params.modelId === "z-ai/glm-5.3-flash"
       ? { type: "json_object" }
       : {
           type: "json_schema",

--- a/tests/unit/providers/gemini-family.test.ts
+++ b/tests/unit/providers/gemini-family.test.ts
@@ -149,15 +149,10 @@ runProviderConfigTest("gemini family", {}, async (capture) => {
     assert.deepEqual(openRouterRequest.reasoning, { effort: "high" });
     assert.equal(Object.hasOwn(openRouterRequest, "temperature"), false);
     assert.deepEqual(openRouterRequest.provider, { require_parameters: true });
-    const responseFormat = openRouterRequest.response_format as {
-      type?: unknown;
-      json_schema?: { strict?: unknown; schema?: unknown };
-    };
-    assert.equal(responseFormat?.type, "json_schema");
-    assert.equal(responseFormat?.json_schema?.strict, true);
-    assert.ok(
-      responseFormat?.json_schema?.schema,
-      "OpenRouter request should include the voxel schema",
+    assert.deepEqual(
+      openRouterRequest.response_format,
+      { type: "json_object" },
+      `OpenRouter ${model.displayName} should avoid broken Google schema translation`,
     );
     assertTraceLine(
       openRouter.traces,
@@ -236,6 +231,14 @@ runProviderConfigTest("gemini family", {}, async (capture) => {
       openRouterToolRequest,
       `OpenRouter ${model.displayName} tool-schema request should be captured`,
     );
+    if (model.openRouterModelId?.startsWith("google/gemini-")) {
+      assert.deepEqual(
+        openRouterToolRequest.response_format,
+        { type: "json_object" },
+        `OpenRouter ${model.displayName} tool mode should avoid broken Google schema translation`,
+      );
+      continue;
+    }
     const openRouterToolFormat = openRouterToolRequest.response_format as {
       json_schema?: { schema?: unknown };
     };


### PR DESCRIPTION
## Summary

- use OpenRouter JSON-object mode for `google/gemini-*` requests
- retain native Gemini structured schemas and OpenRouter Gemma strict schemas
- preserve local schema validation and bounded repair retries
- cover standard and tool-mode Gemini request shapes

## Validation

- `pnpm exec tsx tests/run.ts tests/unit/providers`
- `pnpm exec tsc --noEmit`
- `pnpm exec eslint lib/ai/providers/openrouter.ts tests/unit/providers/gemini-family.test.ts`
- `pnpm build`
- live streamed and non-streamed OpenRouter Gemini 3.7 probes returned populated, schema-valid tool envelopes
- `git diff --check`

*(PR written by Codex)*