### PR TITLE
(feat) gallery: add vertical example carousel, quick search, and skeletons

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 <p align="center">
   <a href="https://minebench.ai"><img alt="Live" src="https://img.shields.io/badge/Live-minebench.ai-0ea5e9?style=flat&logo=vercel&logoColor=white" /></a>
   <a href="https://alpha.minebench.ai"><img alt="Alpha" src="https://img.shields.io/badge/Alpha-alpha.minebench.ai-f59e0b?style=flat&logo=vercel&logoColor=white" /></a>
+  <a href="https://apps.apple.com/app/minebench/id6803704037"><img alt="App Store" src="https://img.shields.io/badge/App%20Store-iOS-000000?style=flat&logo=apple&logoColor=white" /></a>
   <a href="https://github.com/Ammaar-Alam/minebench/releases/latest"><img alt="Latest Release" src="https://img.shields.io/github/v/release/Ammaar-Alam/minebench?style=flat&color=22c55e&label=release&display_name=tag" /></a>
   <a href="LICENSE"><img alt="License: MIT" src="https://img.shields.io/badge/License-MIT-3b82f6?style=flat" /></a>
 </p>

--- a/app/gallery/loading.tsx
+++ b/app/gallery/loading.tsx
@@ -1,0 +1,57 @@
+import Link from "next/link";
+import { GallerySkeletonGrid } from "@/components/gallery/GalleryExplore";
+
+export default function GalleryLoading() {
+  return (
+    <div className="mb-fade-in mx-auto w-full max-w-7xl py-4 sm:py-8">
+      <header className="flex flex-col gap-6 sm:flex-row sm:items-end sm:justify-between">
+        <div>
+          <h1 className="font-display text-3xl font-semibold tracking-tight text-fg sm:text-4xl">Gallery</h1>
+          <p className="mt-2 max-w-md text-sm text-muted">
+            Use a prompt, build it, share the result.
+          </p>
+        </div>
+        <div className="flex flex-wrap items-center gap-3">
+          <Link href="/account#builds" className="inline-flex min-h-11 items-center px-2 text-sm font-semibold text-muted transition-colors hover:text-fg motion-reduce:transition-none">
+            Builds
+          </Link>
+          <Link href="/sign-in?next=/gallery" className="mb-btn mb-btn-primary h-11">
+            Sign in
+          </Link>
+        </div>
+      </header>
+
+      <div className="mt-10 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+        <nav className="flex items-center gap-7" aria-label="Gallery sorting">
+          <span className="relative inline-flex min-h-11 items-center text-sm font-semibold capitalize text-fg after:absolute after:inset-x-0 after:bottom-0 after:h-0.5 after:bg-fg">
+            Top
+          </span>
+          <span className="relative inline-flex min-h-11 items-center text-sm capitalize text-muted">
+            New
+          </span>
+        </nav>
+
+        <div className="relative w-full sm:w-64 md:w-72">
+          <span aria-hidden="true" className="pointer-events-none absolute left-3.5 top-1/2 -translate-y-1/2 text-muted">
+            <svg aria-hidden="true" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.75" strokeLinecap="round" strokeLinejoin="round" className="h-4 w-4">
+              <circle cx="7" cy="7" r="4.5" />
+              <path d="M10.5 10.5L14 14" />
+            </svg>
+          </span>
+          <input
+            type="search"
+            disabled
+            placeholder="Search prompts…"
+            aria-label="Search prompts"
+            className="mb-field h-10 w-full pl-9 pr-9 text-sm placeholder:text-muted/60"
+          />
+          <span aria-hidden="true" className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 hidden rounded border border-border/70 bg-card/40 px-1.5 py-0.5 font-mono text-[10px] text-muted sm:inline-block">
+            /
+          </span>
+        </div>
+      </div>
+
+      <GallerySkeletonGrid count={8} />
+    </div>
+  );
+}

