### PR TITLE
feat(exports): add creator-ready GIF and MP4 exports

### DIFF
--- a/app/account/MediaExportSettings.tsx
+++ b/app/account/MediaExportSettings.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 import {
   DEFAULT_MEDIA_EXPORT_PREFERENCE,
   type MediaExportFileType,
+  type MediaExportFraming,
   type MediaExportPreference,
   type MediaExportQuality,
   readMediaExportPreference,
@@ -27,6 +28,64 @@ const FILE_TYPE_OPTIONS: ReadonlyArray<{
   { value: "mp4", label: "MP4", detail: "Best quality" },
   { value: "gif", label: "GIF", detail: "Compatibility" },
 ];
+
+const FRAMING_OPTIONS: ReadonlyArray<{
+  value: MediaExportFraming;
+  label: string;
+  detail: string;
+}> = [
+  { value: "social-safe", label: "Social safe", detail: "TikTok & Reels" },
+  { value: "full", label: "Full frame", detail: "Every pixel" },
+];
+
+function CreatorOptionGroup<T extends string>({
+  legend,
+  name,
+  value,
+  options,
+  disabled,
+  onChange,
+}: {
+  legend: string;
+  name: string;
+  value: T;
+  options: ReadonlyArray<{ value: T; label: string; detail: string }>;
+  disabled: boolean;
+  onChange: (value: T) => void;
+}) {
+  return (
+    <fieldset disabled={disabled}>
+      <legend className="mb-2 text-xs font-medium text-muted">{legend}</legend>
+      <div className="grid grid-cols-2 overflow-hidden rounded-md border border-border/75">
+        {options.map((option, index) => {
+          const selected = value === option.value;
+          return (
+            <label key={option.value} className="cursor-pointer">
+              <input
+                type="radio"
+                name={name}
+                value={option.value}
+                checked={selected}
+                onChange={() => onChange(option.value)}
+                className="peer sr-only"
+              />
+              <span
+                className={`flex min-h-14 flex-col justify-center px-3 py-2 text-center transition-colors duration-200 peer-focus-visible:ring-2 peer-focus-visible:ring-inset peer-focus-visible:ring-accent/45 motion-reduce:transition-none ${
+                  index > 0 ? "border-l border-border/75" : ""
+                } ${selected ? "bg-fg text-bg" : "bg-transparent text-muted hover:text-fg"}`}
+              >
+                <span className="text-xs font-semibold">{option.label}</span>
+                <span className={`mt-0.5 text-[10px] ${selected ? "text-bg/70" : "text-muted"}`}>
+                  {option.detail}
+                </span>
+              </span>
+            </label>
+          );
+        })}
+      </div>
+    </fieldset>
+  );
+}
 
 export function MediaExportSettings() {
   const [preference, setPreference] = useState<MediaExportPreference>(
@@ -121,36 +180,24 @@ export function MediaExportSettings() {
         }`}
       >
         <div className="overflow-hidden">
-          <fieldset className="pt-4" disabled={!creator}>
-            <legend className="mb-2 text-xs font-medium text-muted">Creator format</legend>
-            <div className="grid grid-cols-2 overflow-hidden rounded-md border border-border/75">
-              {FILE_TYPE_OPTIONS.map((option, index) => {
-                const selected = preference.fileType === option.value;
-                return (
-                  <label key={option.value} className="cursor-pointer">
-                    <input
-                      type="radio"
-                      name="media-export-file-type"
-                      value={option.value}
-                      checked={selected}
-                      onChange={() => save({ ...preference, fileType: option.value })}
-                      className="peer sr-only"
-                    />
-                    <span
-                      className={`flex min-h-14 flex-col justify-center px-3 py-2 text-center transition-colors duration-200 peer-focus-visible:ring-2 peer-focus-visible:ring-inset peer-focus-visible:ring-accent/45 motion-reduce:transition-none ${
-                        index > 0 ? "border-l border-border/75" : ""
-                      } ${selected ? "bg-fg text-bg" : "bg-transparent text-muted hover:text-fg"}`}
-                    >
-                      <span className="text-xs font-semibold">{option.label}</span>
-                      <span className={`mt-0.5 text-[10px] ${selected ? "text-bg/70" : "text-muted"}`}>
-                        {option.detail}
-                      </span>
-                    </span>
-                  </label>
-                );
-              })}
-            </div>
-          </fieldset>
+          <div className="space-y-4 pt-4">
+            <CreatorOptionGroup
+              legend="Format"
+              name="media-export-file-type"
+              value={preference.fileType}
+              options={FILE_TYPE_OPTIONS}
+              disabled={!creator}
+              onChange={(fileType) => save({ ...preference, fileType })}
+            />
+            <CreatorOptionGroup
+              legend="Framing"
+              name="media-export-framing"
+              value={preference.framing}
+              options={FRAMING_OPTIONS}
+              disabled={!creator}
+              onChange={(framing) => save({ ...preference, framing })}
+            />
+          </div>
         </div>
       </div>
 

--- a/app/account/MediaExportSettings.tsx
+++ b/app/account/MediaExportSettings.tsx
@@ -1,0 +1,160 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  DEFAULT_MEDIA_EXPORT_PREFERENCE,
+  type MediaExportFileType,
+  type MediaExportPreference,
+  type MediaExportQuality,
+  readMediaExportPreference,
+  writeMediaExportPreference,
+} from "@/lib/sandbox/mediaExportPreference";
+
+const QUALITY_OPTIONS: ReadonlyArray<{
+  value: MediaExportQuality;
+  label: string;
+  detail: string;
+}> = [
+  { value: "standard", label: "Standard", detail: "GIF · quick sharing" },
+  { value: "creator", label: "Creator", detail: "Full HD · 30 FPS" },
+];
+
+const FILE_TYPE_OPTIONS: ReadonlyArray<{
+  value: MediaExportFileType;
+  label: string;
+  detail: string;
+}> = [
+  { value: "mp4", label: "MP4", detail: "Best quality" },
+  { value: "gif", label: "GIF", detail: "Compatibility" },
+];
+
+export function MediaExportSettings() {
+  const [preference, setPreference] = useState<MediaExportPreference>(
+    DEFAULT_MEDIA_EXPORT_PREFERENCE,
+  );
+  const [saveError, setSaveError] = useState<string | null>(null);
+
+  useEffect(() => {
+    setPreference(readMediaExportPreference());
+  }, []);
+
+  function save(next: MediaExportPreference) {
+    if (!writeMediaExportPreference(next)) {
+      setSaveError("Couldn’t save on this device.");
+      return;
+    }
+    setPreference(next);
+    setSaveError(null);
+  }
+
+  const creator = preference.quality === "creator";
+
+  return (
+    <section
+      className="rounded-md border border-border/80 bg-card/10 p-5"
+      aria-labelledby="media-export-title"
+    >
+      <p className="mb-eyebrow">Exports</p>
+      <h2 id="media-export-title" className="mt-2 text-lg font-semibold tracking-tight text-fg">
+        Export quality
+      </h2>
+      <p className="mt-2 text-sm text-muted">Saved on this device.</p>
+
+      <fieldset className="mt-5 space-y-2">
+        <legend className="sr-only">Export quality</legend>
+        {QUALITY_OPTIONS.map((option) => {
+          const selected = preference.quality === option.value;
+          return (
+            <label key={option.value} className="block cursor-pointer">
+              <input
+                type="radio"
+                name="media-export-quality"
+                value={option.value}
+                checked={selected}
+                onChange={() => save({ ...preference, quality: option.value })}
+                className="peer sr-only"
+              />
+              <span
+                className={`flex min-h-14 items-center justify-between gap-3 rounded-md border px-3 py-2.5 transition-[background-color,border-color,color] duration-200 ease-[cubic-bezier(0.22,1,0.36,1)] peer-focus-visible:ring-2 peer-focus-visible:ring-accent/45 motion-reduce:transition-none ${
+                  selected
+                    ? "border-accent/55 bg-accent/[0.07]"
+                    : "border-border/75 hover:border-border hover:bg-card/25"
+                }`}
+              >
+                <span className="min-w-0">
+                  <span className="block text-sm font-semibold text-fg">{option.label}</span>
+                  <span className="mt-0.5 block text-xs text-muted">{option.detail}</span>
+                </span>
+                <span
+                  aria-hidden="true"
+                  className={`grid h-5 w-5 shrink-0 place-items-center rounded-full border transition-[background-color,border-color] duration-200 motion-reduce:transition-none ${
+                    selected ? "border-accent bg-accent text-bg" : "border-border text-transparent"
+                  }`}
+                >
+                  <svg
+                    viewBox="0 0 20 20"
+                    className={`h-3.5 w-3.5 transition-[opacity,transform] duration-200 ease-[cubic-bezier(0.22,1,0.36,1)] motion-reduce:transition-none ${
+                      selected ? "scale-100 opacity-100" : "scale-75 opacity-0"
+                    }`}
+                  >
+                    <path
+                      d="m5.25 10.25 3 3 6.5-6.5"
+                      fill="none"
+                      stroke="currentColor"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth="2"
+                    />
+                  </svg>
+                </span>
+              </span>
+            </label>
+          );
+        })}
+      </fieldset>
+
+      <div
+        className={`grid transition-[grid-template-rows,opacity,transform] duration-300 ease-[cubic-bezier(0.22,1,0.36,1)] motion-reduce:transform-none motion-reduce:transition-none ${
+          creator
+            ? "grid-rows-[1fr] translate-y-0 opacity-100"
+            : "pointer-events-none grid-rows-[0fr] -translate-y-1 opacity-0"
+        }`}
+      >
+        <div className="overflow-hidden">
+          <fieldset className="pt-4" disabled={!creator}>
+            <legend className="mb-2 text-xs font-medium text-muted">Creator format</legend>
+            <div className="grid grid-cols-2 overflow-hidden rounded-md border border-border/75">
+              {FILE_TYPE_OPTIONS.map((option, index) => {
+                const selected = preference.fileType === option.value;
+                return (
+                  <label key={option.value} className="cursor-pointer">
+                    <input
+                      type="radio"
+                      name="media-export-file-type"
+                      value={option.value}
+                      checked={selected}
+                      onChange={() => save({ ...preference, fileType: option.value })}
+                      className="peer sr-only"
+                    />
+                    <span
+                      className={`flex min-h-14 flex-col justify-center px-3 py-2 text-center transition-colors duration-200 peer-focus-visible:ring-2 peer-focus-visible:ring-inset peer-focus-visible:ring-accent/45 motion-reduce:transition-none ${
+                        index > 0 ? "border-l border-border/75" : ""
+                      } ${selected ? "bg-fg text-bg" : "bg-transparent text-muted hover:text-fg"}`}
+                    >
+                      <span className="text-xs font-semibold">{option.label}</span>
+                      <span className={`mt-0.5 text-[10px] ${selected ? "text-bg/70" : "text-muted"}`}>
+                        {option.detail}
+                      </span>
+                    </span>
+                  </label>
+                );
+              })}
+            </div>
+          </fieldset>
+        </div>
+      </div>
+
+      {saveError ? <p role="alert" className="mt-3 text-sm text-danger">{saveError}</p> : null}
+    </section>
+  );
+}

--- a/app/account/page.tsx
+++ b/app/account/page.tsx
@@ -8,6 +8,7 @@ import { getCurrentAccount } from "@/lib/auth/account";
 import { listSavedGenerations } from "@/lib/generations/service";
 import { PersonalRanking, PersonalRankingSkeleton } from "./PersonalRanking";
 import { GalleryAccountSettings } from "./GalleryAccountSettings";
+import { MediaExportSettings } from "./MediaExportSettings";
 
 export const dynamic = "force-dynamic";
 
@@ -78,6 +79,8 @@ export default async function AccountPage({
             suspendedAt={account.gallerySuspendedAt?.toISOString() ?? null}
             suspensionReason={account.gallerySuspensionReason}
           />
+
+          <MediaExportSettings />
 
           <section className="rounded-md border border-border/80 bg-card/10 p-5" aria-labelledby="security-title">
             <p className="mb-eyebrow">Account</p>

--- a/app/api/generate/route.ts
+++ b/app/api/generate/route.ts
@@ -255,6 +255,7 @@ export async function POST(req: Request) {
                   blockCount: r.blockCount,
                   warnings: r.warnings,
                   generationTimeMs: r.generationTimeMs,
+                  jsonBytes: Buffer.byteLength(r.rawText),
                 },
               });
             } else {

--- a/app/api/sandbox/benchmark/route.ts
+++ b/app/api/sandbox/benchmark/route.ts
@@ -18,7 +18,10 @@ import {
 } from "@/lib/sandbox/benchmarkComparison";
 import { prisma } from "@/lib/prisma";
 import { resolveModelDisplayName } from "@/lib/ai/modelCatalog";
-import { getAverageBenchmarkCostPerBuildUsd } from "@/lib/ai/modelBenchmarkProfiles";
+import {
+  getAverageBenchmarkCostPerBuildUsd,
+  getAverageBenchmarkInferenceTimeMs,
+} from "@/lib/ai/modelBenchmarkProfiles";
 
 export const runtime = "nodejs";
 
@@ -56,6 +59,7 @@ type BenchmarkBuild = {
     blockCount: number;
     generationTimeMs: number;
     averageCostPerBuildUsd: number | null;
+    averageInferenceTimeMs: number | null;
     jsonBytes: number | null;
   };
 };
@@ -359,6 +363,7 @@ export async function GET(req: Request) {
           blockCount: build.blockCount,
           generationTimeMs: build.generationTimeMs,
           averageCostPerBuildUsd: getAverageBenchmarkCostPerBuildUsd(build.model.key),
+          averageInferenceTimeMs: getAverageBenchmarkInferenceTimeMs(build.model.key),
           jsonBytes: build.voxelByteSize,
         },
       };

--- a/app/api/sandbox/benchmark/route.ts
+++ b/app/api/sandbox/benchmark/route.ts
@@ -18,6 +18,7 @@ import {
 } from "@/lib/sandbox/benchmarkComparison";
 import { prisma } from "@/lib/prisma";
 import { resolveModelDisplayName } from "@/lib/ai/modelCatalog";
+import { getAverageBenchmarkCostPerBuildUsd } from "@/lib/ai/modelBenchmarkProfiles";
 
 export const runtime = "nodejs";
 
@@ -54,6 +55,8 @@ type BenchmarkBuild = {
   metrics: {
     blockCount: number;
     generationTimeMs: number;
+    averageCostPerBuildUsd: number | null;
+    jsonBytes: number | null;
   };
 };
 
@@ -309,6 +312,7 @@ export async function GET(req: Request) {
             mode: string;
             blockCount: number;
             generationTimeMs: number;
+            voxelByteSize: number | null;
             voxelSha256: string | null;
             model: {
               key: string;
@@ -354,6 +358,8 @@ export async function GET(req: Request) {
         metrics: {
           blockCount: build.blockCount,
           generationTimeMs: build.generationTimeMs,
+          averageCostPerBuildUsd: getAverageBenchmarkCostPerBuildUsd(build.model.key),
+          jsonBytes: build.voxelByteSize,
         },
       };
     };

--- a/components/gallery/GalleryDetail.tsx
+++ b/components/gallery/GalleryDetail.tsx
@@ -367,6 +367,8 @@ export function GalleryDetail({ candidate }: { candidate: GalleryDetailPayload }
               modelName: example.model.label,
               company: example.attribution,
               blockCount: example.blockCount ?? 0,
+              generationTimeMs: example.generationTimeMs,
+              jsonBytes: example.jsonBytes,
             }]}
             promptText={candidate.prompt}
             cancelKey={`${example.id}:${example.checksum ?? ""}`}
@@ -384,6 +386,8 @@ export function GalleryDetail({ candidate }: { candidate: GalleryDetailPayload }
         modelName: example.model.label,
         company: example.attribution,
         blockCount: example.blockCount ?? 0,
+        generationTimeMs: example.generationTimeMs,
+        jsonBytes: example.jsonBytes,
       }))
     : [];
 

--- a/components/gallery/GalleryYours.tsx
+++ b/components/gallery/GalleryYours.tsx
@@ -299,6 +299,8 @@ function SavedBuildDialog({
                     modelName: generation.model.label,
                     company: "MineBench",
                     blockCount: generation.blockCount ?? 0,
+                    generationTimeMs: generation.generationTimeMs,
+                    jsonBytes: generation.expandedBytes,
                   }]}
                   promptText={generation.prompt}
                   cancelKey={`${generation.id}:${generation.sha256 ?? ""}`}

--- a/components/leaderboard/ModelDetail.tsx
+++ b/components/leaderboard/ModelDetail.tsx
@@ -49,6 +49,7 @@ import {
 import { getConsistencyBand, getConsistencyLabel } from "@/lib/arena/consistencyBands";
 import { ModelBenchmarkDetails } from "@/components/leaderboard/ModelBenchmarkDetails";
 import { buildLeaderboardBuildPath } from "@/lib/deepLinks";
+import { getAverageBenchmarkCostPerBuildUsd } from "@/lib/ai/modelBenchmarkProfiles";
 
 const CHART_WIDTH = 900;
 const CHART_HEIGHT = 304;
@@ -1097,9 +1098,12 @@ export function ModelDetail({ data }: { data: ModelDetailStats }) {
         modelName: data.model.displayName,
         company: data.model.provider,
         blockCount: activePrompt.build.blockCount,
+        averageCostPerBuildUsd: getAverageBenchmarkCostPerBuildUsd(data.model.key),
+        generationTimeMs: activePrompt.build.generationTimeMs,
+        jsonBytes: activePrompt.build.jsonBytes,
       },
     ];
-  }, [activePrompt, data.model.displayName, data.model.provider]);
+  }, [activePrompt, data.model.displayName, data.model.key, data.model.provider]);
 
   const handlePromptPrev = useCallback(() => {
     if (activePromptIndex <= 0) return;

--- a/components/leaderboard/ModelDetail.tsx
+++ b/components/leaderboard/ModelDetail.tsx
@@ -49,7 +49,10 @@ import {
 import { getConsistencyBand, getConsistencyLabel } from "@/lib/arena/consistencyBands";
 import { ModelBenchmarkDetails } from "@/components/leaderboard/ModelBenchmarkDetails";
 import { buildLeaderboardBuildPath } from "@/lib/deepLinks";
-import { getAverageBenchmarkCostPerBuildUsd } from "@/lib/ai/modelBenchmarkProfiles";
+import {
+  getAverageBenchmarkCostPerBuildUsd,
+  getAverageBenchmarkInferenceTimeMs,
+} from "@/lib/ai/modelBenchmarkProfiles";
 
 const CHART_WIDTH = 900;
 const CHART_HEIGHT = 304;
@@ -1100,6 +1103,7 @@ export function ModelDetail({ data }: { data: ModelDetailStats }) {
         blockCount: activePrompt.build.blockCount,
         averageCostPerBuildUsd: getAverageBenchmarkCostPerBuildUsd(data.model.key),
         generationTimeMs: activePrompt.build.generationTimeMs,
+        averageInferenceTimeMs: getAverageBenchmarkInferenceTimeMs(data.model.key),
         jsonBytes: activePrompt.build.jsonBytes,
       },
     ];

--- a/components/sandbox/SandboxBenchmark.tsx
+++ b/components/sandbox/SandboxBenchmark.tsx
@@ -81,6 +81,8 @@ type BenchmarkBuild = {
   metrics: {
     blockCount: number;
     generationTimeMs: number;
+    averageCostPerBuildUsd: number | null;
+    jsonBytes: number | null;
   };
 };
 
@@ -986,9 +988,12 @@ export function SandboxBenchmark() {
             modelName: build.model.displayName,
             company: providerLabel(build.model.provider),
             blockCount: build.metrics.blockCount,
+            averageCostPerBuildUsd: build.metrics.averageCostPerBuildUsd,
+            generationTimeMs: build.metrics.generationTimeMs,
+            jsonBytes: build.metrics.jsonBytes,
           };
         })
-        .filter((target): target is SandboxGifExportTarget => Boolean(target))
+        .filter((target) => target !== null)
     : [];
   const compareTargets =
     readyCompareTargets.length === activeSlots.length ? readyCompareTargets : [];
@@ -1071,6 +1076,9 @@ export function SandboxBenchmark() {
                       modelName: model.displayName,
                       company: providerLabel(model.provider),
                       blockCount: build.metrics.blockCount,
+                      averageCostPerBuildUsd: build.metrics.averageCostPerBuildUsd,
+                      generationTimeMs: build.metrics.generationTimeMs,
+                      jsonBytes: build.metrics.jsonBytes,
                     },
                   ]}
                   promptText={selectedPromptText}

--- a/components/sandbox/SandboxBenchmark.tsx
+++ b/components/sandbox/SandboxBenchmark.tsx
@@ -82,6 +82,7 @@ type BenchmarkBuild = {
     blockCount: number;
     generationTimeMs: number;
     averageCostPerBuildUsd: number | null;
+    averageInferenceTimeMs: number | null;
     jsonBytes: number | null;
   };
 };
@@ -990,6 +991,7 @@ export function SandboxBenchmark() {
             blockCount: build.metrics.blockCount,
             averageCostPerBuildUsd: build.metrics.averageCostPerBuildUsd,
             generationTimeMs: build.metrics.generationTimeMs,
+            averageInferenceTimeMs: build.metrics.averageInferenceTimeMs,
             jsonBytes: build.metrics.jsonBytes,
           };
         })
@@ -1078,6 +1080,7 @@ export function SandboxBenchmark() {
                       blockCount: build.metrics.blockCount,
                       averageCostPerBuildUsd: build.metrics.averageCostPerBuildUsd,
                       generationTimeMs: build.metrics.generationTimeMs,
+                      averageInferenceTimeMs: build.metrics.averageInferenceTimeMs,
                       jsonBytes: build.metrics.jsonBytes,
                     },
                   ]}

--- a/components/sandbox/SandboxGifExportButton.tsx
+++ b/components/sandbox/SandboxGifExportButton.tsx
@@ -48,6 +48,9 @@ const SINGLE_FRAME_DELAY_MS = 40;
 const CREATOR_FRAME_RATE = 30;
 const CREATOR_FRAME_COUNT = 180;
 const CREATOR_DURATION_MS = 6000;
+const CREATOR_MP4_BITRATE = 24_000_000;
+const CREATOR_MP4_QUANTIZER = 12;
+const CREATOR_MP4_METADATA_FONT_SIZE = 14;
 const SOCIAL_SAFE_CAMERA_DISTANCE_SCALE = 1.18;
 const SOCIAL_SAFE_WATERMARK_FONT_SIZE = 16;
 const COMPARISON_PALETTE_SAMPLE_COUNT = 12;
@@ -565,12 +568,14 @@ function drawPanel(
     capture: HTMLCanvasElement;
     captureRect: ExportRect;
     contentBounds: { left: number; right: number } | null;
+    highFidelityMetadata: boolean;
   },
 ) {
-  const { x, y, width, height, target, capture, captureRect, contentBounds } = opts;
+  const { x, y, width, height, target, capture, captureRect, contentBounds, highFidelityMetadata } = opts;
   const { x: captureX, y: captureY, width: captureWidth, height: captureHeight } = captureRect;
   const metaLeft = Math.max(x + PANEL_PAD, contentBounds?.left ?? x + PANEL_PAD);
   const metaRight = Math.min(x + width - PANEL_PAD, contentBounds?.right ?? x + width - PANEL_PAD);
+  const metadataFontSize = highFidelityMetadata ? CREATOR_MP4_METADATA_FONT_SIZE : 11;
 
   ctx.save();
   roundedRectPath(ctx, x, y, width, height, PANEL_RADIUS);
@@ -582,23 +587,29 @@ function drawPanel(
   ctx.restore();
 
   ctx.fillStyle = "rgba(125, 211, 252, 0.96)";
-  ctx.font = '700 11px "IBM Plex Sans", "Segoe UI", sans-serif';
+  ctx.font = `700 ${metadataFontSize}px "IBM Plex Sans", "Segoe UI", sans-serif`;
   ctx.textBaseline = "top";
   ctx.fillText(target.company.toUpperCase(), metaLeft, y + 12);
 
   const blockLabel = `${target.blockCount.toLocaleString()} blocks`;
-  ctx.font = '600 11px "IBM Plex Sans", "Segoe UI", sans-serif';
-  const badgeWidth = Math.ceil(ctx.measureText(blockLabel).width + 16);
+  ctx.font = `600 ${metadataFontSize}px "IBM Plex Sans", "Segoe UI", sans-serif`;
+  const badgePaddingX = highFidelityMetadata ? 10 : 8;
+  const badgeHeight = highFidelityMetadata ? 26 : 22;
+  const badgeWidth = Math.ceil(ctx.measureText(blockLabel).width + badgePaddingX * 2);
   const badgeX = metaRight - badgeWidth;
-  const badgeY = y + 14;
-  roundedRectPath(ctx, badgeX, badgeY, badgeWidth, 22, 11);
+  const badgeY = y + (highFidelityMetadata ? 12 : 14);
+  roundedRectPath(ctx, badgeX, badgeY, badgeWidth, badgeHeight, badgeHeight / 2);
   ctx.fillStyle = "rgba(30, 41, 59, 0.9)";
   ctx.fill();
   ctx.strokeStyle = "rgba(148, 163, 184, 0.34)";
   ctx.lineWidth = 1;
   ctx.stroke();
   ctx.fillStyle = "rgba(226, 232, 240, 0.96)";
-  ctx.fillText(blockLabel, badgeX + 8, badgeY + 5);
+  ctx.fillText(
+    blockLabel,
+    badgeX + badgePaddingX,
+    badgeY + Math.floor((badgeHeight - metadataFontSize) / 2),
+  );
 
   ctx.fillStyle = "rgba(241, 245, 249, 0.98)";
   ctx.font = '700 23px "Sora", "Avenir Next", "Segoe UI", sans-serif';
@@ -627,6 +638,7 @@ function renderCompositeFrame(
   targets: SandboxGifExportTarget[],
   rotationBases: GifExportRotationBases,
   angle: number,
+  highFidelityMetadata = false,
 ) {
   drawBaseBackdrop(ctx, layout.width, layout.height, layout.header);
   const contentBounds = layout.safeInsets
@@ -662,6 +674,7 @@ function renderCompositeFrame(
       capture,
       captureRect,
       contentBounds,
+      highFidelityMetadata,
     });
   }
 }
@@ -885,12 +898,17 @@ async function buildMp4Blob(
   throwIfAborted(signal);
 
   const { width, height } = profile;
-  const quality = new Quality("very-high");
+  const quality = new Quality({
+    bitrate: CREATOR_MP4_BITRATE,
+    quantizer: CREATOR_MP4_QUANTIZER,
+    bitrateMode: "variable",
+  });
   const supported = await canEncodeVideo("avc", {
     width,
     height,
     quality,
     latencyMode: "quality",
+    contentHint: "detail",
   });
   if (!supported) {
     throw new Error("MP4 export isn’t supported in this browser. Choose GIF in Account settings.");
@@ -913,6 +931,7 @@ async function buildMp4Blob(
     quality,
     latencyMode: "quality",
     keyFrameInterval: 2,
+    contentHint: "detail",
   });
   output.addVideoTrack(videoSource, { frameRate: runtime.frameRate });
   const rotationBases = getExportRotationBases(targets);
@@ -932,7 +951,7 @@ async function buildMp4Blob(
     for (let frame = 0; frame < runtime.frameCount; frame += 1) {
       throwIfAborted(signal);
       const t = frame / runtime.frameCount;
-      renderCompositeFrame(frameCtx, layout, targets, rotationBases, t * Math.PI * 2);
+      renderCompositeFrame(frameCtx, layout, targets, rotationBases, t * Math.PI * 2, true);
       await videoSource.add(frame / runtime.frameRate, frameDuration);
       onProgress?.(frame + 1, runtime.frameCount);
 

--- a/components/sandbox/SandboxGifExportButton.tsx
+++ b/components/sandbox/SandboxGifExportButton.tsx
@@ -3,6 +3,7 @@
 import type { RefObject } from "react";
 import { useEffect, useId, useRef, useState } from "react";
 import type { VoxelViewerHandle } from "@/components/voxel/VoxelViewer";
+import { formatBuildDuration, formatBuildJsonSize } from "@/lib/buildMetrics";
 import {
   getSandboxGifExportPanelGrid,
   getSandboxSocialSafeInsets,
@@ -23,6 +24,9 @@ export type SandboxGifExportTarget = {
   modelName: string;
   company: string;
   blockCount: number;
+  averageCostPerBuildUsd?: number | null;
+  generationTimeMs?: number | null;
+  jsonBytes?: number | null;
 };
 
 type Props = {
@@ -122,7 +126,7 @@ const EXPORT_MARGIN_X = 22;
 const EXPORT_MARGIN_BOTTOM = 22;
 const PANEL_GAP = 16;
 const PANEL_PAD = 12;
-const PANEL_META_HEIGHT = 62;
+const PANEL_META_HEIGHT = 88;
 const PANEL_RADIUS = 18;
 const CAPTURE_RADIUS = 14;
 const MIN_EXPORT_PANEL_HEIGHT = 220;
@@ -297,6 +301,24 @@ function fitTextWithEllipsis(ctx: CanvasRenderingContext2D, text: string, maxWid
   }
 
   return `${clean.slice(0, lo).replace(/\s+$/g, "")}${suffix}`;
+}
+
+function formatAverageCostPerBuild(value?: number | null): string | null {
+  if (typeof value !== "number" || !Number.isFinite(value) || value < 0) return null;
+  const digits = value >= 0.1 ? 2 : value >= 0.01 ? 3 : 4;
+  return `$${value.toFixed(digits)}`;
+}
+
+function getPanelStats(target: SandboxGifExportTarget) {
+  const cost = formatAverageCostPerBuild(target.averageCostPerBuildUsd);
+  const duration = formatBuildDuration(target.generationTimeMs);
+  const jsonSize = formatBuildJsonSize(target.jsonBytes);
+  return [
+    { label: "BLOCKS", value: target.blockCount.toLocaleString() },
+    ...(cost ? [{ label: "AVG COST", value: cost }] : []),
+    ...(duration ? [{ label: "TIME", value: duration }] : []),
+    ...(jsonSize ? [{ label: "JSON", value: jsonSize }] : []),
+  ];
 }
 
 function capPromptLines(
@@ -575,7 +597,8 @@ function drawPanel(
   const { x: captureX, y: captureY, width: captureWidth, height: captureHeight } = captureRect;
   const metaLeft = Math.max(x + PANEL_PAD, contentBounds?.left ?? x + PANEL_PAD);
   const metaRight = Math.min(x + width - PANEL_PAD, contentBounds?.right ?? x + width - PANEL_PAD);
-  const metadataFontSize = highFidelityMetadata ? CREATOR_MP4_METADATA_FONT_SIZE : 11;
+  const stats = getPanelStats(target);
+  const metadataFontSize = highFidelityMetadata ? CREATOR_MP4_METADATA_FONT_SIZE : 12;
 
   ctx.save();
   roundedRectPath(ctx, x, y, width, height, PANEL_RADIUS);
@@ -587,28 +610,12 @@ function drawPanel(
   ctx.restore();
 
   ctx.fillStyle = "rgba(125, 211, 252, 0.96)";
-  ctx.font = `700 ${metadataFontSize}px "IBM Plex Sans", "Segoe UI", sans-serif`;
+  ctx.font = `700 ${highFidelityMetadata ? 12 : 10}px "IBM Plex Sans", "Segoe UI", sans-serif`;
   ctx.textBaseline = "top";
-  ctx.fillText(target.company.toUpperCase(), metaLeft, y + 12);
-
-  const blockLabel = `${target.blockCount.toLocaleString()} blocks`;
-  ctx.font = `600 ${metadataFontSize}px "IBM Plex Sans", "Segoe UI", sans-serif`;
-  const badgePaddingX = highFidelityMetadata ? 10 : 8;
-  const badgeHeight = highFidelityMetadata ? 26 : 22;
-  const badgeWidth = Math.ceil(ctx.measureText(blockLabel).width + badgePaddingX * 2);
-  const badgeX = metaRight - badgeWidth;
-  const badgeY = y + (highFidelityMetadata ? 12 : 14);
-  roundedRectPath(ctx, badgeX, badgeY, badgeWidth, badgeHeight, badgeHeight / 2);
-  ctx.fillStyle = "rgba(30, 41, 59, 0.9)";
-  ctx.fill();
-  ctx.strokeStyle = "rgba(148, 163, 184, 0.34)";
-  ctx.lineWidth = 1;
-  ctx.stroke();
-  ctx.fillStyle = "rgba(226, 232, 240, 0.96)";
   ctx.fillText(
-    blockLabel,
-    badgeX + badgePaddingX,
-    badgeY + Math.floor((badgeHeight - metadataFontSize) / 2),
+    fitTextWithEllipsis(ctx, target.company.toUpperCase(), Math.max(1, metaRight - metaLeft)),
+    metaLeft,
+    y + 11,
   );
 
   ctx.fillStyle = "rgba(241, 245, 249, 0.98)";
@@ -616,9 +623,46 @@ function drawPanel(
   const modelLine = fitTextWithEllipsis(
     ctx,
     target.modelName,
-    Math.max(1, metaRight - metaLeft - badgeWidth - 8),
+    Math.max(1, metaRight - metaLeft),
   );
-  ctx.fillText(modelLine, metaLeft, y + 27);
+  ctx.fillText(modelLine, metaLeft, y + 25);
+
+  ctx.strokeStyle = "rgba(148, 163, 184, 0.24)";
+  ctx.lineWidth = 1;
+  ctx.beginPath();
+  ctx.moveTo(metaLeft, y + 56.5);
+  ctx.lineTo(metaRight, y + 56.5);
+  ctx.stroke();
+
+  const statsWidth = Math.max(1, metaRight - metaLeft);
+  const statWidth = statsWidth / stats.length;
+  for (let idx = 0; idx < stats.length; idx += 1) {
+    const stat = stats[idx];
+    if (!stat) continue;
+    const columnX = metaLeft + idx * statWidth;
+    const textX = columnX + (idx > 0 ? 10 : 0);
+    const textWidth = Math.max(1, statWidth - (idx > 0 ? 10 : 0) - 8);
+
+    if (idx > 0) {
+      ctx.strokeStyle = "rgba(148, 163, 184, 0.18)";
+      ctx.beginPath();
+      ctx.moveTo(columnX + 0.5, y + 62);
+      ctx.lineTo(columnX + 0.5, y + 87);
+      ctx.stroke();
+    }
+
+    ctx.fillStyle = "rgba(100, 116, 139, 0.95)";
+    ctx.font = `700 ${highFidelityMetadata ? 10 : 9}px "IBM Plex Sans", "Segoe UI", sans-serif`;
+    ctx.fillText(stat.label, textX, y + 62);
+    ctx.fillStyle = "rgba(226, 232, 240, 0.98)";
+    let valueFontSize = metadataFontSize;
+    ctx.font = `600 ${valueFontSize}px "IBM Plex Sans", "Segoe UI", sans-serif`;
+    while (valueFontSize > 9 && ctx.measureText(stat.value).width > textWidth) {
+      valueFontSize -= 1;
+      ctx.font = `600 ${valueFontSize}px "IBM Plex Sans", "Segoe UI", sans-serif`;
+    }
+    ctx.fillText(fitTextWithEllipsis(ctx, stat.value, textWidth), textX, y + 74);
+  }
 
   ctx.save();
   roundedRectPath(ctx, captureX, captureY, captureWidth, captureHeight, CAPTURE_RADIUS);

--- a/components/sandbox/SandboxGifExportButton.tsx
+++ b/components/sandbox/SandboxGifExportButton.tsx
@@ -26,6 +26,7 @@ export type SandboxGifExportTarget = {
   blockCount: number;
   averageCostPerBuildUsd?: number | null;
   generationTimeMs?: number | null;
+  averageInferenceTimeMs?: number | null;
   jsonBytes?: number | null;
 };
 
@@ -126,7 +127,7 @@ const EXPORT_MARGIN_X = 22;
 const EXPORT_MARGIN_BOTTOM = 22;
 const PANEL_GAP = 16;
 const PANEL_PAD = 12;
-const PANEL_META_HEIGHT = 88;
+const PANEL_META_HEIGHT = 48;
 const PANEL_RADIUS = 18;
 const CAPTURE_RADIUS = 14;
 const MIN_EXPORT_PANEL_HEIGHT = 220;
@@ -311,12 +312,16 @@ function formatAverageCostPerBuild(value?: number | null): string | null {
 
 function getPanelStats(target: SandboxGifExportTarget) {
   const cost = formatAverageCostPerBuild(target.averageCostPerBuildUsd);
-  const duration = formatBuildDuration(target.generationTimeMs);
+  const generationTime = formatBuildDuration(target.generationTimeMs);
+  const averageInferenceTime = generationTime
+    ? null
+    : formatBuildDuration(target.averageInferenceTimeMs);
+  const duration = generationTime ?? averageInferenceTime;
   const jsonSize = formatBuildJsonSize(target.jsonBytes);
   return [
     { label: "BLOCKS", value: target.blockCount.toLocaleString() },
     ...(cost ? [{ label: "AVG COST", value: cost }] : []),
-    ...(duration ? [{ label: "TIME", value: duration }] : []),
+    ...(duration ? [{ label: generationTime ? "TIME" : "AVG TIME", value: duration }] : []),
     ...(jsonSize ? [{ label: "JSON", value: jsonSize }] : []),
   ];
 }
@@ -599,6 +604,11 @@ function drawPanel(
   const metaRight = Math.min(x + width - PANEL_PAD, contentBounds?.right ?? x + width - PANEL_PAD);
   const stats = getPanelStats(target);
   const metadataFontSize = highFidelityMetadata ? CREATOR_MP4_METADATA_FONT_SIZE : 12;
+  const metadataWidth = Math.max(1, metaRight - metaLeft);
+  const identityFraction = stats.length >= 4 ? 0.34 : stats.length === 3 ? 0.4 : 0.5;
+  const identityWidth = Math.min(260, metadataWidth * identityFraction);
+  const statsLeft = metaLeft + identityWidth + 12;
+  const statsWidth = Math.max(1, metaRight - statsLeft);
 
   ctx.save();
   roundedRectPath(ctx, x, y, width, height, PANEL_RADIUS);
@@ -613,9 +623,9 @@ function drawPanel(
   ctx.font = `700 ${highFidelityMetadata ? 12 : 10}px "IBM Plex Sans", "Segoe UI", sans-serif`;
   ctx.textBaseline = "top";
   ctx.fillText(
-    fitTextWithEllipsis(ctx, target.company.toUpperCase(), Math.max(1, metaRight - metaLeft)),
+    fitTextWithEllipsis(ctx, target.company.toUpperCase(), identityWidth),
     metaLeft,
-    y + 11,
+    y + 9,
   );
 
   ctx.fillStyle = "rgba(241, 245, 249, 0.98)";
@@ -623,37 +633,41 @@ function drawPanel(
   const modelLine = fitTextWithEllipsis(
     ctx,
     target.modelName,
-    Math.max(1, metaRight - metaLeft),
+    identityWidth,
   );
-  ctx.fillText(modelLine, metaLeft, y + 25);
+  ctx.fillText(modelLine, metaLeft, y + 22);
 
-  ctx.strokeStyle = "rgba(148, 163, 184, 0.24)";
+  ctx.strokeStyle = "rgba(148, 163, 184, 0.2)";
   ctx.lineWidth = 1;
   ctx.beginPath();
-  ctx.moveTo(metaLeft, y + 56.5);
-  ctx.lineTo(metaRight, y + 56.5);
+  ctx.moveTo(statsLeft - 6.5, y + 10);
+  ctx.lineTo(statsLeft - 6.5, y + 47);
   ctx.stroke();
 
-  const statsWidth = Math.max(1, metaRight - metaLeft);
   const statWidth = statsWidth / stats.length;
   for (let idx = 0; idx < stats.length; idx += 1) {
     const stat = stats[idx];
     if (!stat) continue;
-    const columnX = metaLeft + idx * statWidth;
+    const columnX = statsLeft + idx * statWidth;
     const textX = columnX + (idx > 0 ? 10 : 0);
     const textWidth = Math.max(1, statWidth - (idx > 0 ? 10 : 0) - 8);
 
     if (idx > 0) {
       ctx.strokeStyle = "rgba(148, 163, 184, 0.18)";
       ctx.beginPath();
-      ctx.moveTo(columnX + 0.5, y + 62);
-      ctx.lineTo(columnX + 0.5, y + 87);
+      ctx.moveTo(columnX + 0.5, y + 10);
+      ctx.lineTo(columnX + 0.5, y + 47);
       ctx.stroke();
     }
 
     ctx.fillStyle = "rgba(100, 116, 139, 0.95)";
-    ctx.font = `700 ${highFidelityMetadata ? 10 : 9}px "IBM Plex Sans", "Segoe UI", sans-serif`;
-    ctx.fillText(stat.label, textX, y + 62);
+    let labelFontSize = highFidelityMetadata ? 10 : 9;
+    ctx.font = `700 ${labelFontSize}px "IBM Plex Sans", "Segoe UI", sans-serif`;
+    while (labelFontSize > 8 && ctx.measureText(stat.label).width > textWidth) {
+      labelFontSize -= 1;
+      ctx.font = `700 ${labelFontSize}px "IBM Plex Sans", "Segoe UI", sans-serif`;
+    }
+    ctx.fillText(fitTextWithEllipsis(ctx, stat.label, textWidth), textX, y + 11);
     ctx.fillStyle = "rgba(226, 232, 240, 0.98)";
     let valueFontSize = metadataFontSize;
     ctx.font = `600 ${valueFontSize}px "IBM Plex Sans", "Segoe UI", sans-serif`;
@@ -661,7 +675,7 @@ function drawPanel(
       valueFontSize -= 1;
       ctx.font = `600 ${valueFontSize}px "IBM Plex Sans", "Segoe UI", sans-serif`;
     }
-    ctx.fillText(fitTextWithEllipsis(ctx, stat.value, textWidth), textX, y + 74);
+    ctx.fillText(fitTextWithEllipsis(ctx, stat.value, textWidth), textX, y + 25);
   }
 
   ctx.save();

--- a/components/sandbox/SandboxGifExportButton.tsx
+++ b/components/sandbox/SandboxGifExportButton.tsx
@@ -5,12 +5,15 @@ import { useEffect, useId, useRef, useState } from "react";
 import type { VoxelViewerHandle } from "@/components/voxel/VoxelViewer";
 import {
   getSandboxGifExportPanelGrid,
+  getSandboxSocialSafeInsets,
   type SandboxGifExportLayoutFormat,
+  type SandboxSocialSafeInsets,
 } from "@/lib/sandbox/gifExportLayout";
 import {
   DEFAULT_MEDIA_EXPORT_PREFERENCE,
   getEffectiveMediaExportFileType,
   type MediaExportFileType,
+  type MediaExportFraming,
   type MediaExportQuality,
   readMediaExportPreference,
 } from "@/lib/sandbox/mediaExportPreference";
@@ -45,6 +48,7 @@ const SINGLE_FRAME_DELAY_MS = 40;
 const CREATOR_FRAME_RATE = 30;
 const CREATOR_FRAME_COUNT = 180;
 const CREATOR_DURATION_MS = 6000;
+const SOCIAL_SAFE_CAMERA_DISTANCE_SCALE = 1.18;
 const COMPARISON_PALETTE_SAMPLE_COUNT = 12;
 const SINGLE_PALETTE_SAMPLE_COUNT = 16;
 const COMPARISON_PALETTE_SAMPLE_LONG_EDGE = 640;
@@ -130,7 +134,13 @@ type ExportLayout = {
     title: string;
     promptLines: string[];
     urlText: string;
+    x: number;
+    right: number;
+    titleY: number;
+    promptY: number;
   };
+  safeInsets: SandboxSocialSafeInsets | null;
+  cameraDistanceScale: number;
 };
 type ExportRect = ExportLayout["panelRects"][number];
 
@@ -142,6 +152,7 @@ type GifExportRuntime = {
   frameDelaysMs: number[];
   paletteSampleCount: number;
   paletteSampleLongEdge: number;
+  socialSafe: boolean;
 };
 type GifExportRotationBases = number[];
 
@@ -173,6 +184,7 @@ function buildFrameDelaySchedule(frameCount: number, frameDelayMs: number): numb
 function getExportRuntime(
   format: GifExportLayoutFormat,
   quality: MediaExportQuality,
+  framing: MediaExportFraming,
 ): GifExportRuntime {
   const single = format === "single";
   const creator = quality === "creator";
@@ -192,6 +204,7 @@ function getExportRuntime(
     frameDelaysMs: buildFrameDelaySchedule(frameCount, frameDelayMs),
     paletteSampleCount: single ? SINGLE_PALETTE_SAMPLE_COUNT : COMPARISON_PALETTE_SAMPLE_COUNT,
     paletteSampleLongEdge: single ? SINGLE_PALETTE_SAMPLE_LONG_EDGE : COMPARISON_PALETTE_SAMPLE_LONG_EDGE,
+    socialSafe: quality === "creator" && framing === "social-safe" && format !== "wide",
   };
 }
 
@@ -321,13 +334,20 @@ function buildExportLayout(
   height: number,
   promptText: string,
   format: GifExportLayoutFormat,
+  framing: MediaExportFraming,
 ): ExportLayout {
   const safeCount = Math.max(1, Math.min(4, count));
   const panelGap = safeCount === 1 ? 0 : PANEL_GAP;
   const grid = getSandboxGifExportPanelGrid(safeCount, format);
+  const socialSafe = framing === "social-safe" && format !== "wide";
+  const safeInsets = socialSafe ? getSandboxSocialSafeInsets(width, height) : null;
+  const headerX = safeInsets?.left ?? 28;
+  const headerRight = width - (safeInsets?.right ?? 28);
+  const titleY = safeInsets?.top ?? 18;
+  const promptY = socialSafe ? titleY + 42 : 60;
   ctx.font = HEADER_PROMPT_FONT;
   const normalizedPrompt = promptText.replace(/\s+/g, " ").trim();
-  const promptMaxWidth = width - 56;
+  const promptMaxWidth = Math.max(1, headerRight - headerX);
   const allPromptLines = wrapTextLines(ctx, `Prompt: ${normalizedPrompt || "sandbox prompt"}`, promptMaxWidth);
   const maxPanelTop =
     height -
@@ -335,9 +355,14 @@ function buildExportLayout(
     panelGap * (grid.rows - 1) -
     MIN_EXPORT_PANEL_HEIGHT * grid.rows;
   // free-form prompts still need room for viewers
-  const maxPromptLines = Math.floor((maxPanelTop - 84) / HEADER_PROMPT_LINE_HEIGHT);
+  const maxPromptLines = Math.floor(
+    (maxPanelTop - promptY - 24) / HEADER_PROMPT_LINE_HEIGHT,
+  );
   const promptLines = capPromptLines(ctx, allPromptLines, maxPromptLines, promptMaxWidth);
-  const panelTop = Math.max(104, 60 + promptLines.length * HEADER_PROMPT_LINE_HEIGHT + 24);
+  const panelTop = Math.max(
+    socialSafe ? promptY + 24 : 104,
+    promptY + promptLines.length * HEADER_PROMPT_LINE_HEIGHT + 24,
+  );
   const panelWidth =
     (width - EXPORT_MARGIN_X * 2 - panelGap * (grid.columns - 1)) / grid.columns;
   const panelHeight =
@@ -367,7 +392,13 @@ function buildExportLayout(
       title: safeCount > 1 ? "MineBench Comparison" : "MineBench Build",
       promptLines,
       urlText: "minebench.ai",
+      x: headerX,
+      right: headerRight,
+      titleY,
+      promptY,
     },
+    safeInsets,
+    cameraDistanceScale: socialSafe ? SOCIAL_SAFE_CAMERA_DISTANCE_SCALE : 1,
   };
 }
 
@@ -464,6 +495,10 @@ function drawBaseBackdrop(
     title: string;
     promptLines: string[];
     urlText: string;
+    x: number;
+    right: number;
+    titleY: number;
+    promptY: number;
   },
 ) {
   ctx.fillStyle = "#0b1220";
@@ -493,19 +528,22 @@ function drawBaseBackdrop(
   ctx.fillStyle = "rgba(203, 213, 225, 0.98)";
   ctx.font = '700 28px "Sora", "Avenir Next", "Segoe UI", sans-serif';
   ctx.textBaseline = "top";
-  ctx.fillText(opts.title, 28, 18);
+  ctx.fillText(opts.title, opts.x, opts.titleY);
 
   ctx.fillStyle = "rgba(203, 213, 225, 0.95)";
   ctx.font = HEADER_PROMPT_FONT;
-  const promptY = 60;
   for (let i = 0; i < opts.promptLines.length; i += 1) {
-    ctx.fillText(opts.promptLines[i] ?? "", 28, promptY + i * HEADER_PROMPT_LINE_HEIGHT);
+    ctx.fillText(
+      opts.promptLines[i] ?? "",
+      opts.x,
+      opts.promptY + i * HEADER_PROMPT_LINE_HEIGHT,
+    );
   }
 
   ctx.fillStyle = "rgba(100, 116, 139, 0.85)";
   ctx.font = '500 11px "IBM Plex Sans", "Segoe UI", sans-serif';
   const urlW = ctx.measureText(opts.urlText).width;
-  ctx.fillText(opts.urlText, Math.max(28, width - 28 - urlW), 22);
+  ctx.fillText(opts.urlText, Math.max(opts.x, opts.right - urlW), opts.titleY + 4);
 }
 
 function drawPanel(
@@ -518,10 +556,13 @@ function drawPanel(
     target: SandboxGifExportTarget;
     capture: HTMLCanvasElement;
     captureRect: ExportRect;
+    contentBounds: { left: number; right: number } | null;
   },
 ) {
-  const { x, y, width, height, target, capture, captureRect } = opts;
+  const { x, y, width, height, target, capture, captureRect, contentBounds } = opts;
   const { x: captureX, y: captureY, width: captureWidth, height: captureHeight } = captureRect;
+  const metaLeft = Math.max(x + PANEL_PAD, contentBounds?.left ?? x + PANEL_PAD);
+  const metaRight = Math.min(x + width - PANEL_PAD, contentBounds?.right ?? x + width - PANEL_PAD);
 
   ctx.save();
   roundedRectPath(ctx, x, y, width, height, PANEL_RADIUS);
@@ -535,12 +576,12 @@ function drawPanel(
   ctx.fillStyle = "rgba(125, 211, 252, 0.96)";
   ctx.font = '700 11px "IBM Plex Sans", "Segoe UI", sans-serif';
   ctx.textBaseline = "top";
-  ctx.fillText(target.company.toUpperCase(), x + PANEL_PAD, y + 12);
+  ctx.fillText(target.company.toUpperCase(), metaLeft, y + 12);
 
   const blockLabel = `${target.blockCount.toLocaleString()} blocks`;
   ctx.font = '600 11px "IBM Plex Sans", "Segoe UI", sans-serif';
   const badgeWidth = Math.ceil(ctx.measureText(blockLabel).width + 16);
-  const badgeX = x + width - PANEL_PAD - badgeWidth;
+  const badgeX = metaRight - badgeWidth;
   const badgeY = y + 14;
   roundedRectPath(ctx, badgeX, badgeY, badgeWidth, 22, 11);
   ctx.fillStyle = "rgba(30, 41, 59, 0.9)";
@@ -556,9 +597,9 @@ function drawPanel(
   const modelLine = fitTextWithEllipsis(
     ctx,
     target.modelName,
-    Math.max(1, width - PANEL_PAD * 2 - badgeWidth - 8),
+    Math.max(1, metaRight - metaLeft - badgeWidth - 8),
   );
-  ctx.fillText(modelLine, x + PANEL_PAD, y + 27);
+  ctx.fillText(modelLine, metaLeft, y + 27);
 
   ctx.save();
   roundedRectPath(ctx, captureX, captureY, captureWidth, captureHeight, CAPTURE_RADIUS);
@@ -580,6 +621,9 @@ function renderCompositeFrame(
   angle: number,
 ) {
   drawBaseBackdrop(ctx, layout.width, layout.height, layout.header);
+  const contentBounds = layout.safeInsets
+    ? { left: layout.safeInsets.left, right: layout.width - layout.safeInsets.right }
+    : null;
 
   for (let idx = 0; idx < targets.length; idx += 1) {
     const target = targets[idx];
@@ -595,6 +639,7 @@ function renderCompositeFrame(
       rotationY: (rotationBases[idx] ?? 0) + angle,
       width: captureRect.width,
       height: captureRect.height,
+      distanceScale: layout.cameraDistanceScale,
     });
     if (!capture) {
       throw new Error("One of the viewers is not ready for export");
@@ -608,6 +653,7 @@ function renderCompositeFrame(
       target,
       capture,
       captureRect,
+      contentBounds,
     });
   }
 }
@@ -638,6 +684,7 @@ async function buildPaletteSamples(
     sampleCanvas.height,
     "",
     format,
+    runtime.socialSafe ? "social-safe" : "full",
   );
   const samples: ArrayBuffer[] = [];
   const sampleFrames = buildPaletteSampleFrames(runtime.frameCount, runtime.paletteSampleCount);
@@ -750,7 +797,15 @@ async function buildGifBlob(
     worker.postMessage({ type: "palette", samples: paletteSamples }, paletteSamples);
   }
 
-  const layout = buildExportLayout(frameCtx, targets.length, width, height, promptText, format);
+  const layout = buildExportLayout(
+    frameCtx,
+    targets.length,
+    width,
+    height,
+    promptText,
+    format,
+    runtime.socialSafe ? "social-safe" : "full",
+  );
 
   try {
     const inFlight: Promise<void>[] = [];
@@ -853,7 +908,15 @@ async function buildMp4Blob(
   });
   output.addVideoTrack(videoSource, { frameRate: runtime.frameRate });
   const rotationBases = getExportRotationBases(targets);
-  const layout = buildExportLayout(frameCtx, targets.length, width, height, promptText, format);
+  const layout = buildExportLayout(
+    frameCtx,
+    targets.length,
+    width,
+    height,
+    promptText,
+    format,
+    runtime.socialSafe ? "social-safe" : "full",
+  );
   const frameDuration = 1 / runtime.frameRate;
 
   try {
@@ -1029,7 +1092,11 @@ export function SandboxGifExportButton({ targets, promptText, label, iconOnly, e
         targets.length,
         exportPreference.quality,
       );
-      const runtime = getExportRuntime(exportFormat, exportPreference.quality);
+      const runtime = getExportRuntime(
+        exportFormat,
+        exportPreference.quality,
+        exportPreference.framing,
+      );
       setProgress({ done: 0, total: runtime.frameCount });
       let finalBlob: Blob | null = null;
 

--- a/components/sandbox/SandboxGifExportButton.tsx
+++ b/components/sandbox/SandboxGifExportButton.tsx
@@ -395,8 +395,9 @@ function buildExportLayout(
     socialSafe ? promptY + 24 : 104,
     promptY + promptLines.length * HEADER_PROMPT_LINE_HEIGHT + 24,
   );
-  const panelAreaLeft = safeInsets?.left ?? EXPORT_MARGIN_X;
-  const panelAreaRight = safeInsets ? width - safeInsets.right : width - EXPORT_MARGIN_X;
+  const panelInsets = grid.columns > 1 ? safeInsets : null;
+  const panelAreaLeft = panelInsets?.left ?? EXPORT_MARGIN_X;
+  const panelAreaRight = panelInsets ? width - panelInsets.right : width - EXPORT_MARGIN_X;
   const panelAreaWidth = Math.max(1, panelAreaRight - panelAreaLeft);
   const panelWidth =
     (panelAreaWidth - panelGap * (grid.columns - 1)) / grid.columns;

--- a/components/sandbox/SandboxGifExportButton.tsx
+++ b/components/sandbox/SandboxGifExportButton.tsx
@@ -7,6 +7,13 @@ import {
   getSandboxGifExportPanelGrid,
   type SandboxGifExportLayoutFormat,
 } from "@/lib/sandbox/gifExportLayout";
+import {
+  DEFAULT_MEDIA_EXPORT_PREFERENCE,
+  getEffectiveMediaExportFileType,
+  type MediaExportFileType,
+  type MediaExportQuality,
+  readMediaExportPreference,
+} from "@/lib/sandbox/mediaExportPreference";
 
 export type SandboxGifExportTarget = {
   viewerRef: RefObject<VoxelViewerHandle | null>;
@@ -35,6 +42,9 @@ const COMPARISON_FRAME_COUNT = 108;
 const SINGLE_FRAME_COUNT = 135;
 const COMPARISON_FRAME_DELAY_MS = 40;
 const SINGLE_FRAME_DELAY_MS = 40;
+const CREATOR_FRAME_RATE = 30;
+const CREATOR_FRAME_COUNT = 180;
+const CREATOR_DURATION_MS = 6000;
 const COMPARISON_PALETTE_SAMPLE_COUNT = 12;
 const SINGLE_PALETTE_SAMPLE_COUNT = 16;
 const COMPARISON_PALETTE_SAMPLE_LONG_EDGE = 640;
@@ -68,11 +78,36 @@ const EXPORT_RENDER_PROFILES: Record<
     { width: 540, height: 960 },
   ],
 };
+const CREATOR_EXPORT_RENDER_PROFILES: Record<
+  GifExportLayoutFormat,
+  ReadonlyArray<{ width: number; height: number }>
+> = {
+  single: [
+    { width: 1080, height: 1920 },
+    { width: 900, height: 1600 },
+    { width: 810, height: 1440 },
+  ],
+  wide: [
+    { width: 1920, height: 1080 },
+    { width: 1600, height: 900 },
+    { width: 1440, height: 810 },
+  ],
+  vertical: [
+    { width: 1080, height: 1920 },
+    { width: 900, height: 1600 },
+    { width: 810, height: 1440 },
+  ],
+};
 const MULTI_ROW_WIDE_RENDER_PROFILES = [
   { width: 1440, height: 1080 },
   { width: 1280, height: 960 },
   { width: 960, height: 720 },
   { width: 800, height: 600 },
+] as const;
+const CREATOR_MULTI_ROW_WIDE_RENDER_PROFILES = [
+  { width: 1920, height: 1440 },
+  { width: 1600, height: 1200 },
+  { width: 1440, height: 1080 },
 ] as const;
 
 const EXPORT_MARGIN_X = 22;
@@ -99,9 +134,10 @@ type ExportLayout = {
 };
 type ExportRect = ExportLayout["panelRects"][number];
 
-type GifRenderProfile = (typeof EXPORT_RENDER_PROFILES)[GifExportLayoutFormat][number];
+type GifRenderProfile = { width: number; height: number };
 type GifExportRuntime = {
   frameCount: number;
+  frameRate: number;
   frameDelayMs: number;
   frameDelaysMs: number[];
   paletteSampleCount: number;
@@ -112,24 +148,46 @@ type GifExportRotationBases = number[];
 function getExportRenderProfiles(
   format: GifExportLayoutFormat,
   targetCount: number,
+  quality: MediaExportQuality,
 ): ReadonlyArray<GifRenderProfile> {
   if (format === "wide" && targetCount > 2) {
-    return MULTI_ROW_WIDE_RENDER_PROFILES;
+    return quality === "creator"
+      ? CREATOR_MULTI_ROW_WIDE_RENDER_PROFILES
+      : MULTI_ROW_WIDE_RENDER_PROFILES;
   }
-  return EXPORT_RENDER_PROFILES[format];
+  return quality === "creator"
+    ? CREATOR_EXPORT_RENDER_PROFILES[format]
+    : EXPORT_RENDER_PROFILES[format];
 }
 
 function buildFrameDelaySchedule(frameCount: number, frameDelayMs: number): number[] {
-  const delayTicks = Math.max(1, Math.round(frameDelayMs / GIF_DELAY_TICK_MS));
-  return Array.from({ length: frameCount }, () => delayTicks * GIF_DELAY_TICK_MS);
+  let elapsedTicks = 0;
+  return Array.from({ length: frameCount }, (_, frame) => {
+    const nextElapsedTicks = Math.round(((frame + 1) * frameDelayMs) / GIF_DELAY_TICK_MS);
+    const delayTicks = Math.max(1, nextElapsedTicks - elapsedTicks);
+    elapsedTicks = nextElapsedTicks;
+    return delayTicks * GIF_DELAY_TICK_MS;
+  });
 }
 
-function getExportRuntime(format: GifExportLayoutFormat): GifExportRuntime {
+function getExportRuntime(
+  format: GifExportLayoutFormat,
+  quality: MediaExportQuality,
+): GifExportRuntime {
   const single = format === "single";
-  const frameCount = single ? SINGLE_FRAME_COUNT : COMPARISON_FRAME_COUNT;
-  const frameDelayMs = single ? SINGLE_FRAME_DELAY_MS : COMPARISON_FRAME_DELAY_MS;
+  const creator = quality === "creator";
+  const frameCount = creator
+    ? CREATOR_FRAME_COUNT
+    : single
+      ? SINGLE_FRAME_COUNT
+      : COMPARISON_FRAME_COUNT;
+  const frameRate = creator
+    ? CREATOR_FRAME_RATE
+    : 1000 / (single ? SINGLE_FRAME_DELAY_MS : COMPARISON_FRAME_DELAY_MS);
+  const frameDelayMs = creator ? CREATOR_DURATION_MS / CREATOR_FRAME_COUNT : 1000 / frameRate;
   return {
     frameCount,
+    frameRate,
     frameDelayMs,
     frameDelaysMs: buildFrameDelaySchedule(frameCount, frameDelayMs),
     paletteSampleCount: single ? SINGLE_PALETTE_SAMPLE_COUNT : COMPARISON_PALETTE_SAMPLE_COUNT,
@@ -749,6 +807,84 @@ async function buildGifBlob(
   }
 }
 
+async function buildMp4Blob(
+  targets: SandboxGifExportTarget[],
+  promptText: string,
+  format: GifExportLayoutFormat,
+  profile: GifRenderProfile,
+  runtime: GifExportRuntime,
+  onProgress?: (done: number, total: number) => void,
+  signal?: AbortSignal,
+) {
+  throwIfAborted(signal);
+  const { BufferTarget, CanvasSource, Mp4OutputFormat, Output, Quality, canEncodeVideo } =
+    await import("mediabunny");
+  throwIfAborted(signal);
+
+  const { width, height } = profile;
+  const quality = new Quality("very-high");
+  const supported = await canEncodeVideo("avc", {
+    width,
+    height,
+    quality,
+    latencyMode: "quality",
+  });
+  if (!supported) {
+    throw new Error("MP4 export isn’t supported in this browser. Choose GIF in Account settings.");
+  }
+
+  const frameCanvas = document.createElement("canvas");
+  frameCanvas.width = width;
+  frameCanvas.height = height;
+  const frameCtx = frameCanvas.getContext("2d", { willReadFrequently: false });
+  if (!frameCtx) throw new Error("Unable to initialize MP4 export canvas");
+  frameCtx.imageSmoothingEnabled = true;
+  frameCtx.imageSmoothingQuality = "high";
+
+  const output = new Output({
+    format: new Mp4OutputFormat(),
+    target: new BufferTarget(),
+  });
+  const videoSource = new CanvasSource(frameCanvas, {
+    codec: "avc",
+    quality,
+    latencyMode: "quality",
+    keyFrameInterval: 2,
+  });
+  output.addVideoTrack(videoSource, { frameRate: runtime.frameRate });
+  const rotationBases = getExportRotationBases(targets);
+  const layout = buildExportLayout(frameCtx, targets.length, width, height, promptText, format);
+  const frameDuration = 1 / runtime.frameRate;
+
+  try {
+    await output.start();
+    for (let frame = 0; frame < runtime.frameCount; frame += 1) {
+      throwIfAborted(signal);
+      const t = frame / runtime.frameCount;
+      renderCompositeFrame(frameCtx, layout, targets, rotationBases, t * Math.PI * 2);
+      await videoSource.add(frame / runtime.frameRate, frameDuration);
+      onProgress?.(frame + 1, runtime.frameCount);
+
+      if (frame > 0 && frame % YIELD_EVERY_FRAMES === 0) {
+        await waitForNextPaint();
+        throwIfAborted(signal);
+      }
+    }
+
+    videoSource.close();
+    await output.finalize();
+    throwIfAborted(signal);
+    const buffer = output.target.buffer;
+    if (!buffer) throw new Error("MP4 export finished without video data");
+    return new Blob([buffer], { type: "video/mp4" });
+  } catch (error) {
+    if (output.state !== "finalized" && output.state !== "canceled") {
+      await output.cancel().catch(() => undefined);
+    }
+    throw error;
+  }
+}
+
 function triggerDownload(blob: Blob, fileName: string) {
   const url = URL.createObjectURL(blob);
   const a = document.createElement("a");
@@ -808,7 +944,7 @@ function GifFormatSelector({
   return (
     <div
       role="group"
-      aria-label="GIF format"
+      aria-label="Export layout"
       className={`inline-flex shrink-0 items-center rounded-full text-muted ${
         embedded
           ? "p-0"
@@ -819,7 +955,7 @@ function GifFormatSelector({
     >
       {GIF_FORMATS.map((value) => {
         const active = format === value;
-        const label = value === "wide" ? "Wide GIF" : "Vertical GIF";
+        const label = value === "wide" ? "Wide" : "Vertical";
         return (
           <button
             key={value}
@@ -829,7 +965,7 @@ function GifFormatSelector({
             aria-pressed={active}
             title={label}
             onClick={() => onChange(value)}
-            className={`grid place-items-center rounded-full transition-colors duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/55 disabled:cursor-not-allowed disabled:opacity-45 ${
+            className={`grid place-items-center rounded-full transition-colors duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/55 motion-reduce:transition-none disabled:cursor-not-allowed disabled:opacity-45 ${
               compact ? "h-7 w-7" : "h-8 w-8"
             } ${
               active
@@ -852,11 +988,19 @@ export function SandboxGifExportButton({ targets, promptText, label, iconOnly, e
   const [error, setError] = useState<string | null>(null);
   const [progress, setProgress] = useState<{ done: number; total: number } | null>(null);
   const [format, setFormat] = useState<GifExportFormat>("wide");
+  const [preference, setPreference] = useState(DEFAULT_MEDIA_EXPORT_PREFERENCE);
+  const [activeFileType, setActiveFileType] = useState<MediaExportFileType | null>(null);
   const exportAbortRef = useRef<AbortController | null>(null);
 
   const hasTargets = targets.length > 0;
   const canChooseFormat = targets.length > 1;
   const exportFormat: GifExportLayoutFormat = canChooseFormat ? format : "single";
+
+  useEffect(() => {
+    const saved = readMediaExportPreference();
+    setPreference(saved);
+    if (saved.quality === "creator") setFormat("vertical");
+  }, []);
 
   useEffect(() => {
     exportAbortRef.current?.abort();
@@ -869,6 +1013,10 @@ export function SandboxGifExportButton({ targets, promptText, label, iconOnly, e
       setError("Viewer is still loading. Try again in a second.");
       return;
     }
+    const exportPreference = readMediaExportPreference();
+    const fileType = getEffectiveMediaExportFileType(exportPreference);
+    setPreference(exportPreference);
+    setActiveFileType(fileType);
     setExporting(true);
     setOptimizing(false);
     setError(null);
@@ -876,70 +1024,102 @@ export function SandboxGifExportButton({ targets, promptText, label, iconOnly, e
     exportAbortRef.current = abortController;
     await waitForNextPaint();
     try {
-      const profiles = getExportRenderProfiles(exportFormat, targets.length);
-      const runtime = getExportRuntime(exportFormat);
+      const profiles = getExportRenderProfiles(
+        exportFormat,
+        targets.length,
+        exportPreference.quality,
+      );
+      const runtime = getExportRuntime(exportFormat, exportPreference.quality);
       setProgress({ done: 0, total: runtime.frameCount });
       let finalBlob: Blob | null = null;
-      let smallestBlob: Blob | null = null;
 
-      for (let idx = 0; idx < profiles.length; idx += 1) {
-        const profile = profiles[idx] ?? profiles[profiles.length - 1];
-        setOptimizing(false);
-        setProgress({ done: 0, total: runtime.frameCount });
+      if (fileType === "mp4") {
+        for (let idx = 0; idx < profiles.length; idx += 1) {
+          const profile = profiles[idx] ?? profiles[profiles.length - 1];
+          setProgress({ done: 0, total: runtime.frameCount });
+          try {
+            finalBlob = await buildMp4Blob(
+              targets,
+              promptText ?? "",
+              exportFormat,
+              profile,
+              runtime,
+              (done, total) => {
+                if (done === total || done % 2 === 0) setProgress({ done, total });
+              },
+              abortController.signal,
+            );
+            break;
+          } catch (err) {
+            if (err instanceof Error && err.name === "AbortError") throw err;
+            if (idx === profiles.length - 1) throw err;
+            console.warn("[media-export] MP4 profile skipped", profile, err);
+            await waitForNextPaint();
+            throwIfAborted(abortController.signal);
+          }
+        }
+      } else {
+        let smallestBlob: Blob | null = null;
+        const enforceSizeTarget = exportPreference.quality === "standard";
 
-        let blob: Blob;
-        try {
-          blob = await buildGifBlob(
-            targets,
-            promptText ?? "",
-            exportFormat,
-            profile,
-            runtime,
-            (done, total) => {
-              if (done === total || done % 2 === 0) setProgress({ done, total });
-            },
-            abortController.signal,
-          );
-        } catch (err) {
-          if (err instanceof Error && err.name === "AbortError") throw err;
-          if (idx === profiles.length - 1) throw err;
-          console.warn("[gif-export] render profile skipped", profile, err);
-          await waitForNextPaint();
-          throwIfAborted(abortController.signal);
-          continue;
+        for (let idx = 0; idx < profiles.length; idx += 1) {
+          const profile = profiles[idx] ?? profiles[profiles.length - 1];
+          setOptimizing(false);
+          setProgress({ done: 0, total: runtime.frameCount });
+
+          let blob: Blob;
+          try {
+            blob = await buildGifBlob(
+              targets,
+              promptText ?? "",
+              exportFormat,
+              profile,
+              runtime,
+              (done, total) => {
+                if (done === total || done % 2 === 0) setProgress({ done, total });
+              },
+              abortController.signal,
+            );
+          } catch (err) {
+            if (err instanceof Error && err.name === "AbortError") throw err;
+            if (idx === profiles.length - 1) throw err;
+            console.warn("[media-export] GIF profile skipped", profile, err);
+            await waitForNextPaint();
+            throwIfAborted(abortController.signal);
+            continue;
+          }
+
+          if (
+            enforceSizeTarget &&
+            blob.size > GIF_TARGET_MAX_BYTES &&
+            idx < profiles.length - 1
+          ) {
+            await waitForNextPaint();
+            throwIfAborted(abortController.signal);
+            continue;
+          }
+
+          smallestBlob = blob;
+          const enforceTarget =
+            enforceSizeTarget && blob.size > GIF_TARGET_MAX_BYTES && idx === profiles.length - 1;
+          const shouldOptimize = shouldTryGifOptimization(blob, enforceTarget);
+          if (shouldOptimize) {
+            setOptimizing(true);
+            setProgress(null);
+          }
+
+          const optimizedBlob = await optimizeGifBlobForDownload(blob, abortController.signal, {
+            enforceTarget,
+          });
+          if (optimizedBlob.size < smallestBlob.size) smallestBlob = optimizedBlob;
+          finalBlob = optimizedBlob;
+          break;
         }
 
-        if (blob.size > GIF_TARGET_MAX_BYTES && idx < profiles.length - 1) {
-          await waitForNextPaint();
-          throwIfAborted(abortController.signal);
-          continue;
-        }
-
-        smallestBlob = blob;
-
-        const enforceTarget = blob.size > GIF_TARGET_MAX_BYTES && idx === profiles.length - 1;
-        const shouldOptimize = shouldTryGifOptimization(blob, enforceTarget);
-        if (shouldOptimize) {
-          setOptimizing(true);
-          setProgress(null);
-        }
-
-        const optimizedBlob = await optimizeGifBlobForDownload(blob, abortController.signal, {
-          enforceTarget,
-        });
-        if (!smallestBlob || optimizedBlob.size < smallestBlob.size) {
-          smallestBlob = optimizedBlob;
-        }
-
-        finalBlob = optimizedBlob;
-        break;
+        if (!finalBlob) finalBlob = smallestBlob;
       }
-
       if (!finalBlob) {
-        finalBlob = smallestBlob;
-      }
-      if (!finalBlob) {
-        throw new Error("GIF export failed");
+        throw new Error(`${fileType.toUpperCase()} export failed`);
       }
 
       const modelToken = targets
@@ -951,15 +1131,20 @@ export function SandboxGifExportButton({ targets, promptText, label, iconOnly, e
       const stamp = new Date().toISOString().replace(/[:.]/g, "-");
       const typeToken = targets.length > 1 ? "compare" : "build";
       const formatToken =
-        exportFormat === "vertical" ? "vertical" : exportFormat === "single" ? "viewer" : "wide";
-      const fileName = `minebench-${typeToken}-${formatToken}-${modelToken}-${promptToken}-${stamp}.gif`;
+        exportFormat === "vertical" ||
+        (exportFormat === "single" && exportPreference.quality === "creator")
+          ? "vertical"
+          : exportFormat === "single"
+            ? "viewer"
+            : "wide";
+      const fileName = `minebench-${typeToken}-${formatToken}-${modelToken}-${promptToken}-${stamp}.${fileType}`;
       throwIfAborted(abortController.signal);
       triggerDownload(finalBlob, fileName);
     } catch (err) {
       if (err instanceof Error && err.name === "AbortError") return;
-      const message = err instanceof Error ? err.message : "GIF export failed";
+      const message = err instanceof Error ? err.message : "Export failed";
       setError(message);
-      console.error("[gif-export]", err);
+      console.error("[media-export]", err);
     } finally {
       if (exportAbortRef.current === abortController) {
         exportAbortRef.current = null;
@@ -967,16 +1152,24 @@ export function SandboxGifExportButton({ targets, promptText, label, iconOnly, e
       setOptimizing(false);
       setExporting(false);
       setProgress(null);
+      setActiveFileType(null);
     }
   }
 
+  const preferredFileType = getEffectiveMediaExportFileType(preference);
+  const displayedFileType = activeFileType ?? preferredFileType;
+  const idleLabel = label ?? (targets.length > 1 ? "Export comparison GIF" : "Export GIF");
+  const fileTypeLabel =
+    displayedFileType === "mp4" ? idleLabel.replace(/\bGIF\b/g, "MP4") : idleLabel;
   const displayLabel = exporting
     ? optimizing
       ? "Optimizing..."
       : progress
-        ? `Rendering ${Math.max(0, progress.done)}/${progress.total}`
-        : "Rendering..."
-    : (label ?? (targets.length > 1 ? "Export comparison GIF" : "Export GIF"));
+        ? `${displayedFileType === "mp4" ? "Encoding" : "Rendering"} ${Math.max(0, progress.done)}/${progress.total}`
+        : displayedFileType === "mp4"
+          ? "Encoding..."
+          : "Rendering..."
+    : fileTypeLabel;
   const buttonTitle = error ?? displayLabel;
   const busy = exporting || optimizing;
   const isUnavailable = !hasTargets;
@@ -1001,7 +1194,7 @@ export function SandboxGifExportButton({ targets, promptText, label, iconOnly, e
       title={iconOnly && !embedded ? undefined : buttonTitle}
       onClick={() => void handleExport()}
       disabled={isUnavailable}
-      className={`inline-flex select-none items-center justify-center font-semibold text-fg transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/35 ${
+      className={`inline-flex select-none items-center justify-center font-semibold text-fg transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/35 motion-reduce:transition-none ${
         embedded ? "mb-btn mb-btn-ghost rounded-md border border-border/70 bg-bg/55" : "rounded-full"
       } ${
         iconOnly
@@ -1013,7 +1206,7 @@ export function SandboxGifExportButton({ targets, promptText, label, iconOnly, e
         <svg
           aria-hidden="true"
           viewBox="0 0 24 24"
-          className={`h-4 w-4 ${exporting ? "animate-pulse" : ""}`}
+          className={`h-4 w-4 ${exporting ? "animate-pulse motion-reduce:animate-none" : ""}`}
         >
           <path
             d="M4 8a3 3 0 0 1 3-3h1.4l1.1-1.6A2 2 0 0 1 11.2 2h1.6a2 2 0 0 1 1.7.9L15.6 5H17a3 3 0 0 1 3 3v8a3 3 0 0 1-3 3H7a3 3 0 0 1-3-3V8Z"
@@ -1046,7 +1239,7 @@ export function SandboxGifExportButton({ targets, promptText, label, iconOnly, e
         id={tooltipId}
         role="status"
         aria-live={busy ? "polite" : undefined}
-        className={`pointer-events-none absolute right-[calc(100%+0.55rem)] top-1/2 z-[40] w-max max-w-[min(16rem,calc(100vw-8rem))] -translate-y-1/2 rounded-full border border-border/80 bg-[linear-gradient(180deg,rgba(8,13,30,0.98),rgba(5,9,22,0.96))] px-3 py-1.5 text-right text-[11px] text-fg shadow-[0_18px_44px_-24px_rgba(4,11,31,0.9)] backdrop-blur-md transition duration-150 ${shouldKeepTooltipVisible ? "translate-x-0 opacity-100" : "translate-x-1 opacity-0 group-hover/gif-export:translate-x-0 group-hover/gif-export:opacity-100 group-focus-within/gif-export:translate-x-0 group-focus-within/gif-export:opacity-100"}`}
+        className={`pointer-events-none absolute right-[calc(100%+0.55rem)] top-1/2 z-[40] w-max max-w-[min(16rem,calc(100vw-8rem))] -translate-y-1/2 rounded-full border border-border/80 bg-[linear-gradient(180deg,rgba(8,13,30,0.98),rgba(5,9,22,0.96))] px-3 py-1.5 text-right text-[11px] text-fg shadow-[0_18px_44px_-24px_rgba(4,11,31,0.9)] backdrop-blur-md transition duration-150 motion-reduce:transition-none ${shouldKeepTooltipVisible ? "translate-x-0 opacity-100" : "translate-x-1 opacity-0 group-hover/gif-export:translate-x-0 group-hover/gif-export:opacity-100 group-focus-within/gif-export:translate-x-0 group-focus-within/gif-export:opacity-100"}`}
       >
         <span className="block truncate">{buttonTitle}</span>
       </div>

--- a/components/sandbox/SandboxGifExportButton.tsx
+++ b/components/sandbox/SandboxGifExportButton.tsx
@@ -49,6 +49,7 @@ const CREATOR_FRAME_RATE = 30;
 const CREATOR_FRAME_COUNT = 180;
 const CREATOR_DURATION_MS = 6000;
 const SOCIAL_SAFE_CAMERA_DISTANCE_SCALE = 1.18;
+const SOCIAL_SAFE_WATERMARK_FONT_SIZE = 16;
 const COMPARISON_PALETTE_SAMPLE_COUNT = 12;
 const SINGLE_PALETTE_SAMPLE_COUNT = 16;
 const COMPARISON_PALETTE_SAMPLE_LONG_EDGE = 640;
@@ -138,6 +139,7 @@ type ExportLayout = {
     right: number;
     titleY: number;
     promptY: number;
+    socialSafe: boolean;
   };
   safeInsets: SandboxSocialSafeInsets | null;
   cameraDistanceScale: number;
@@ -396,6 +398,7 @@ function buildExportLayout(
       right: headerRight,
       titleY,
       promptY,
+      socialSafe,
     },
     safeInsets,
     cameraDistanceScale: socialSafe ? SOCIAL_SAFE_CAMERA_DISTANCE_SCALE : 1,
@@ -499,6 +502,7 @@ function drawBaseBackdrop(
     right: number;
     titleY: number;
     promptY: number;
+    socialSafe: boolean;
   },
 ) {
   ctx.fillStyle = "#0b1220";
@@ -540,8 +544,12 @@ function drawBaseBackdrop(
     );
   }
 
-  ctx.fillStyle = "rgba(100, 116, 139, 0.85)";
-  ctx.font = '500 11px "IBM Plex Sans", "Segoe UI", sans-serif';
+  ctx.fillStyle = opts.socialSafe
+    ? "rgba(148, 163, 184, 0.9)"
+    : "rgba(100, 116, 139, 0.85)";
+  ctx.font = `${opts.socialSafe ? 600 : 500} ${
+    opts.socialSafe ? SOCIAL_SAFE_WATERMARK_FONT_SIZE : 11
+  }px "IBM Plex Sans", "Segoe UI", sans-serif`;
   const urlW = ctx.measureText(opts.urlText).width;
   ctx.fillText(opts.urlText, Math.max(opts.x, opts.right - urlW), opts.titleY + 4);
 }

--- a/components/sandbox/SandboxGifExportButton.tsx
+++ b/components/sandbox/SandboxGifExportButton.tsx
@@ -395,8 +395,11 @@ function buildExportLayout(
     socialSafe ? promptY + 24 : 104,
     promptY + promptLines.length * HEADER_PROMPT_LINE_HEIGHT + 24,
   );
+  const panelAreaLeft = safeInsets?.left ?? EXPORT_MARGIN_X;
+  const panelAreaRight = safeInsets ? width - safeInsets.right : width - EXPORT_MARGIN_X;
+  const panelAreaWidth = Math.max(1, panelAreaRight - panelAreaLeft);
   const panelWidth =
-    (width - EXPORT_MARGIN_X * 2 - panelGap * (grid.columns - 1)) / grid.columns;
+    (panelAreaWidth - panelGap * (grid.columns - 1)) / grid.columns;
   const panelHeight =
     (height - panelTop - EXPORT_MARGIN_BOTTOM - panelGap * (grid.rows - 1)) / grid.rows;
   const panelRects: ExportLayout["panelRects"] = [];
@@ -404,7 +407,7 @@ function buildExportLayout(
   for (let row = 0; row < grid.rows; row += 1) {
     const columnsInRow = grid.rowColumns[row] ?? grid.columns;
     const rowWidth = panelWidth * columnsInRow + panelGap * Math.max(0, columnsInRow - 1);
-    const rowX = EXPORT_MARGIN_X + (width - EXPORT_MARGIN_X * 2 - rowWidth) / 2;
+    const rowX = panelAreaLeft + (panelAreaWidth - rowWidth) / 2;
 
     for (let column = 0; column < columnsInRow && panelRects.length < safeCount; column += 1) {
       panelRects.push({

--- a/components/sandbox/SandboxLive.tsx
+++ b/components/sandbox/SandboxLive.tsx
@@ -406,7 +406,15 @@ function getResultJsonBytes(result: ModelResult): number | undefined {
   ) {
     return result.customBuildExpandedBytes;
   }
-  const source = result.rawText;
+  let source: string | undefined;
+  if (result.voxelBuild != null) {
+    try {
+      source = JSON.stringify(result.voxelBuild);
+    } catch {
+      source = undefined;
+    }
+  }
+  source ??= result.rawText;
   return source ? new Blob([source]).size : undefined;
 }
 

--- a/components/sandbox/SandboxLive.tsx
+++ b/components/sandbox/SandboxLive.tsx
@@ -398,6 +398,18 @@ function getRawBuildJsonForExport(args: {
   }
 }
 
+function getResultJsonBytes(result: ModelResult): number | undefined {
+  if (
+    typeof result.customBuildExpandedBytes === "number" &&
+    Number.isFinite(result.customBuildExpandedBytes) &&
+    result.customBuildExpandedBytes >= 0
+  ) {
+    return result.customBuildExpandedBytes;
+  }
+  const source = result.rawText;
+  return source ? new Blob([source]).size : undefined;
+}
+
 function customBuildStageLabel(status: SavedGenerationPayload): string {
   if (status.status === "succeeded") return "Ready";
   if (status.status === "failed") return "Failed";
@@ -1411,9 +1423,11 @@ export function SandboxLive({
         modelName: model.displayName,
         company: model.providerLabel,
         blockCount: result.metrics?.blockCount ?? 0,
+        generationTimeMs: result.metrics?.generationTimeMs,
+        jsonBytes: getResultJsonBytes(result),
       };
     })
-    .filter((target): target is SandboxGifExportTarget => Boolean(target));
+    .filter((target) => target !== null);
   const comparePrompt = selectedModels
     .map((model) => results.get(model.id)?.submittedPrompt)
     .find((value): value is string => Boolean(value)) ?? prompt;
@@ -1440,6 +1454,8 @@ export function SandboxLive({
               modelName,
               company: providerName,
               blockCount: r.metrics?.blockCount ?? 0,
+              generationTimeMs: r.metrics?.generationTimeMs,
+              jsonBytes: getResultJsonBytes(r),
             },
           ]
         : [];

--- a/components/sandbox/SandboxLive.tsx
+++ b/components/sandbox/SandboxLive.tsx
@@ -66,7 +66,12 @@ type ModelResult = {
   rawText?: string;
   attempt?: number;
   retryReason?: string;
-  metrics?: { blockCount: number; warnings: string[]; generationTimeMs: number };
+  metrics?: {
+    blockCount: number;
+    warnings: string[];
+    generationTimeMs: number;
+    jsonBytes?: number;
+  };
   startedAt?: number;
   customBuildId?: string;
   customBuildPageUrl?: string;
@@ -406,16 +411,7 @@ function getResultJsonBytes(result: ModelResult): number | undefined {
   ) {
     return result.customBuildExpandedBytes;
   }
-  let source: string | undefined;
-  if (result.voxelBuild != null) {
-    try {
-      source = JSON.stringify(result.voxelBuild);
-    } catch {
-      source = undefined;
-    }
-  }
-  source ??= result.rawText;
-  return source ? new Blob([source]).size : undefined;
+  return result.metrics?.jsonBytes;
 }
 
 function customBuildStageLabel(status: SavedGenerationPayload): string {

--- a/components/voxel/VoxelViewer.tsx
+++ b/components/voxel/VoxelViewer.tsx
@@ -71,6 +71,7 @@ export type VoxelViewerHandle = {
     rotationY?: number;
     width?: number;
     height?: number;
+    distanceScale?: number;
   }) => HTMLCanvasElement | null;
 };
 
@@ -984,6 +985,10 @@ export const VoxelViewer = forwardRef<VoxelViewerHandle, ViewerProps>(function V
         const width = Math.max(1, Math.floor(opts?.width ?? source.width));
         const height = Math.max(1, Math.floor(opts?.height ?? source.height));
         const targetAspect = width / height;
+        const distanceScale =
+          typeof opts?.distanceScale === "number" && Number.isFinite(opts.distanceScale)
+            ? Math.max(1, opts.distanceScale)
+            : 1;
         const cameraOffset = camera.position.clone().sub(controls.target);
         const distance = cameraOffset.length();
         const exportRenderer = getExportRenderer();
@@ -991,14 +996,19 @@ export const VoxelViewer = forwardRef<VoxelViewerHandle, ViewerProps>(function V
         try {
           if (rotationY !== null) vg.group.rotation.y = rotationY;
 
-          if (distance > 0 && targetAspect !== previousAspect) {
-            const targetDistance = retargetDistanceForAspect({
-              ...getRotatingBoundsFraming(camera, bounds, cameraOffset.y / distance),
-              distance,
-              sourceAspect: previousAspect,
-              targetAspect,
-            });
-            camera.position.copy(controls.target).addScaledVector(cameraOffset, targetDistance / distance);
+          if (distance > 0 && (targetAspect !== previousAspect || distanceScale !== 1)) {
+            const targetDistance =
+              targetAspect === previousAspect
+                ? distance
+                : retargetDistanceForAspect({
+                    ...getRotatingBoundsFraming(camera, bounds, cameraOffset.y / distance),
+                    distance,
+                    sourceAspect: previousAspect,
+                    targetAspect,
+                  });
+            camera.position
+              .copy(controls.target)
+              .addScaledVector(cameraOffset, (targetDistance * distanceScale) / distance);
           }
           camera.aspect = targetAspect;
           camera.updateProjectionMatrix();

--- a/lib/ai/modelBenchmarkProfiles.ts
+++ b/lib/ai/modelBenchmarkProfiles.ts
@@ -593,3 +593,10 @@ export function getAverageBenchmarkCostPerBuildUsd(modelKey: string): number | n
   if (!profile?.totalCost || !profile.buildCount || profile.buildCount <= 0) return null;
   return profile.totalCost.usd / profile.buildCount;
 }
+
+export function getAverageBenchmarkInferenceTimeMs(modelKey: string): number | null {
+  const milliseconds = getModelBenchmarkProfile(modelKey)?.averageInference?.milliseconds;
+  return typeof milliseconds === "number" && Number.isFinite(milliseconds) && milliseconds > 0
+    ? milliseconds
+    : null;
+}

--- a/lib/ai/modelBenchmarkProfiles.ts
+++ b/lib/ai/modelBenchmarkProfiles.ts
@@ -587,3 +587,9 @@ export const MODEL_BENCHMARK_PROFILES = Object.fromEntries(
 export function getModelBenchmarkProfile(modelKey: string): ModelBenchmarkProfile | null {
   return MODEL_BENCHMARK_PROFILES[modelKey as ModelKey] ?? null;
 }
+
+export function getAverageBenchmarkCostPerBuildUsd(modelKey: string): number | null {
+  const profile = getModelBenchmarkProfile(modelKey);
+  if (!profile?.totalCost || !profile.buildCount || profile.buildCount <= 0) return null;
+  return profile.totalCost.usd / profile.buildCount;
+}

--- a/lib/ai/types.ts
+++ b/lib/ai/types.ts
@@ -80,5 +80,15 @@ export type GenerateEvent =
   | { type: "start"; modelKey: string }
   | { type: "retry"; modelKey: string; attempt: number; reason?: string }
   | { type: "delta"; modelKey: string; delta: string }
-  | { type: "result"; modelKey: string; voxelBuild: VoxelBuild; metrics: { blockCount: number; warnings: string[]; generationTimeMs: number } }
+  | {
+      type: "result";
+      modelKey: string;
+      voxelBuild: VoxelBuild;
+      metrics: {
+        blockCount: number;
+        warnings: string[];
+        generationTimeMs: number;
+        jsonBytes: number;
+      };
+    }
   | { type: "error"; modelKey: string; message: string; rawText?: string };

--- a/lib/arena/stats.ts
+++ b/lib/arena/stats.ts
@@ -188,6 +188,8 @@ export type ModelPromptBreakdown = {
     palette: "simple" | "advanced";
     mode: string;
     blockCount: number;
+    generationTimeMs: number;
+    jsonBytes: number | null;
   } | null;
 };
 
@@ -1215,6 +1217,8 @@ async function queryModelDetailStats(modelKeyOrSlug: string): Promise<ModelDetai
         palette: true,
         mode: true,
         blockCount: true,
+        generationTimeMs: true,
+        voxelByteSize: true,
         voxelSha256: true,
         prompt: {
           select: { text: true },
@@ -1288,6 +1292,8 @@ async function queryModelDetailStats(modelKeyOrSlug: string): Promise<ModelDetai
         palette,
         mode: build.mode,
         blockCount: build.blockCount,
+        generationTimeMs: build.generationTimeMs,
+        jsonBytes: build.voxelByteSize,
       },
     });
   }

--- a/lib/sandbox/gifExportLayout.ts
+++ b/lib/sandbox/gifExportLayout.ts
@@ -6,6 +6,23 @@ export type SandboxGifExportPanelGrid = {
   rowColumns: number[];
 };
 
+export type SandboxSocialSafeInsets = {
+  left: number;
+  right: number;
+  top: number;
+};
+
+export function getSandboxSocialSafeInsets(
+  width: number,
+  height: number,
+): SandboxSocialSafeInsets {
+  return {
+    left: Math.round(width * 0.1),
+    right: Math.round(width * 0.2),
+    top: Math.round(height * 0.1),
+  };
+}
+
 export function getSandboxGifExportPanelGrid(
   count: number,
   format: SandboxGifExportLayoutFormat,

--- a/lib/sandbox/mediaExportPreference.ts
+++ b/lib/sandbox/mediaExportPreference.ts
@@ -1,17 +1,21 @@
 export type MediaExportQuality = "standard" | "creator";
 export type MediaExportFileType = "gif" | "mp4";
+export type MediaExportFraming = "full" | "social-safe";
 
 export type MediaExportPreference = Readonly<{
   quality: MediaExportQuality;
   fileType: MediaExportFileType;
+  framing: MediaExportFraming;
 }>;
 
 type StorageLike = Pick<Storage, "getItem" | "setItem">;
 
-export const MEDIA_EXPORT_PREFERENCE_STORAGE_KEY = "minebench:media-export:v1";
+const LEGACY_MEDIA_EXPORT_PREFERENCE_STORAGE_KEY = "minebench:media-export:v1";
+export const MEDIA_EXPORT_PREFERENCE_STORAGE_KEY = "minebench:media-export:v2";
 export const DEFAULT_MEDIA_EXPORT_PREFERENCE: MediaExportPreference = {
   quality: "standard",
   fileType: "mp4",
+  framing: "social-safe",
 };
 
 function browserStorage(): StorageLike | null {
@@ -22,14 +26,19 @@ export function parseMediaExportPreference(raw: string | null): MediaExportPrefe
   if (!raw) return DEFAULT_MEDIA_EXPORT_PREFERENCE;
 
   try {
-    const value = JSON.parse(raw) as { quality?: unknown; fileType?: unknown };
+    const value = JSON.parse(raw) as {
+      quality?: unknown;
+      fileType?: unknown;
+      framing?: unknown;
+    };
     if (value.quality !== "standard" && value.quality !== "creator") {
       return DEFAULT_MEDIA_EXPORT_PREFERENCE;
     }
     if (value.fileType !== "gif" && value.fileType !== "mp4") {
       return DEFAULT_MEDIA_EXPORT_PREFERENCE;
     }
-    return { quality: value.quality, fileType: value.fileType };
+    const framing = value.framing === "full" ? "full" : "social-safe";
+    return { quality: value.quality, fileType: value.fileType, framing };
   } catch {
     return DEFAULT_MEDIA_EXPORT_PREFERENCE;
   }
@@ -40,7 +49,15 @@ export function readMediaExportPreference(
 ): MediaExportPreference {
   if (!storage) return DEFAULT_MEDIA_EXPORT_PREFERENCE;
   try {
-    return parseMediaExportPreference(storage.getItem(MEDIA_EXPORT_PREFERENCE_STORAGE_KEY));
+    const saved = storage.getItem(MEDIA_EXPORT_PREFERENCE_STORAGE_KEY);
+    if (saved) return parseMediaExportPreference(saved);
+
+    const legacy = storage.getItem(LEGACY_MEDIA_EXPORT_PREFERENCE_STORAGE_KEY);
+    const migrated = parseMediaExportPreference(legacy);
+    if (legacy) {
+      storage.setItem(MEDIA_EXPORT_PREFERENCE_STORAGE_KEY, JSON.stringify(migrated));
+    }
+    return migrated;
   } catch {
     return DEFAULT_MEDIA_EXPORT_PREFERENCE;
   }

--- a/lib/sandbox/mediaExportPreference.ts
+++ b/lib/sandbox/mediaExportPreference.ts
@@ -1,0 +1,66 @@
+export type MediaExportQuality = "standard" | "creator";
+export type MediaExportFileType = "gif" | "mp4";
+
+export type MediaExportPreference = Readonly<{
+  quality: MediaExportQuality;
+  fileType: MediaExportFileType;
+}>;
+
+type StorageLike = Pick<Storage, "getItem" | "setItem">;
+
+export const MEDIA_EXPORT_PREFERENCE_STORAGE_KEY = "minebench:media-export:v1";
+export const DEFAULT_MEDIA_EXPORT_PREFERENCE: MediaExportPreference = {
+  quality: "standard",
+  fileType: "mp4",
+};
+
+function browserStorage(): StorageLike | null {
+  return typeof window === "undefined" ? null : window.localStorage;
+}
+
+export function parseMediaExportPreference(raw: string | null): MediaExportPreference {
+  if (!raw) return DEFAULT_MEDIA_EXPORT_PREFERENCE;
+
+  try {
+    const value = JSON.parse(raw) as { quality?: unknown; fileType?: unknown };
+    if (value.quality !== "standard" && value.quality !== "creator") {
+      return DEFAULT_MEDIA_EXPORT_PREFERENCE;
+    }
+    if (value.fileType !== "gif" && value.fileType !== "mp4") {
+      return DEFAULT_MEDIA_EXPORT_PREFERENCE;
+    }
+    return { quality: value.quality, fileType: value.fileType };
+  } catch {
+    return DEFAULT_MEDIA_EXPORT_PREFERENCE;
+  }
+}
+
+export function readMediaExportPreference(
+  storage: StorageLike | null = browserStorage(),
+): MediaExportPreference {
+  if (!storage) return DEFAULT_MEDIA_EXPORT_PREFERENCE;
+  try {
+    return parseMediaExportPreference(storage.getItem(MEDIA_EXPORT_PREFERENCE_STORAGE_KEY));
+  } catch {
+    return DEFAULT_MEDIA_EXPORT_PREFERENCE;
+  }
+}
+
+export function writeMediaExportPreference(
+  preference: MediaExportPreference,
+  storage: StorageLike | null = browserStorage(),
+): boolean {
+  if (!storage) return false;
+  try {
+    storage.setItem(MEDIA_EXPORT_PREFERENCE_STORAGE_KEY, JSON.stringify(preference));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function getEffectiveMediaExportFileType(
+  preference: MediaExportPreference,
+): MediaExportFileType {
+  return preference.quality === "creator" ? preference.fileType : "gif";
+}

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "fflate": "^0.8.3",
     "gifenc": "^1.0.3",
     "gifsicle-wasm-browser": "^1.5.19",
+    "mediabunny": "1.55.3",
     "next": "^15.0.0",
     "nodemailer": "^9.0.5",
     "obscenity": "0.4.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
       gifsicle-wasm-browser:
         specifier: ^1.5.19
         version: 1.5.19
+      mediabunny:
+        specifier: 1.55.3
+        version: 1.55.3
       next:
         specifier: ^15.0.0
         version: 15.5.9(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -1259,6 +1262,12 @@ packages:
 
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
+
+  '@types/dom-mediacapture-transform@0.1.12':
+    resolution: {integrity: sha512-d7/QsLRwF864A5mgIM/YrfiglHoYn7zgCcAoJgW404r+2DwnNr7EBbLnCWpmOMgH8y0te73L1AV6H1bmauaWFw==}
+
+  '@types/dom-webcodecs@0.1.13':
+    resolution: {integrity: sha512-O5hkiFIcjjszPIYyUSyvScyvrBoV3NOEEZx/pMlsu44TKzWNkLVBBxnxJz42in5n3QIolYOcBYFCPZZ0h8SkwQ==}
 
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
@@ -3084,6 +3093,9 @@ packages:
   media-typer@1.1.1:
     resolution: {integrity: sha512-yz3xRaG20c6/BOzvYoDaGtPmGscs7YivItZEEqe6GbwNfHuxu9YNmvnEkMzKldAGY4/80pRcQRZSEnhquk9XuQ==}
     engines: {node: '>= 0.8'}
+
+  mediabunny@1.55.3:
+    resolution: {integrity: sha512-kpBhMiJHGmerizzObAT1XLZDyImO4ZEKXaxjjfxGVkycQ0U5of/xlLepm1Izp3P+3jlaedFSRI5fJnv3Q5xV6A==}
 
   merge-descriptors@2.0.0:
     resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
@@ -5210,6 +5222,12 @@ snapshots:
     dependencies:
       tslib: 2.8.1
     optional: true
+
+  '@types/dom-mediacapture-transform@0.1.12':
+    dependencies:
+      '@types/dom-webcodecs': 0.1.13
+
+  '@types/dom-webcodecs@0.1.13': {}
 
   '@types/estree@1.0.8': {}
 
@@ -7413,6 +7431,11 @@ snapshots:
   math-intrinsics@1.1.0: {}
 
   media-typer@1.1.1: {}
+
+  mediabunny@1.55.3:
+    dependencies:
+      '@types/dom-mediacapture-transform': 0.1.12
+      '@types/dom-webcodecs': 0.1.13
 
   merge-descriptors@2.0.0: {}
 

--- a/tests/ui/gif-export-config.test.ts
+++ b/tests/ui/gif-export-config.test.ts
@@ -159,6 +159,7 @@ assert.equal(readNumericConst("CREATOR_MP4_METADATA_FONT_SIZE"), 14);
 assert.equal(creatorFrameCount / creatorFrameRate, creatorDurationMs / 1000);
 assert.equal(readNumericConst("SOCIAL_SAFE_CAMERA_DISTANCE_SCALE"), 1.18);
 assert.equal(readNumericConst("SOCIAL_SAFE_WATERMARK_FONT_SIZE"), 16);
+assert.equal(readNumericConst("PANEL_META_HEIGHT"), 88);
 assert.equal(readNumericConst("COMPARISON_PALETTE_SAMPLE_COUNT"), 12);
 assert.equal(readNumericConst("COMPARISON_PALETTE_SAMPLE_LONG_EDGE"), 640);
 
@@ -263,6 +264,17 @@ assert.ok(
   sourceText.includes('exportPreference.quality === "standard"') &&
     sourceText.includes("enforceSizeTarget && blob.size > GIF_TARGET_MAX_BYTES"),
   "only Standard GIFs should fall back to the sharing-size target",
+);
+assert.ok(
+  sourceText.includes('label: "BLOCKS"') &&
+    sourceText.includes('label: "AVG COST"') &&
+    sourceText.includes('label: "TIME"') &&
+    sourceText.includes('label: "JSON"') &&
+    sourceText.includes("averageCostPerBuildUsd?: number | null") &&
+    benchmarkSourceText.includes("averageCostPerBuildUsd: build.metrics.averageCostPerBuildUsd") &&
+    benchmarkSourceText.includes("generationTimeMs: build.metrics.generationTimeMs") &&
+    benchmarkSourceText.includes("jsonBytes: build.metrics.jsonBytes"),
+  "export panels should use a structured metric rail backed by benchmark metadata",
 );
 assert.ok(
   accountSourceText.includes("<MediaExportSettings />") &&

--- a/tests/ui/gif-export-config.test.ts
+++ b/tests/ui/gif-export-config.test.ts
@@ -9,6 +9,7 @@ import {
 const SOURCE_PATH = "components/sandbox/SandboxGifExportButton.tsx";
 const sourceText = readFileSync(SOURCE_PATH, "utf8");
 const benchmarkSourceText = readFileSync("components/sandbox/SandboxBenchmark.tsx", "utf8");
+const benchmarkRouteSourceText = readFileSync("app/api/sandbox/benchmark/route.ts", "utf8");
 const viewerSourceText = readFileSync("components/voxel/VoxelViewer.tsx", "utf8");
 const accountSourceText = readFileSync("app/account/page.tsx", "utf8");
 const settingsSourceText = readFileSync("app/account/MediaExportSettings.tsx", "utf8");
@@ -159,7 +160,7 @@ assert.equal(readNumericConst("CREATOR_MP4_METADATA_FONT_SIZE"), 14);
 assert.equal(creatorFrameCount / creatorFrameRate, creatorDurationMs / 1000);
 assert.equal(readNumericConst("SOCIAL_SAFE_CAMERA_DISTANCE_SCALE"), 1.18);
 assert.equal(readNumericConst("SOCIAL_SAFE_WATERMARK_FONT_SIZE"), 16);
-assert.equal(readNumericConst("PANEL_META_HEIGHT"), 88);
+assert.equal(readNumericConst("PANEL_META_HEIGHT"), 48);
 assert.equal(readNumericConst("COMPARISON_PALETTE_SAMPLE_COUNT"), 12);
 assert.equal(readNumericConst("COMPARISON_PALETTE_SAMPLE_LONG_EDGE"), 640);
 
@@ -268,13 +269,19 @@ assert.ok(
 assert.ok(
   sourceText.includes('label: "BLOCKS"') &&
     sourceText.includes('label: "AVG COST"') &&
-    sourceText.includes('label: "TIME"') &&
+    sourceText.includes('generationTime ? "TIME" : "AVG TIME"') &&
     sourceText.includes('label: "JSON"') &&
+    sourceText.includes("const statsLeft = metaLeft + identityWidth + 12") &&
     sourceText.includes("averageCostPerBuildUsd?: number | null") &&
+    sourceText.includes("averageInferenceTimeMs?: number | null") &&
     benchmarkSourceText.includes("averageCostPerBuildUsd: build.metrics.averageCostPerBuildUsd") &&
     benchmarkSourceText.includes("generationTimeMs: build.metrics.generationTimeMs") &&
+    benchmarkSourceText.includes("averageInferenceTimeMs: build.metrics.averageInferenceTimeMs") &&
+    benchmarkRouteSourceText.includes(
+      "averageInferenceTimeMs: getAverageBenchmarkInferenceTimeMs(build.model.key)",
+    ) &&
     benchmarkSourceText.includes("jsonBytes: build.metrics.jsonBytes"),
-  "export panels should use a structured metric rail backed by benchmark metadata",
+  "export panels should use a compact metric rail with benchmark timing fallback",
 );
 assert.ok(
   accountSourceText.includes("<MediaExportSettings />") &&

--- a/tests/ui/gif-export-config.test.ts
+++ b/tests/ui/gif-export-config.test.ts
@@ -10,6 +10,7 @@ const SOURCE_PATH = "components/sandbox/SandboxGifExportButton.tsx";
 const sourceText = readFileSync(SOURCE_PATH, "utf8");
 const benchmarkSourceText = readFileSync("components/sandbox/SandboxBenchmark.tsx", "utf8");
 const benchmarkRouteSourceText = readFileSync("app/api/sandbox/benchmark/route.ts", "utf8");
+const liveSourceText = readFileSync("components/sandbox/SandboxLive.tsx", "utf8");
 const viewerSourceText = readFileSync("components/voxel/VoxelViewer.tsx", "utf8");
 const accountSourceText = readFileSync("app/account/page.tsx", "utf8");
 const settingsSourceText = readFileSync("app/account/MediaExportSettings.tsx", "utf8");
@@ -297,10 +298,18 @@ assert.ok(
 );
 assert.ok(
   sourceText.includes('runtime.socialSafe ? "social-safe" : "full"') &&
+    sourceText.includes("const panelAreaLeft = safeInsets?.left ?? EXPORT_MARGIN_X") &&
+    sourceText.includes("const panelAreaRight = safeInsets ? width - safeInsets.right : width - EXPORT_MARGIN_X") &&
+    sourceText.includes("const rowX = panelAreaLeft + (panelAreaWidth - rowWidth) / 2") &&
     sourceText.includes("distanceScale: layout.cameraDistanceScale") &&
     sourceText.includes("opts.socialSafe ? SOCIAL_SAFE_WATERMARK_FONT_SIZE : 11") &&
     viewerSourceText.includes("opts?.distanceScale"),
-  "Creator social framing should protect metadata, widen camera framing, and strengthen the watermark",
+  "Creator social framing should protect panels and metadata, widen camera framing, and strengthen the watermark",
+);
+assert.ok(
+  liveSourceText.includes("source = JSON.stringify(result.voxelBuild)") &&
+    liveSourceText.includes("source ??= result.rawText"),
+  "live sandbox export metrics should measure parsed build JSON before falling back to stream text",
 );
 
 console.log("gif export config checks passed");

--- a/tests/ui/gif-export-config.test.ts
+++ b/tests/ui/gif-export-config.test.ts
@@ -10,6 +10,7 @@ const SOURCE_PATH = "components/sandbox/SandboxGifExportButton.tsx";
 const sourceText = readFileSync(SOURCE_PATH, "utf8");
 const benchmarkSourceText = readFileSync("components/sandbox/SandboxBenchmark.tsx", "utf8");
 const benchmarkRouteSourceText = readFileSync("app/api/sandbox/benchmark/route.ts", "utf8");
+const generateRouteSourceText = readFileSync("app/api/generate/route.ts", "utf8");
 const liveSourceText = readFileSync("components/sandbox/SandboxLive.tsx", "utf8");
 const viewerSourceText = readFileSync("components/voxel/VoxelViewer.tsx", "utf8");
 const accountSourceText = readFileSync("app/account/page.tsx", "utf8");
@@ -298,8 +299,9 @@ assert.ok(
 );
 assert.ok(
   sourceText.includes('runtime.socialSafe ? "social-safe" : "full"') &&
-    sourceText.includes("const panelAreaLeft = safeInsets?.left ?? EXPORT_MARGIN_X") &&
-    sourceText.includes("const panelAreaRight = safeInsets ? width - safeInsets.right : width - EXPORT_MARGIN_X") &&
+    sourceText.includes("const panelInsets = grid.columns > 1 ? safeInsets : null") &&
+    sourceText.includes("const panelAreaLeft = panelInsets?.left ?? EXPORT_MARGIN_X") &&
+    sourceText.includes("const panelAreaRight = panelInsets ? width - panelInsets.right : width - EXPORT_MARGIN_X") &&
     sourceText.includes("const rowX = panelAreaLeft + (panelAreaWidth - rowWidth) / 2") &&
     sourceText.includes("distanceScale: layout.cameraDistanceScale") &&
     sourceText.includes("opts.socialSafe ? SOCIAL_SAFE_WATERMARK_FONT_SIZE : 11") &&
@@ -307,9 +309,9 @@ assert.ok(
   "Creator social framing should protect panels and metadata, widen camera framing, and strengthen the watermark",
 );
 assert.ok(
-  liveSourceText.includes("source = JSON.stringify(result.voxelBuild)") &&
-    liveSourceText.includes("source ??= result.rawText"),
-  "live sandbox export metrics should measure parsed build JSON before falling back to stream text",
+  liveSourceText.includes("return result.metrics?.jsonBytes") &&
+    generateRouteSourceText.includes("jsonBytes: Buffer.byteLength(r.rawText)"),
+  "live sandbox export metrics should use the complete response size instead of truncated stream text",
 );
 
 console.log("gif export config checks passed");

--- a/tests/ui/gif-export-config.test.ts
+++ b/tests/ui/gif-export-config.test.ts
@@ -153,6 +153,7 @@ assert.equal(creatorFrameCount, 180);
 assert.equal(creatorDurationMs, 6000);
 assert.equal(creatorFrameCount / creatorFrameRate, creatorDurationMs / 1000);
 assert.equal(readNumericConst("SOCIAL_SAFE_CAMERA_DISTANCE_SCALE"), 1.18);
+assert.equal(readNumericConst("SOCIAL_SAFE_WATERMARK_FONT_SIZE"), 16);
 assert.equal(readNumericConst("COMPARISON_PALETTE_SAMPLE_COUNT"), 12);
 assert.equal(readNumericConst("COMPARISON_PALETTE_SAMPLE_LONG_EDGE"), 640);
 
@@ -270,8 +271,9 @@ assert.ok(
 assert.ok(
   sourceText.includes('runtime.socialSafe ? "social-safe" : "full"') &&
     sourceText.includes("distanceScale: layout.cameraDistanceScale") &&
+    sourceText.includes("opts.socialSafe ? SOCIAL_SAFE_WATERMARK_FONT_SIZE : 11") &&
     viewerSourceText.includes("opts?.distanceScale"),
-  "Creator social framing should protect compositor metadata and widen camera framing",
+  "Creator social framing should protect metadata, widen camera framing, and strengthen the watermark",
 );
 
 console.log("gif export config checks passed");

--- a/tests/ui/gif-export-config.test.ts
+++ b/tests/ui/gif-export-config.test.ts
@@ -141,6 +141,8 @@ const singleFrameDelayMs = readNumericConst("SINGLE_FRAME_DELAY_MS");
 const creatorFrameRate = readNumericConst("CREATOR_FRAME_RATE");
 const creatorFrameCount = readNumericConst("CREATOR_FRAME_COUNT");
 const creatorDurationMs = readNumericConst("CREATOR_DURATION_MS");
+const creatorMp4Bitrate = readNumericConst("CREATOR_MP4_BITRATE");
+const creatorMp4Quantizer = readNumericConst("CREATOR_MP4_QUANTIZER");
 
 assert.equal(comparisonFrameCount, 108);
 assert.equal(singleFrameCount, 135);
@@ -151,6 +153,9 @@ assert.equal(singleFrameCount * singleFrameDelayMs, 5400);
 assert.equal(creatorFrameRate, 30);
 assert.equal(creatorFrameCount, 180);
 assert.equal(creatorDurationMs, 6000);
+assert.equal(creatorMp4Bitrate, 24_000_000);
+assert.equal(creatorMp4Quantizer, 12);
+assert.equal(readNumericConst("CREATOR_MP4_METADATA_FONT_SIZE"), 14);
 assert.equal(creatorFrameCount / creatorFrameRate, creatorDurationMs / 1000);
 assert.equal(readNumericConst("SOCIAL_SAFE_CAMERA_DISTANCE_SCALE"), 1.18);
 assert.equal(readNumericConst("SOCIAL_SAFE_WATERMARK_FONT_SIZE"), 16);
@@ -246,10 +251,13 @@ assert.ok(
 assert.ok(
   sourceText.includes('await import("mediabunny")') &&
     sourceText.includes('codec: "avc"') &&
-    sourceText.includes('new Quality("very-high")') &&
+    sourceText.includes("bitrate: CREATOR_MP4_BITRATE") &&
+    sourceText.includes("quantizer: CREATOR_MP4_QUANTIZER") &&
+    sourceText.includes('contentHint: "detail"') &&
+    sourceText.includes("t * Math.PI * 2, true") &&
     sourceText.includes("frame / runtime.frameRate") &&
     sourceText.includes('type: "video/mp4"'),
-  "Creator MP4 should be a lazily loaded, deterministic, very-high-quality H.264 export",
+  "Creator MP4 should be a lazily loaded, deterministic, detail-preserving H.264 export",
 );
 assert.ok(
   sourceText.includes('exportPreference.quality === "standard"') &&

--- a/tests/ui/gif-export-config.test.ts
+++ b/tests/ui/gif-export-config.test.ts
@@ -7,6 +7,8 @@ const SOURCE_PATH = "components/sandbox/SandboxGifExportButton.tsx";
 const sourceText = readFileSync(SOURCE_PATH, "utf8");
 const benchmarkSourceText = readFileSync("components/sandbox/SandboxBenchmark.tsx", "utf8");
 const viewerSourceText = readFileSync("components/voxel/VoxelViewer.tsx", "utf8");
+const accountSourceText = readFileSync("app/account/page.tsx", "utf8");
+const settingsSourceText = readFileSync("app/account/MediaExportSettings.tsx", "utf8");
 const sourceFile = ts.createSourceFile(SOURCE_PATH, sourceText, ts.ScriptTarget.Latest, true, ts.ScriptKind.TSX);
 
 function readNumericConst(name: string): number {
@@ -133,6 +135,9 @@ const comparisonFrameCount = readNumericConst("COMPARISON_FRAME_COUNT");
 const singleFrameCount = readNumericConst("SINGLE_FRAME_COUNT");
 const comparisonFrameDelayMs = readNumericConst("COMPARISON_FRAME_DELAY_MS");
 const singleFrameDelayMs = readNumericConst("SINGLE_FRAME_DELAY_MS");
+const creatorFrameRate = readNumericConst("CREATOR_FRAME_RATE");
+const creatorFrameCount = readNumericConst("CREATOR_FRAME_COUNT");
+const creatorDurationMs = readNumericConst("CREATOR_DURATION_MS");
 
 assert.equal(comparisonFrameCount, 108);
 assert.equal(singleFrameCount, 135);
@@ -140,6 +145,10 @@ assert.equal(comparisonFrameDelayMs, 40);
 assert.equal(singleFrameDelayMs, 40);
 assert.equal(comparisonFrameCount * comparisonFrameDelayMs, 4320);
 assert.equal(singleFrameCount * singleFrameDelayMs, 5400);
+assert.equal(creatorFrameRate, 30);
+assert.equal(creatorFrameCount, 180);
+assert.equal(creatorDurationMs, 6000);
+assert.equal(creatorFrameCount / creatorFrameRate, creatorDurationMs / 1000);
 assert.equal(readNumericConst("COMPARISON_PALETTE_SAMPLE_COUNT"), 12);
 assert.equal(readNumericConst("COMPARISON_PALETTE_SAMPLE_LONG_EDGE"), 640);
 
@@ -152,6 +161,14 @@ for (const profile of multiRowWideProfiles) {
   const panelHeight = (profile.height - 107 - 22 - 16) / 2;
   assert.ok(panelHeight >= 220, "multi-row wide profiles should preserve usable panel height");
 }
+const creatorProfiles = readRenderProfiles("CREATOR_EXPORT_RENDER_PROFILES");
+assert.deepEqual(creatorProfiles.single?.[0], { width: 1080, height: 1920 });
+assert.deepEqual(creatorProfiles.wide?.[0], { width: 1920, height: 1080 });
+assert.deepEqual(creatorProfiles.vertical?.[0], { width: 1080, height: 1920 });
+assert.deepEqual(readProfileArray("CREATOR_MULTI_ROW_WIDE_RENDER_PROFILES")[0], {
+  width: 1920,
+  height: 1440,
+});
 assert.deepEqual(getSandboxGifExportPanelGrid(1, "single"), {
   columns: 1,
   rows: 1,
@@ -215,6 +232,29 @@ assert.ok(
   sourceText.includes("aria-describedby={iconOnly && !embedded ? tooltipId : undefined}") &&
     sourceText.includes("title={iconOnly && !embedded ? undefined : buttonTitle}"),
   "embedded icon exports should expose a native tooltip without referencing an omitted tooltip node",
+);
+assert.ok(
+  sourceText.includes('await import("mediabunny")') &&
+    sourceText.includes('codec: "avc"') &&
+    sourceText.includes('new Quality("very-high")') &&
+    sourceText.includes("frame / runtime.frameRate") &&
+    sourceText.includes('type: "video/mp4"'),
+  "Creator MP4 should be a lazily loaded, deterministic, very-high-quality H.264 export",
+);
+assert.ok(
+  sourceText.includes('exportPreference.quality === "standard"') &&
+    sourceText.includes("enforceSizeTarget && blob.size > GIF_TARGET_MAX_BYTES"),
+  "only Standard GIFs should fall back to the sharing-size target",
+);
+assert.ok(
+  accountSourceText.includes("<MediaExportSettings />") &&
+    settingsSourceText.includes('value: "standard"') &&
+    settingsSourceText.includes('value: "creator"') &&
+    settingsSourceText.includes('value: "mp4"') &&
+    settingsSourceText.includes('value: "gif"') &&
+    settingsSourceText.includes("grid-rows-[1fr]") &&
+    settingsSourceText.includes("motion-reduce:transition-none"),
+  "Account should expose accessible Standard and Creator choices with a reduced-motion format reveal",
 );
 
 console.log("gif export config checks passed");

--- a/tests/ui/gif-export-config.test.ts
+++ b/tests/ui/gif-export-config.test.ts
@@ -1,7 +1,10 @@
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import ts from "typescript";
-import { getSandboxGifExportPanelGrid } from "../../lib/sandbox/gifExportLayout";
+import {
+  getSandboxGifExportPanelGrid,
+  getSandboxSocialSafeInsets,
+} from "../../lib/sandbox/gifExportLayout";
 
 const SOURCE_PATH = "components/sandbox/SandboxGifExportButton.tsx";
 const sourceText = readFileSync(SOURCE_PATH, "utf8");
@@ -149,6 +152,7 @@ assert.equal(creatorFrameRate, 30);
 assert.equal(creatorFrameCount, 180);
 assert.equal(creatorDurationMs, 6000);
 assert.equal(creatorFrameCount / creatorFrameRate, creatorDurationMs / 1000);
+assert.equal(readNumericConst("SOCIAL_SAFE_CAMERA_DISTANCE_SCALE"), 1.18);
 assert.equal(readNumericConst("COMPARISON_PALETTE_SAMPLE_COUNT"), 12);
 assert.equal(readNumericConst("COMPARISON_PALETTE_SAMPLE_LONG_EDGE"), 640);
 
@@ -168,6 +172,11 @@ assert.deepEqual(creatorProfiles.vertical?.[0], { width: 1080, height: 1920 });
 assert.deepEqual(readProfileArray("CREATOR_MULTI_ROW_WIDE_RENDER_PROFILES")[0], {
   width: 1920,
   height: 1440,
+});
+assert.deepEqual(getSandboxSocialSafeInsets(1080, 1920), {
+  left: 108,
+  right: 216,
+  top: 192,
 });
 assert.deepEqual(getSandboxGifExportPanelGrid(1, "single"), {
   columns: 1,
@@ -252,9 +261,17 @@ assert.ok(
     settingsSourceText.includes('value: "creator"') &&
     settingsSourceText.includes('value: "mp4"') &&
     settingsSourceText.includes('value: "gif"') &&
+    settingsSourceText.includes('value: "social-safe"') &&
+    settingsSourceText.includes('value: "full"') &&
     settingsSourceText.includes("grid-rows-[1fr]") &&
     settingsSourceText.includes("motion-reduce:transition-none"),
   "Account should expose accessible Standard and Creator choices with a reduced-motion format reveal",
+);
+assert.ok(
+  sourceText.includes('runtime.socialSafe ? "social-safe" : "full"') &&
+    sourceText.includes("distanceScale: layout.cameraDistanceScale") &&
+    viewerSourceText.includes("opts?.distanceScale"),
+  "Creator social framing should protect compositor metadata and widen camera framing",
 );
 
 console.log("gif export config checks passed");

--- a/tests/unit/ai/model-benchmark-profiles.test.ts
+++ b/tests/unit/ai/model-benchmark-profiles.test.ts
@@ -3,6 +3,7 @@ import {
   HISTORICAL_BENCHMARK_OUTPUT_CAPS,
   MODEL_BENCHMARK_PROFILES,
   getAverageBenchmarkCostPerBuildUsd,
+  getAverageBenchmarkInferenceTimeMs,
   getModelBenchmarkProfile,
   resolveBenchmarkOutputCap,
   resolveCurrentGeneratedBenchmarkMetrics,
@@ -62,6 +63,8 @@ assert.deepEqual(gpt56.totalCost, { usd: 710.82 });
 assert.equal(gpt56.buildCount, 15);
 assert.equal(getAverageBenchmarkCostPerBuildUsd("openai_gpt_5_6_sol"), 710.82 / 15);
 assert.equal(getAverageBenchmarkCostPerBuildUsd("openai_gpt_5_4"), null);
+assert.equal(getAverageBenchmarkInferenceTimeMs("openai_gpt_5_6_sol"), 1_516_200);
+assert.equal(getAverageBenchmarkInferenceTimeMs("openai_gpt_4_5_web_harness"), null);
 
 assert.equal(
   resolveBenchmarkOutputCap("openai_gpt_5_6_sol", {

--- a/tests/unit/ai/model-benchmark-profiles.test.ts
+++ b/tests/unit/ai/model-benchmark-profiles.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import {
   HISTORICAL_BENCHMARK_OUTPUT_CAPS,
   MODEL_BENCHMARK_PROFILES,
+  getAverageBenchmarkCostPerBuildUsd,
   getModelBenchmarkProfile,
   resolveBenchmarkOutputCap,
   resolveCurrentGeneratedBenchmarkMetrics,
@@ -59,6 +60,8 @@ assert.ok(
 );
 assert.deepEqual(gpt56.totalCost, { usd: 710.82 });
 assert.equal(gpt56.buildCount, 15);
+assert.equal(getAverageBenchmarkCostPerBuildUsd("openai_gpt_5_6_sol"), 710.82 / 15);
+assert.equal(getAverageBenchmarkCostPerBuildUsd("openai_gpt_5_4"), null);
 
 assert.equal(
   resolveBenchmarkOutputCap("openai_gpt_5_6_sol", {

--- a/tests/unit/sandbox/media-export-preference.test.ts
+++ b/tests/unit/sandbox/media-export-preference.test.ts
@@ -1,0 +1,64 @@
+import assert from "node:assert/strict";
+import {
+  DEFAULT_MEDIA_EXPORT_PREFERENCE,
+  getEffectiveMediaExportFileType,
+  MEDIA_EXPORT_PREFERENCE_STORAGE_KEY,
+  parseMediaExportPreference,
+  readMediaExportPreference,
+  writeMediaExportPreference,
+} from "../../../lib/sandbox/mediaExportPreference";
+
+assert.deepEqual(parseMediaExportPreference(null), DEFAULT_MEDIA_EXPORT_PREFERENCE);
+assert.deepEqual(parseMediaExportPreference("not-json"), DEFAULT_MEDIA_EXPORT_PREFERENCE);
+assert.deepEqual(
+  parseMediaExportPreference(JSON.stringify({ quality: "creator", fileType: "gif" })),
+  { quality: "creator", fileType: "gif" },
+);
+assert.deepEqual(
+  parseMediaExportPreference(JSON.stringify({ quality: "ultra", fileType: "mp4" })),
+  DEFAULT_MEDIA_EXPORT_PREFERENCE,
+);
+
+assert.equal(
+  getEffectiveMediaExportFileType({ quality: "standard", fileType: "mp4" }),
+  "gif",
+);
+assert.equal(
+  getEffectiveMediaExportFileType({ quality: "creator", fileType: "mp4" }),
+  "mp4",
+);
+
+let savedKey = "";
+let savedValue = "";
+const storage = {
+  getItem(key: string) {
+    return key === MEDIA_EXPORT_PREFERENCE_STORAGE_KEY ? savedValue || null : null;
+  },
+  setItem(key: string, value: string) {
+    savedKey = key;
+    savedValue = value;
+  },
+};
+
+assert.equal(
+  writeMediaExportPreference({ quality: "creator", fileType: "mp4" }, storage),
+  true,
+);
+assert.equal(savedKey, MEDIA_EXPORT_PREFERENCE_STORAGE_KEY);
+assert.deepEqual(readMediaExportPreference(storage), { quality: "creator", fileType: "mp4" });
+
+const unavailableStorage = {
+  getItem() {
+    throw new Error("disabled");
+  },
+  setItem() {
+    throw new Error("disabled");
+  },
+};
+assert.deepEqual(readMediaExportPreference(unavailableStorage), DEFAULT_MEDIA_EXPORT_PREFERENCE);
+assert.equal(
+  writeMediaExportPreference({ quality: "creator", fileType: "gif" }, unavailableStorage),
+  false,
+);
+
+console.log("media export preference checks passed");

--- a/tests/unit/sandbox/media-export-preference.test.ts
+++ b/tests/unit/sandbox/media-export-preference.test.ts
@@ -12,7 +12,14 @@ assert.deepEqual(parseMediaExportPreference(null), DEFAULT_MEDIA_EXPORT_PREFEREN
 assert.deepEqual(parseMediaExportPreference("not-json"), DEFAULT_MEDIA_EXPORT_PREFERENCE);
 assert.deepEqual(
   parseMediaExportPreference(JSON.stringify({ quality: "creator", fileType: "gif" })),
-  { quality: "creator", fileType: "gif" },
+  { quality: "creator", fileType: "gif", framing: "social-safe" },
+  "existing preferences should migrate to the creator-safe default",
+);
+assert.deepEqual(
+  parseMediaExportPreference(
+    JSON.stringify({ quality: "creator", fileType: "mp4", framing: "full" }),
+  ),
+  { quality: "creator", fileType: "mp4", framing: "full" },
 );
 assert.deepEqual(
   parseMediaExportPreference(JSON.stringify({ quality: "ultra", fileType: "mp4" })),
@@ -20,32 +27,61 @@ assert.deepEqual(
 );
 
 assert.equal(
-  getEffectiveMediaExportFileType({ quality: "standard", fileType: "mp4" }),
+  getEffectiveMediaExportFileType({
+    quality: "standard",
+    fileType: "mp4",
+    framing: "social-safe",
+  }),
   "gif",
 );
 assert.equal(
-  getEffectiveMediaExportFileType({ quality: "creator", fileType: "mp4" }),
+  getEffectiveMediaExportFileType({
+    quality: "creator",
+    fileType: "mp4",
+    framing: "social-safe",
+  }),
   "mp4",
 );
 
 let savedKey = "";
 let savedValue = "";
+const storedValues = new Map<string, string>();
 const storage = {
   getItem(key: string) {
-    return key === MEDIA_EXPORT_PREFERENCE_STORAGE_KEY ? savedValue || null : null;
+    return storedValues.get(key) ?? null;
   },
   setItem(key: string, value: string) {
     savedKey = key;
     savedValue = value;
+    storedValues.set(key, value);
   },
 };
 
+storedValues.set(
+  "minebench:media-export:v1",
+  JSON.stringify({ quality: "creator", fileType: "mp4" }),
+);
+assert.deepEqual(readMediaExportPreference(storage), {
+  quality: "creator",
+  fileType: "mp4",
+  framing: "social-safe",
+});
+assert.equal(savedKey, MEDIA_EXPORT_PREFERENCE_STORAGE_KEY);
+assert.ok(savedValue.includes('"framing":"social-safe"'));
+
 assert.equal(
-  writeMediaExportPreference({ quality: "creator", fileType: "mp4" }, storage),
+  writeMediaExportPreference(
+    { quality: "creator", fileType: "mp4", framing: "social-safe" },
+    storage,
+  ),
   true,
 );
 assert.equal(savedKey, MEDIA_EXPORT_PREFERENCE_STORAGE_KEY);
-assert.deepEqual(readMediaExportPreference(storage), { quality: "creator", fileType: "mp4" });
+assert.deepEqual(readMediaExportPreference(storage), {
+  quality: "creator",
+  fileType: "mp4",
+  framing: "social-safe",
+});
 
 const unavailableStorage = {
   getItem() {
@@ -57,7 +93,10 @@ const unavailableStorage = {
 };
 assert.deepEqual(readMediaExportPreference(unavailableStorage), DEFAULT_MEDIA_EXPORT_PREFERENCE);
 assert.equal(
-  writeMediaExportPreference({ quality: "creator", fileType: "gif" }, unavailableStorage),
+  writeMediaExportPreference(
+    { quality: "creator", fileType: "gif", framing: "full" },
+    unavailableStorage,
+  ),
   false,
 );
 


### PR DESCRIPTION
## Summary

- add Standard and Creator export preferences to Account, with Creator GIF/MP4 and Full/Social safe framing
- export six-second, 30 FPS H.264 MP4s at creator resolution with detail-preserving encoder settings and fallback profiles
- keep focal content inside vertical-platform safe areas while preserving a full-bleed composition and prominent branding
- use compact per-build headers with blocks, benchmark cost, exact or average inference time, and JSON size across Sandbox, Gallery, and saved builds
- preserve Standard GIF behavior, device-local preferences, cancellation, and encoder fallback

## Validation

- validated on Alpha at commit 70f5d453
- pnpm exec tsc --noEmit
- pnpm lint
- pnpm test (112 test files)
- pnpm build

*(PR written by Codex)*