### PR TITLE
(fix) support custom OpenAI-compatible endpoint base URLs and paths

### DIFF
--- a/lib/ai/providers/customApiGuard.ts
+++ b/lib/ai/providers/customApiGuard.ts
@@ -12,23 +12,22 @@ export type ResolvedCustomApiTarget = {
   family: 4 | 6;
 };
 
-function normalizeBaseUrl(raw?: string): string {
+function buildChatCompletionsUrl(raw?: string): URL {
   const candidate = raw ?? process.env.CUSTOM_API_BASE_URL;
-  if (!candidate) {
+  if (!candidate?.trim()) {
     throw new Error("Missing custom API server URL");
   }
-  const base = candidate
-    .trim()
-    .replace(/\/+$/, "");
-  if (base.endsWith("/chat/completions")) {
-    return base.slice(0, -"/chat/completions".length);
-  }
-  return base;
-}
+  const url = new URL(candidate.trim());
+  const pathname = url.pathname.replace(/\/+$/, "");
 
-function buildChatCompletionsUrl(raw?: string): URL {
-  const base = normalizeBaseUrl(raw);
-  return new URL(base.endsWith("/v1") ? `${base}/chat/completions` : `${base}/v1/chat/completions`);
+  if (pathname.endsWith("/chat/completions")) {
+    url.pathname = pathname;
+  } else if (!pathname || pathname === "") {
+    url.pathname = "/v1/chat/completions";
+  } else {
+    url.pathname = `${pathname}/chat/completions`;
+  }
+  return url;
 }
 
 function normalizeIpAddress(address: string): string {

--- a/tests/unit/providers/custom-api-guard.test.ts
+++ b/tests/unit/providers/custom-api-guard.test.ts
@@ -1,0 +1,91 @@
+import assert from "node:assert/strict";
+import dns from "node:dns/promises";
+import { resolveCustomApiTarget } from "../../../lib/ai/providers/customApiGuard";
+
+const originalLookup = dns.lookup;
+
+Object.defineProperty(dns, "lookup", {
+  configurable: true,
+  value: async (hostname: string) => {
+    return [{ address: "93.184.216.34", family: 4 }];
+  },
+});
+
+async function main() {
+  // Standard OpenAI root
+  const root = await resolveCustomApiTarget("https://api.openai.com");
+  assert.equal(root.url.toString(), "https://api.openai.com/v1/chat/completions");
+
+  // Standard OpenAI root with trailing slash
+  const rootSlash = await resolveCustomApiTarget("https://api.openai.com/");
+  assert.equal(rootSlash.url.toString(), "https://api.openai.com/v1/chat/completions");
+
+  // Standard OpenAI /v1
+  const v1 = await resolveCustomApiTarget("https://api.openai.com/v1");
+  assert.equal(v1.url.toString(), "https://api.openai.com/v1/chat/completions");
+
+  // Standard OpenAI /v1 with trailing slash
+  const v1Slash = await resolveCustomApiTarget("https://api.openai.com/v1/");
+  assert.equal(v1Slash.url.toString(), "https://api.openai.com/v1/chat/completions");
+
+  // Full /v1/chat/completions
+  const full = await resolveCustomApiTarget("https://api.openai.com/v1/chat/completions");
+  assert.equal(full.url.toString(), "https://api.openai.com/v1/chat/completions");
+
+  // Full /v1/chat/completions with trailing slash
+  const fullSlash = await resolveCustomApiTarget("https://api.openai.com/v1/chat/completions/");
+  assert.equal(fullSlash.url.toString(), "https://api.openai.com/v1/chat/completions");
+
+  // ByteDance VolcEngine Ark Coding Plan subpath /api/coding/v3
+  const arkCoding = await resolveCustomApiTarget("https://ark.cn-beijing.volces.com/api/coding/v3");
+  assert.equal(
+    arkCoding.url.toString(),
+    "https://ark.cn-beijing.volces.com/api/coding/v3/chat/completions",
+  );
+
+  // ByteDance VolcEngine Ark Coding Plan full endpoint /api/coding/v3/chat/completions
+  const arkCodingFull = await resolveCustomApiTarget(
+    "https://ark.cn-beijing.volces.com/api/coding/v3/chat/completions",
+  );
+  assert.equal(
+    arkCodingFull.url.toString(),
+    "https://ark.cn-beijing.volces.com/api/coding/v3/chat/completions",
+  );
+
+  // ByteDance VolcEngine Ark standard /api/v3
+  const arkV3 = await resolveCustomApiTarget("https://ark.cn-beijing.volces.com/api/v3");
+  assert.equal(
+    arkV3.url.toString(),
+    "https://ark.cn-beijing.volces.com/api/v3/chat/completions",
+  );
+
+  // Cloudflare AI Gateway custom subpath
+  const cf = await resolveCustomApiTarget(
+    "https://gateway.ai.cloudflare.com/v1/account-id/my-gateway/openai",
+  );
+  assert.equal(
+    cf.url.toString(),
+    "https://gateway.ai.cloudflare.com/v1/account-id/my-gateway/openai/chat/completions",
+  );
+
+  // URL with query params
+  const withQuery = await resolveCustomApiTarget("https://api.example.com/v1?version=2024-02-01");
+  assert.equal(
+    withQuery.url.toString(),
+    "https://api.example.com/v1/chat/completions?version=2024-02-01",
+  );
+
+  console.log("custom api guard target resolution checks passed");
+}
+
+main()
+  .finally(() => {
+    Object.defineProperty(dns, "lookup", {
+      configurable: true,
+      value: originalLookup,
+    });
+  })
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });


### PR DESCRIPTION
### Summary
Fixes custom OpenAI-compatible endpoint URL resolution to correctly support provider base URLs with arbitrary subpaths (such as ByteDance VolcEngine Ark's `/api/coding/v3`, Cloudflare AI Gateway, custom proxy paths), explicit `/chat/completions` endpoints, and root URLs.

### Changes
- Updated `buildChatCompletionsUrl` in `lib/ai/providers/customApiGuard.ts` to preserve existing URL subpaths when constructing `/chat/completions`.
- Added unit test coverage in `tests/unit/providers/custom-api-guard.test.ts`.

*(PR written by Codex)*