### PR TITLE
fix(worker): bound shutdown drain and release in-flight jobs

### DIFF
--- a/lib/custom-builds/jobs.ts
+++ b/lib/custom-builds/jobs.ts
@@ -216,6 +216,42 @@ export async function completeCustomBuildJob(
   });
 }
 
+export async function releaseCustomBuildJob(
+  jobId: string,
+  workerId: string,
+  client: PrismaClient | PrismaTx = prisma,
+): Promise<boolean> {
+  const rows = await client.$queryRaw<Array<{ id: string; customBuildId: string; type: string }>>`
+    UPDATE "CustomBuildJob"
+    SET status = 'queued'::"CustomBuildJobStatus",
+        "lockedBy" = NULL,
+        "lockedAt" = NULL,
+        "leaseExpiresAt" = NULL,
+        "runAfter" = now(),
+        attempts = GREATEST(0, attempts - 1),
+        "updatedAt" = now()
+    WHERE id = ${jobId}
+      AND status = 'running'::"CustomBuildJobStatus"
+      AND "lockedBy" = ${workerId}
+    RETURNING id, "customBuildId", type::text;
+  `;
+  if (rows.length !== 1) return false;
+  const row = rows[0];
+  if (row?.type === "generate" && row.customBuildId) {
+    await client.customBuild.updateMany({
+      where: {
+        id: row.customBuildId,
+        status: "running",
+      },
+      data: {
+        status: "queued",
+        currentStage: "queued",
+      },
+    });
+  }
+  return true;
+}
+
 export async function failCustomBuildJob(
   jobId: string,
   workerId: string,

--- a/lib/custom-builds/lease.ts
+++ b/lib/custom-builds/lease.ts
@@ -5,12 +5,28 @@ export class CustomBuildLeaseLostError extends Error {
   }
 }
 
+export class CustomBuildWorkerShutdownError extends Error {
+  constructor(message = "Custom build worker is shutting down.") {
+    super(message);
+    this.name = "CustomBuildWorkerShutdownError";
+  }
+}
+
 export function isCustomBuildLeaseLostError(error: unknown): error is CustomBuildLeaseLostError {
   return error instanceof CustomBuildLeaseLostError;
 }
 