--- a/components/gallery/GalleryDetail.tsx
+++ b/components/gallery/GalleryDetail.tsx
@@ -169,6 +169,33 @@ export function GalleryDetail({ candidate }: { candidate: GalleryDetailPayload }
   const [reportOpen, setReportOpen] = useState(false);
   const [removing, setRemoving] = useState(false);
   const [actionError, setActionError] = useState<string | null>(null);
+  const examplesScrollRef = useRef<HTMLDivElement>(null);
+  const [canScrollUp, setCanScrollUp] = useState(false);
+  const [canScrollDown, setCanScrollDown] = useState(false);
+
+  const updateScrollState = useCallback(() => {
+    const el = examplesScrollRef.current;
+    if (!el) return;
+    const { scrollTop, scrollHeight, clientHeight } = el;
+    setCanScrollUp(scrollTop > 4);
+    setCanScrollDown(scrollTop + clientHeight < scrollHeight - 4);
+  }, []);
+
+  useEffect(() => {
+    updateScrollState();
+    const el = examplesScrollRef.current;
+    if (!el) return;
+    const handleResize = () => updateScrollState();
+    window.addEventListener("resize", handleResize);
+    return () => window.removeEventListener("resize", handleResize);
+  }, [examples, updateScrollState]);
+
+  function scrollExamples(direction: "up" | "down") {
+    const el = examplesScrollRef.current;
+    if (!el) return;
+    const delta = direction === "up" ? -240 : 240;
+    el.scrollBy({ top: delta, behavior: "smooth" });
+  }
   const selectedExamples = selectedIds
     .map((id) => examples.find((example) => example.id === id))
     .filter((example): example is GalleryExamplePayload => Boolean(example));
@@ -418,9 +445,9 @@ export function GalleryDetail({ candidate }: { candidate: GalleryDetailPayload }
       {actionError ? <p role="alert" className="mt-5 text-sm text-danger">{actionError}</p> : null}
 
       {selected ? (
-        <section className="mt-10 grid gap-6 sm:mt-12 lg:grid-cols-[minmax(0,1fr)_18rem]" aria-labelledby="viewer-title">
+        <section className="mt-10 grid gap-6 sm:mt-12 lg:grid-cols-[minmax(0,1fr)_18rem] lg:items-start" aria-labelledby="viewer-title">
           {selectedExamples.length > 1 ? (
-            <div className="min-w-0">
+            <div className="min-w-0 self-start">
               <div className="mb-3 flex min-h-9 flex-wrap items-center justify-between gap-3">
                 <p className="mb-eyebrow">Compare</p>
                 <SandboxGifExportButton
@@ -438,46 +465,138 @@ export function GalleryDetail({ candidate }: { candidate: GalleryDetailPayload }
                 ))}
               </div>
             </div>
-          ) : renderViewerCard(selected, false)}
-          <div>
+          ) : (
+            <div className="min-w-0 self-start">
+              {renderViewerCard(selected, false)}
+            </div>
+          )}
+          <div className="min-w-0 self-start lg:sticky lg:top-4">
             <div className="flex min-h-9 items-center justify-between gap-3">
-              <h2 id="viewer-title" className="mb-eyebrow">Examples</h2>
-              {examples.length > 1 ? (
-                <button
-                  type="button"
-                  aria-pressed={compareMode}
-                  className="min-h-9 rounded px-2 text-xs font-medium text-muted transition-colors hover:text-fg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/45 motion-reduce:transition-none"
-                  onClick={() => {
-                    if (compareMode) {
-                      setCompareMode(false);
-                      setSelectedIds(selectedIds.slice(0, 1));
-                    } else {
-                      setCompareMode(true);
-                    }
-                  }}
-                >
-                  {compareMode ? "Single" : "Compare"}
-                </button>
-              ) : null}
+              <div className="flex items-center gap-2">
+                <h2 id="viewer-title" className="mb-eyebrow">Examples</h2>
+                {examples.length > 1 ? (
+                  <span className="rounded-full border border-border/70 bg-card/20 px-1.5 py-0.5 font-mono text-[10px] text-muted">
+                    {examples.length}
+                  </span>
+                ) : null}
+              </div>
+              <div className="flex items-center gap-1">
+                {examples.length > 2 ? (
+                  <div className="hidden items-center gap-1 lg:flex">
+                    <button
+                      type="button"
+                      aria-label="Previous example"
+                      disabled={!canScrollUp}
+                      onClick={() => scrollExamples("up")}
+                      className="grid h-7 w-7 place-items-center rounded border border-border/70 bg-card/20 text-muted transition-[background-color,color,opacity] hover:bg-card/60 hover:text-fg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/45 disabled:pointer-events-none disabled:opacity-20 motion-reduce:transition-none"
+                    >
+                      <svg aria-hidden="true" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.75" strokeLinecap="round" strokeLinejoin="round" className="h-3.5 w-3.5">
+                        <path d="M3.5 10L8 5.5L12.5 10" />
+                      </svg>
+                    </button>
+                    <button
+                      type="button"
+                      aria-label="Next example"
+                      disabled={!canScrollDown}
+                      onClick={() => scrollExamples("down")}
+                      className="grid h-7 w-7 place-items-center rounded border border-border/70 bg-card/20 text-muted transition-[background-color,color,opacity] hover:bg-card/60 hover:text-fg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/45 disabled:pointer-events-none disabled:opacity-20 motion-reduce:transition-none"
+                    >
+                      <svg aria-hidden="true" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.75" strokeLinecap="round" strokeLinejoin="round" className="h-3.5 w-3.5">
+                        <path d="M3.5 6L8 10.5L12.5 6" />
+                      </svg>
+                    </button>
+                  </div>
+                ) : null}
+                {examples.length > 1 ? (
+                  <button
+                    type="button"
+                    aria-pressed={compareMode}
+                    className="min-h-8 rounded px-2 text-xs font-medium text-muted transition-colors hover:text-fg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/45 motion-reduce:transition-none"
+                    onClick={() => {
+                      if (compareMode) {
+                        setCompareMode(false);
+                        setSelectedIds(selectedIds.slice(0, 1));
+                      } else {
+                        setCompareMode(true);
+                      }
+                    }}
+                  >
+                    {compareMode ? "Single" : "Compare"}
+                  </button>
+                ) : null}
+              </div>
             </div>
