### PR TITLE
fix(onboarding): improve anonymous generation conversion

### DIFF
--- a/app/api/generate/route.ts
+++ b/app/api/generate/route.ts
@@ -127,10 +127,9 @@ export async function POST(req: Request) {
   if (!allowServerKeys && (!providerKeys || Object.values(providerKeys).every((v) => !v))) {
     return NextResponse.json(
       {
-        error:
-          "No API keys provided. Add an OpenRouter key or a provider key (OpenAI/Anthropic/Gemini/Moonshot/DeepSeek/MiniMax/xAI/Meta/Z.AI/etc.) in Sandbox settings.",
+        error: "Add an OpenRouter or provider API key in Generate settings.",
       },
-      { status: 401 }
+      { status: 400 }
     );
   }
 

--- a/app/sandbox/page.tsx
+++ b/app/sandbox/page.tsx
@@ -49,6 +49,9 @@ export default async function SandboxPage({
   const prompt =
     !hasComparisonState && typeof promptParam === "string" ? promptParam : undefined;
   const account = await getCurrentAccount().catch(() => null);
+  const hostedGeminiEnabled = Boolean(
+    process.env.MINEBENCH_FREE_OPENROUTER_API_KEY?.trim(),
+  );
   return (
     <>
       <script
@@ -59,9 +62,10 @@ export default async function SandboxPage({
       <Sandbox
         initialPrompt={prompt}
         signedIn={Boolean(account)}
+        hostedGeminiEnabled={hostedGeminiEnabled}
         hostedGeminiAvailable={Boolean(
           account &&
-          process.env.MINEBENCH_FREE_OPENROUTER_API_KEY?.trim() &&
+          hostedGeminiEnabled &&
           account.hostedGenerationCount < account.hostedGenerationLimit
         )}
         hasPublicNickname={Boolean(account?.publicNickname)}

--- a/app/sandbox/page.tsx
+++ b/app/sandbox/page.tsx
@@ -49,6 +49,9 @@ export default async function SandboxPage({
   const prompt =
     !hasComparisonState && typeof promptParam === "string" ? promptParam : undefined;
   const account = await getCurrentAccount().catch(() => null);
+  const anonymousServerKeysEnabled =
+    process.env.NODE_ENV !== "production" ||
+    process.env.MINEBENCH_ALLOW_SERVER_KEYS === "1";
   const hostedGeminiEnabled = Boolean(
     process.env.MINEBENCH_FREE_OPENROUTER_API_KEY?.trim(),
   );
@@ -62,6 +65,7 @@ export default async function SandboxPage({
       <Sandbox
         initialPrompt={prompt}
         signedIn={Boolean(account)}
+        anonymousServerKeysEnabled={anonymousServerKeysEnabled}
         hostedGeminiEnabled={hostedGeminiEnabled}
         hostedGeminiAvailable={Boolean(
           account &&

--- a/components/arena/Arena.tsx
+++ b/components/arena/Arena.tsx
@@ -1158,6 +1158,80 @@ function RevealLane({
   );
 }
 
+function ArenaAccountPrompt({
+  open,
+  onDismiss,
+}: {
+  open: boolean;
+  onDismiss: () => void;
+}) {
+  const dialogRef = useRef<HTMLDialogElement>(null);
+
+  useEffect(() => {
+    const dialog = dialogRef.current;
+    if (!dialog) return;
+    if (open && !dialog.open) dialog.showModal();
+    if (!open && dialog.open) dialog.close();
+  }, [open]);
+
+  return (
+    <dialog
+      ref={dialogRef}
+      aria-labelledby="arena-account-prompt-title"
+      aria-describedby="arena-account-prompt-description"
+      className="mb-dialog m-auto w-[min(30rem,calc(100%-2rem))] rounded-md border-0 bg-card p-0 text-fg ring-1 ring-border-xl backdrop:bg-bg/60 backdrop:backdrop-blur-sm"
+      onCancel={(event) => {
+        event.preventDefault();
+        onDismiss();
+      }}
+      onClose={onDismiss}
+      onClick={(event) => {
+        const dialog = event.currentTarget;
+        if (event.target !== dialog) return;
+        const bounds = dialog.getBoundingClientRect();
+        if (
+          event.clientX < bounds.left ||
+          event.clientX > bounds.right ||
+          event.clientY < bounds.top ||
+          event.clientY > bounds.bottom
+        ) {
+          onDismiss();
+        }
+      }}
+    >
+      <div className="space-y-6 p-6 sm:p-7">
+        <div>
+          <p className="mb-eyebrow text-accent">For a limited time</p>
+          <h2
+            id="arena-account-prompt-title"
+            className="mt-2 font-display text-2xl font-semibold tracking-tight"
+          >
+            Unlimited Gemini 3.7 Flash generations
+          </h2>
+          <p
+            id="arena-account-prompt-description"
+            className="mt-3 text-sm leading-6 text-muted"
+          >
+            Sign in to generate free, save your builds, and keep your votes.
+          </p>
+          <p className="mt-2 text-sm font-medium text-fg">No API key needed.</p>
+        </div>
+        <div className="grid gap-2 sm:grid-cols-2">
+          <Link
+            href="/sign-in?next=/sandbox%3Fmode%3Dlive"
+            className="mb-btn mb-btn-primary h-11"
+          >
+            Start free
+          </Link>
+          <button type="button" className="mb-btn h-11" onClick={onDismiss}>
+            Not now
+          </button>
+        </div>
+      </div>
+    </dialog>
+  );
+}
+
 function PipelineArrow() {
   return (
     <div
@@ -1212,6 +1286,7 @@ export function Arena() {
   const [slowInitialLoad, setSlowInitialLoad] = useState(false);
   const [submitting, setSubmitting] = useState(false);
   const [arenaConversionOpen, setArenaConversionOpen] = useState(false);
+  const [arenaConversionQueued, setArenaConversionQueued] = useState(false);
   const [voteConfirming, setVoteConfirming] = useState<VoteConfirmTarget | null>(null);
   const voteConfirmTimerRef = useRef<number | null>(null);
   const [voteWarning, setVoteWarning] = useState<string | null>(null);
@@ -1446,6 +1521,12 @@ export function Arena() {
   useEffect(() => {
     revealRef.current = reveal;
   }, [reveal]);
+
+  useEffect(() => {
+    if (!arenaConversionQueued || reveal.kind !== "none" || transitioning) return;
+    setArenaConversionQueued(false);
+    setArenaConversionOpen(true);
+  }, [arenaConversionQueued, reveal.kind, transitioning]);
 
   useEffect(() => {
     sideLoadStateRef.current = sideLoadState;
@@ -2576,7 +2657,7 @@ export function Arena() {
     } catch {
       // The in-memory guard still keeps the prompt one-time for this tab
     }
-    setArenaConversionOpen(true);
+    setArenaConversionQueued(true);
   }
 
   async function handleVote(choice: VoteChoice) {
@@ -3262,37 +3343,6 @@ export function Arena() {
             </div>
           </div>
 
-          {arenaConversionOpen ? (
-            <aside
-              role="status"
-              className="flex flex-col gap-4 border-t border-accent/30 bg-accent/[0.06] px-4 py-4 sm:flex-row sm:items-center sm:justify-between"
-            >
-              <div className="min-w-0">
-                <span className="mb-eyebrow text-accent">8 votes in</span>
-                <p className="mt-1 font-display text-lg font-semibold tracking-tight text-fg">
-                  Keep your 8 votes
-                </p>
-                <p className="mt-1 text-sm text-muted">
-                  Generate free with Gemini 3.7 Flash.
-                </p>
-              </div>
-              <div className="flex shrink-0 items-center gap-2">
-                <Link
-                  href="/sign-in?next=/sandbox%3Fmode%3Dlive"
-                  className="mb-btn mb-btn-primary h-11 px-4 text-sm"
-                >
-                  Sign in
-                </Link>
-                <button
-                  type="button"
-                  className="mb-btn mb-btn-ghost h-11 px-3 text-sm"
-                  onClick={() => setArenaConversionOpen(false)}
-                >
-                  Not now
-                </button>
-              </div>
-            </aside>
-          ) : null}
       </div>
 
       {/* how it works — pipeline diagram */}
@@ -3427,6 +3477,11 @@ export function Arena() {
           </a>
         </form>
       </section>
+
+      <ArenaAccountPrompt
+        open={arenaConversionOpen}
+        onDismiss={() => setArenaConversionOpen(false)}
+      />
     </div>
   );
 }

--- a/components/arena/Arena.tsx
+++ b/components/arena/Arena.tsx
@@ -1161,18 +1161,23 @@ function RevealLane({
 function ArenaAccountPrompt({
   open,
   onDismiss,
+  onShown,
 }: {
   open: boolean;
   onDismiss: () => void;
+  onShown: () => void;
 }) {
   const dialogRef = useRef<HTMLDialogElement>(null);
 
   useEffect(() => {
     const dialog = dialogRef.current;
     if (!dialog) return;
-    if (open && !dialog.open) dialog.showModal();
+    if (open && !dialog.open) {
+      dialog.showModal();
+      onShown();
+    }
     if (!open && dialog.open) dialog.close();
-  }, [open]);
+  }, [onShown, open]);
 
   return (
     <dialog
@@ -2625,6 +2630,15 @@ export function Arena() {
     }
   }
 
+  function markArenaConversionSeen() {
+    arenaConversionSeenRef.current = true;
+    try {
+      window.localStorage.setItem(ANONYMOUS_VOTE_CONVERSION_SEEN_KEY, "1");
+    } catch {
+      // The in-memory guard still keeps the prompt one-time for this tab
+    }
+  }
+
   function recordAnonymousVoteForConversion() {
     if (hasSupabaseAuthCookie(document.cookie) || arenaConversionSeenRef.current) return;
 
@@ -2651,12 +2665,6 @@ export function Arena() {
     anonymousVoteCountRef.current = voteCount;
     if (voteCount < ANONYMOUS_VOTE_CONVERSION_THRESHOLD) return;
 
-    arenaConversionSeenRef.current = true;
-    try {
-      window.localStorage.setItem(ANONYMOUS_VOTE_CONVERSION_SEEN_KEY, "1");
-    } catch {
-      // The in-memory guard still keeps the prompt one-time for this tab
-    }
     setArenaConversionQueued(true);
   }
 
@@ -3481,6 +3489,7 @@ export function Arena() {
       <ArenaAccountPrompt
         open={arenaConversionOpen}
         onDismiss={() => setArenaConversionOpen(false)}
+        onShown={markArenaConversionSeen}
       />
     </div>
   );

--- a/components/arena/Arena.tsx
+++ b/components/arena/Arena.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from "next/link";
 import { useCallback, useEffect, useRef, useState } from "react";
 import {
   ARENA_MESH_FACTS_MIN_BLOCKS,
@@ -41,6 +42,7 @@ import { AnimatedPrompt } from "@/components/arena/AnimatedPrompt";
 import { ModelReveal } from "@/components/arena/ModelReveal";
 import { ErrorState } from "@/components/ErrorState";
 import { trackEvent } from "@/lib/analytics";
+import { hasSupabaseAuthCookie } from "@/lib/auth/cookies";
 import {
   getArenaBlockCountBucket,
   getArenaLatencyBucket,
@@ -1191,6 +1193,9 @@ function isInteractiveTarget(target: EventTarget | null) {
 }
 
 const ARENA_PREMESH_MAX_BLOCK_COUNT = 150_000;
+const ANONYMOUS_VOTE_CONVERSION_THRESHOLD = 8;
+const ANONYMOUS_VOTE_COUNT_KEY = "mb_arena_anonymous_vote_count_v1";
+const ANONYMOUS_VOTE_CONVERSION_SEEN_KEY = "mb_arena_conversion_seen_v1";
 
 function getArenaPremeshedMeshKey(
   matchupId: string,
@@ -1206,6 +1211,7 @@ export function Arena() {
   const [retrying, setRetrying] = useState(false);
   const [slowInitialLoad, setSlowInitialLoad] = useState(false);
   const [submitting, setSubmitting] = useState(false);
+  const [arenaConversionOpen, setArenaConversionOpen] = useState(false);
   const [voteConfirming, setVoteConfirming] = useState<VoteConfirmTarget | null>(null);
   const voteConfirmTimerRef = useRef<number | null>(null);
   const [voteWarning, setVoteWarning] = useState<string | null>(null);
@@ -1252,6 +1258,8 @@ export function Arena() {
   const stuckAutoSkipTimeoutRef = useRef<number | null>(null);
   const advanceNowRequestedAtRef = useRef<number | null>(null);
   const nextMatchupLoadingRef = useRef(false);
+  const anonymousVoteCountRef = useRef(0);
+  const arenaConversionSeenRef = useRef(false);
   const handleVoteRef = useRef<(choice: VoteChoice) => Promise<void>>(
     async () => undefined
   );
@@ -2536,6 +2544,41 @@ export function Arena() {
     }
   }
 
+  function recordAnonymousVoteForConversion() {
+    if (hasSupabaseAuthCookie(document.cookie) || arenaConversionSeenRef.current) return;
+
+    let voteCount = anonymousVoteCountRef.current + 1;
+    try {
+      if (window.localStorage.getItem(ANONYMOUS_VOTE_CONVERSION_SEEN_KEY)) {
+        arenaConversionSeenRef.current = true;
+        return;
+      }
+      const storedVoteCount = Number.parseInt(
+        window.localStorage.getItem(ANONYMOUS_VOTE_COUNT_KEY) ?? "0",
+        10,
+      );
+      voteCount =
+        Math.max(
+          Number.isFinite(storedVoteCount) ? storedVoteCount : 0,
+          voteCount - 1,
+        ) + 1;
+      window.localStorage.setItem(ANONYMOUS_VOTE_COUNT_KEY, String(voteCount));
+    } catch {
+      // Keep counting in this tab when storage is unavailable
+    }
+
+    anonymousVoteCountRef.current = voteCount;
+    if (voteCount < ANONYMOUS_VOTE_CONVERSION_THRESHOLD) return;
+
+    arenaConversionSeenRef.current = true;
+    try {
+      window.localStorage.setItem(ANONYMOUS_VOTE_CONVERSION_SEEN_KEY, "1");
+    } catch {
+      // The in-memory guard still keeps the prompt one-time for this tab
+    }
+    setArenaConversionOpen(true);
+  }
+
   async function handleVote(choice: VoteChoice) {
     if (!matchup || submitting) return;
     if (isMatchupVoteBlocked(matchup, sideLoadStateRef.current)) return;
@@ -2551,6 +2594,7 @@ export function Arena() {
     try {
       const response = await submitArenaAction(matchup.id, choice);
       advanceAt = completeReveal(matchup.id, response, REVEAL_MS_AFTER_VOTE);
+      recordAnonymousVoteForConversion();
     } catch (err) {
       const msg = err instanceof Error ? err.message : "Couldn't record your vote.";
       flashVoteWarning(msg);
@@ -3217,6 +3261,38 @@ export function Arena() {
               </div>
             </div>
           </div>
+
+          {arenaConversionOpen ? (
+            <aside
+              role="status"
+              className="flex flex-col gap-4 border-t border-accent/30 bg-accent/[0.06] px-4 py-4 sm:flex-row sm:items-center sm:justify-between"
+            >
+              <div className="min-w-0">
+                <span className="mb-eyebrow text-accent">8 votes in</span>
+                <p className="mt-1 font-display text-lg font-semibold tracking-tight text-fg">
+                  Keep your 8 votes
+                </p>
+                <p className="mt-1 text-sm text-muted">
+                  Generate free with Gemini 3.7 Flash.
+                </p>
+              </div>
+              <div className="flex shrink-0 items-center gap-2">
+                <Link
+                  href="/sign-in?next=/sandbox%3Fmode%3Dlive"
+                  className="mb-btn mb-btn-primary h-11 px-4 text-sm"
+                >
+                  Sign in
+                </Link>
+                <button
+                  type="button"
+                  className="mb-btn mb-btn-ghost h-11 px-3 text-sm"
+                  onClick={() => setArenaConversionOpen(false)}
+                >
+                  Not now
+                </button>
+              </div>
+            </aside>
+          ) : null}
       </div>
 
       {/* how it works — pipeline diagram */}

--- a/components/sandbox/GenerationPreflightDialog.tsx
+++ b/components/sandbox/GenerationPreflightDialog.tsx
@@ -5,13 +5,19 @@ import { useEffect, useRef } from "react";
 
 export function GenerationPreflightDialog({
   open,
+  mode,
+  message,
   signInHref,
   onContinue,
+  onUseKey,
   onClose,
 }: {
   open: boolean;
+  mode: "free" | "save" | "key";
+  message?: string;
   signInHref: string;
   onContinue: () => void;
+  onUseKey: () => void;
   onClose: () => void;
 }) {
   const dialogRef = useRef<HTMLDialogElement>(null);
@@ -39,14 +45,36 @@ export function GenerationPreflightDialog({
         <div>
           <p className="mb-eyebrow">Generate</p>
           <h2 id="generation-preflight-title" className="mt-2 text-2xl font-semibold tracking-tight">
-            Keep this build
+            {mode === "free"
+              ? "Generate for free"
+              : mode === "key"
+                ? "Connect this model"
+                : "Keep this build"}
           </h2>
-          <p className="mt-2 text-sm leading-6 text-muted">Sign in to save it automatically.</p>
+          <p className="mt-2 text-sm leading-6 text-muted">
+            {mode === "free"
+              ? "Sign in. No API key needed."
+              : mode === "key"
+                ? message ?? "Add the required API key to generate."
+                : "Sign in to save it automatically."}
+          </p>
         </div>
-        <div className="grid gap-2 sm:grid-cols-2">
-          <Link href={signInHref} className="mb-btn mb-btn-primary h-11">Sign in</Link>
-          <button type="button" className="mb-btn h-11" onClick={onContinue}>Continue</button>
-        </div>
+        {mode === "free" ? (
+          <div className="grid gap-2 sm:grid-cols-2">
+            <Link href={signInHref} className="mb-btn mb-btn-primary h-11">Start free</Link>
+            <button type="button" className="mb-btn h-11" onClick={onClose}>Not now</button>
+          </div>
+        ) : mode === "key" ? (
+          <div className="grid gap-2 sm:grid-cols-2">
+            <button type="button" className="mb-btn mb-btn-primary h-11" onClick={onUseKey}>Add key</button>
+            <button type="button" className="mb-btn h-11" onClick={onClose}>Not now</button>
+          </div>
+        ) : (
+          <div className="grid gap-2 sm:grid-cols-2">
+            <Link href={signInHref} className="mb-btn mb-btn-primary h-11">Sign in</Link>
+            <button type="button" className="mb-btn h-11" onClick={onContinue}>Continue</button>
+          </div>
+        )}
       </div>
     </dialog>
   );

--- a/components/sandbox/Sandbox.tsx
+++ b/components/sandbox/Sandbox.tsx
@@ -83,6 +83,7 @@ function SandboxModeTabs({
 export function Sandbox({
   initialPrompt,
   signedIn,
+  anonymousServerKeysEnabled,
   hostedGeminiEnabled,
   hostedGeminiAvailable,
   hasPublicNickname,
@@ -90,6 +91,7 @@ export function Sandbox({
 }: {
   initialPrompt?: string;
   signedIn: boolean;
+  anonymousServerKeysEnabled: boolean;
   hostedGeminiEnabled: boolean;
   hostedGeminiAvailable: boolean;
   hasPublicNickname: boolean;
@@ -140,6 +142,7 @@ export function Sandbox({
           key={livePrompt ?? "default"}
           initialPrompt={livePrompt}
           signedIn={signedIn}
+          anonymousServerKeysEnabled={anonymousServerKeysEnabled}
           hostedGeminiEnabled={hostedGeminiEnabled}
           hostedGeminiAvailable={hostedGeminiAvailable}
           hasPublicNickname={hasPublicNickname}

--- a/components/sandbox/Sandbox.tsx
+++ b/components/sandbox/Sandbox.tsx
@@ -83,12 +83,14 @@ function SandboxModeTabs({
 export function Sandbox({
   initialPrompt,
   signedIn,
+  hostedGeminiEnabled,
   hostedGeminiAvailable,
   hasPublicNickname,
   gallerySuspended,
 }: {
   initialPrompt?: string;
   signedIn: boolean;
+  hostedGeminiEnabled: boolean;
   hostedGeminiAvailable: boolean;
   hasPublicNickname: boolean;
   gallerySuspended: boolean;
@@ -138,6 +140,7 @@ export function Sandbox({
           key={livePrompt ?? "default"}
           initialPrompt={livePrompt}
           signedIn={signedIn}
+          hostedGeminiEnabled={hostedGeminiEnabled}
           hostedGeminiAvailable={hostedGeminiAvailable}
           hasPublicNickname={hasPublicNickname}
           gallerySuspended={gallerySuspended}

--- a/components/sandbox/SandboxLive.tsx
+++ b/components/sandbox/SandboxLive.tsx
@@ -33,6 +33,7 @@ type SelectedModelValue =
   | ModelKey
   | typeof OPENROUTER_MODEL_VALUE
   | typeof CUSTOM_MODEL_VALUE;
+type GenerationPreflightMode = "free" | "save" | "key";
 
 type CustomSandboxModel = {
   displayName: string;
@@ -111,6 +112,7 @@ const OPENROUTER_MODEL_VALUE = "__openrouter__";
 const CUSTOM_MODEL_VALUE = "__custom_api__";
 const HOSTED_GEMINI_MODEL_KEY = "gemini_3_7_flash";
 const HOSTED_GEMINI_NOTICE_KEY = "mb_hosted_gemini_3_7_notice_v1";
+let anonymousHostedGeminiNoticeShown = false;
 const DEFAULT_CUSTOM_MODEL: CustomSandboxModel = {
   displayName: "OpenAI-compatible model",
   modelId: "",
@@ -135,9 +137,13 @@ const DEFAULT_MODEL_B: ModelKey =
 
 function HostedGeminiAnnouncement({
   open,
+  signedIn,
+  signInHref,
   onDismiss,
 }: {
   open: boolean;
+  signedIn: boolean;
+  signInHref: string;
   onDismiss: () => void;
 }) {
   const dialogRef = useRef<HTMLDialogElement>(null);
@@ -165,12 +171,21 @@ function HostedGeminiAnnouncement({
             Gemini 3.7 Flash is free
           </h2>
           <p className="mt-2 text-sm leading-6 text-muted">
-            Signed-in users can generate without a Gemini or OpenRouter API key for a limited time.
+            {signedIn
+              ? "No API key needed for a limited time."
+              : "Sign in. No API key needed."}
           </p>
         </div>
-        <button type="button" className="mb-btn mb-btn-primary h-11 w-full" onClick={onDismiss}>
-          Got it
-        </button>
+        {signedIn ? (
+          <button type="button" className="mb-btn mb-btn-primary h-11 w-full" onClick={onDismiss}>
+            Start building
+          </button>
+        ) : (
+          <div className="grid gap-2 sm:grid-cols-2">
+            <Link href={signInHref} className="mb-btn mb-btn-primary h-11">Start free</Link>
+            <button type="button" className="mb-btn h-11" onClick={onDismiss}>Not now</button>
+          </div>
+        )}
       </div>
     </dialog>
   );
@@ -535,12 +550,14 @@ function customBuildRetryProvider(status: SavedGenerationPayload): keyof Provide
 export function SandboxLive({
   initialPrompt,
   signedIn,
+  hostedGeminiEnabled,
   hostedGeminiAvailable,
   hasPublicNickname,
   gallerySuspended,
 }: {
   initialPrompt?: string;
   signedIn: boolean;
+  hostedGeminiEnabled: boolean;
   hostedGeminiAvailable: boolean;
   hasPublicNickname: boolean;
   gallerySuspended: boolean;
@@ -567,14 +584,21 @@ export function SandboxLive({
   );
   const [running, setRunning] = useState(false);
   const [requestError, setRequestError] = useState<string | null>(null);
-  const [showGenerationPreflight, setShowGenerationPreflight] = useState(false);
+  const [generationPreflight, setGenerationPreflight] =
+    useState<GenerationPreflightMode | null>(null);
+  const [generationPreflightMessage, setGenerationPreflightMessage] = useState<string>();
   const [showHostedGeminiAnnouncement, setShowHostedGeminiAnnouncement] = useState(false);
   const savedKeyCount = Object.values(providerKeys).filter((value) => Boolean(value?.trim())).length;
-  const canUseHostedGemini = Boolean(
-    hostedGeminiAvailable &&
-    !providerKeys.gemini?.trim() &&
-    !providerKeys.openrouter?.trim(),
+  const showHostedGeminiOffer = Boolean(
+    hostedGeminiEnabled &&
+    (!signedIn ||
+      (hostedGeminiAvailable &&
+        !providerKeys.gemini?.trim() &&
+        !providerKeys.openrouter?.trim())),
   );
+  const signInHref = `/sign-in?next=${encodeURIComponent(
+    `/sandbox?mode=live&prompt=${encodeURIComponent(prompt)}`,
+  )}`;
   const [apiKeysOpen, setApiKeysOpen] = useState(false);
   const [providerKeysOpen, setProviderKeysOpen] = useState(false);
   const [, forceRender] = useState(0);
@@ -588,6 +612,7 @@ export function SandboxLive({
   );
   const viewerARef = useRef<VoxelViewerHandle | null>(null);
   const viewerBRef = useRef<VoxelViewerHandle | null>(null);
+  const apiKeysSectionRef = useRef<HTMLElement | null>(null);
 
   const modelGroups = useMemo(() => {
     const groups = new Map<string, (typeof ENABLED_MODELS)[number][]>();
@@ -674,7 +699,17 @@ export function SandboxLive({
   }, [providerKeys]);
 
   useEffect(() => {
-    if (!signedIn || !hostedGeminiAvailable) return;
+    if (!hostedGeminiEnabled || (signedIn && !hostedGeminiAvailable)) {
+      setShowHostedGeminiAnnouncement(false);
+      return;
+    }
+    if (!signedIn) {
+      if (!anonymousHostedGeminiNoticeShown) {
+        anonymousHostedGeminiNoticeShown = true;
+        setShowHostedGeminiAnnouncement(true);
+      }
+      return;
+    }
     try {
       if (!window.localStorage.getItem(HOSTED_GEMINI_NOTICE_KEY)) {
         setShowHostedGeminiAnnouncement(true);
@@ -682,17 +717,19 @@ export function SandboxLive({
     } catch {
       setShowHostedGeminiAnnouncement(true);
     }
-  }, [hostedGeminiAvailable, signedIn]);
+  }, [hostedGeminiAvailable, hostedGeminiEnabled, signedIn]);
 
   function dismissHostedGeminiAnnouncement() {
-    try {
-      window.localStorage.setItem(HOSTED_GEMINI_NOTICE_KEY, "1");
-    } catch {}
+    if (signedIn) {
+      try {
+        window.localStorage.setItem(HOSTED_GEMINI_NOTICE_KEY, "1");
+      } catch {}
+    }
     setShowHostedGeminiAnnouncement(false);
   }
 
   function modelOptionLabel(model: (typeof ENABLED_MODELS)[number]): string {
-    return model.key === HOSTED_GEMINI_MODEL_KEY && canUseHostedGemini
+    return model.key === HOSTED_GEMINI_MODEL_KEY && showHostedGeminiOffer
       ? `${model.displayName} · Free`
       : model.displayName;
   }
@@ -869,6 +906,44 @@ export function SandboxLive({
       displayName: model.displayName,
       modelId: model.modelId,
     };
+  }
+
+  function hasProviderKey(model: SelectedLiveModel): boolean {
+    return Object.values(
+      selectGenerationProviderKeys([customBuildRequestModel(model)], providerKeys),
+    ).some((value) => Boolean(value?.trim()));
+  }
+
+  function missingProviderKeyMessage(models: SelectedLiveModel[]): string {
+    if (models.length !== 1) {
+      return "Add the required API keys for the selected models.";
+    }
+    const [model] = models;
+    if (model.kind === "custom") {
+      return model.provider === "openrouter"
+        ? `Add an OpenRouter key to generate with ${model.displayName}.`
+        : `Add an API key to generate with ${model.displayName}.`;
+    }
+    const catalogModel = ENABLED_MODELS.find((entry) => entry.key === model.modelKey);
+    if (!catalogModel || catalogModel.forceOpenRouter) {
+      return `Add an OpenRouter key to generate with ${model.displayName}.`;
+    }
+    const directLabel =
+      DIRECT_PROVIDER_KEYS.find(([provider]) => provider === catalogModel.provider)?.[1] ??
+      providerLabel(catalogModel.provider);
+    const article = /^[aeiou]/i.test(directLabel) ? "an" : "a";
+    return catalogModel.openRouterModelId
+      ? `Add ${article} ${directLabel} or OpenRouter key to generate with ${model.displayName}.`
+      : `Add ${article} ${directLabel} key to generate with ${model.displayName}.`;
+  }
+
+  function openApiKeys() {
+    setGenerationPreflight(null);
+    setApiKeysOpen(true);
+    setProviderKeysOpen(true);
+    window.requestAnimationFrame(() => {
+      apiKeysSectionRef.current?.scrollIntoView({ block: "start" });
+    });
   }
 
   function applyCustomBuildStatus(args: {
@@ -1179,8 +1254,40 @@ export function SandboxLive({
       setRequestError("Enter a chat completions URL for the OpenAI-compatible model.");
       return;
     }
+    const requestModels = selectedModels.map(customBuildRequestModel);
+    const missingProviderModels = selectedModels.filter((model) => {
+      if (
+        signedIn &&
+        hostedGeminiAvailable &&
+        model.kind === "catalog" &&
+        model.modelKey === HOSTED_GEMINI_MODEL_KEY
+      ) {
+        return false;
+      }
+      return !hasProviderKey(model);
+    });
+    const selectedFreeHostedGemini = Boolean(
+      hostedGeminiEnabled &&
+      missingProviderModels.length === 1 &&
+      missingProviderModels[0]?.kind === "catalog" &&
+      missingProviderModels[0].modelKey === HOSTED_GEMINI_MODEL_KEY,
+    );
     if (!signedIn && !continueTransient) {
-      setShowGenerationPreflight(true);
+      if (selectedFreeHostedGemini) {
+        setGenerationPreflightMessage(undefined);
+        setGenerationPreflight("free");
+      } else if (missingProviderModels.length > 0) {
+        setGenerationPreflightMessage(missingProviderKeyMessage(missingProviderModels));
+        setGenerationPreflight("key");
+      } else {
+        setGenerationPreflightMessage(undefined);
+        setGenerationPreflight("save");
+      }
+      return;
+    }
+    if (missingProviderModels.length > 0) {
+      setRequestError(missingProviderKeyMessage(missingProviderModels));
+      openApiKeys();
       return;
     }
     const durableRunId = signedIn ? durableRunSequenceRef.current + 1 : null;
@@ -1214,7 +1321,6 @@ export function SandboxLive({
     const abortController = new AbortController();
     generateAbortRef.current = abortController;
     try {
-      const requestModels = selectedModels.map(customBuildRequestModel);
       const sanitizedKeys = selectGenerationProviderKeys(requestModels, providerKeys);
 
       if (signedIn) {
@@ -1607,6 +1713,23 @@ export function SandboxLive({
           <div className="text-sm text-muted">Build from your own prompt.</div>
         </div>
 
+        {showHostedGeminiOffer ? (
+          <div className="-mx-4 flex flex-col gap-3 border-y border-accent/20 bg-accent/[0.06] px-4 py-3 sm:-mx-5 sm:flex-row sm:items-center sm:justify-between sm:px-5">
+            <div className="min-w-0">
+              <div className="mb-eyebrow text-accent">Free right now</div>
+              <div className="mt-1 text-sm font-semibold text-fg">Gemini 3.7 Flash</div>
+              <div className="mt-0.5 text-xs text-muted">
+                {signedIn ? "No API key needed." : "Sign in. No API key needed."}
+              </div>
+            </div>
+            {!signedIn ? (
+              <Link href={signInHref} className="mb-btn mb-btn-primary h-11 shrink-0 px-4">
+                Start free
+              </Link>
+            ) : null}
+          </div>
+        ) : null}
+
         <label className="flex flex-col gap-2">
           <span className="mb-eyebrow">Prompt</span>
           <textarea
@@ -1793,7 +1916,7 @@ export function SandboxLive({
         </section>
 
         {requestError ? (
-          <div className="rounded-md border border-danger/30 bg-danger/[0.08] px-3 py-2 text-xs text-danger">
+          <div role="alert" className="rounded-md border border-danger/30 bg-danger/[0.08] px-3 py-2 text-xs text-danger">
             {requestError}
           </div>
         ) : null}
@@ -1832,7 +1955,7 @@ export function SandboxLive({
         {resultCards}
       </div>
 
-      <section className="border-t border-border/70 xl:col-span-2">
+      <section ref={apiKeysSectionRef} className="scroll-mt-24 border-t border-border/70 xl:col-span-2">
         <button
           type="button"
           aria-expanded={apiKeysOpen}
@@ -1973,16 +2096,21 @@ export function SandboxLive({
       </section>
 
       <GenerationPreflightDialog
-        open={showGenerationPreflight}
-        signInHref={`/sign-in?next=${encodeURIComponent(`/sandbox?mode=live&prompt=${encodeURIComponent(prompt)}`)}`}
-        onClose={() => setShowGenerationPreflight(false)}
+        open={generationPreflight !== null}
+        mode={generationPreflight ?? "save"}
+        message={generationPreflightMessage}
+        signInHref={signInHref}
+        onClose={() => setGenerationPreflight(null)}
         onContinue={() => {
-          setShowGenerationPreflight(false);
+          setGenerationPreflight(null);
           void runGenerate(true);
         }}
+        onUseKey={openApiKeys}
       />
       <HostedGeminiAnnouncement
         open={showHostedGeminiAnnouncement}
+        signedIn={signedIn}
+        signInHref={signInHref}
         onDismiss={dismissHostedGeminiAnnouncement}
       />
     </div>

--- a/components/sandbox/SandboxLive.tsx
+++ b/components/sandbox/SandboxLive.tsx
@@ -550,6 +550,7 @@ function customBuildRetryProvider(status: SavedGenerationPayload): keyof Provide
 export function SandboxLive({
   initialPrompt,
   signedIn,
+  anonymousServerKeysEnabled,
   hostedGeminiEnabled,
   hostedGeminiAvailable,
   hasPublicNickname,
@@ -557,6 +558,7 @@ export function SandboxLive({
 }: {
   initialPrompt?: string;
   signedIn: boolean;
+  anonymousServerKeysEnabled: boolean;
   hostedGeminiEnabled: boolean;
   hostedGeminiAvailable: boolean;
   hasPublicNickname: boolean;
@@ -1256,6 +1258,7 @@ export function SandboxLive({
     }
     const requestModels = selectedModels.map(customBuildRequestModel);
     const missingProviderModels = selectedModels.filter((model) => {
+      if (!signedIn && anonymousServerKeysEnabled) return false;
       if (
         signedIn &&
         hostedGeminiAvailable &&

--- a/tests/ui/arena-anonymous-conversion.test.ts
+++ b/tests/ui/arena-anonymous-conversion.test.ts
@@ -54,6 +54,7 @@ function effectBodyTextContaining(marker: string): string {
 const voteBody = functionBodyText("handleVote");
 const skipBody = functionBodyText("handleSkip");
 const conversionBody = functionBodyText("recordAnonymousVoteForConversion");
+const markConversionSeenBody = functionBodyText("markArenaConversionSeen");
 const promptBody = functionBodyText("ArenaAccountPrompt");
 const promptTimingEffect = effectBodyTextContaining("arenaConversionQueued");
 const submitIndex = voteBody.indexOf("await submitArenaAction");
@@ -69,7 +70,11 @@ assert.ok(
   conversionBody.includes("hasSupabaseAuthCookie(document.cookie)") &&
     conversionBody.includes("window.localStorage.getItem(ANONYMOUS_VOTE_CONVERSION_SEEN_KEY)") &&
     conversionBody.includes("window.localStorage.setItem(ANONYMOUS_VOTE_COUNT_KEY") &&
-    conversionBody.includes("window.localStorage.setItem(ANONYMOUS_VOTE_CONVERSION_SEEN_KEY"),
+    !conversionBody.includes("window.localStorage.setItem(ANONYMOUS_VOTE_CONVERSION_SEEN_KEY") &&
+    markConversionSeenBody.includes("arenaConversionSeenRef.current = true") &&
+    markConversionSeenBody.includes(
+      "window.localStorage.setItem(ANONYMOUS_VOTE_CONVERSION_SEEN_KEY",
+    ),
   "the Arena conversion should remain anonymous-only and appear once per browser",
 );
 assert.ok(
@@ -81,6 +86,7 @@ assert.ok(
 );
 assert.ok(
   promptBody.includes("dialog.showModal()") &&
+    promptBody.indexOf("dialog.showModal()") < promptBody.indexOf("onShown()") &&
     promptBody.includes("dialog.close()") &&
     promptBody.includes("onCancel") &&
     promptBody.includes("event.target !== dialog") &&
@@ -100,6 +106,7 @@ assert.ok(
     promptTimingEffect.includes("transitioning") &&
     promptTimingEffect.includes("setArenaConversionQueued(false)") &&
     promptTimingEffect.includes("setArenaConversionOpen(true)") &&
+    sourceText.includes("onShown={markArenaConversionSeen}") &&
     sourceText.includes("<ArenaAccountPrompt") &&
     !sourceText.includes("Keep your 8 votes"),
   "the modal should wait until the eighth vote reveal and transition have finished",

--- a/tests/ui/arena-anonymous-conversion.test.ts
+++ b/tests/ui/arena-anonymous-conversion.test.ts
@@ -26,9 +26,36 @@ function functionBodyText(name: string): string {
   return body;
 }
 
+function effectBodyTextContaining(marker: string): string {
+  let body = "";
+  const visit = (node: ts.Node) => {
+    if (
+      ts.isCallExpression(node) &&
+      node.expression.getText(sourceFile) === "useEffect" &&
+      node.arguments.length > 0
+    ) {
+      const callback = node.arguments[0];
+      if (
+        callback &&
+        (ts.isArrowFunction(callback) || ts.isFunctionExpression(callback)) &&
+        callback.body.getText(sourceFile).includes(marker)
+      ) {
+        body = callback.body.getText(sourceFile);
+        return;
+      }
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sourceFile);
+  if (!body) throw new Error(`useEffect containing ${marker} should be declared`);
+  return body;
+}
+
 const voteBody = functionBodyText("handleVote");
 const skipBody = functionBodyText("handleSkip");
 const conversionBody = functionBodyText("recordAnonymousVoteForConversion");
+const promptBody = functionBodyText("ArenaAccountPrompt");
+const promptTimingEffect = effectBodyTextContaining("arenaConversionQueued");
 const submitIndex = voteBody.indexOf("await submitArenaAction");
 const conversionIndex = voteBody.indexOf("recordAnonymousVoteForConversion()");
 
@@ -53,11 +80,29 @@ assert.ok(
   "only a durable vote should advance the anonymous conversion counter",
 );
 assert.ok(
-  sourceText.includes("Keep your 8 votes") &&
-    sourceText.includes("Generate free with Gemini 3.7 Flash.") &&
+  promptBody.includes("dialog.showModal()") &&
+    promptBody.includes("dialog.close()") &&
+    promptBody.includes("onCancel") &&
+    promptBody.includes("event.target !== dialog") &&
+    sourceText.includes("For a limited time") &&
+    sourceText.includes("Unlimited Gemini 3.7 Flash generations") &&
+    sourceText.includes("Sign in to generate free, save your builds, and keep your votes.") &&
+    sourceText.includes("No API key needed.") &&
     sourceText.includes("/sign-in?next=/sandbox%3Fmode%3Dlive") &&
+    sourceText.includes("Start free") &&
     sourceText.includes("Not now"),
-  "the conversion should connect saved votes to the free Generate flow without blocking Arena",
+  "the conversion should use a restrained, dismissible account modal with the full offer",
+);
+assert.ok(
+  conversionBody.includes("setArenaConversionQueued(true)") &&
+    !conversionBody.includes("setArenaConversionOpen(true)") &&
+    promptTimingEffect.includes('reveal.kind !== "none"') &&
+    promptTimingEffect.includes("transitioning") &&
+    promptTimingEffect.includes("setArenaConversionQueued(false)") &&
+    promptTimingEffect.includes("setArenaConversionOpen(true)") &&
+    sourceText.includes("<ArenaAccountPrompt") &&
+    !sourceText.includes("Keep your 8 votes"),
+  "the modal should wait until the eighth vote reveal and transition have finished",
 );
 
 console.log("arena anonymous conversion contract checks passed");

--- a/tests/ui/arena-anonymous-conversion.test.ts
+++ b/tests/ui/arena-anonymous-conversion.test.ts
@@ -1,0 +1,63 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import ts from "typescript";
+
+const SOURCE_PATH = "components/arena/Arena.tsx";
+const sourceText = readFileSync(SOURCE_PATH, "utf8");
+const sourceFile = ts.createSourceFile(
+  SOURCE_PATH,
+  sourceText,
+  ts.ScriptTarget.Latest,
+  true,
+  ts.ScriptKind.TSX,
+);
+
+function functionBodyText(name: string): string {
+  let body = "";
+  const visit = (node: ts.Node) => {
+    if (ts.isFunctionDeclaration(node) && node.name?.text === name && node.body) {
+      body = node.body.getText(sourceFile);
+      return;
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sourceFile);
+  if (!body) throw new Error(`${name} should be declared`);
+  return body;
+}
+
+const voteBody = functionBodyText("handleVote");
+const skipBody = functionBodyText("handleSkip");
+const conversionBody = functionBodyText("recordAnonymousVoteForConversion");
+const submitIndex = voteBody.indexOf("await submitArenaAction");
+const conversionIndex = voteBody.indexOf("recordAnonymousVoteForConversion()");
+
+assert.ok(
+  sourceText.includes("const ANONYMOUS_VOTE_CONVERSION_THRESHOLD = 8") &&
+    sourceText.includes("ANONYMOUS_VOTE_COUNT_KEY") &&
+    sourceText.includes("ANONYMOUS_VOTE_CONVERSION_SEEN_KEY"),
+  "the anonymous conversion should wait for eight successful votes and persist its progress",
+);
+assert.ok(
+  conversionBody.includes("hasSupabaseAuthCookie(document.cookie)") &&
+    conversionBody.includes("window.localStorage.getItem(ANONYMOUS_VOTE_CONVERSION_SEEN_KEY)") &&
+    conversionBody.includes("window.localStorage.setItem(ANONYMOUS_VOTE_COUNT_KEY") &&
+    conversionBody.includes("window.localStorage.setItem(ANONYMOUS_VOTE_CONVERSION_SEEN_KEY"),
+  "the Arena conversion should remain anonymous-only and appear once per browser",
+);
+assert.ok(
+  submitIndex >= 0 &&
+    conversionIndex > submitIndex &&
+    conversionIndex < voteBody.indexOf("await loadNextMatchup") &&
+    !skipBody.includes("recordAnonymousVoteForConversion"),
+  "only a durable vote should advance the anonymous conversion counter",
+);
+assert.ok(
+  sourceText.includes("Keep your 8 votes") &&
+    sourceText.includes("Generate free with Gemini 3.7 Flash.") &&
+    sourceText.includes("/sign-in?next=/sandbox%3Fmode%3Dlive") &&
+    sourceText.includes("Not now"),
+  "the conversion should connect saved votes to the free Generate flow without blocking Arena",
+);
+
+console.log("arena anonymous conversion contract checks passed");

--- a/tests/ui/sandbox-live-durable.test.ts
+++ b/tests/ui/sandbox-live-durable.test.ts
@@ -4,6 +4,9 @@ import ts from "typescript";
 
 const SOURCE_PATH = "components/sandbox/SandboxLive.tsx";
 const sourceText = readFileSync(SOURCE_PATH, "utf8");
+const sandboxPageText = readFileSync("app/sandbox/page.tsx", "utf8");
+const preflightText = readFileSync("components/sandbox/GenerationPreflightDialog.tsx", "utf8");
+const generateRouteText = readFileSync("app/api/generate/route.ts", "utf8");
 const sourceFile = ts.createSourceFile(SOURCE_PATH, sourceText, ts.ScriptTarget.Latest, true, ts.ScriptKind.TSX);
 
 function functionBodyText(name: string): string {
@@ -52,7 +55,9 @@ const stopBody = functionBodyText("stopGenerate");
 const watchBody = functionBodyText("watchCustomBuild");
 const retryBody = functionBodyText("retryCustomBuild");
 const completedBuildBody = functionBodyText("readCustomBuildViewer");
+const dismissHostedGeminiBody = functionBodyText("dismissHostedGeminiAnnouncement");
 const inputResetEffect = effectBodyTextContaining("lastGenerateInputRef.current === inputSignature");
+const hostedGeminiEffect = effectBodyTextContaining("HOSTED_GEMINI_NOTICE_KEY");
 const assignIndex = durableBody.indexOf("customBuildAbortRef.current = args.abortController");
 assert.ok(assignIndex >= 0, "durable generation should store the active abort controller");
 assert.equal(
@@ -163,15 +168,22 @@ assert.ok(
 );
 assert.ok(
   runBody.includes("if (!signedIn && !continueTransient)") &&
-    runBody.includes("setShowGenerationPreflight(true)") &&
+    runBody.includes('setGenerationPreflight("free")') &&
+    runBody.includes('setGenerationPreflight("key")') &&
+    runBody.includes('setGenerationPreflight("save")') &&
     runBody.includes("if (signedIn)") &&
     runBody.includes("await runGenerateDurable") &&
     runBody.includes('fetch("/api/generate"'),
-  "every signed-out attempt should stop at preflight while signed-in attempts use durable generation",
+  "signed-out generation should distinguish the free, missing-key, and save preflight paths",
 );
 assert.ok(
   sourceText.includes("<GenerationPreflightDialog") &&
     sourceText.includes("void runGenerate(true)") &&
+    sourceText.includes("openApiKeys") &&
+    preflightText.includes('mode: "free" | "save" | "key"') &&
+    preflightText.includes("Generate for free") &&
+    preflightText.includes("Connect this model") &&
+    preflightText.includes("Add key") &&
     sourceText.includes("customBuildPageUrl") &&
     sourceText.includes("<GenerationGalleryButton") &&
     sourceText.includes('label="Export GIF"') &&
@@ -180,6 +192,14 @@ assert.ok(
     !sourceText.includes('"Generating…"') &&
     !sourceText.includes("DURABLE_CUSTOM_BUILDS_ENABLED"),
   "preflight continuation and renderer-owned saved build actions should remain visible without duplicate page controls",
+);
+const missingKeyErrorIndex = generateRouteText.indexOf(
+  "Add an OpenRouter or provider API key in Generate settings.",
+);
+assert.ok(
+  missingKeyErrorIndex >= 0 &&
+    generateRouteText.slice(missingKeyErrorIndex, missingKeyErrorIndex + 200).includes("status: 400"),
+  "missing Generate credentials should remain a readable validation error instead of an access denial",
 );
 assert.ok(
   sourceText.includes("downloadSavedGenerationJson") &&
@@ -208,16 +228,26 @@ assert.ok(
 assert.ok(
   sourceText.includes("HOSTED_GEMINI_NOTICE_KEY") &&
     sourceText.includes("Gemini 3.7 Flash is free") &&
-    sourceText.includes("if (!signedIn || !hostedGeminiAvailable) return") &&
-    sourceText.includes("window.localStorage.getItem(HOSTED_GEMINI_NOTICE_KEY)") &&
-    sourceText.includes("window.localStorage.setItem(HOSTED_GEMINI_NOTICE_KEY") &&
+    sourceText.includes("Free right now") &&
+    sourceText.includes("No API key needed.") &&
+    sourceText.includes("Start free") &&
+    sourceText.includes("let anonymousHostedGeminiNoticeShown = false") &&
+    sandboxPageText.includes("const hostedGeminiEnabled = Boolean(") &&
+    sandboxPageText.includes("hostedGeminiEnabled={hostedGeminiEnabled}") &&
+    hostedGeminiEffect.includes("!hostedGeminiEnabled") &&
+    hostedGeminiEffect.includes("if (!signedIn)") &&
+    hostedGeminiEffect.includes("anonymousHostedGeminiNoticeShown = true") &&
+    hostedGeminiEffect.indexOf("if (!signedIn)") <
+      hostedGeminiEffect.indexOf("window.localStorage.getItem(HOSTED_GEMINI_NOTICE_KEY)") &&
+    dismissHostedGeminiBody.includes("if (signedIn)") &&
+    dismissHostedGeminiBody.includes("window.localStorage.setItem(HOSTED_GEMINI_NOTICE_KEY") &&
     sourceText.includes("!providerKeys.gemini?.trim()") &&
     sourceText.includes("!providerKeys.openrouter?.trim()") &&
     sourceText.includes("`${model.displayName} · Free`") &&
     retryBody.includes("...(providerKey ? { providerKey } : {})") &&
     !retryBody.includes("Add the required API key") &&
     !sourceText.includes("hostedGenerationCount"),
-  "the signed-in Gemini offer should announce once, defer to user keys, support hosted retries, and avoid a live usage counter",
+  "the free Gemini offer should appear on every anonymous page load, persist in Generate, defer to user keys, and remain one-time for signed-in users",
 );
 
 console.log("sandbox saved-generation contract checks passed");

--- a/tests/ui/sandbox-live-durable.test.ts
+++ b/tests/ui/sandbox-live-durable.test.ts
@@ -5,6 +5,7 @@ import ts from "typescript";
 const SOURCE_PATH = "components/sandbox/SandboxLive.tsx";
 const sourceText = readFileSync(SOURCE_PATH, "utf8");
 const sandboxPageText = readFileSync("app/sandbox/page.tsx", "utf8");
+const sandboxShellText = readFileSync("components/sandbox/Sandbox.tsx", "utf8");
 const preflightText = readFileSync("components/sandbox/GenerationPreflightDialog.tsx", "utf8");
 const generateRouteText = readFileSync("app/api/generate/route.ts", "utf8");
 const sourceFile = ts.createSourceFile(SOURCE_PATH, sourceText, ts.ScriptTarget.Latest, true, ts.ScriptKind.TSX);
@@ -175,6 +176,14 @@ assert.ok(
     runBody.includes("await runGenerateDurable") &&
     runBody.includes('fetch("/api/generate"'),
   "signed-out generation should distinguish the free, missing-key, and save preflight paths",
+);
+assert.ok(
+  sandboxPageText.includes('process.env.NODE_ENV !== "production"') &&
+    sandboxPageText.includes('process.env.MINEBENCH_ALLOW_SERVER_KEYS === "1"') &&
+    sandboxPageText.includes("anonymousServerKeysEnabled={anonymousServerKeysEnabled}") &&
+    sandboxShellText.includes("anonymousServerKeysEnabled={anonymousServerKeysEnabled}") &&
+    runBody.includes("if (!signedIn && anonymousServerKeysEnabled)"),
+  "signed-out generation should still continue when the Generate route permits server keys",
 );
 assert.ok(
   sourceText.includes("<GenerationPreflightDialog") &&

--- a/tests/unit/client-error-response.test.ts
+++ b/tests/unit/client-error-response.test.ts
@@ -41,6 +41,20 @@ async function main() {
     "Prompt is required.",
   );
 
+  const missingKeyError = new Response(
+    JSON.stringify({
+      error: "Add an OpenRouter or provider API key in Generate settings.",
+    }),
+    {
+      status: 400,
+      headers: { "Content-Type": "application/json" },
+    },
+  );
+  assert.equal(
+    await readClientErrorResponse(missingKeyError, "Request failed"),
+    "Add an OpenRouter or provider API key in Generate settings.",
+  );
+
   const htmlError = new Response("<html>Internal Server Error</html>", {
     status: 400,
     headers: { "Content-Type": "text/html" },


### PR DESCRIPTION
## Summary

- surfaces the limited-time unlimited Gemini 3.7 Flash offer on every logged-out Generate load
- guides keyless generation attempts to free sign-in or the correct provider settings
- invites anonymous Arena voters to sign in after eight successful votes with a one-time post-reveal modal
- highlights saved builds and votes without gating the Arena experience

## Validation

- `pnpm exec tsx tests/ui/arena-anonymous-conversion.test.ts`
- `pnpm exec tsx tests/ui/sandbox-live-durable.test.ts`
- targeted ESLint on the changed Arena files
- `git diff --check`

*(PR written by Codex)*