+export function isCustomBuildWorkerShutdownError(
+  error: unknown,
+): error is CustomBuildWorkerShutdownError {
+  return error instanceof CustomBuildWorkerShutdownError;
+}
+
 export function throwIfCustomBuildLeaseLost(signal?: AbortSignal): void {
   if (!signal?.aborted) return;
+  if (isCustomBuildWorkerShutdownError(signal.reason)) {
+    throw signal.reason;
+  }
   if (isCustomBuildLeaseLostError(signal.reason)) {
     throw signal.reason;
   }

--- a/lib/custom-builds/worker.ts
+++ b/lib/custom-builds/worker.ts
@@ -9,13 +9,16 @@ import {
   failCustomBuildJob,
   getCustomBuildJobLeaseSeconds,
   recoverStaleCustomBuildJobLeases,
+  releaseCustomBuildJob,
   renewCustomBuildJobLease,
 } from "@/lib/custom-builds/jobs";
 import { runCustomBuildExportJob } from "@/lib/custom-builds/exportJob";
 import { isTerminalCustomBuildGenerateError, runCustomBuildGenerateJob } from "@/lib/custom-builds/generateJob";
 import {
   CustomBuildLeaseLostError,
+  CustomBuildWorkerShutdownError,
   isCustomBuildLeaseLostError,
+  isCustomBuildWorkerShutdownError,
   throwIfCustomBuildLeaseLost,
 } from "@/lib/custom-builds/lease";
 import { redactSensitiveText } from "@/lib/custom-builds/sanitize";
@@ -43,6 +46,10 @@ export function getCustomBuildWorkerPollMs(): number {
 
 export function getCustomBuildWorkerConcurrency(): number {
   return readIntEnv("CUSTOM_BUILD_WORKER_CONCURRENCY", 10, 1, 20);
+}
+
+export function getCustomBuildWorkerShutdownGraceMs(): number {
+  return readIntEnv("CUSTOM_BUILD_WORKER_SHUTDOWN_GRACE_MS", 15_000, 1_000, 120_000);
 }
 
 export function getCustomBuildWorkerId(): string {
@@ -193,12 +200,12 @@ async function processClaimedJob(
   job: CustomBuildJob,
   workerId: string,
   processingGate: ReturnType<typeof createCustomBuildProcessingGate>,
+  leaseAbort = new AbortController(),
 ): Promise<{
   processed: boolean;
   jobId?: string;
   jobType?: string;
 }> {
-  const leaseAbort = new AbortController();
   const heartbeat = startCustomBuildJobHeartbeat(job, workerId, leaseAbort);
 
   try {
@@ -207,6 +214,11 @@ async function processClaimedJob(
     await completeCustomBuildJob(job.id, workerId);
     return { processed: true, jobId: job.id, jobType: job.type };
   } catch (error) {
+    if (isCustomBuildWorkerShutdownError(error)) {
+      console.warn(`custom build job ${job.id} releasing for worker shutdown`);
+      await releaseCustomBuildJob(job.id, workerId);
+      return { processed: false, jobId: job.id, jobType: job.type };
+    }
     if (isCustomBuildLeaseLostError(error)) {
       console.warn(`custom build job ${job.id} stopped: ${redactSensitiveText(error)}`);
       return { processed: true, jobId: job.id, jobType: job.type };
@@ -267,7 +279,9 @@ async function checkAndReportQueueHealth(): Promise<void> {
 export async function runCustomBuildWorkerLoop(workerId = getCustomBuildWorkerId()): Promise<void> {
   let shutdownRequested = false;
   const concurrency = getCustomBuildWorkerConcurrency();
+  const shutdownGraceMs = getCustomBuildWorkerShutdownGraceMs();
   const processingGate = createCustomBuildProcessingGate();
+  const activeControllers = new Set<AbortController>();
   const activeJobs = new Set<Promise<unknown>>();
   const heartbeat = startActiveGenerationsHeartbeat(
     () => activeJobs.size,
@@ -279,10 +293,22 @@ export async function runCustomBuildWorkerLoop(workerId = getCustomBuildWorkerId
   const queueHeartbeat = setInterval(() => {
     void checkAndReportQueueHealth();
   }, 30_000);
+  let shutdownTimer: NodeJS.Timeout | null = null;
+  const triggerShutdownAbort = () => {
+    for (const controller of activeControllers) {
+      if (!controller.signal.aborted) {
+        controller.abort(new CustomBuildWorkerShutdownError());
+      }
+    }
+  };
   const stop = () => {
     if (shutdownRequested) return;
     shutdownRequested = true;
     recordActiveGenerations(activeJobs.size, "worker", undefined, false);
+    if (activeJobs.size > 0 && !shutdownTimer) {
+      shutdownTimer = setTimeout(triggerShutdownAbort, shutdownGraceMs);
+      shutdownTimer.unref?.();
+    }
   };
   process.once("SIGINT", stop);
   process.once("SIGTERM", stop);
@@ -295,11 +321,19 @@ export async function runCustomBuildWorkerLoop(workerId = getCustomBuildWorkerId
         const job = await claimNextCustomBuildJob(workerId);
         if (!job) break;
         claimed = true;
-        const active = processClaimedJob(job, workerId, processingGate);
+        const controller = new AbortController();
+        activeControllers.add(controller);
+        const active = processClaimedJob(job, workerId, processingGate, controller);
         activeJobs.add(active);
         void active.then(
-          () => activeJobs.delete(active),
-          () => activeJobs.delete(active),
+          () => {
+            activeControllers.delete(controller);
+            activeJobs.delete(active);
+          },
+          () => {
+            activeControllers.delete(controller);
+            activeJobs.delete(active);
+          },
         );
       }
 
@@ -311,8 +345,14 @@ export async function runCustomBuildWorkerLoop(workerId = getCustomBuildWorkerId
       }
     }
 
+    if (shutdownRequested && activeJobs.size > 0 && !shutdownTimer) {
+      shutdownTimer = setTimeout(triggerShutdownAbort, shutdownGraceMs);
+      shutdownTimer.unref?.();
+    }
+
     await Promise.all(activeJobs);
   } finally {
+    if (shutdownTimer) clearTimeout(shutdownTimer);
     clearInterval(heartbeat);
     clearInterval(queueHeartbeat);
     await prisma.$disconnect();

--- a/tests/unit/custom-builds/jobs.test.ts
+++ b/tests/unit/custom-builds/jobs.test.ts
@@ -6,6 +6,7 @@ async function main() {
   const {
     failCustomBuildJob,
     recoverStaleCustomBuildJobLeases,
+    releaseCustomBuildJob,
     renewCustomBuildJobLease,
   } = await import("../../../lib/custom-builds/jobs");
 
@@ -144,6 +145,28 @@ async function main() {
   assert.equal(parentFailure?.status, "failed");
   assert.equal(parentFailure?.errorRetryable, false);
   assert.ok(parentFailure?.deletionPendingAt instanceof Date);
+
+  let releaseQuery = "";
+  const releaseUpdates: Array<Record<string, unknown>> = [];
+  const releaseClient = {
+    $queryRaw: async (strings: TemplateStringsArray) => {
+      releaseQuery = strings.join("?");
+      return [{ id: "released-job-row", customBuildId: "released-build-row", type: "generate" }];
+    },
+    customBuild: {
+      updateMany: async (args: { data: Record<string, unknown> }) => {
+        releaseUpdates.push(args.data);
+        return { count: 1 };
+      },
+    },
+  };
+  const released = await releaseCustomBuildJob("released-job-row", "worker-row", releaseClient as never);
+  assert.equal(released, true);
+  assert.match(releaseQuery, /status = 'queued'/);
+  assert.match(releaseQuery, /attempts = GREATEST\(0, attempts - 1\)/);
+  assert.equal(releaseUpdates.length, 1);
+  assert.equal(releaseUpdates[0]?.status, "queued");
+  assert.equal(releaseUpdates[0]?.currentStage, "queued");
 
   console.log("custom build stale job recovery checks passed");
 }

--- a/tests/unit/custom-builds/worker.test.ts
+++ b/tests/unit/custom-builds/worker.test.ts
@@ -18,6 +18,7 @@ async function main() {
     getCustomBuildWorkerConcurrency,
     getCustomBuildWorkerHeartbeatMs,
     getCustomBuildWorkerId,
+    getCustomBuildWorkerShutdownGraceMs,
     isTerminalCustomBuildJobFailure,
   } = await import("../../../lib/custom-builds/worker");
 
@@ -26,6 +27,16 @@ async function main() {
     true,
     "a terminally failed build must not leave its job runnable",
   );
+
+  assert.equal(
+    getCustomBuildWorkerShutdownGraceMs(),
+    15_000,
+    "worker shutdown grace period should default to 15s",
+  );
+
+  process.env.CUSTOM_BUILD_WORKER_SHUTDOWN_GRACE_MS = "5000";
+  assert.equal(getCustomBuildWorkerShutdownGraceMs(), 5_000);
+  delete process.env.CUSTOM_BUILD_WORKER_SHUTDOWN_GRACE_MS;
 
   assert.equal(
     getCustomBuildWorkerConcurrency(),
@@ -135,6 +146,11 @@ async function main() {
     workerSource.includes("isCustomBuildLeaseLostError(error)") &&
       workerSource.includes("return { processed: true, jobId: job.id, jobType: job.type };"),
     "lost leases should stop the worker path without failing a job it may no longer own",
+  );
+  assert.ok(
+    workerSource.includes("isCustomBuildWorkerShutdownError(error)") &&
+      workerSource.includes("await releaseCustomBuildJob(job.id, workerId);"),
+    "worker shutdown should cleanly release claimed jobs back to queued status",
   );
   assert.ok(
     workerSource.includes("const queueHeartbeat = setInterval") &&


### PR DESCRIPTION
### Summary

Bounds generation worker shutdown drain duration and enables clean, atomic job releasing on worker restart/shutdown to prevent queue starvation and stuck jobs.

### Key Changes
- **`lib/custom-builds/lease.ts`**: Define `CustomBuildWorkerShutdownError` and update `throwIfCustomBuildLeaseLost` to propagate shutdown cancellation.
- **`lib/custom-builds/jobs.ts`**: Add `releaseCustomBuildJob` to atomically return a running job to `status: 'queued'`, clear leases, reset `runAfter` to `now()`, and decrement `attempts` so interrupted runs do not penalize retry budgets.
- **`lib/custom-builds/worker.ts`**: Add configurable `CUSTOM_BUILD_WORKER_SHUTDOWN_GRACE_MS` (default 15s) in `runCustomBuildWorkerLoop`. When `SIGTERM`/`SIGINT` occurs, in-flight jobs are given a 15s grace period before being aborted and released back to the queue.
- **Tests**: Add unit test coverage in `tests/unit/custom-builds/worker.test.ts` and `tests/unit/custom-builds/jobs.test.ts`.

*(PR written by Codex)*