-            <div className="mt-3 grid grid-cols-2 gap-2 lg:grid-cols-1">
-              {examples.map((example) => {
-                const selectedOrder = selectedIds.indexOf(example.id);
-                const atLimit = compareMode && selectedOrder < 0 && selectedIds.length >= MAX_COMPARISON_EXAMPLES;
-                return (
-                <button key={example.id} type="button" aria-pressed={selectedOrder >= 0} aria-disabled={atLimit || undefined} onClick={(event) => selectExample(event, example.id)} className={`group/example relative min-w-0 overflow-hidden rounded-md border text-left transition-[transform,border-color,background-color,opacity] duration-200 ease-out hover:-translate-y-0.5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/50 active:translate-y-0 motion-reduce:transform-none motion-reduce:transition-none ${selectedOrder >= 0 ? "border-accent/65 bg-accent/5" : "border-border bg-card/10 hover:border-muted"} ${atLimit ? "opacity-50" : ""}`}>
-                  {compareMode && selectedOrder >= 0 ? <span aria-hidden="true" className="absolute right-2 top-2 z-10 grid h-6 w-6 place-items-center rounded-full bg-accent text-xs font-semibold text-bg shadow-soft">{selectedOrder + 1}</span> : null}
-                  {example.previewUrl ? <div className="relative aspect-[16/9] bg-bg"><Image src={example.previewUrl} alt="" fill unoptimized sizes="18rem" className="object-contain p-1.5 transition-transform duration-300 ease-out group-hover/example:scale-[1.025] motion-reduce:transition-none" /></div> : null}
-                  <div className="p-3"><p className="truncate text-sm font-medium text-fg">{example.model.label}</p><p className="mt-1 truncate text-xs text-muted">{example.attribution}</p><p className="mt-2 flex flex-wrap gap-x-2 font-mono text-[10px] text-muted">{example.blockCount != null ? <span>{example.blockCount.toLocaleString()} blocks</span> : null}{formatBuildJsonSize(example.jsonBytes) ? <span>{formatBuildJsonSize(example.jsonBytes)} JSON</span> : null}{formatBuildDuration(example.generationTimeMs) ? <span>{formatBuildDuration(example.generationTimeMs)}</span> : null}</p></div>
-                </button>
-                );
-              })}
+            <div className="relative mt-3">
+              <div
+                aria-hidden="true"
+                className={`pointer-events-none absolute inset-x-0 top-0 z-10 hidden h-8 bg-gradient-to-b from-bg to-transparent transition-opacity duration-200 lg:block ${canScrollUp ? "opacity-100" : "opacity-0"}`}
+              />
+              <div
+                ref={examplesScrollRef}
+                onScroll={updateScrollState}
+                className="grid grid-cols-2 gap-2 lg:max-h-[520px] xl:max-h-[560px] lg:flex lg:flex-col lg:overflow-y-auto lg:overscroll-contain lg:scroll-smooth lg:snap-y lg:snap-proximity [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+              >
+                {examples.map((example) => {
+                  const selectedOrder = selectedIds.indexOf(example.id);
+                  const atLimit = compareMode && selectedOrder < 0 && selectedIds.length >= MAX_COMPARISON_EXAMPLES;
+                  return (
+                    <button
+                      key={example.id}
+                      type="button"
+                      aria-pressed={selectedOrder >= 0}
+                      aria-disabled={atLimit || undefined}
+                      onClick={(event) => selectExample(event, example.id)}
+                      className={`group/example relative min-w-0 shrink-0 snap-start overflow-hidden rounded-md border text-left transition-[transform,border-color,background-color,opacity,box-shadow] duration-200 ease-out hover:-translate-y-0.5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/50 active:translate-y-0 motion-reduce:transform-none motion-reduce:transition-none ${
+                        selectedOrder >= 0
+                          ? "border-accent/65 bg-accent/5 shadow-soft"
+                          : "border-border bg-card/10 hover:border-muted hover:bg-card/20"
+                      } ${atLimit ? "opacity-50" : ""}`}
+                    >
+                      {compareMode && selectedOrder >= 0 ? (
+                        <span aria-hidden="true" className="absolute right-2 top-2 z-10 grid h-6 w-6 place-items-center rounded-full bg-accent text-xs font-semibold text-bg shadow-soft">
+                          {selectedOrder + 1}
+                        </span>
+                      ) : null}
+                      {example.previewUrl ? (
+                        <div className="relative aspect-[16/9] bg-bg">
+                          <Image
+                            src={example.previewUrl}
+                            alt=""
+                            fill
+                            unoptimized
+                            sizes="18rem"
+                            className="object-contain p-1.5 transition-transform duration-300 ease-out group-hover/example:scale-[1.025] motion-reduce:transition-none"
+                          />
+                        </div>
+                      ) : null}
+                      <div className="p-3">
+                        <p className="truncate text-sm font-medium text-fg">{example.model.label}</p>
+                        <p className="mt-1 truncate text-xs text-muted">{example.attribution}</p>
+                        <p className="mt-2 flex flex-wrap gap-x-2 font-mono text-[10px] text-muted">
+                          {example.blockCount != null ? <span>{example.blockCount.toLocaleString()} blocks</span> : null}
+                          {formatBuildJsonSize(example.jsonBytes) ? <span>{formatBuildJsonSize(example.jsonBytes)} JSON</span> : null}
+                          {formatBuildDuration(example.generationTimeMs) ? <span>{formatBuildDuration(example.generationTimeMs)}</span> : null}
+                        </p>
+                      </div>
+                    </button>
+                  );
+                })}
+                {nextExamplesCursor ? (
+                  <button
+                    type="button"
+                    className="mb-btn mt-1 h-10 w-full shrink-0"
+                    disabled={loadingMore}
+                    onClick={() => void loadMoreExamples()}
+                  >
+                    {loadingMore ? "Loading…" : "More examples"}
+                  </button>
+                ) : null}
+              </div>
+              <div
+                aria-hidden="true"
+                className={`pointer-events-none absolute inset-x-0 bottom-0 z-10 hidden h-6 bg-gradient-to-t from-bg to-transparent transition-opacity duration-200 lg:block ${canScrollDown ? "opacity-100" : "opacity-0"}`}
+              />
             </div>
