### PR TITLE
fix(gallery): serve native preview images

### DIFF
--- a/app/api/gallery/examples/[id]/[kind]/route.ts
+++ b/app/api/gallery/examples/[id]/[kind]/route.ts
@@ -24,7 +24,7 @@ export async function GET(request: Request, context: { params: Promise<{ id: str
         bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength) as ArrayBuffer,
         {
           headers: {
-            "Cache-Control": "public, max-age=300, s-maxage=3600, stale-while-revalidate=86400",
+            "Cache-Control": "public, max-age=300, s-maxage=3600",
             "Content-Type": "image/png",
           },
         },

--- a/app/api/gallery/examples/[id]/[kind]/route.ts
+++ b/app/api/gallery/examples/[id]/[kind]/route.ts
@@ -1,10 +1,11 @@
 import { createCustomBuildArtifactSignedUrl, downloadCustomBuildArtifactBytes } from "@/lib/custom-builds/storage";
 import { apiServiceError } from "@/lib/gallery/api";
+import { rasterizeGalleryPreview } from "@/lib/gallery/preview";
 import { GalleryServiceError, getPublicGalleryExampleArtifact } from "@/lib/gallery/service";
 
 export const runtime = "nodejs";
 
-export async function GET(_request: Request, context: { params: Promise<{ id: string; kind: string }> }) {
+export async function GET(request: Request, context: { params: Promise<{ id: string; kind: string }> }) {
   const { id, kind } = await context.params;
   const kinds = kind === "preview"
     ? (["preview_svg"] as const)
@@ -17,6 +18,18 @@ export async function GET(_request: Request, context: { params: Promise<{ id: st
   try {
     const artifact = await getPublicGalleryExampleArtifact(id, [...kinds]);
     if (!artifact) throw new GalleryServiceError("not_found", "Artifact not found.");
+    if (kind === "preview" && new URL(request.url).searchParams.get("format") === "png") {
+      const bytes = await rasterizeGalleryPreview(await downloadCustomBuildArtifactBytes(artifact));
+      return new Response(
+        bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength) as ArrayBuffer,
+        {
+          headers: {
+            "Cache-Control": "public, max-age=300, s-maxage=3600, stale-while-revalidate=86400",
+            "Content-Type": "image/png",
+          },
+        },
+      );
+    }
     const signedUrl = await createCustomBuildArtifactSignedUrl(artifact);
     if (signedUrl.startsWith("file:")) {
       const bytes = await downloadCustomBuildArtifactBytes(artifact);

--- a/lib/gallery/preview.ts
+++ b/lib/gallery/preview.ts
@@ -99,3 +99,8 @@ export function buildGalleryPreviewSvg(build: VoxelBuild): string {
 
   return `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${WIDTH} ${HEIGHT}" aria-hidden="true"><g opacity="0.98">${paths.join("")}</g></svg>`;
 }
+
+export async function rasterizeGalleryPreview(svg: Uint8Array): Promise<Uint8Array> {
+  const { default: sharp } = await import("sharp");
+  return sharp(svg).png({ compressionLevel: 9 }).toBuffer();
+}

--- a/tests/unit/gallery/preview-raster.test.ts
+++ b/tests/unit/gallery/preview-raster.test.ts
@@ -1,0 +1,19 @@
+import assert from "node:assert/strict";
+import { rasterizeGalleryPreview } from "../../../lib/gallery/preview";
+
+async function main() {
+  const png = await rasterizeGalleryPreview(
+    Buffer.from(
+      '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 4 3"><rect width="4" height="3" fill="#123456"/></svg>',
+    ),
+  );
+
+  assert.deepEqual(Array.from(png.subarray(0, 8)), [137, 80, 78, 71, 13, 10, 26, 10]);
+  assert.ok(png.byteLength > 8);
+  console.log("gallery preview raster checks passed");
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

- add an opt-in PNG representation for finished Gallery SVG previews
- preserve the existing web SVG and native binary artifact responses
- cache raster responses and cover PNG encoding with a focused regression test

## Validation

- `pnpm exec tsc --noEmit`
- `pnpm lint`
- `pnpm exec tsx tests/unit/gallery/preview.test.ts`
- `pnpm exec tsx tests/unit/gallery/preview-raster.test.ts`
- `pnpm build`

*(PR written by Codex)*