### PR TITLE
feat(generations): add hosted Gemini and Gallery navigation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,6 +40,8 @@ ZAI_API_KEY=
 # OpenRouter (alternative/fallback for all providers)
 # If a direct provider key is missing or fails, OpenRouter will be used as fallback
 OPENROUTER_API_KEY=
+# Server-only key for the signed-in Gemini 3.7 Flash promotion
+MINEBENCH_FREE_OPENROUTER_API_KEY=
 
 # Optional SEO verification token (Google Search Console)
 GOOGLE_SITE_VERIFICATION=

--- a/app/admin/gallery/actions.ts
+++ b/app/admin/gallery/actions.ts
@@ -11,6 +11,7 @@ import {
   setGalleryCandidateHidden,
   setGalleryPersonVoteBlocked,
   setGalleryPublishingSuspension,
+  setHostedGenerationLimit,
 } from "@/lib/gallery/service";
 
 const mutationSchema = z.discriminatedUnion("type", [
@@ -28,6 +29,11 @@ const mutationSchema = z.discriminatedUnion("type", [
     reason: z.string().trim().max(240).optional(),
   }),
   z.object({ type: z.literal("votes_blocked"), personId: z.string().min(1).max(120), blocked: z.boolean() }),
+  z.object({
+    type: z.literal("hosted_generation_limit"),
+    userId: z.string().uuid(),
+    limit: z.number().int().min(0).max(2_147_483_647),
+  }),
 ]);
 
 async function adminId() {
@@ -70,6 +76,9 @@ export async function mutateGalleryAdmin(input: unknown) {
         break;
       case "votes_blocked":
         await setGalleryPersonVoteBlocked(actorId, parsed.data.personId, parsed.data.blocked);
+        break;
+      case "hosted_generation_limit":
+        await setHostedGenerationLimit(actorId, parsed.data.userId, parsed.data.limit);
         break;
     }
     refreshGalleryAdmin();

--- a/app/api/generations/[id]/retry/route.ts
+++ b/app/api/generations/[id]/retry/route.ts
@@ -6,7 +6,7 @@ import { retrySavedGeneration } from "@/lib/generations/service";
 export const runtime = "nodejs";
 
 const retryRequest = z.object({
-  providerKey: z.string().trim().min(1).max(4000),
+  providerKey: z.string().trim().min(1).max(4000).optional(),
   customBaseUrl: z.string().trim().url().max(4000).optional(),
 });
 

--- a/app/gallery/[publicId]/page.tsx
+++ b/app/gallery/[publicId]/page.tsx
@@ -20,11 +20,24 @@ export async function generateMetadata({ params }: { params: Promise<{ publicId:
   };
 }
 
-export default async function GalleryDetailPage({ params }: { params: Promise<{ publicId: string }> }) {
-  const [cookieStore, account] = await Promise.all([cookies(), getCurrentAccount().catch(() => null)]);
-  const candidate = await getGalleryCandidate((await params).publicId, {
+export default async function GalleryDetailPage({
+  params,
+  searchParams,
+}: {
+  params: Promise<{ publicId: string }>;
+  searchParams: Promise<{ sort?: string }>;
+}) {
+  const [route, query, cookieStore, account] = await Promise.all([
+    params,
+    searchParams,
+    cookies(),
+    getCurrentAccount().catch(() => null),
+  ]);
+  const sort = query.sort === "new" ? "new" : "top";
+  const candidate = await getGalleryCandidate(route.publicId, {
     sessionId: cookieStore.get(ARENA_SESSION_COOKIE)?.value ?? null,
     userId: account?.id,
+    navigationSort: sort,
   });
   if (!candidate) notFound();
   return <GalleryDetail candidate={candidate} />;

--- a/app/sandbox/page.tsx
+++ b/app/sandbox/page.tsx
@@ -59,6 +59,11 @@ export default async function SandboxPage({
       <Sandbox
         initialPrompt={prompt}
         signedIn={Boolean(account)}
+        hostedGeminiAvailable={Boolean(
+          account &&
+          process.env.MINEBENCH_FREE_OPENROUTER_API_KEY?.trim() &&
+          account.hostedGenerationCount < account.hostedGenerationLimit
+        )}
         hasPublicNickname={Boolean(account?.publicNickname)}
         gallerySuspended={Boolean(account?.gallerySuspendedAt)}
       />

--- a/components/gallery/GalleryAdminDashboard.tsx
+++ b/components/gallery/GalleryAdminDashboard.tsx
@@ -21,7 +21,8 @@ type Mutation =
   | { type: "example_hidden"; exampleId: string }
   | { type: "candidate_selected"; publicId: string; selected: boolean }
   | { type: "account_suspended"; userId: string; suspended: boolean; reason?: string }
-  | { type: "votes_blocked"; personId: string; blocked: boolean };
+  | { type: "votes_blocked"; personId: string; blocked: boolean }
+  | { type: "hosted_generation_limit"; userId: string; limit: number };
 
 const dateTime = new Intl.DateTimeFormat("en-US", {
   dateStyle: "medium",
@@ -171,6 +172,7 @@ function PersonInspector({
       </div>
     );
   }
+  const userId = person.userId;
 
   return (
     <div className="min-h-0 min-w-0 space-y-5">
@@ -205,7 +207,50 @@ function PersonInspector({
           <dt className="text-muted">Location</dt>
           <dd className="mt-1 truncate font-medium text-fg" title={person.location ?? "Unavailable"}>{person.location ?? "Unavailable"}</dd>
         </div>
+        {userId ? (
+          <>
+            <div className="min-w-0 rounded-md border border-border/60 bg-card/20 p-2.5">
+              <dt className="text-muted">Total generations</dt>
+              <dd className="mt-1 font-medium tabular-nums text-fg">{(person.totalGenerationCount ?? 0).toLocaleString()}</dd>
+            </div>
+            <div className="min-w-0 rounded-md border border-border/60 bg-card/20 p-2.5">
+              <dt className="text-muted">Hosted generations</dt>
+              <dd className="mt-1 font-medium tabular-nums text-fg">
+                {(person.hostedGenerationCount ?? 0).toLocaleString()} / {(person.hostedGenerationLimit ?? 0).toLocaleString()}
+              </dd>
+            </div>
+          </>
+        ) : null}
       </dl>
+
+      {userId ? (
+        <form
+          key={`${person.id}:${person.hostedGenerationLimit}`}
+          className="flex items-end gap-2"
+          onSubmit={(event) => {
+            event.preventDefault();
+            const limit = Number(new FormData(event.currentTarget).get("limit"));
+            void onMutate({ type: "hosted_generation_limit", userId, limit });
+          }}
+        >
+          <label className="min-w-0 flex-1 space-y-1">
+            <span className="text-xs font-medium text-muted">Hosted limit</span>
+            <input
+              className="mb-field h-9"
+              type="number"
+              name="limit"
+              min={0}
+              max={2_147_483_647}
+              step={1}
+              required
+              defaultValue={person.hostedGenerationLimit ?? 0}
+            />
+          </label>
+          <button type="submit" disabled={pending} className="mb-btn h-9 text-xs">
+            {pending ? "Saving…" : "Save"}
+          </button>
+        </form>
+      ) : null}
 
       <div className="flex flex-wrap gap-2">
         {person.userId && person.email ? (
@@ -408,7 +453,11 @@ export function GalleryAdminDashboard({ dashboard }: { dashboard: Dashboard }) {
       return false;
     }
     setNotice(null);
-    if (selectedPersonId && (mutation.type === "account_suspended" || mutation.type === "votes_blocked")) {
+    if (selectedPersonId && (
+      mutation.type === "account_suspended" ||
+      mutation.type === "votes_blocked" ||
+      mutation.type === "hosted_generation_limit"
+    )) {
       await loadPerson(selectedPersonId);
     }
     startTransition(() => router.refresh());
@@ -515,7 +564,14 @@ export function GalleryAdminDashboard({ dashboard }: { dashboard: Dashboard }) {
                 <div className="max-h-[32rem] min-h-0 flex-1 divide-y divide-border overflow-y-auto border-b border-border pr-1 lg:max-h-none">
                   {people.map((entry) => (
                     <button key={entry.id} type="button" className="flex min-h-14 w-full items-center justify-between gap-3 py-3 text-left transition-colors hover:text-accent focus-visible:outline-none focus-visible:text-accent" onClick={() => void loadPerson(entry.id)}>
-                      <span className="min-w-0"><span className="block truncate text-sm font-medium">{entry.label}</span><span className="block truncate text-xs text-muted">{entry.location ?? formatDate(entry.lastSeenAt)}</span></span>
+                      <span className="min-w-0">
+                        <span className="block truncate text-sm font-medium">{entry.label}</span>
+                        <span className="block truncate text-xs text-muted">
+                          {entry.totalGenerationCount == null
+                            ? entry.location ?? formatDate(entry.lastSeenAt)
+                            : `${entry.totalGenerationCount.toLocaleString()} total · ${(entry.hostedGenerationCount ?? 0).toLocaleString()} / ${(entry.hostedGenerationLimit ?? 0).toLocaleString()} hosted`}
+                        </span>
+                      </span>
                       <span className="flex shrink-0 items-center gap-2 text-[11px] text-muted">
                         {entry.suspended ? "Suspended" : entry.voteBlocked ? "Votes blocked" : null}
                         <span aria-hidden="true" className={`h-1.5 w-1.5 rounded-full ${entry.online ? "bg-success" : "bg-muted/50"}`} />

--- a/components/gallery/GalleryDetail.tsx
+++ b/components/gallery/GalleryDetail.tsx
@@ -25,6 +25,11 @@ const SandboxGifExportButton = dynamic(
 type GalleryDetailPayload = GalleryCandidatePayload & {
   examples: GalleryExamplePayload[];
   nextExamplesCursor: string | null;
+  navigation: {
+    sort: "top" | "new";
+    previousId: string | null;
+    nextId: string | null;
+  } | null;
 };
 
 type ExampleViewerState = {
@@ -34,6 +39,53 @@ type ExampleViewerState = {
 };
 
 const MAX_COMPARISON_EXAMPLES = 4;
+
+function galleryDetailHref(publicId: string, sort: "top" | "new") {
+  return `/gallery/${publicId}${sort === "new" ? "?sort=new" : ""}`;
+}
+
+function GalleryNavigationArrow({
+  direction,
+  publicId,
+  sort,
+}: {
+  direction: "previous" | "next";
+  publicId: string | null;
+  sort: "top" | "new";
+}) {
+  const previous = direction === "previous";
+  const label = previous ? "Previous build" : "Next build";
+  const icon = (
+    <svg
+      aria-hidden="true"
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.75"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={`h-4 w-4 transition-transform duration-200 ease-[cubic-bezier(0.22,1,0.36,1)] group-active:scale-90 motion-reduce:transform-none motion-reduce:transition-none ${previous ? "group-hover:-translate-x-0.5 group-active:-translate-x-1" : "group-hover:translate-x-0.5 group-active:translate-x-1"}`}
+    >
+      <path d={previous ? "M10 3.5L5.5 8L10 12.5" : "M6 3.5L10.5 8L6 12.5"} />
+    </svg>
+  );
+  const divider = previous ? "" : "border-l border-border/70";
+
+  if (!publicId) {
+    return <span aria-hidden="true" className={`grid h-11 w-11 place-items-center text-muted/25 ${divider}`}>{icon}</span>;
+  }
+  return (
+    <Link
+      href={galleryDetailHref(publicId, sort)}
+      aria-label={label}
+      aria-keyshortcuts={previous ? "ArrowLeft" : "ArrowRight"}
+      title={`${label} (${previous ? "Left" : "Right"} Arrow)`}
+      className={`group grid h-11 w-11 place-items-center text-muted transition-colors duration-200 ease-[cubic-bezier(0.22,1,0.36,1)] hover:bg-card/50 hover:text-fg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-accent/45 active:bg-card/70 motion-reduce:transition-none ${divider}`}
+    >
+      {icon}
+    </Link>
+  );
+}
 
 function ReportDialog({
   open,
@@ -103,6 +155,7 @@ function ReportDialog({
 
 export function GalleryDetail({ candidate }: { candidate: GalleryDetailPayload }) {
   const router = useRouter();
+  const navigation = candidate.navigation;
   const [examples, setExamples] = useState(candidate.examples);
   const [nextExamplesCursor, setNextExamplesCursor] = useState(candidate.nextExamplesCursor);
   const [loadingMore, setLoadingMore] = useState(false);
@@ -238,6 +291,29 @@ export function GalleryDetail({ candidate }: { candidate: GalleryDetailPayload }
     viewerStatesRef.current = {};
   }, []);
 
+  useEffect(() => {
+    if (!navigation || reportOpen) return;
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.defaultPrevented || event.repeat || event.isComposing) return;
+      if (event.metaKey || event.ctrlKey || event.altKey || event.shiftKey) return;
+      const target = event.target;
+      if (target instanceof HTMLElement && (
+        target.isContentEditable ||
+        target.closest("input, textarea, select, dialog, [contenteditable='true'], [role='menu']")
+      )) return;
+      const publicId = event.key === "ArrowLeft"
+        ? navigation.previousId
+        : event.key === "ArrowRight"
+          ? navigation.nextId
+          : null;
+      if (!publicId) return;
+      event.preventDefault();
+      router.push(galleryDetailHref(publicId, navigation.sort));
+    };
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [navigation, reportOpen, router]);
+
   function selectExample(event: React.MouseEvent<HTMLButtonElement>, exampleId: string) {
     const additive = event.metaKey || event.ctrlKey;
     if (compareMode && selectedIds.length === 1 && selectedIds[0] === exampleId) {
@@ -313,11 +389,17 @@ export function GalleryDetail({ candidate }: { candidate: GalleryDetailPayload }
 
   return (
     <article className="mb-fade-in mx-auto w-full max-w-7xl py-4 sm:py-8">
-      <nav aria-label="Breadcrumb">
-        <Link href="/gallery" className="group inline-flex min-h-11 items-center gap-2 text-sm font-medium text-muted transition-colors hover:text-fg motion-reduce:transition-none">
+      <nav aria-label="Gallery navigation" className="flex items-center justify-between gap-4">
+        <Link href={navigation?.sort === "new" ? "/gallery?sort=new" : "/gallery"} className="group inline-flex min-h-11 items-center gap-2 text-sm font-medium text-muted transition-colors hover:text-fg motion-reduce:transition-none">
           <span aria-hidden="true" className="transition-transform duration-200 group-hover:-translate-x-0.5 motion-reduce:transform-none motion-reduce:transition-none">←</span>
           Gallery
         </Link>
+        {navigation ? (
+          <div className="flex overflow-hidden rounded-md border border-border/70 bg-card/10">
+            <GalleryNavigationArrow direction="previous" publicId={navigation.previousId} sort={navigation.sort} />
+            <GalleryNavigationArrow direction="next" publicId={navigation.nextId} sort={navigation.sort} />
+          </div>
+        ) : null}
       </nav>
 
       <header className="mt-6 max-w-5xl sm:mt-8">

--- a/components/gallery/GalleryExplore.tsx
+++ b/components/gallery/GalleryExplore.tsx
@@ -87,7 +87,15 @@ function SubmissionDialog({
   );
 }
 
-function GalleryCard({ candidate, delayed }: { candidate: GalleryCandidatePayload; delayed: boolean }) {
+function GalleryCard({
+  candidate,
+  delayed,
+  sort,
+}: {
+  candidate: GalleryCandidatePayload;
+  delayed: boolean;
+  sort: "top" | "new";
+}) {
   const modelLabels = [...new Set(
     [candidate.cover?.model.label, candidate.alternate?.model.label]
       .filter((label): label is string => Boolean(label)),
@@ -96,7 +104,7 @@ function GalleryCard({ candidate, delayed }: { candidate: GalleryCandidatePayloa
   const duration = formatBuildDuration(candidate.cover?.generationTimeMs);
   return (
     <article className={`group flex min-w-0 flex-col overflow-hidden rounded-md border border-border/80 bg-card/10 transition-[transform,border-color,background-color,box-shadow] duration-200 ease-out hover:-translate-y-0.5 hover:border-accent/35 hover:bg-card/20 hover:shadow-soft active:translate-y-0 motion-reduce:transform-none motion-reduce:transition-none mb-card-enter ${delayed ? "mb-card-enter-delay" : ""}`}>
-      <Link href={`/gallery/${candidate.id}`} className="flex flex-1 flex-col focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-accent/50">
+      <Link href={`/gallery/${candidate.id}${sort === "new" ? "?sort=new" : ""}`} className="flex flex-1 flex-col focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-accent/50">
         {candidate.cover?.previewUrl ? (
           <div className="relative aspect-[4/3] overflow-hidden bg-bg/45">
             <Image
@@ -233,7 +241,7 @@ export function GalleryExplore({
       <div key={activeSort} className="mb-fade-in">
         {items.length ? (
           <div className="mt-7 grid grid-cols-1 gap-5 md:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4">
-            {items.map((candidate, index) => <GalleryCard key={candidate.id} candidate={candidate} delayed={index % 2 === 1} />)}
+            {items.map((candidate, index) => <GalleryCard key={candidate.id} candidate={candidate} delayed={index % 2 === 1} sort={activeSort} />)}
           </div>
         ) : (
           <section className="mt-14 py-10 sm:mt-20 sm:py-14" aria-labelledby="empty-gallery-title">

--- a/components/gallery/GalleryYours.tsx
+++ b/components/gallery/GalleryYours.tsx
@@ -121,13 +121,12 @@ function GenerationActions({
         throw new Error("Reconnect this model in Generate.");
       }
       const providerKey = loadProviderKeysFromStorage()[retryProvider]?.trim();
-      if (!providerKey) throw new Error("Add the required API key in Generate first.");
       const response = await fetch(
         `/api/generations/${encodeURIComponent(generation.id)}/retry`,
         {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ providerKey }),
+          body: JSON.stringify(providerKey ? { providerKey } : {}),
         },
       );
       const body = (await response.json().catch(() => null)) as {

--- a/components/sandbox/Sandbox.tsx
+++ b/components/sandbox/Sandbox.tsx
@@ -83,11 +83,13 @@ function SandboxModeTabs({
 export function Sandbox({
   initialPrompt,
   signedIn,
+  hostedGeminiAvailable,
   hasPublicNickname,
   gallerySuspended,
 }: {
   initialPrompt?: string;
   signedIn: boolean;
+  hostedGeminiAvailable: boolean;
   hasPublicNickname: boolean;
   gallerySuspended: boolean;
 }) {
@@ -136,6 +138,7 @@ export function Sandbox({
           key={livePrompt ?? "default"}
           initialPrompt={livePrompt}
           signedIn={signedIn}
+          hostedGeminiAvailable={hostedGeminiAvailable}
           hasPublicNickname={hasPublicNickname}
           gallerySuspended={gallerySuspended}
         />

--- a/components/sandbox/SandboxLive.tsx
+++ b/components/sandbox/SandboxLive.tsx
@@ -104,6 +104,8 @@ const DIRECT_PROVIDER_KEYS = [
 ] as const satisfies ReadonlyArray<readonly [keyof ProviderApiKeys, string]>;
 const OPENROUTER_MODEL_VALUE = "__openrouter__";
 const CUSTOM_MODEL_VALUE = "__custom_api__";
+const HOSTED_GEMINI_MODEL_KEY = "gemini_3_7_flash";
+const HOSTED_GEMINI_NOTICE_KEY = "mb_hosted_gemini_3_7_notice_v1";
 const DEFAULT_CUSTOM_MODEL: CustomSandboxModel = {
   displayName: "OpenAI-compatible model",
   modelId: "",
@@ -125,6 +127,49 @@ const DEFAULT_MODEL_B: ModelKey =
   )?.key ??
   ENABLED_MODELS.find((model) => model.key !== DEFAULT_MODEL_A)?.key ??
   DEFAULT_MODEL_A;
+
+function HostedGeminiAnnouncement({
+  open,
+  onDismiss,
+}: {
+  open: boolean;
+  onDismiss: () => void;
+}) {
+  const dialogRef = useRef<HTMLDialogElement>(null);
+
+  useEffect(() => {
+    const dialog = dialogRef.current;
+    if (open && dialog && !dialog.open) dialog.showModal();
+  }, [open]);
+
+  if (!open) return null;
+  return (
+    <dialog
+      ref={dialogRef}
+      aria-labelledby="hosted-gemini-title"
+      className="mb-dialog m-auto w-[min(28rem,calc(100%-2rem))] rounded-md border-0 bg-card p-0 text-fg ring-1 ring-border-xl backdrop:bg-bg/60 backdrop:backdrop-blur-sm"
+      onCancel={(event) => {
+        event.preventDefault();
+        onDismiss();
+      }}
+    >
+      <div className="space-y-6 p-6 sm:p-7">
+        <div>
+          <p className="mb-eyebrow">Generate</p>
+          <h2 id="hosted-gemini-title" className="mt-2 text-2xl font-semibold tracking-tight">
+            Gemini 3.7 Flash is free
+          </h2>
+          <p className="mt-2 text-sm leading-6 text-muted">
+            Signed-in users can generate without a Gemini or OpenRouter API key for a limited time.
+          </p>
+        </div>
+        <button type="button" className="mb-btn mb-btn-primary h-11 w-full" onClick={onDismiss}>
+          Got it
+        </button>
+      </div>
+    </dialog>
+  );
+}
 
 function safeJsonParseObject(text: string): Record<string, unknown> | null {
   try {
@@ -474,11 +519,13 @@ function customBuildRetryProvider(status: SavedGenerationPayload): keyof Provide
 export function SandboxLive({
   initialPrompt,
   signedIn,
+  hostedGeminiAvailable,
   hasPublicNickname,
   gallerySuspended,
 }: {
   initialPrompt?: string;
   signedIn: boolean;
+  hostedGeminiAvailable: boolean;
   hasPublicNickname: boolean;
   gallerySuspended: boolean;
 }) {
@@ -505,7 +552,13 @@ export function SandboxLive({
   const [running, setRunning] = useState(false);
   const [requestError, setRequestError] = useState<string | null>(null);
   const [showGenerationPreflight, setShowGenerationPreflight] = useState(false);
+  const [showHostedGeminiAnnouncement, setShowHostedGeminiAnnouncement] = useState(false);
   const savedKeyCount = Object.values(providerKeys).filter((value) => Boolean(value?.trim())).length;
+  const canUseHostedGemini = Boolean(
+    hostedGeminiAvailable &&
+    !providerKeys.gemini?.trim() &&
+    !providerKeys.openrouter?.trim(),
+  );
   const [apiKeysOpen, setApiKeysOpen] = useState(false);
   const [providerKeysOpen, setProviderKeysOpen] = useState(false);
   const [, forceRender] = useState(0);
@@ -603,6 +656,30 @@ export function SandboxLive({
   useEffect(() => {
     saveProviderKeysToStorage(providerKeys);
   }, [providerKeys]);
+
+  useEffect(() => {
+    if (!signedIn || !hostedGeminiAvailable) return;
+    try {
+      if (!window.localStorage.getItem(HOSTED_GEMINI_NOTICE_KEY)) {
+        setShowHostedGeminiAnnouncement(true);
+      }
+    } catch {
+      setShowHostedGeminiAnnouncement(true);
+    }
+  }, [hostedGeminiAvailable, signedIn]);
+
+  function dismissHostedGeminiAnnouncement() {
+    try {
+      window.localStorage.setItem(HOSTED_GEMINI_NOTICE_KEY, "1");
+    } catch {}
+    setShowHostedGeminiAnnouncement(false);
+  }
+
+  function modelOptionLabel(model: (typeof ENABLED_MODELS)[number]): string {
+    return model.key === HOSTED_GEMINI_MODEL_KEY && canUseHostedGemini
+      ? `${model.displayName} · Free`
+      : model.displayName;
+  }
 
   useEffect(() => {
     if (lastGenerateInputRef.current === inputSignature) return;
@@ -1590,7 +1667,7 @@ export function SandboxLive({
                           model.key === modelPair.b
                         }
                       >
-                        {model.displayName}
+                        {modelOptionLabel(model)}
                       </option>
                     ))}
                   </optgroup>
@@ -1634,7 +1711,7 @@ export function SandboxLive({
                           value={model.key}
                           disabled={!isAdHocModelValue(modelPair.a) && model.key === modelPair.a}
                         >
-                          {model.displayName}
+                          {modelOptionLabel(model)}
                         </option>
                       ))}
                     </optgroup>
@@ -1887,6 +1964,10 @@ export function SandboxLive({
           setShowGenerationPreflight(false);
           void runGenerate(true);
         }}
+      />
+      <HostedGeminiAnnouncement
+        open={showHostedGeminiAnnouncement}
+        onDismiss={dismissHostedGeminiAnnouncement}
       />
     </div>
   );

--- a/components/sandbox/SandboxLive.tsx
+++ b/components/sandbox/SandboxLive.tsx
@@ -997,10 +997,6 @@ export function SandboxLive({
     const providerKey = existing.retryProvider
       ? providerKeys[existing.retryProvider]?.trim()
       : undefined;
-    if (!providerKey) {
-      setRequestError("Add the required API key before retrying.");
-      return;
-    }
     const abortController = new AbortController();
     customBuildAbortRef.current = abortController;
     setRunning(true);
@@ -1013,7 +1009,7 @@ export function SandboxLive({
           headers: { "Content-Type": "application/json" },
           signal: abortController.signal,
           body: JSON.stringify({
-            providerKey,
+            ...(providerKey ? { providerKey } : {}),
             ...(model.kind === "custom" && model.provider === "custom"
               ? { customBaseUrl: model.baseUrl }
               : {}),

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -97,6 +97,7 @@ Copy `.env.example` to `.env` and set what you need.
 - `META_MODEL_API_KEY`
 - `ZAI_API_KEY`
 - `OPENROUTER_API_KEY`
+- `MINEBENCH_FREE_OPENROUTER_API_KEY` (server-only key for the signed-in Gemini 3.7 Flash promotion)
 
 ### Optional Provider and Runtime Tuning
 

--- a/docs/privacy-policy.md
+++ b/docs/privacy-policy.md
@@ -1,6 +1,6 @@
 # MineBench Privacy Policy
 
-Effective and last updated: August 26, 2026
+Effective and last updated: August 28, 2026
 
 MineBench is an independent service operated by Ammaar Alam in the United States. This Privacy Policy explains how MineBench handles information when you use [minebench.ai](https://minebench.ai), participate in model evaluations, use MineBench's generation tools, or communicate with MineBench.
 
@@ -24,7 +24,9 @@ Do not submit personal, confidential, or sensitive information in prompts or fil
 
 ## API Credentials and Model Providers
 
-API credentials entered in Sandbox are stored in your browser's local storage. They pass through MineBench's server with a generation request and are sent to the model provider or custom endpoint you select. MineBench does not intentionally retain those credentials after the request.
+API credentials entered in Sandbox are stored in your browser's local storage. They pass through MineBench's server with a generation request and are sent to the model provider or custom endpoint you select. For saved generations, MineBench temporarily encrypts the required credential while the job is processed and deletes it when processing ends.
+
+For limited hosted generation offers, MineBench may supply the provider credential instead. The prompt, generation settings, and model output are still processed by OpenRouter and the underlying model provider.
 
 The selected provider processes prompts and related information under its own terms and privacy practices. You can remove saved credentials through Sandbox settings or by clearing MineBench site data in your browser.
 

--- a/lib/auth/account.ts
+++ b/lib/auth/account.ts
@@ -19,6 +19,8 @@ export type PublicAccount = {
   isMineBenchAdmin: boolean;
   gallerySuspendedAt: Date | null;
   gallerySuspensionReason: string | null;
+  hostedGenerationCount: number;
+  hostedGenerationLimit: number;
   createdAt: Date;
 };
 
@@ -74,6 +76,8 @@ export async function syncAuthUser(authUser: SupabaseAuthUser): Promise<PublicAc
       isMineBenchAdmin: true,
       gallerySuspendedAt: true,
       gallerySuspensionReason: true,
+      hostedGenerationCount: true,
+      hostedGenerationLimit: true,
       createdAt: true,
     },
   });

--- a/lib/gallery/api.ts
+++ b/lib/gallery/api.ts
@@ -16,6 +16,7 @@ const STATUS_BY_CODE: Record<string, number> = {
   duplicate_unavailable: 409,
   generation_mismatch: 409,
   generation_not_available: 409,
+  hosted_generation_limit_reached: 409,
   nickname_required: 409,
   public_examples_require_confirmation: 409,
   selected_candidate: 409,

--- a/lib/gallery/service.ts
+++ b/lib/gallery/service.ts
@@ -25,6 +25,7 @@ import {
 import { hashVoteSession } from "@/lib/voteBlock";
 
 const RETENTION_MS = 30 * 24 * 60 * 60 * 1000;
+const MAX_HOSTED_GENERATION_LIMIT = 2_147_483_647;
 
 async function deliverGalleryEmail(task: Promise<void>, context: string) {
   try {
@@ -880,6 +881,29 @@ export async function setGalleryPublishingSuspension(
   return { suspended: input.suspended, changed: account.changed };
 }
 
+export async function setHostedGenerationLimit(
+  adminId: string,
+  userId: string,
+  limit: number,
+) {
+  await requireMineBenchAdmin(adminId);
+  if (!Number.isInteger(limit) || limit < 0 || limit > MAX_HOSTED_GENERATION_LIMIT) {
+    throw new GalleryServiceError("invalid_request", "Enter a valid hosted generation limit.");
+  }
+  try {
+    return await prisma.user.update({
+      where: { id: userId },
+      data: { hostedGenerationLimit: limit },
+      select: { hostedGenerationCount: true, hostedGenerationLimit: true },
+    });
+  } catch (error) {
+    if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === "P2025") {
+      throw new GalleryServiceError("not_found", "Account not found.");
+    }
+    throw error;
+  }
+}
+
 export async function updateGalleryNickname(userId: string, draft: string) {
   const value = normalizeGalleryNickname(draft);
   if (!value.display) {
@@ -1312,6 +1336,9 @@ export async function getGalleryAdminDashboard(
         publicNickname: true,
         lastSeenAt: true,
         gallerySuspendedAt: true,
+        totalGenerationCount: true,
+        hostedGenerationCount: true,
+        hostedGenerationLimit: true,
       },
     }),
     prisma.publicSessionActivity.findMany({
@@ -1332,6 +1359,9 @@ export async function getGalleryAdminDashboard(
             email: true,
             publicNickname: true,
             gallerySuspendedAt: true,
+            totalGenerationCount: true,
+            hostedGenerationCount: true,
+            hostedGenerationLimit: true,
           },
         },
       },
@@ -1355,6 +1385,9 @@ export async function getGalleryAdminDashboard(
     online: boolean;
     suspended: boolean;
     voteBlocked: boolean;
+    totalGenerationCount: number | null;
+    hostedGenerationCount: number | null;
+    hostedGenerationLimit: number | null;
   }>();
 
   for (const account of accounts) {
@@ -1367,6 +1400,9 @@ export async function getGalleryAdminDashboard(
       online: false,
       suspended: Boolean(account.gallerySuspendedAt),
       voteBlocked: blockedUsers.has(account.id),
+      totalGenerationCount: account.totalGenerationCount,
+      hostedGenerationCount: account.hostedGenerationCount,
+      hostedGenerationLimit: account.hostedGenerationLimit,
     });
   }
 
@@ -1390,6 +1426,9 @@ export async function getGalleryAdminDashboard(
         online: Boolean(existing?.online || online),
         suspended: Boolean(session.user.gallerySuspendedAt),
         voteBlocked: Boolean(existing?.voteBlocked || blockedUsers.has(session.userId) || sessionBlocked),
+        totalGenerationCount: session.user.totalGenerationCount,
+        hostedGenerationCount: session.user.hostedGenerationCount,
+        hostedGenerationLimit: session.user.hostedGenerationLimit,
       });
       continue;
     }
@@ -1402,6 +1441,9 @@ export async function getGalleryAdminDashboard(
       online,
       suspended: false,
       voteBlocked: sessionBlocked,
+      totalGenerationCount: null,
+      hostedGenerationCount: null,
+      hostedGenerationLimit: null,
     });
   }
 
@@ -1463,6 +1505,9 @@ async function resolveGalleryAdminPerson(personId: string) {
         lastSeenAt: true,
         gallerySuspendedAt: true,
         gallerySuspensionReason: true,
+        totalGenerationCount: true,
+        hostedGenerationCount: true,
+        hostedGenerationLimit: true,
         publicSessionActivities: {
           orderBy: { lastSeenAt: "desc" },
           take: 50,
@@ -1492,6 +1537,9 @@ async function resolveGalleryAdminPerson(personId: string) {
       location: latest ? adminLocation(latest) : null,
       suspendedAt: user.gallerySuspendedAt,
       suspensionReason: user.gallerySuspensionReason,
+      totalGenerationCount: user.totalGenerationCount,
+      hostedGenerationCount: user.hostedGenerationCount,
+      hostedGenerationLimit: user.hostedGenerationLimit,
     };
   }
 
@@ -1519,6 +1567,9 @@ async function resolveGalleryAdminPerson(personId: string) {
       location: adminLocation(session),
       suspendedAt: null,
       suspensionReason: null,
+      totalGenerationCount: null,
+      hostedGenerationCount: null,
+      hostedGenerationLimit: null,
     };
   }
 
@@ -1642,6 +1693,9 @@ export async function getGalleryAdminPerson(adminId: string, personId: string) {
     online: Boolean(person.lastSeenAt && person.lastSeenAt.getTime() >= Date.now() - PUBLIC_SESSION_ONLINE_MS),
     suspended: Boolean(person.suspendedAt),
     suspensionReason: person.suspensionReason,
+    totalGenerationCount: person.totalGenerationCount,
+    hostedGenerationCount: person.hostedGenerationCount,
+    hostedGenerationLimit: person.hostedGenerationLimit,
     voteBlocked: Boolean(voteBlocked),
     contributions: contributions.map((candidate) => ({
       publicId: candidate.publicId,

--- a/lib/gallery/service.ts
+++ b/lib/gallery/service.ts
@@ -209,8 +209,16 @@ function publicCandidate(
 export type GalleryCandidatePayload = ReturnType<typeof publicCandidate>;
 export type GalleryExamplePayload = ReturnType<typeof publicExample>;
 
+type GallerySort = "top" | "new";
+
+function galleryCandidateOrder(sort: GallerySort): Prisma.GalleryCandidateOrderByWithRelationInput[] {
+  return sort === "top"
+    ? [{ upvoteCount: "desc" }, { publishedAt: "desc" }, { id: "desc" }]
+    : [{ publishedAt: "desc" }, { id: "desc" }];
+}
+
 export async function listGalleryCandidates(options: {
-  sort: "top" | "new";
+  sort: GallerySort;
   cursor?: string | null;
   limit?: number;
   sessionId?: string | null;
@@ -242,9 +250,7 @@ export async function listGalleryCandidates(options: {
   const rows = await prisma.galleryCandidate.findMany({
     where: { AND: [publicCandidateWhere, cursorWhere] },
     select: candidateListSelect,
-    orderBy: options.sort === "top"
-      ? [{ upvoteCount: "desc" }, { publishedAt: "desc" }, { id: "desc" }]
-      : [{ publishedAt: "desc" }, { id: "desc" }],
+    orderBy: galleryCandidateOrder(options.sort),
     take: limit + 1,
   });
   const page = rows.slice(0, limit);
@@ -288,6 +294,7 @@ export async function getGalleryCandidate(
     userId?: string | null;
     examplesCursor?: string | null;
     examplesLimit?: number;
+    navigationSort?: GallerySort;
   } = {},
 ) {
   const candidate = await prisma.galleryCandidate.findFirst({
@@ -297,7 +304,7 @@ export async function getGalleryCandidate(
   if (!candidate) return null;
   const limit = Math.max(1, Math.min(options.examplesLimit ?? 24, 48));
   const cursor = decodeGalleryCursor(options.examplesCursor);
-  const [cover, exampleCount, upvoted] = await Promise.all([
+  const [cover, exampleCount, upvoted, previousCandidates, nextCandidates] = await Promise.all([
     prisma.galleryExample.findFirst({
       where: { candidateId: candidate.id, ...publicExampleWhere },
       select: exampleSelect,
@@ -316,6 +323,26 @@ export async function getGalleryCandidate(
         select: { id: true },
       })
       : null,
+    options.navigationSort
+      ? prisma.galleryCandidate.findMany({
+          where: publicCandidateWhere,
+          cursor: { id: candidate.id },
+          skip: 1,
+          take: -1,
+          select: { publicId: true },
+          orderBy: galleryCandidateOrder(options.navigationSort),
+        })
+      : [],
+    options.navigationSort
+      ? prisma.galleryCandidate.findMany({
+          where: publicCandidateWhere,
+          cursor: { id: candidate.id },
+          skip: 1,
+          take: 1,
+          select: { publicId: true },
+          orderBy: galleryCandidateOrder(options.navigationSort),
+        })
+      : [],
   ]);
   const additional = await prisma.galleryExample.findMany({
     where: {
@@ -344,6 +371,13 @@ export async function getGalleryCandidate(
       .map(publicExample),
     nextExamplesCursor: additional.length > limit && last
       ? encodeGalleryCursor({ score: 0, publishedAt: last.createdAt, id: last.id })
+      : null,
+    navigation: options.navigationSort
+      ? {
+          sort: options.navigationSort,
+          previousId: previousCandidates[0]?.publicId ?? null,
+          nextId: nextCandidates[0]?.publicId ?? null,
+        }
       : null,
   };
 }

--- a/lib/generations/service.ts
+++ b/lib/generations/service.ts
@@ -15,6 +15,7 @@ import { prisma } from "@/lib/prisma";
 const STORAGE_FAILSAFE_BYTES = 1024 * 1024 * 1024;
 const SECRET_TTL_MS = 24 * 60 * 60 * 1000;
 const GENERATE_JOB_MAX_ATTEMPTS = 2;
+const HOSTED_GEMINI_MODEL_KEY = "gemini_3_7_flash";
 
 export class GenerationServiceError extends Error {
   constructor(
@@ -191,10 +192,28 @@ export async function createSavedGenerations(input: CreateSavedGenerationsInput)
     );
   }
 
+  const hostedOpenRouterKey = process.env.MINEBENCH_FREE_OPENROUTER_API_KEY?.trim();
+  const hasUserGeminiCredential = Boolean(
+    input.providerKeys.gemini?.trim() || input.providerKeys.openrouter?.trim(),
+  );
   let resolved;
   try {
     resolved = await Promise.all(
-      input.models.map((model) => resolveSavedGenerationModel(model, input.providerKeys)),
+      input.models.map(async (request) => {
+        const usesHostedGeneration = Boolean(
+          hostedOpenRouterKey &&
+          !hasUserGeminiCredential &&
+          request.kind === "catalog" &&
+          request.modelKey === HOSTED_GEMINI_MODEL_KEY,
+        );
+        const model = await resolveSavedGenerationModel(
+          request,
+          usesHostedGeneration
+            ? { ...input.providerKeys, openrouter: hostedOpenRouterKey }
+            : input.providerKeys,
+        );
+        return { model, usesHostedGeneration };
+      }),
     );
   } catch (error) {
     if (error instanceof GenerationServiceError) throw error;
@@ -206,7 +225,7 @@ export async function createSavedGenerations(input: CreateSavedGenerationsInput)
   }
 
   const now = new Date();
-  const prepared = resolved.map((model) => {
+  const prepared = resolved.map(({ model, usesHostedGeneration }) => {
     const id = randomUUID();
     const publicId = generateCustomBuildPublicId();
     const credential = encryptProviderKey(model.credential.value, {
@@ -216,10 +235,33 @@ export async function createSavedGenerations(input: CreateSavedGenerationsInput)
     const endpoint = model.customBaseUrl
       ? encryptSecretValue(model.customBaseUrl, id)
       : null;
-    return { id, publicId, model, credential, endpoint };
+    return { id, publicId, model, credential, endpoint, usesHostedGeneration };
   });
 
   await prisma.$transaction(async (tx) => {
+    const hostedGenerationCount = prepared.filter((item) => item.usesHostedGeneration).length;
+    const account = await tx.$queryRaw<Array<{ id: string }>>`
+      UPDATE "User"
+      SET
+        "totalGenerationCount" = "totalGenerationCount" + ${prepared.length},
+        "hostedGenerationCount" = "hostedGenerationCount" + ${hostedGenerationCount},
+        "updatedAt" = ${now}
+      WHERE id = ${input.ownerId}::uuid
+        AND (
+          ${hostedGenerationCount} = 0 OR
+          "hostedGenerationCount" + ${hostedGenerationCount} <= "hostedGenerationLimit"
+        )
+      RETURNING id
+    `;
+    if (account.length !== 1) {
+      throw new GenerationServiceError(
+        hostedGenerationCount > 0 ? "hosted_generation_limit_reached" : "invalid_request",
+        hostedGenerationCount > 0
+          ? "Free Gemini 3.7 Flash limit reached. Add a Gemini or OpenRouter key to continue."
+          : "Account not found.",
+      );
+    }
+
     for (const item of prepared) {
       await tx.customBuild.create({
         data: {
@@ -239,6 +281,7 @@ export async function createSavedGenerations(input: CreateSavedGenerationsInput)
           modelDisplayName: item.model.modelDisplayName,
           openRouterModelId: item.model.openRouterModelId,
           preferOpenRouter: item.model.preferOpenRouter,
+          usesHostedGeneration: item.usesHostedGeneration,
           reasoning: input.reasoning,
           requestedIpHash: input.requestedIpHash,
           requestedUserAgentHash: input.requestedUserAgentHash,

--- a/lib/generations/service.ts
+++ b/lib/generations/service.ts
@@ -396,7 +396,7 @@ function retryCredentialProvider(build: {
 export async function retrySavedGeneration(
   ownerId: string,
   publicId: string,
-  input: { providerKey: string; customBaseUrl?: string },
+  input: { providerKey?: string; customBaseUrl?: string },
 ) {
   const now = new Date();
   const build = await prisma.customBuild.findFirst({
@@ -406,8 +406,10 @@ export async function retrySavedGeneration(
       status: true,
       errorRetryable: true,
       modelKind: true,
+      modelKey: true,
       modelProvider: true,
       preferOpenRouter: true,
+      usesHostedGeneration: true,
     },
   });
   if (!build) throw new GenerationServiceError("not_found", "Saved generation not found.");
@@ -415,7 +417,13 @@ export async function retrySavedGeneration(
     throw new GenerationServiceError("not_retryable", "This generation cannot be retried.");
   }
   const provider = retryCredentialProvider(build);
-  const providerKey = input.providerKey.trim();
+  const providerKey = input.providerKey?.trim() || (
+    build.usesHostedGeneration &&
+    build.modelKey === HOSTED_GEMINI_MODEL_KEY &&
+    provider === "openrouter"
+      ? process.env.MINEBENCH_FREE_OPENROUTER_API_KEY?.trim()
+      : undefined
+  );
   if (!provider || !providerKey) {
     throw new GenerationServiceError("missing_provider_key", "Reconnect this model in Generate.");
   }

--- a/prisma/migrations/20260828120000_hosted_gemini_generations/migration.sql
+++ b/prisma/migrations/20260828120000_hosted_gemini_generations/migration.sql
@@ -1,0 +1,20 @@
+ALTER TABLE "User"
+  ADD COLUMN "totalGenerationCount" INTEGER NOT NULL DEFAULT 0,
+  ADD COLUMN "hostedGenerationCount" INTEGER NOT NULL DEFAULT 0,
+  ADD COLUMN "hostedGenerationLimit" INTEGER NOT NULL DEFAULT 100,
+  ADD CONSTRAINT "User_totalGenerationCount_check" CHECK ("totalGenerationCount" >= 0),
+  ADD CONSTRAINT "User_hostedGenerationCount_check" CHECK ("hostedGenerationCount" >= 0),
+  ADD CONSTRAINT "User_hostedGenerationLimit_check" CHECK ("hostedGenerationLimit" >= 0);
+
+UPDATE "User" AS account
+SET "totalGenerationCount" = generations.count
+FROM (
+  SELECT "ownerId", COUNT(*)::INTEGER AS count
+  FROM "CustomBuild"
+  WHERE "ownerId" IS NOT NULL
+  GROUP BY "ownerId"
+) AS generations
+WHERE account.id = generations."ownerId";
+
+ALTER TABLE "CustomBuild"
+  ADD COLUMN "usesHostedGeneration" BOOLEAN NOT NULL DEFAULT false;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -67,6 +67,9 @@ model User {
   gallerySuspensionReason  String?   @db.VarChar(240)
   gallerySuspendedById     String?   @db.Uuid
   galleryRestoredAt        DateTime?
+  totalGenerationCount     Int       @default(0)
+  hostedGenerationCount    Int       @default(0)
+  hostedGenerationLimit    Int       @default(100)
   createdAt                DateTime  @default(now())
   updatedAt                DateTime  @updatedAt
 
@@ -597,6 +600,7 @@ model CustomBuild {
   openRouterModelId String?
   legacyCustomBaseUrl String? @map("customBaseUrl") @ignore
   preferOpenRouter  Boolean @default(false)
+  usesHostedGeneration Boolean @default(false)
   reasoning         String?
 
   blockCount       Int?

--- a/tests/integration/gallery/admin-dashboard.test.ts
+++ b/tests/integration/gallery/admin-dashboard.test.ts
@@ -25,9 +25,11 @@ async function main() {
   const {
     getGalleryAdminDashboard,
     getGalleryAdminPerson,
+    GalleryServiceError,
     setGalleryCandidateHidden,
     setGalleryPersonVoteBlocked,
     setGalleryPublishingSuspension,
+    setHostedGenerationLimit,
   } = await import("../../../lib/gallery/service");
   const { touchPublicSessionActivity } = await import("../../../lib/publicPresence");
   const { hashVoteSession } = await import("../../../lib/voteBlock");
@@ -37,7 +39,44 @@ async function main() {
     await db.user.createMany({
       data: [
         { id: adminId, email: `admin-${suffix}@example.test`, isMineBenchAdmin: true },
-        { id: memberId, email: `member-${suffix}@example.test`, publicNickname: "Builder" },
+        {
+          id: memberId,
+          email: `member-${suffix}@example.test`,
+          publicNickname: "Builder",
+          totalGenerationCount: 2,
+          hostedGenerationCount: 7,
+          hostedGenerationLimit: 125,
+        },
+      ],
+    });
+    await db.customBuild.createMany({
+      data: [
+        {
+          publicId: `cst_admin_one_${suffix}`,
+          ownerId: memberId,
+          promptText,
+          promptSha256: "a".repeat(64),
+          gridSize: 64,
+          palette: "simple",
+          modelKind: "catalog",
+          modelProvider: "gemini",
+          modelId: "gemini-3.7-flash",
+          modelDisplayName: "Gemini 3.7 Flash",
+          usesHostedGeneration: true,
+        },
+        {
+          publicId: `cst_admin_two_${suffix}`,
+          ownerId: memberId,
+          promptText,
+          promptSha256: "b".repeat(64),
+          gridSize: 64,
+          palette: "simple",
+          modelKind: "catalog",
+          modelProvider: "gemini",
+          modelId: "gemini-3.7-flash",
+          modelDisplayName: "Gemini 3.7 Flash",
+          removedAt: now,
+        },
       ],
     });
     const presenceResponse = await recordPresence(new Request("http://localhost/api/presence", { method: "POST" }));
@@ -151,9 +190,35 @@ async function main() {
 
     const member = dashboard.people.find((person) => person.id === `user:${memberId}`);
     assert.ok(member);
+    assert.equal(member.totalGenerationCount, 2);
+    assert.equal(member.hostedGenerationCount, 7);
+    assert.equal(member.hostedGenerationLimit, 125);
     const detail = await getGalleryAdminPerson(adminId, member!.id);
     assert.deepEqual(new Set(detail.votes.map((vote) => vote.source)), new Set(["Arena", "Gallery"]));
     assert.equal(JSON.stringify(detail).includes(memberSession), false);
+    assert.equal(detail.totalGenerationCount, 2, "removed generations remain part of the lifetime total");
+    assert.equal(detail.hostedGenerationCount, 7);
+    assert.equal(detail.hostedGenerationLimit, 125);
+
+    await setHostedGenerationLimit(adminId, memberId, 0);
+    assert.deepEqual(
+      await db.user.findUniqueOrThrow({
+        where: { id: memberId },
+        select: { hostedGenerationCount: true, hostedGenerationLimit: true },
+      }),
+      { hostedGenerationCount: 7, hostedGenerationLimit: 0 },
+      "changing the promotional cap must not change usage or the lifetime generation total",
+    );
+    await setHostedGenerationLimit(adminId, memberId, 4);
+    assert.equal((await getGalleryAdminPerson(adminId, member!.id)).hostedGenerationLimit, 4);
+    await assert.rejects(
+      () => setHostedGenerationLimit(adminId, memberId, -1),
+      (error: unknown) => error instanceof GalleryServiceError && error.code === "invalid_request",
+    );
+    await assert.rejects(
+      () => setHostedGenerationLimit(memberId, memberId, 100),
+      (error: unknown) => error instanceof GalleryServiceError && error.code === "forbidden",
+    );
 
     await setGalleryPublishingSuspension(adminId, memberId, { suspended: true });
     await setGalleryPublishingSuspension(adminId, memberId, { suspended: true });
@@ -193,6 +258,7 @@ async function main() {
     });
     await db.galleryModerationRecord.deleteMany({ where: { OR: [{ actorUserId: adminId }, { subjectUserId: memberId }] } });
     await db.galleryCandidate.deleteMany({ where: { uploaderId: memberId } });
+    await db.customBuild.deleteMany({ where: { ownerId: memberId } });
     await db.vote.deleteMany({ where: { sessionId: memberSession } });
     await db.matchup.deleteMany({ where: { prompt: { text: promptText } } });
     await db.build.deleteMany({ where: { prompt: { text: promptText } } });

--- a/tests/integration/gallery/application-service.test.ts
+++ b/tests/integration/gallery/application-service.test.ts
@@ -8,6 +8,8 @@ async function main() {
     return;
   }
   process.env.CUSTOM_BUILD_KEY_ENCRYPTION_SECRET = "gallery-test-encryption-secret";
+  const previousHostedKey = process.env.MINEBENCH_FREE_OPENROUTER_API_KEY;
+  process.env.MINEBENCH_FREE_OPENROUTER_API_KEY = "hosted-openrouter-secret";
   const db = new PrismaClient();
   const ownerId = randomUUID();
   const otherId = randomUUID();
@@ -55,10 +57,136 @@ async function main() {
     assert.equal(rows.every((row) => row.jobs[0]?.maxAttempts === 2), true);
     assert.equal(rows.every((row) => row.secret?.keyCiphertext !== "request-only-secret"), true);
     assert.notEqual(rows[0]?.secret?.keyCiphertext, rows[1]?.secret?.keyCiphertext);
+    assert.equal(rows.every((row) => !row.usesHostedGeneration), true);
+    assert.deepEqual(
+      await db.user.findUniqueOrThrow({
+        where: { id: ownerId },
+        select: { totalGenerationCount: true, hostedGenerationCount: true },
+      }),
+      { totalGenerationCount: 2, hostedGenerationCount: 0 },
+    );
 
     assert.equal(await getSavedGeneration(otherId, created[0]!.id), null);
     assert.equal((await getSavedGeneration(ownerId, created[0]!.id))?.prompt, "A tiny observatory");
     assert.equal((await listSavedGenerations(ownerId, { limit: 10 })).items.length, 2);
+
+    const hosted = await createSavedGenerations({
+      ownerId,
+      prompt: "A hosted observatory",
+      gridSize: 64,
+      palette: "simple",
+      models: [{ id: "hosted", kind: "catalog", modelKey: "gemini_3_7_flash" }],
+      providerKeys: {},
+    });
+    const hostedRow = await db.customBuild.findUniqueOrThrow({
+      where: { publicId: hosted[0]!.id },
+      include: { secret: true },
+    });
+    assert.equal(hostedRow.usesHostedGeneration, true);
+    assert.equal(hostedRow.preferOpenRouter, true);
+    assert.equal(hostedRow.openRouterModelId, "google/gemini-3.7-flash");
+    assert.equal(hostedRow.secret?.provider, "openrouter");
+    assert.notEqual(hostedRow.secret?.keyCiphertext, "hosted-openrouter-secret");
+    assert.deepEqual(
+      await db.user.findUniqueOrThrow({
+        where: { id: ownerId },
+        select: { totalGenerationCount: true, hostedGenerationCount: true },
+      }),
+      { totalGenerationCount: 3, hostedGenerationCount: 1 },
+    );
+
+    const routedWithUserKey = await createSavedGenerations({
+      ownerId,
+      prompt: "A user-funded observatory",
+      gridSize: 64,
+      palette: "simple",
+      models: [{ id: "user-funded", kind: "catalog", modelKey: "gemini_3_7_flash" }],
+      providerKeys: { openrouter: "user-openrouter-secret" },
+    });
+    assert.equal(
+      (await db.customBuild.findUniqueOrThrow({ where: { publicId: routedWithUserKey[0]!.id } })).usesHostedGeneration,
+      false,
+    );
+    assert.deepEqual(
+      await db.user.findUniqueOrThrow({
+        where: { id: ownerId },
+        select: { totalGenerationCount: true, hostedGenerationCount: true },
+      }),
+      { totalGenerationCount: 4, hostedGenerationCount: 1 },
+    );
+
+    await assert.rejects(
+      () => createSavedGenerations({
+        ownerId,
+        prompt: "An ineligible hosted model",
+        gridSize: 64,
+        palette: "simple",
+        models: [{ id: "ineligible", kind: "catalog", modelKey: "openai_gpt_5_4_mini" }],
+        providerKeys: {},
+      }),
+      (error: unknown) => error instanceof GenerationServiceError && error.code === "missing_provider_key",
+    );
+
+    await db.user.update({
+      where: { id: otherId },
+      data: { hostedGenerationCount: 99, hostedGenerationLimit: 100 },
+    });
+    const concurrent = await Promise.allSettled([
+      createSavedGenerations({
+        ownerId: otherId,
+        prompt: "First concurrent hosted build",
+        gridSize: 64,
+        palette: "simple",
+        models: [{ id: "concurrent-one", kind: "catalog", modelKey: "gemini_3_7_flash" }],
+        providerKeys: {},
+      }),
+      createSavedGenerations({
+        ownerId: otherId,
+        prompt: "Second concurrent hosted build",
+        gridSize: 64,
+        palette: "simple",
+        models: [{ id: "concurrent-two", kind: "catalog", modelKey: "gemini_3_7_flash" }],
+        providerKeys: {},
+      }),
+    ]);
+    assert.equal(concurrent.filter((result) => result.status === "fulfilled").length, 1);
+    assert.equal(concurrent.filter((result) => result.status === "rejected").length, 1);
+    assert.equal(
+      concurrent.some((result) =>
+        result.status === "rejected" &&
+        result.reason instanceof GenerationServiceError &&
+        result.reason.code === "hosted_generation_limit_reached"
+      ),
+      true,
+    );
+    assert.deepEqual(
+      await db.user.findUniqueOrThrow({
+        where: { id: otherId },
+        select: { totalGenerationCount: true, hostedGenerationCount: true },
+      }),
+      { totalGenerationCount: 1, hostedGenerationCount: 100 },
+    );
+    assert.equal(await db.customBuild.count({ where: { ownerId: otherId, usesHostedGeneration: true } }), 1);
+
+    const byokAtLimit = await createSavedGenerations({
+      ownerId: otherId,
+      prompt: "A build after the hosted limit",
+      gridSize: 64,
+      palette: "simple",
+      models: [{ id: "byok-at-limit", kind: "catalog", modelKey: "gemini_3_7_flash" }],
+      providerKeys: { gemini: "user-gemini-secret" },
+    });
+    assert.equal(
+      (await db.customBuild.findUniqueOrThrow({ where: { publicId: byokAtLimit[0]!.id } })).usesHostedGeneration,
+      false,
+    );
+    assert.deepEqual(
+      await db.user.findUniqueOrThrow({
+        where: { id: otherId },
+        select: { totalGenerationCount: true, hostedGenerationCount: true },
+      }),
+      { totalGenerationCount: 2, hostedGenerationCount: 100 },
+    );
 
     await db.customBuild.update({
       where: { id: rows[0]!.id },
@@ -189,6 +317,8 @@ async function main() {
     await db.customBuild.deleteMany({ where: { ownerId: { in: [ownerId, otherId] } } });
     await db.user.deleteMany({ where: { id: { in: [ownerId, otherId] } } });
     await db.$disconnect();
+    if (previousHostedKey === undefined) delete process.env.MINEBENCH_FREE_OPENROUTER_API_KEY;
+    else process.env.MINEBENCH_FREE_OPENROUTER_API_KEY = previousHostedKey;
   }
 }
 

--- a/tests/integration/gallery/application-service.test.ts
+++ b/tests/integration/gallery/application-service.test.ts
@@ -189,6 +189,37 @@ async function main() {
     );
 
     await db.customBuild.update({
+      where: { id: hostedRow.id },
+      data: {
+        status: "failed",
+        currentStage: "failed",
+        completedAt: new Date(),
+        errorCode: "generation_failed",
+        errorMessage: "No valid build was returned.",
+        errorRetryable: true,
+      },
+    });
+    await db.customBuildJob.updateMany({
+      where: { customBuildId: hostedRow.id },
+      data: { status: "failed", completedAt: new Date() },
+    });
+    await db.customBuildSecret.deleteMany({ where: { customBuildId: hostedRow.id } });
+    assert.equal((await retrySavedGeneration(ownerId, hosted[0]!.id, {})).status, "queued");
+    const hostedRetrySecret = await db.customBuildSecret.findUniqueOrThrow({
+      where: { customBuildId: hostedRow.id },
+    });
+    assert.equal(hostedRetrySecret.provider, "openrouter");
+    assert.notEqual(hostedRetrySecret.keyCiphertext, "hosted-openrouter-secret");
+    assert.deepEqual(
+      await db.user.findUniqueOrThrow({
+        where: { id: ownerId },
+        select: { totalGenerationCount: true, hostedGenerationCount: true },
+      }),
+      { totalGenerationCount: 4, hostedGenerationCount: 1 },
+      "retrying an existing hosted build must not consume another allowance",
+    );
+
+    await db.customBuild.update({
       where: { id: rows[0]!.id },
       data: {
         status: "failed",

--- a/tests/integration/gallery/gallery-service.test.ts
+++ b/tests/integration/gallery/gallery-service.test.ts
@@ -131,6 +131,67 @@ async function main() {
     assert.equal(caseVariant.created, false);
     assert.equal(caseVariant.candidate.id, created.candidate.id);
 
+    const navigationIds = {
+      newest: `gal_${suffix}newest`,
+      highest: `gal_${suffix}highest`,
+      middle: `gal_${suffix}middle`,
+      hidden: `gal_${suffix}hidden`,
+    };
+    await db.galleryCandidate.createMany({
+      data: [
+        {
+          id: `nav_${suffix}_newest`,
+          publicId: navigationIds.newest,
+          promptText: `Newest navigation prompt ${suffix}`,
+          promptKey: `navigation-newest-${suffix}`,
+          uploaderId,
+          upvoteCount: 1_000_100,
+          publishedAt: new Date("2035-01-03T00:00:00.000Z"),
+        },
+        {
+          id: `nav_${suffix}_highest`,
+          publicId: navigationIds.highest,
+          promptText: `Highest navigation prompt ${suffix}`,
+          promptKey: `navigation-highest-${suffix}`,
+          uploaderId,
+          upvoteCount: 1_000_300,
+          publishedAt: new Date("2035-01-02T00:00:00.000Z"),
+        },
+        {
+          id: `nav_${suffix}_middle`,
+          publicId: navigationIds.middle,
+          promptText: `Middle navigation prompt ${suffix}`,
+          promptKey: `navigation-middle-${suffix}`,
+          uploaderId,
+          upvoteCount: 1_000_200,
+          publishedAt: new Date("2035-01-01T00:00:00.000Z"),
+        },
+        {
+          id: `nav_${suffix}_hidden`,
+          publicId: navigationIds.hidden,
+          promptText: `Hidden navigation prompt ${suffix}`,
+          promptKey: `navigation-hidden-${suffix}`,
+          uploaderId,
+          upvoteCount: 1_000_250,
+          publishedAt: new Date("2035-01-01T12:00:00.000Z"),
+          adminHiddenAt: new Date(),
+        },
+      ],
+    });
+    assert.deepEqual(
+      (await getGalleryCandidate(navigationIds.highest, { navigationSort: "new" }))?.navigation,
+      { sort: "new", previousId: navigationIds.newest, nextId: navigationIds.middle },
+      "New navigation should follow visible publication order",
+    );
+    assert.deepEqual(
+      (await getGalleryCandidate(navigationIds.middle, { navigationSort: "top" }))?.navigation,
+      { sort: "top", previousId: navigationIds.highest, nextId: navigationIds.newest },
+      "Top navigation should follow visible vote order",
+    );
+    await db.galleryCandidate.deleteMany({
+      where: { publicId: { in: Object.values(navigationIds) } },
+    });
+
     const legacyCandidate = await db.galleryCandidate.create({
       data: {
         publicId: `gal_${suffix}legacy`,

--- a/tests/ui/gallery-actions.test.ts
+++ b/tests/ui/gallery-actions.test.ts
@@ -76,6 +76,14 @@ assert.ok(
   "reported Gallery examples should expose the exact-build moderation action",
 );
 assert.ok(
+  adminActions.includes('type: z.literal("hosted_generation_limit")') &&
+    adminActions.includes("setHostedGenerationLimit") &&
+    adminDashboard.includes("Total generations") &&
+    adminDashboard.includes("Hosted generations") &&
+    adminDashboard.includes('name="limit"'),
+  "Gallery admin should show lifetime and hosted generation counts with an editable hosted limit",
+);
+assert.ok(
   galleryService.includes('action: { label: "Appeal", href: galleryUrl("/account") }'),
   "suspension email should link directly to the account appeal surface",
 );

--- a/tests/ui/gallery-actions.test.ts
+++ b/tests/ui/gallery-actions.test.ts
@@ -66,6 +66,8 @@ assert.ok(
     yours.includes("<VoxelEmptyState") &&
     yours.includes('generation.error?.retryable') &&
     yours.includes('/retry`') &&
+    yours.includes("JSON.stringify(providerKey ? { providerKey } : {})") &&
+    !yours.includes("Add the required API key") &&
     yours.includes("embedded"),
   "saved builds should open privately, reuse lifecycle placeholders, support retry, and expose owner verification details",
 );

--- a/tests/ui/gallery-actions.test.ts
+++ b/tests/ui/gallery-actions.test.ts
@@ -40,6 +40,17 @@ assert.ok(
   "public examples should support accessible four-build comparison through the shared GIF exporter",
 );
 assert.ok(
+  detail.includes("GalleryNavigationArrow") &&
+    detail.includes('aria-keyshortcuts={previous ? "ArrowLeft" : "ArrowRight"}') &&
+    detail.includes('event.key === "ArrowLeft"') &&
+    detail.includes('event.key === "ArrowRight"') &&
+    detail.includes("event.repeat || event.isComposing") &&
+    detail.includes("motion-reduce:transform-none") &&
+    explore.includes('sort === "new" ? "?sort=new" : ""') &&
+    galleryDetailPage.includes("navigationSort: sort"),
+  "Gallery details should preserve their ordering and expose polished pointer and keyboard navigation",
+);
+assert.ok(
   galleryClient.includes("body.created === false") &&
     galleryClient.includes("/examples`") &&
     yours.includes("Add to Gallery") &&

--- a/tests/ui/sandbox-live-durable.test.ts
+++ b/tests/ui/sandbox-live-durable.test.ts
@@ -50,6 +50,7 @@ const requestModelBody = functionBodyText("customBuildRequestModel");
 const runBody = functionBodyText("runGenerate");
 const stopBody = functionBodyText("stopGenerate");
 const watchBody = functionBodyText("watchCustomBuild");
+const retryBody = functionBodyText("retryCustomBuild");
 const completedBuildBody = functionBodyText("readCustomBuildViewer");
 const inputResetEffect = effectBodyTextContaining("lastGenerateInputRef.current === inputSignature");
 const assignIndex = durableBody.indexOf("customBuildAbortRef.current = args.abortController");
@@ -213,8 +214,10 @@ assert.ok(
     sourceText.includes("!providerKeys.gemini?.trim()") &&
     sourceText.includes("!providerKeys.openrouter?.trim()") &&
     sourceText.includes("`${model.displayName} · Free`") &&
+    retryBody.includes("...(providerKey ? { providerKey } : {})") &&
+    !retryBody.includes("Add the required API key") &&
     !sourceText.includes("hostedGenerationCount"),
-  "the signed-in Gemini offer should announce once, defer to user keys, and avoid a live usage counter",
+  "the signed-in Gemini offer should announce once, defer to user keys, support hosted retries, and avoid a live usage counter",
 );
 
 console.log("sandbox saved-generation contract checks passed");

--- a/tests/ui/sandbox-live-durable.test.ts
+++ b/tests/ui/sandbox-live-durable.test.ts
@@ -204,5 +204,17 @@ assert.ok(
     !sourceText.includes("a pirate ship with sails"),
   "Generate should start blank with Gemini 3.7 Flash selected",
 );
+assert.ok(
+  sourceText.includes("HOSTED_GEMINI_NOTICE_KEY") &&
+    sourceText.includes("Gemini 3.7 Flash is free") &&
+    sourceText.includes("if (!signedIn || !hostedGeminiAvailable) return") &&
+    sourceText.includes("window.localStorage.getItem(HOSTED_GEMINI_NOTICE_KEY)") &&
+    sourceText.includes("window.localStorage.setItem(HOSTED_GEMINI_NOTICE_KEY") &&
+    sourceText.includes("!providerKeys.gemini?.trim()") &&
+    sourceText.includes("!providerKeys.openrouter?.trim()") &&
+    sourceText.includes("`${model.displayName} · Free`") &&
+    !sourceText.includes("hostedGenerationCount"),
+  "the signed-in Gemini offer should announce once, defer to user keys, and avoid a live usage counter",
+);
 
 console.log("sandbox saved-generation contract checks passed");


### PR DESCRIPTION
## Summary

- Offer signed-in users limited-time Gemini 3.7 Flash generations without requiring an API key, while keeping user-supplied Gemini and OpenRouter keys authoritative
- Enforce the hosted allowance atomically per account and track it separately from the uncapped lifetime generation count shown in Gallery administration
- Add previous and next Gallery build navigation that preserves Top or New ordering across pointer controls and guarded Left/Right Arrow shortcuts
- Document the server-only hosted key and the provider-processing implications in the public privacy and local-development docs

## Validation

- Confirmed the hosted Gemini flow end to end on Alpha
- `pnpm exec tsc --noEmit`
- `pnpm lint` (passes with two pre-existing warnings in generated Workflow routes)
- `pnpm test` (111 test files passed)
- `node scripts/run-postgres-tests.mjs` (10 integration test files passed)
- `pnpm build`
- Alpha file tree matches this branch at deployment commit `f8b283a3`

## Production rollout

- Apply additive migration `20260828120000_hosted_gemini_generations` before deploying the application
- Add `MINEBENCH_FREE_OPENROUTER_API_KEY` as a Sensitive Production environment variable before deployment; do not expose it through a `PUBLIC_` variable
- The generation worker does not need the OpenRouter key in its environment because each hosted request stores the credential in the existing encrypted per-job secret

*(PR written by Codex)*