-            {nextExamplesCursor ? (
-              <button type="button" className="mb-btn mt-3 h-10 w-full" disabled={loadingMore} onClick={() => void loadMoreExamples()}>
-                {loadingMore ? "Loading…" : "More examples"}
-              </button>
-            ) : null}
             {examplesError ? <p className="mt-2 text-xs text-danger">{examplesError}</p> : null}
           </div>
         </section>

--- a/components/gallery/GalleryExplore.tsx
+++ b/components/gallery/GalleryExplore.tsx
@@ -3,11 +3,55 @@
 import Image from "next/image";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useDeferredValue, useMemo, useRef, useState } from "react";
 import type { GalleryCandidatePayload } from "@/lib/gallery/service";
 import { GalleryVoteButton } from "@/components/gallery/GalleryVoteButton";
 import { VoxelEmptyState } from "@/components/voxel/VoxelEmptyState";
 import { formatBuildDuration, formatBuildJsonSize } from "@/lib/buildMetrics";
+
+export function GalleryCardSkeleton({ delayed = false }: { delayed?: boolean }) {
+  return (
+    <article
+      aria-hidden="true"
+      className={`flex min-w-0 flex-col overflow-hidden rounded-md border border-border/70 bg-card/10 ${delayed ? "mb-card-enter-delay" : ""}`}
+    >
+      <div className="relative aspect-[4/3] overflow-hidden bg-bg/40">
+        <div className="absolute inset-0 animate-pulse bg-card/25" />
+      </div>
+      <div className="flex flex-1 flex-col gap-3 p-5">
+        <div className="flex items-center justify-between gap-3">
+          <div className="h-3 w-20 animate-pulse rounded bg-border/50" />
+          <div className="h-3 w-12 animate-pulse rounded bg-border/30" />
+        </div>
+        <div className="space-y-2">
+          <div className="h-5 w-4/5 animate-pulse rounded bg-border/45" />
+          <div className="h-5 w-3/5 animate-pulse rounded bg-border/35" />
+        </div>
+        <div className="mt-auto flex items-center gap-2 pt-3">
+          <div className="h-3.5 w-32 animate-pulse rounded bg-border/30" />
+        </div>
+        <div className="flex flex-wrap gap-x-3 gap-y-1">
+          <div className="h-3 w-16 animate-pulse rounded bg-border/25" />
+          <div className="h-3 w-14 animate-pulse rounded bg-border/25" />
+        </div>
+      </div>
+      <div className="flex items-center justify-between border-t border-border/40 px-3 py-2">
+        <div className="h-7 w-12 animate-pulse rounded bg-border/30" />
+        <div className="h-7 w-20 animate-pulse rounded bg-border/30" />
+      </div>
+    </article>
+  );
+}
+
+export function GallerySkeletonGrid({ count = 8 }: { count?: number }) {
+  return (
+    <div className="mt-7 grid grid-cols-1 gap-5 md:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4" aria-busy="true" aria-label="Loading gallery prompts">
+      {Array.from({ length: count }, (_, i) => (
+        <GalleryCardSkeleton key={i} delayed={i % 2 === 1} />
+      ))}
+    </div>
+  );
+}
 
 function SubmissionDialog({
   open,
@@ -159,14 +203,53 @@ export function GalleryExplore({
   const [cursor, setCursor] = useState(initialCursor);
   const [activeSort, setActiveSort] = useState(sort);
   const [loading, setLoading] = useState(false);
+  const [loadingMore, setLoadingMore] = useState(false);
   const [loadError, setLoadError] = useState<string | null>(null);
   const [submitOpen, setSubmitOpen] = useState(false);
+  const [searchQuery, setSearchQuery] = useState("");
+  const deferredQuery = useDeferredValue(searchQuery);
+  const searchInputRef = useRef<HTMLInputElement>(null);
+
+  const normalizedQuery = deferredQuery.trim().toLowerCase();
+  const visibleItems = useMemo(() => {
+    if (!normalizedQuery) return items;
+    return items.filter((item) => {
+      if (item.prompt.toLowerCase().includes(normalizedQuery)) return true;
+      if (item.attribution.toLowerCase().includes(normalizedQuery)) return true;
+      if (item.cover?.model.label.toLowerCase().includes(normalizedQuery)) return true;
+      if (item.alternate?.model.label.toLowerCase().includes(normalizedQuery)) return true;
+      return false;
+    });
+  }, [items, normalizedQuery]);
 
   useEffect(() => {
     setItems(initialItems);
     setCursor(initialCursor);
     setActiveSort(sort);
   }, [initialCursor, initialItems, sort]);
+
+  useEffect(() => {
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.defaultPrevented || event.repeat || event.isComposing) return;
+      const target = event.target;
+      if (
+        target instanceof HTMLElement &&
+        (target.isContentEditable || target.closest("input, textarea, select, dialog, [contenteditable='true']"))
+      ) {
+        if (event.key === "Escape" && target === searchInputRef.current) {
+          setSearchQuery("");
+          searchInputRef.current?.blur();
+        }
+        return;
+      }
+      if (event.key === "/" && !event.metaKey && !event.ctrlKey && !event.altKey) {
+        event.preventDefault();
+        searchInputRef.current?.focus();
+      }
+    }
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, []);
 
   async function changeSort(nextSort: "top" | "new") {
     if (nextSort === activeSort || loading) return;
@@ -188,8 +271,8 @@ export function GalleryExplore({
   }
 
   async function loadMore() {
-    if (!cursor || loading) return;
-    setLoading(true);
+    if (!cursor || loading || loadingMore) return;
+    setLoadingMore(true);
     setLoadError(null);
     try {
       const response = await fetch(`/api/gallery/candidates?sort=${activeSort}&cursor=${encodeURIComponent(cursor)}`, { cache: "no-store" });
@@ -200,7 +283,7 @@ export function GalleryExplore({
     } catch {
       setLoadError("Gallery unavailable");
     } finally {
-      setLoading(false);
+      setLoadingMore(false);
     }
   }
 
@@ -223,34 +306,97 @@ export function GalleryExplore({
         </div>
       </header>
 
-      <nav className="mt-10 flex items-center gap-7" aria-label="Gallery sorting">
-        {(["top", "new"] as const).map((option) => (
-          <button
-            key={option}
-            type="button"
-            disabled={loading}
-            aria-current={activeSort === option ? "page" : undefined}
-            className={`relative inline-flex min-h-11 items-center text-sm capitalize transition-colors after:absolute after:inset-x-0 after:bottom-0 after:h-0.5 after:origin-left after:bg-fg after:transition-transform after:duration-200 after:ease-out motion-reduce:transition-none motion-reduce:after:transition-none ${activeSort === option ? "font-semibold text-fg after:scale-x-100" : "text-muted after:scale-x-0 hover:text-fg"}`}
-            onClick={() => void changeSort(option)}
-          >
-            {option}
-          </button>
-        ))}
-      </nav>
+      <div className="mt-10 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+        <nav className="flex items-center gap-7" aria-label="Gallery sorting">
+          {(["top", "new"] as const).map((option) => (
+            <button
+              key={option}
+              type="button"
+              disabled={loading}
+              aria-current={activeSort === option ? "page" : undefined}
+              className={`relative inline-flex min-h-11 items-center text-sm capitalize transition-colors after:absolute after:inset-x-0 after:bottom-0 after:h-0.5 after:origin-left after:bg-fg after:transition-transform after:duration-200 after:ease-out motion-reduce:transition-none motion-reduce:after:transition-none ${activeSort === option ? "font-semibold text-fg after:scale-x-100" : "text-muted after:scale-x-0 hover:text-fg"}`}
+              onClick={() => void changeSort(option)}
+            >
+              {option}
+            </button>
+          ))}
+        </nav>
+
+        <div className="relative w-full sm:w-64 md:w-72">
+          <span aria-hidden="true" className="pointer-events-none absolute left-3.5 top-1/2 -translate-y-1/2 text-muted">
+            <svg aria-hidden="true" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.75" strokeLinecap="round" strokeLinejoin="round" className="h-4 w-4">
+              <circle cx="7" cy="7" r="4.5" />
+              <path d="M10.5 10.5L14 14" />
+            </svg>
+          </span>
+          <input
+            ref={searchInputRef}
+            type="search"
+            placeholder="Search prompts…"
+            value={searchQuery}
+            onChange={(event) => setSearchQuery(event.target.value)}
+            aria-label="Search prompts"
+            className="mb-field h-10 w-full pl-9 pr-9 text-sm placeholder:text-muted/60 focus-visible:ring-2 focus-visible:ring-accent/50"
+          />
+          {searchQuery ? (
+            <button
+              type="button"
+              aria-label="Clear search"
+              onClick={() => {
+                setSearchQuery("");
+                searchInputRef.current?.focus();
+              }}
+              className="absolute right-2.5 top-1/2 -translate-y-1/2 rounded p-1 text-muted transition-colors hover:text-fg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/45"
+            >
+              <svg aria-hidden="true" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.75" strokeLinecap="round" strokeLinejoin="round" className="h-3.5 w-3.5">
+                <path d="M4 4L12 12M12 4L4 12" />
+              </svg>
+            </button>
+          ) : (
+            <span aria-hidden="true" className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 hidden rounded border border-border/70 bg-card/40 px-1.5 py-0.5 font-mono text-[10px] text-muted sm:inline-block">
+              /
+            </span>
+          )}
+        </div>
+      </div>
 
       <div key={activeSort} className="mb-fade-in">
-        {items.length ? (
+        {loading ? (
+          <GallerySkeletonGrid count={8} />
+        ) : visibleItems.length ? (
           <div className="mt-7 grid grid-cols-1 gap-5 md:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4">
-            {items.map((candidate, index) => <GalleryCard key={candidate.id} candidate={candidate} delayed={index % 2 === 1} sort={activeSort} />)}
+            {visibleItems.map((candidate, index) => <GalleryCard key={candidate.id} candidate={candidate} delayed={index % 2 === 1} sort={activeSort} />)}
+            {loadingMore ? (
+              Array.from({ length: 4 }, (_, i) => (
+                <GalleryCardSkeleton key={`loading-more-${i}`} delayed={i % 2 === 1} />
+              ))
+            ) : null}
           </div>
         ) : (
-          <section className="mt-14 py-10 sm:mt-20 sm:py-14" aria-labelledby="empty-gallery-title">
-            <h2 id="empty-gallery-title" className="font-display text-xl font-semibold tracking-tight text-muted sm:text-2xl">No prompts yet.</h2>
+          <section className="mt-14 py-10 text-center sm:mt-20 sm:py-14" aria-labelledby="empty-gallery-title">
+            <h2 id="empty-gallery-title" className="font-display text-xl font-semibold tracking-tight text-muted sm:text-2xl">
+              {searchQuery ? "No matching prompts." : "No prompts yet."}
+            </h2>
+            {searchQuery ? (
+              <button
+                type="button"
+                onClick={() => setSearchQuery("")}
+                className="mb-btn mt-4 h-10 text-sm"
+              >
+                Clear search
+              </button>
+            ) : null}
           </section>
         )}
       </div>
 
-      {cursor ? <div className="mt-12 flex justify-center"><button type="button" className="mb-btn h-11 min-w-36" disabled={loading} onClick={() => void loadMore()}>{loading ? "Loading…" : "More"}</button></div> : null}
+      {cursor && !searchQuery && !loading ? (
+        <div className="mt-12 flex justify-center">
+          <button type="button" className="mb-btn h-11 min-w-36" disabled={loadingMore} onClick={() => void loadMore()}>
+            {loadingMore ? "Loading…" : "More"}
+          </button>
+        </div>
+      ) : null}
       {loadError ? <p role="status" className="mt-6 text-center text-sm text-danger">{loadError}</p> : null}
       <SubmissionDialog open={submitOpen} hasNickname={hasNickname} onClose={() => setSubmitOpen(false)} />
     </div>

--- a/components/gallery/GalleryExplore.tsx
+++ b/components/gallery/GalleryExplore.tsx
@@ -222,10 +222,14 @@ export function GalleryExplore({
     });
   }, [items, normalizedQuery]);
 
+  const activeSortRef = useRef(activeSort);
+  activeSortRef.current = activeSort;
+
   useEffect(() => {
     setItems(initialItems);
     setCursor(initialCursor);
     setActiveSort(sort);
+    activeSortRef.current = sort;
   }, [initialCursor, initialItems, sort]);
 
   useEffect(() => {
@@ -252,7 +256,7 @@ export function GalleryExplore({
   }, []);
 
   async function changeSort(nextSort: "top" | "new") {
-    if (nextSort === activeSort || loading) return;
+    if (nextSort === activeSort || loading || loadingMore) return;
     setLoading(true);
     setLoadError(null);
     try {
@@ -262,6 +266,7 @@ export function GalleryExplore({
       setItems(page.items);
       setCursor(page.nextCursor);
       setActiveSort(nextSort);
+      activeSortRef.current = nextSort;
       window.history.replaceState(window.history.state, "", nextSort === "new" ? "/gallery?sort=new" : "/gallery");
     } catch {
       setLoadError("Gallery unavailable");
@@ -272,18 +277,24 @@ export function GalleryExplore({
 
   async function loadMore() {
     if (!cursor || loading || loadingMore) return;
+    const requestSort = activeSort;
     setLoadingMore(true);
     setLoadError(null);
     try {
-      const response = await fetch(`/api/gallery/candidates?sort=${activeSort}&cursor=${encodeURIComponent(cursor)}`, { cache: "no-store" });
+      const response = await fetch(`/api/gallery/candidates?sort=${requestSort}&cursor=${encodeURIComponent(cursor)}`, { cache: "no-store" });
       const page = (await response.json()) as { items: GalleryCandidatePayload[]; nextCursor: string | null };
       if (!response.ok) throw new Error("Gallery unavailable");
+      if (activeSortRef.current !== requestSort) return;
       setItems((current) => [...current, ...page.items]);
       setCursor(page.nextCursor);
     } catch {
-      setLoadError("Gallery unavailable");
+      if (activeSortRef.current === requestSort) {
+        setLoadError("Gallery unavailable");
+      }
     } finally {
-      setLoadingMore(false);
+      if (activeSortRef.current === requestSort) {
+        setLoadingMore(false);
+      }
     }
   }
 
@@ -312,7 +323,7 @@ export function GalleryExplore({
             <button
               key={option}
               type="button"
-              disabled={loading}
+              disabled={loading || loadingMore}
               aria-current={activeSort === option ? "page" : undefined}
               className={`relative inline-flex min-h-11 items-center text-sm capitalize transition-colors after:absolute after:inset-x-0 after:bottom-0 after:h-0.5 after:origin-left after:bg-fg after:transition-transform after:duration-200 after:ease-out motion-reduce:transition-none motion-reduce:after:transition-none ${activeSort === option ? "font-semibold text-fg after:scale-x-100" : "text-muted after:scale-x-0 hover:text-fg"}`}
               onClick={() => void changeSort(option)}
@@ -377,23 +388,35 @@ export function GalleryExplore({
             <h2 id="empty-gallery-title" className="font-display text-xl font-semibold tracking-tight text-muted sm:text-2xl">
               {searchQuery ? "No matching prompts." : "No prompts yet."}
             </h2>
-            {searchQuery ? (
-              <button
-                type="button"
-                onClick={() => setSearchQuery("")}
-                className="mb-btn mt-4 h-10 text-sm"
-              >
-                Clear search
-              </button>
-            ) : null}
+            <div className="mt-4 flex flex-wrap items-center justify-center gap-3">
+              {searchQuery ? (
+                <button
+                  type="button"
+                  onClick={() => setSearchQuery("")}
+                  className="mb-btn h-10 text-sm"
+                >
+                  Clear search
+                </button>
+              ) : null}
+              {cursor && searchQuery ? (
+                <button
+                  type="button"
+                  disabled={loadingMore}
+                  onClick={() => void loadMore()}
+                  className="mb-btn mb-btn-primary h-10 text-sm"
+                >
+                  {loadingMore ? "Loading…" : "Load more prompts"}
+                </button>
+              ) : null}
+            </div>
           </section>
         )}
       </div>
 
-      {cursor && !searchQuery && !loading ? (
+      {cursor && !loading ? (
         <div className="mt-12 flex justify-center">
           <button type="button" className="mb-btn h-11 min-w-36" disabled={loadingMore} onClick={() => void loadMore()}>
-            {loadingMore ? "Loading…" : "More"}
+            {loadingMore ? "Loading…" : searchQuery ? "Load more prompts" : "More"}
           </button>
         </div>
       ) : null}


### PR DESCRIPTION
## Summary

- **Vertical Example Carousel**: In `components/gallery/GalleryDetail.tsx`, constrained the example card list to a scrollable vertical carousel (`[scrollbar-width:none] [&::-webkit-scrollbar]:hidden`) with soft top/bottom gradient depth masks, `snap-y` snap scrolling, and discrete up/down navigation buttons. Fixed the voxel renderer container height to prevent stretching empty grid space.
- **Gallery Skeletons**: Added `GalleryCardSkeleton` and `GallerySkeletonGrid` components for instant visual structure during sort switching and cursor pagination. Added `app/gallery/loading.tsx` for route-level skeleton transitions.
- **Optimized Quick Search**: Added instant client search with `useDeferredValue` and `useMemo` in `components/gallery/GalleryExplore.tsx`, supporting `/` to focus and `Escape` to clear.
- **README App Store Badge**: Added a styled Shields.io App Store badge linking directly to the iOS app on the App Store.

## Verification

- `pnpm test:ui` passed (4 test files).
- `pnpm test:unit` passed (95 test files).
- `pnpm test` passed (112 test files).
- `pnpm lint` passed with 0 errors.

*(PR written by Codex)*