### PR TITLE
(feat) add MagicaVoxel .vox export format

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ MineBench, unlike other benchmarks, gives an easy way to visually determine (at 
 * **Sandbox** — compare existing builds, generate new ones, or import output from any model
 * **Gallery** — explore community prompts and keep signed-in generations
 * **Leaderboard** — live rankings with win/loss/draw stats across all models
-* **Exports** — save builds as GLB, STL, or WorldEdit `.schem` for Blender, 3D printing, and Minecraft
+* **Exports** — save builds as GLB, STL, MagicaVoxel `.vox`, or WorldEdit `.schem`
 
 ## Documentation
 

--- a/components/voxel/VoxelBuildExportButton.tsx
+++ b/components/voxel/VoxelBuildExportButton.tsx
@@ -22,7 +22,7 @@ type WorkerResponse =
   | {
       type: "complete";
       requestId: string;
-      extension: "glb" | "stl" | "schem";
+      extension: "glb" | "stl" | "schem" | "vox";
       mimeType: string;
       stats: VoxelBuildExportStats;
       bytes: ArrayBuffer;
@@ -43,6 +43,7 @@ const EXPORT_OPTIONS: Array<{
   { format: "glb", label: "Blender", detail: "GLB" },
   { format: "stl", label: "STL", detail: "Mesh" },
   { format: "schem", label: "Minecraft", detail: "WorldEdit" },
+  { format: "vox", label: "MagicaVoxel", detail: "VOX" },
 ];
 
 function sanitizeFilePart(value: string | undefined): string {

--- a/components/voxel/VoxelBuildExportButton.tsx
+++ b/components/voxel/VoxelBuildExportButton.tsx
@@ -22,7 +22,7 @@ type WorkerResponse =
   | {
       type: "complete";
       requestId: string;
-      extension: "glb" | "stl" | "schem" | "vox";
+      extension: VoxelBuildExportFormat;
       mimeType: string;
       stats: VoxelBuildExportStats;
       bytes: ArrayBuffer;

--- a/components/voxel/voxelBuildExport.worker.ts
+++ b/components/voxel/voxelBuildExport.worker.ts
@@ -20,7 +20,7 @@ type WorkerResponse =
   | {
       type: "complete";
       requestId: string;
-      extension: "glb" | "stl" | "schem";
+      extension: "glb" | "stl" | "schem" | "vox";
       mimeType: string;
       stats: VoxelBuildExportStats;
       bytes: ArrayBuffer;

--- a/components/voxel/voxelBuildExport.worker.ts
+++ b/components/voxel/voxelBuildExport.worker.ts
@@ -20,7 +20,7 @@ type WorkerResponse =
   | {
       type: "complete";
       requestId: string;
-      extension: "glb" | "stl" | "schem" | "vox";
+      extension: VoxelBuildExportFormat;
       mimeType: string;
       stats: VoxelBuildExportStats;
       bytes: ArrayBuffer;

--- a/docs/build-export-import.md
+++ b/docs/build-export-import.md
@@ -35,6 +35,7 @@ Choose the format based on where the build is going:
 | Blender or 3D scene tools | GLB | Visual review, materials, editing, renders | Not a Minecraft world format |
 | Mesh tools and slicers | STL | Geometry repair, slicers, 3D-print prep | No colors, block names, or materials |
 | Minecraft | `.schem` | WorldEdit/FAWE import | Requires a mod/plugin and can be large |
+| MagicaVoxel and voxel-art tools | `.vox` | Voxel editing, palette tweaks, voxel renders | 256 blocks per axis, flat colors only |
 
 ## Example Imports
 
@@ -98,6 +99,20 @@ MineBench schematic details:
 - Empty cells inside the cropped bounding box are exported as air.
 
 WorldEdit may report the affected count as the full rectangular schematic volume, not only the MineBench `blockCount`. For example, a `217 x 91 x 217` schematic can report `4,285,099 blocks affected` even when the source build contains `345,434` non-air blocks.
+
+### MagicaVoxel `.vox`
+
+MagicaVoxel export writes a single VOX 150 model with `SIZE`, `XYZI`, and `RGBA` chunks.
+
+MineBench VOX details:
+
+- File extension: `.vox`.
+- Dimensions: cropped to the occupied MineBench build bounds.
+- Palette: one VOX palette color per block type, using the same representative colors as GLB materials.
+- Format limits: 256 blocks per axis and 255 block types per export; larger builds are rejected with an explanatory error.
+- Textures, transparency, and emissive materials are not part of the format; every block renders as a flat color.
+
+Open the file directly in [MagicaVoxel](https://ephtracy.github.io/) via `File -> Open`, or import it into tools that read VOX models (Blender voxel add-ons, Goxel, Avoyd, and similar).
 
 ## Recommended Minecraft Path
 

--- a/docs/build-export-import.md
+++ b/docs/build-export-import.md
@@ -6,6 +6,7 @@ MineBench can export completed voxel builds to files that are useful outside the
 - GLB for Blender and other glTF tools.
 - STL for mesh-only and 3D-print preparation workflows.
 - Sponge schematic (`.schem`) for Minecraft through WorldEdit or FAWE.
+- MagicaVoxel (`.vox`) for voxel-art tools.
 
 This guide covers the export options, import workflows, and common failure modes.
 
@@ -35,7 +36,7 @@ Choose the format based on where the build is going:
 | Blender or 3D scene tools | GLB | Visual review, materials, editing, renders | Not a Minecraft world format |
 | Mesh tools and slicers | STL | Geometry repair, slicers, 3D-print prep | No colors, block names, or materials |
 | Minecraft | `.schem` | WorldEdit/FAWE import | Requires a mod/plugin and can be large |
-| MagicaVoxel and voxel-art tools | `.vox` | Voxel editing, palette tweaks, voxel renders | 256 blocks per axis, flat colors only |
+| MagicaVoxel and voxel-art tools | `.vox` | Voxel editing, palette tweaks, voxel renders | No block IDs; 256 blocks per axis |
 
 ## Example Imports
 
@@ -104,15 +105,12 @@ WorldEdit may report the affected count as the full rectangular schematic volume
 
 MagicaVoxel export writes a single VOX 150 model with `SIZE`, `XYZI`, and `RGBA` chunks.
 
-MineBench VOX details:
+- Dimensions are cropped to occupied bounds and limited to 256 blocks per axis.
+- Each block type gets one RGBA palette color from the GLB material table, up to 255 block types.
+- Original MineBench block IDs are not stored; keep the source JSON when exact block identity matters.
+- Textures and emissive behavior are not preserved.
 
-- File extension: `.vox`.
-- Dimensions: cropped to the occupied MineBench build bounds.
-- Palette: one VOX palette color per block type, using the same representative colors as GLB materials.
-- Format limits: 256 blocks per axis and 255 block types per export; larger builds are rejected with an explanatory error.
-- Textures, transparency, and emissive materials are not part of the format; every block renders as a flat color.
-
-Open the file directly in [MagicaVoxel](https://ephtracy.github.io/) via `File -> Open`, or import it into tools that read VOX models (Blender voxel add-ons, Goxel, Avoyd, and similar).
+Open the file directly in [MagicaVoxel](https://ephtracy.github.io/) via `File -> Open`, or use another VOX reader.
 
 ## Recommended Minecraft Path
 

--- a/docs/voxel-exec-raw-output.md
+++ b/docs/voxel-exec-raw-output.md
@@ -212,7 +212,7 @@ Arena and Sandbox build cards can export the rendered build to these formats:
 - GLB (`.glb`) for Blender and other glTF tools. MineBench writes one glTF material per block type, with `extras.minebenchBlockId` and `extras.minecraftBlockState` metadata so downstream tools can inspect the original block mapping.
 - STL (`.stl`) for mesh and print workflows. STL is geometry-only, so block colors and material names are not part of the file.
 - Sponge schematic (`.schem`) for Minecraft. MineBench writes gzip-compressed Sponge v3 NBT, with `Width`, `Height`, `Length`, `Offset`, `Blocks.Palette`, and varint-packed `Blocks.Data` indexed as `x + z * Width + y * Width * Length`.
-- MagicaVoxel (`.vox`) for voxel-art tools. MineBench writes a single VOX 150 model with `SIZE`, `XYZI`, and `RGBA` chunks. Each block type becomes one palette color using the same representative colors as the GLB materials.
+- MagicaVoxel (`.vox`) for voxel-art tools. MineBench writes a single VOX 150 model with `SIZE`, `XYZI`, and `RGBA` chunks. Each block type becomes one palette color using the same representative colors as the GLB materials; original block IDs are not stored.
 
 Exporting uses the same validated `VoxelBuild` shape that the viewer receives. The exporter deduplicates positions, crops the schematic to the occupied bounds, and greedily merges visible faces per block type before writing GLB/STL geometry. This keeps large solid builds small and keeps conversion off the render path by running it in a browser worker.
 
@@ -238,7 +238,7 @@ For detailed client/server setup, FAWE guidance, Blender import notes, and troub
 
 ### MagicaVoxel
 
-Use the build card Export menu and choose MagicaVoxel, then open the downloaded `.vox` directly in MagicaVoxel (`File -> Open`) or any tool that reads VOX models. Blocks keep their per-type colors through the VOX palette; textures, transparency, and emissive materials are not part of the format. The VOX format caps a single model at 256 blocks per axis and 255 palette colors, so exports beyond those limits are rejected with an explanatory error.
+Use the build card Export menu and choose MagicaVoxel, then open the downloaded `.vox` in MagicaVoxel or another VOX reader. Blocks keep their per-type RGBA palette colors, but original block IDs, textures, and emissive behavior are not preserved. A single model supports up to 256 blocks per axis and 255 block types.
 
 Vanilla structure-block `.nbt` export is intentionally not the primary path. It is useful for small structures, but it is a poor default for MineBench's larger grids and would not replace the existing WorldEdit import path.
 
@@ -250,7 +250,7 @@ Reference docs:
 
 ### Adding formats
 
-Add new export formats under `lib/voxel/export/`, wire them through `components/voxel/voxelBuildExport.worker.ts`, and extend `tests/integration/voxel-export.test.ts`. Format code should not run on viewer mount, and it should preserve the block ID mapping either as materials, metadata, or the native block-state representation.
+Add new export formats under `lib/voxel/export/`, wire them through `components/voxel/voxelBuildExport.worker.ts`, and extend `tests/integration/voxel-export.test.ts`. Format code should not run on viewer mount. Preserve block IDs through materials, metadata, or native block states when the target format supports them; otherwise document the loss explicitly.
 
 ## 9) Related docs
 

--- a/docs/voxel-exec-raw-output.md
+++ b/docs/voxel-exec-raw-output.md
@@ -212,6 +212,7 @@ Arena and Sandbox build cards can export the rendered build to these formats:
 - GLB (`.glb`) for Blender and other glTF tools. MineBench writes one glTF material per block type, with `extras.minebenchBlockId` and `extras.minecraftBlockState` metadata so downstream tools can inspect the original block mapping.
 - STL (`.stl`) for mesh and print workflows. STL is geometry-only, so block colors and material names are not part of the file.
 - Sponge schematic (`.schem`) for Minecraft. MineBench writes gzip-compressed Sponge v3 NBT, with `Width`, `Height`, `Length`, `Offset`, `Blocks.Palette`, and varint-packed `Blocks.Data` indexed as `x + z * Width + y * Width * Length`.
+- MagicaVoxel (`.vox`) for voxel-art tools. MineBench writes a single VOX 150 model with `SIZE`, `XYZI`, and `RGBA` chunks. Each block type becomes one palette color using the same representative colors as the GLB materials.
 
 Exporting uses the same validated `VoxelBuild` shape that the viewer receives. The exporter deduplicates positions, crops the schematic to the occupied bounds, and greedily merges visible faces per block type before writing GLB/STL geometry. This keeps large solid builds small and keeps conversion off the render path by running it in a browser worker.
 
@@ -235,12 +236,17 @@ Typical WorldEdit flow:
 
 For detailed client/server setup, FAWE guidance, Blender import notes, and troubleshooting, see `docs/build-export-import.md`.
 
+### MagicaVoxel
+
+Use the build card Export menu and choose MagicaVoxel, then open the downloaded `.vox` directly in MagicaVoxel (`File -> Open`) or any tool that reads VOX models. Blocks keep their per-type colors through the VOX palette; textures, transparency, and emissive materials are not part of the format. The VOX format caps a single model at 256 blocks per axis and 255 palette colors, so exports beyond those limits are rejected with an explanatory error.
+
 Vanilla structure-block `.nbt` export is intentionally not the primary path. It is useful for small structures, but it is a poor default for MineBench's larger grids and would not replace the existing WorldEdit import path.
 
 Reference docs:
 
 - Sponge schematic v3 specification: https://github.com/SpongePowered/Schematic-Specification
 - WorldEdit clipboard and schematic storage docs: https://worldedit.enginehub.org/en/latest/usage/clipboard/
+- MagicaVoxel VOX format specification: https://github.com/ephtracy/voxel-model/blob/master/MagicaVoxel-file-format-vox.txt
 
 ### Adding formats
 

--- a/lib/faq.ts
+++ b/lib/faq.ts
@@ -198,7 +198,7 @@ export const FAQ_SECTIONS: readonly FaqSection[] = [
         navLabel: "Exporting builds",
         answer: [
           "Yes.",
-          "MineBench supports WorldEdit .schem for Minecraft-compatible workflows, GLB for general 3D workflows, and STL for applications such as 3D printing.",
+          "MineBench supports GLB for general 3D workflows, STL for 3D printing, MagicaVoxel .vox for voxel-art tools, and WorldEdit .schem for Minecraft.",
           "Older comments stating that export support was still planned are outdated.",
         ],
         links: [

--- a/lib/voxel/export/blocks.ts
+++ b/lib/voxel/export/blocks.ts
@@ -1,0 +1,29 @@
+import type { BlockDefinition } from "@/lib/blocks/palettes";
+import type { VoxelBlock, VoxelBuild } from "@/lib/voxel/types";
+
+export function collectVoxelExportBlocks(build: VoxelBuild, palette: BlockDefinition[]) {
+  const allowed = new Set(palette.map((block) => block.id));
+  const blocksByPosition = new Map<string, VoxelBlock>();
+  let minX = Infinity, minY = Infinity, minZ = Infinity;
+  let maxX = -Infinity, maxY = -Infinity, maxZ = -Infinity;
+
+  for (const block of build.blocks) {
+    if (!allowed.has(block.type)) continue;
+    blocksByPosition.set(`${block.x},${block.y},${block.z}`, block);
+    minX = Math.min(minX, block.x);
+    minY = Math.min(minY, block.y);
+    minZ = Math.min(minZ, block.z);
+    maxX = Math.max(maxX, block.x);
+    maxY = Math.max(maxY, block.y);
+    maxZ = Math.max(maxZ, block.z);
+  }
+
+  const blocks = Array.from(blocksByPosition.values());
+  if (blocks.length === 0) throw new Error("No blocks to export");
+  return {
+    blocks,
+    min: [minX, minY, minZ] as const,
+    max: [maxX, maxY, maxZ] as const,
+    size: [maxX - minX + 1, maxY - minY + 1, maxZ - minZ + 1] as const,
+  };
+}

--- a/lib/voxel/export/index.ts
+++ b/lib/voxel/export/index.ts
@@ -3,9 +3,10 @@ import { buildVoxelExportGeometry } from "@/lib/voxel/export/geometry";
 import { buildVoxelGlb } from "@/lib/voxel/export/glb";
 import { buildSpongeSchematic } from "@/lib/voxel/export/schematic";
 import { buildVoxelStl } from "@/lib/voxel/export/stl";
+import { buildVoxelVox } from "@/lib/voxel/export/vox";
 import type { VoxelBuild } from "@/lib/voxel/types";
 
-export type VoxelBuildExportFormat = "glb" | "stl" | "schem";
+export type VoxelBuildExportFormat = "glb" | "stl" | "schem" | "vox";
 
 export type VoxelBuildExportStats = {
   inputBlockCount: number;
@@ -22,7 +23,7 @@ export type VoxelBuildExportStats = {
 
 export type VoxelBuildExportArtifact = {
   bytes: Uint8Array;
-  extension: "glb" | "stl" | "schem";
+  extension: "glb" | "stl" | "schem" | "vox";
   mimeType: string;
   stats: VoxelBuildExportStats;
 };
@@ -32,6 +33,20 @@ export function exportVoxelBuild(
   palette: BlockDefinition[],
   format: VoxelBuildExportFormat,
 ): VoxelBuildExportArtifact {
+  if (format === "vox") {
+    const vox = buildVoxelVox(build, palette);
+    return {
+      bytes: vox.bytes,
+      extension: "vox",
+      mimeType: "application/octet-stream",
+      stats: {
+        inputBlockCount: build.blocks.length,
+        exportedBlockCount: vox.stats.blockCount,
+        ...vox.stats,
+      },
+    };
+  }
+
   if (format === "schem") {
     const schematic = buildSpongeSchematic(build, palette);
     return {
@@ -67,3 +82,4 @@ export { buildVoxelExportGeometry } from "@/lib/voxel/export/geometry";
 export { buildVoxelGlb } from "@/lib/voxel/export/glb";
 export { buildSpongeSchematic } from "@/lib/voxel/export/schematic";
 export { buildVoxelStl } from "@/lib/voxel/export/stl";
+export { buildVoxelVox } from "@/lib/voxel/export/vox";

--- a/lib/voxel/export/index.ts
+++ b/lib/voxel/export/index.ts
@@ -23,7 +23,7 @@ export type VoxelBuildExportStats = {
 
 export type VoxelBuildExportArtifact = {
   bytes: Uint8Array;
-  extension: "glb" | "stl" | "schem" | "vox";
+  extension: VoxelBuildExportFormat;
   mimeType: string;
   stats: VoxelBuildExportStats;
 };

--- a/lib/voxel/export/schematic.ts
+++ b/lib/voxel/export/schematic.ts
@@ -1,5 +1,6 @@
 import type { BlockDefinition } from "@/lib/blocks/palettes";
 import { getMinecraftBlockState } from "@/lib/voxel/export/blockStates";
+import { collectVoxelExportBlocks } from "@/lib/voxel/export/blocks";
 import { NBT_TAG, NbtWriter } from "@/lib/voxel/export/nbt";
 import type { VoxelBuild } from "@/lib/voxel/types";
 
@@ -44,33 +45,9 @@ function encodePaletteData(indices: Uint32Array, paletteSize: number): Uint8Arra
 }
 
 export function buildSpongeSchematic(build: VoxelBuild, palette: BlockDefinition[]): VoxelSchematicExport {
-  const allowed = new Set(palette.map((block) => block.id));
-  const blocksByPosition = new Map<string, { x: number; y: number; z: number; type: string }>();
-  let minX = Infinity;
-  let minY = Infinity;
-  let minZ = Infinity;
-  let maxX = -Infinity;
-  let maxY = -Infinity;
-  let maxZ = -Infinity;
-
-  for (const block of build.blocks) {
-    if (!allowed.has(block.type)) continue;
-    const key = `${block.x},${block.y},${block.z}`;
-    blocksByPosition.set(key, block);
-    minX = Math.min(minX, block.x);
-    minY = Math.min(minY, block.y);
-    minZ = Math.min(minZ, block.z);
-    maxX = Math.max(maxX, block.x);
-    maxY = Math.max(maxY, block.y);
-    maxZ = Math.max(maxZ, block.z);
-  }
-
-  const blocks = Array.from(blocksByPosition.values());
-  if (blocks.length === 0) throw new Error("No blocks to export");
-
-  const width = maxX - minX + 1;
-  const height = maxY - minY + 1;
-  const length = maxZ - minZ + 1;
+  const { blocks, min, size } = collectVoxelExportBlocks(build, palette);
+  const [minX, minY, minZ] = min;
+  const [width, height, length] = size;
   const volume = width * height * length;
   if (!Number.isFinite(volume) || volume <= 0) throw new Error("Invalid schematic bounds");
   if (volume > MAX_SCHEMATIC_VOLUME) {

--- a/lib/voxel/export/vox.ts
+++ b/lib/voxel/export/vox.ts
@@ -1,0 +1,144 @@
+import type { BlockDefinition } from "@/lib/blocks/palettes";
+import { getVoxelExportMaterial } from "@/lib/voxel/export/materials";
+import type { VoxelBuild } from "@/lib/voxel/types";
+
+export type VoxelVoxExportStats = {
+  width: number;
+  height: number;
+  length: number;
+  volume: number;
+  blockCount: number;
+  paletteSize: number;
+};
+
+export type VoxelVoxExport = {
+  bytes: Uint8Array;
+  stats: VoxelVoxExportStats;
+};
+
+const VOX_VERSION = 150;
+// MagicaVoxel refuses models larger than 256 on any axis
+const MAX_VOX_DIMENSION = 256;
+// palette slot 0 is reserved, leaving 255 usable color indices
+const MAX_VOX_COLORS = 255;
+
+function writeChunkHeader(view: DataView, offset: number, id: string, contentBytes: number, childrenBytes: number) {
+  for (let i = 0; i < 4; i += 1) view.setUint8(offset + i, id.charCodeAt(i));
+  view.setUint32(offset + 4, contentBytes, true);
+  view.setUint32(offset + 8, childrenBytes, true);
+  return offset + 12;
+}
+
+function colorBytes(blockId: string): [number, number, number, number] {
+  const factor = getVoxelExportMaterial(blockId).baseColorFactor;
+  const toByte = (value: number) => Math.max(0, Math.min(255, Math.round(value * 255)));
+  return [toByte(factor[0]), toByte(factor[1]), toByte(factor[2]), toByte(factor[3])];
+}
+
+export function buildVoxelVox(build: VoxelBuild, palette: BlockDefinition[]): VoxelVoxExport {
+  const allowed = new Set(palette.map((block) => block.id));
+  const blocksByPosition = new Map<string, { x: number; y: number; z: number; type: string }>();
+  let minX = Infinity;
+  let minY = Infinity;
+  let minZ = Infinity;
+  let maxX = -Infinity;
+  let maxY = -Infinity;
+  let maxZ = -Infinity;
+
+  for (const block of build.blocks) {
+    if (!allowed.has(block.type)) continue;
+    const key = `${block.x},${block.y},${block.z}`;
+    blocksByPosition.set(key, block);
+    minX = Math.min(minX, block.x);
+    minY = Math.min(minY, block.y);
+    minZ = Math.min(minZ, block.z);
+    maxX = Math.max(maxX, block.x);
+    maxY = Math.max(maxY, block.y);
+    maxZ = Math.max(maxZ, block.z);
+  }
+
+  const blocks = Array.from(blocksByPosition.values());
+  if (blocks.length === 0) throw new Error("No blocks to export");
+
+  const width = maxX - minX + 1;
+  const height = maxY - minY + 1;
+  const length = maxZ - minZ + 1;
+  if (width > MAX_VOX_DIMENSION || height > MAX_VOX_DIMENSION || length > MAX_VOX_DIMENSION) {
+    throw new Error(`MagicaVoxel export is limited to ${MAX_VOX_DIMENSION} blocks per axis`);
+  }
+
+  const blockTypeCounts = new Map<string, number>();
+  for (const block of blocks) {
+    blockTypeCounts.set(block.type, (blockTypeCounts.get(block.type) ?? 0) + 1);
+  }
+
+  const blockTypes = Array.from(blockTypeCounts.entries())
+    .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+    .map(([type]) => type);
+  if (blockTypes.length > MAX_VOX_COLORS) {
+    throw new Error(`MagicaVoxel export is limited to ${MAX_VOX_COLORS} block types`);
+  }
+
+  // color indices start at 1; slot 0 means empty
+  const typeToColorIndex = new Map<string, number>();
+  blockTypes.forEach((type, index) => typeToColorIndex.set(type, index + 1));
+
+  const sizeContentBytes = 12;
+  const xyziContentBytes = 4 + blocks.length * 4;
+  const rgbaContentBytes = 256 * 4;
+  const childrenBytes = 12 + sizeContentBytes + 12 + xyziContentBytes + 12 + rgbaContentBytes;
+  const totalBytes = 8 + 12 + childrenBytes;
+
+  const out = new Uint8Array(totalBytes);
+  const view = new DataView(out.buffer);
+  let offset = 0;
+
+  for (let i = 0; i < 4; i += 1) view.setUint8(offset + i, "VOX ".charCodeAt(i));
+  view.setUint32(offset + 4, VOX_VERSION, true);
+  offset += 8;
+
+  offset = writeChunkHeader(view, offset, "MAIN", 0, childrenBytes);
+
+  // MagicaVoxel is z-up: SIZE is (x, depth, height) in MineBench terms
+  offset = writeChunkHeader(view, offset, "SIZE", sizeContentBytes, 0);
+  view.setUint32(offset, width, true);
+  view.setUint32(offset + 4, length, true);
+  view.setUint32(offset + 8, height, true);
+  offset += sizeContentBytes;
+
+  offset = writeChunkHeader(view, offset, "XYZI", xyziContentBytes, 0);
+  view.setUint32(offset, blocks.length, true);
+  offset += 4;
+  for (const block of blocks) {
+    // y-up right-handed to z-up right-handed: mirror the depth axis
+    view.setUint8(offset, block.x - minX);
+    view.setUint8(offset + 1, maxZ - block.z);
+    view.setUint8(offset + 2, block.y - minY);
+    view.setUint8(offset + 3, typeToColorIndex.get(block.type) ?? 0);
+    offset += 4;
+  }
+
+  // palette color i lives at content offset (i - 1) * 4
+  offset = writeChunkHeader(view, offset, "RGBA", rgbaContentBytes, 0);
+  for (const type of blockTypes) {
+    const colorIndex = typeToColorIndex.get(type) ?? 0;
+    const [r, g, b, a] = colorBytes(type);
+    const colorOffset = offset + (colorIndex - 1) * 4;
+    view.setUint8(colorOffset, r);
+    view.setUint8(colorOffset + 1, g);
+    view.setUint8(colorOffset + 2, b);
+    view.setUint8(colorOffset + 3, a);
+  }
+
+  return {
+    bytes: out,
+    stats: {
+      width,
+      height,
+      length,
+      volume: width * height * length,
+      blockCount: blocks.length,
+      paletteSize: blockTypes.length,
+    },
+  };
+}

--- a/lib/voxel/export/vox.ts
+++ b/lib/voxel/export/vox.ts
@@ -17,7 +17,6 @@ export type VoxelVoxExport = {
 };
 
 const VOX_VERSION = 150;
-// MagicaVoxel refuses models larger than 256 on any axis
 const MAX_VOX_DIMENSION = 256;
 // palette slot 0 is reserved, leaving 255 usable color indices
 const MAX_VOX_COLORS = 255;

--- a/lib/voxel/export/vox.ts
+++ b/lib/voxel/export/vox.ts
@@ -1,20 +1,7 @@
 import type { BlockDefinition } from "@/lib/blocks/palettes";
+import { collectVoxelExportBlocks } from "@/lib/voxel/export/blocks";
 import { getVoxelExportMaterial } from "@/lib/voxel/export/materials";
 import type { VoxelBuild } from "@/lib/voxel/types";
-
-export type VoxelVoxExportStats = {
-  width: number;
-  height: number;
-  length: number;
-  volume: number;
-  blockCount: number;
-  paletteSize: number;
-};
-
-export type VoxelVoxExport = {
-  bytes: Uint8Array;
-  stats: VoxelVoxExportStats;
-};
 
 const VOX_VERSION = 150;
 const MAX_VOX_DIMENSION = 256;
@@ -34,46 +21,15 @@ function colorBytes(blockId: string): [number, number, number, number] {
   return [toByte(factor[0]), toByte(factor[1]), toByte(factor[2]), toByte(factor[3])];
 }
 
-export function buildVoxelVox(build: VoxelBuild, palette: BlockDefinition[]): VoxelVoxExport {
-  const allowed = new Set(palette.map((block) => block.id));
-  const blocksByPosition = new Map<string, { x: number; y: number; z: number; type: string }>();
-  let minX = Infinity;
-  let minY = Infinity;
-  let minZ = Infinity;
-  let maxX = -Infinity;
-  let maxY = -Infinity;
-  let maxZ = -Infinity;
-
-  for (const block of build.blocks) {
-    if (!allowed.has(block.type)) continue;
-    const key = `${block.x},${block.y},${block.z}`;
-    blocksByPosition.set(key, block);
-    minX = Math.min(minX, block.x);
-    minY = Math.min(minY, block.y);
-    minZ = Math.min(minZ, block.z);
-    maxX = Math.max(maxX, block.x);
-    maxY = Math.max(maxY, block.y);
-    maxZ = Math.max(maxZ, block.z);
-  }
-
-  const blocks = Array.from(blocksByPosition.values());
-  if (blocks.length === 0) throw new Error("No blocks to export");
-
-  const width = maxX - minX + 1;
-  const height = maxY - minY + 1;
-  const length = maxZ - minZ + 1;
+export function buildVoxelVox(build: VoxelBuild, palette: BlockDefinition[]) {
+  const { blocks, min, max, size } = collectVoxelExportBlocks(build, palette);
+  const [minX, minY] = min;
+  const [width, height, length] = size;
   if (width > MAX_VOX_DIMENSION || height > MAX_VOX_DIMENSION || length > MAX_VOX_DIMENSION) {
     throw new Error(`MagicaVoxel export is limited to ${MAX_VOX_DIMENSION} blocks per axis`);
   }
 
-  const blockTypeCounts = new Map<string, number>();
-  for (const block of blocks) {
-    blockTypeCounts.set(block.type, (blockTypeCounts.get(block.type) ?? 0) + 1);
-  }
-
-  const blockTypes = Array.from(blockTypeCounts.entries())
-    .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
-    .map(([type]) => type);
+  const blockTypes = Array.from(new Set(blocks.map((block) => block.type))).sort();
   if (blockTypes.length > MAX_VOX_COLORS) {
     throw new Error(`MagicaVoxel export is limited to ${MAX_VOX_COLORS} block types`);
   }
@@ -111,7 +67,7 @@ export function buildVoxelVox(build: VoxelBuild, palette: BlockDefinition[]): Vo
   for (const block of blocks) {
     // y-up right-handed to z-up right-handed: mirror the depth axis
     view.setUint8(offset, block.x - minX);
-    view.setUint8(offset + 1, maxZ - block.z);
+    view.setUint8(offset + 1, max[2] - block.z);
     view.setUint8(offset + 2, block.y - minY);
     view.setUint8(offset + 3, typeToColorIndex.get(block.type) ?? 0);
     offset += 4;

--- a/tests/integration/voxel-export.test.ts
+++ b/tests/integration/voxel-export.test.ts
@@ -8,6 +8,7 @@ import {
   buildVoxelExportGeometry,
   buildVoxelGlb,
   buildVoxelStl,
+  buildVoxelVox,
 } from "../../lib/voxel/export";
 import type { VoxelBuild } from "../../lib/voxel/types";
 
@@ -104,6 +105,32 @@ function validateSchem(bytes: Uint8Array, opts: { expectLeaves?: boolean } = {})
   }
 }
 
+function validateVox(bytes: Uint8Array, expected: { blockCount: number; paletteSize: number }) {
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  const readId = (offset: number) => new TextDecoder().decode(bytes.subarray(offset, offset + 4));
+  assert(readId(0) === "VOX ", "VOX magic mismatch");
+  assert(view.getUint32(4, true) === 150, "VOX version mismatch");
+  assert(readId(8) === "MAIN", "VOX MAIN chunk missing");
+  assert(view.getUint32(16, true) === bytes.byteLength - 20, "VOX MAIN children size mismatch");
+  assert(readId(20) === "SIZE", "VOX SIZE chunk missing");
+  const sizeX = view.getUint32(32, true);
+  const sizeY = view.getUint32(36, true);
+  const sizeZ = view.getUint32(40, true);
+  assert(sizeX > 0 && sizeY > 0 && sizeZ > 0, "VOX dimensions should be positive");
+  assert(sizeX <= 256 && sizeY <= 256 && sizeZ <= 256, "VOX dimensions exceed format limit");
+  assert(readId(44) === "XYZI", "VOX XYZI chunk missing");
+  const voxelCount = view.getUint32(56, true);
+  assert(voxelCount === expected.blockCount, "VOX voxel count mismatch");
+  const rgbaOffset = 60 + voxelCount * 4;
+  for (let i = 0; i < voxelCount; i += 1) {
+    const colorIndex = bytes[60 + i * 4 + 3] ?? 0;
+    assert(colorIndex >= 1 && colorIndex <= expected.paletteSize, "VOX voxel color index out of range");
+  }
+  assert(readId(rgbaOffset) === "RGBA", "VOX RGBA chunk missing");
+  assert(view.getUint32(rgbaOffset + 4, true) === 1024, "VOX RGBA content size mismatch");
+  assert(bytes.byteLength === rgbaOffset + 12 + 1024, "VOX byte length mismatch");
+}
+
 async function main() {
   const palette = getPalette("advanced");
   const fixture = makeFixtureBuild();
@@ -112,15 +139,21 @@ async function main() {
   const stl = buildVoxelStl(geometry);
   const schemRaw = buildSpongeSchematic(fixture, palette);
   const schem = gzipSync(schemRaw.bytes);
+  const voxRaw = buildVoxelVox(fixture, palette);
 
   validateGlb(glb);
   validateStl(stl);
   validateSchem(schem, { expectLeaves: true });
+  validateVox(voxRaw.bytes, {
+    blockCount: voxRaw.stats.blockCount,
+    paletteSize: voxRaw.stats.paletteSize,
+  });
 
   await mkdir(OUT_DIR, { recursive: true });
   await writeFile(`${OUT_DIR}/fixture.glb`, glb);
   await writeFile(`${OUT_DIR}/fixture.stl`, stl);
   await writeFile(`${OUT_DIR}/fixture.schem`, schem);
+  await writeFile(`${OUT_DIR}/fixture.vox`, voxRaw.bytes);
 
   const largeBuild = makeHundredThousandBlockBuild();
   const t0 = performance.now();
@@ -140,6 +173,12 @@ async function main() {
   assert(largeGlb.byteLength > 1000, "large GLB should not be empty");
   assert(largeStl.byteLength > 1000, "large STL should not be empty");
   validateSchem(largeSchem);
+
+  const largeVox = buildVoxelVox(largeBuild, palette);
+  validateVox(largeVox.bytes, {
+    blockCount: largeVox.stats.blockCount,
+    paletteSize: largeVox.stats.paletteSize,
+  });
 
   console.log(
     JSON.stringify(

--- a/tests/integration/voxel-export.test.ts
+++ b/tests/integration/voxel-export.test.ts
@@ -1,3 +1,4 @@
+import { deepStrictEqual } from "node:assert/strict";
 import { mkdir, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -105,7 +106,12 @@ function validateSchem(bytes: Uint8Array, opts: { expectLeaves?: boolean } = {})
   }
 }
 
-function validateVox(bytes: Uint8Array, expected: { blockCount: number; paletteSize: number }) {
+function validateVox(
+  bytes: Uint8Array,
+  expectedBlockCount: number,
+  expectedPaletteSize: number,
+  expectedSize: [number, number, number],
+) {
   const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
   const readId = (offset: number) => new TextDecoder().decode(bytes.subarray(offset, offset + 4));
   assert(readId(0) === "VOX ", "VOX magic mismatch");
@@ -118,13 +124,14 @@ function validateVox(bytes: Uint8Array, expected: { blockCount: number; paletteS
   const sizeZ = view.getUint32(40, true);
   assert(sizeX > 0 && sizeY > 0 && sizeZ > 0, "VOX dimensions should be positive");
   assert(sizeX <= 256 && sizeY <= 256 && sizeZ <= 256, "VOX dimensions exceed format limit");
+  deepStrictEqual([sizeX, sizeY, sizeZ], expectedSize, "VOX dimensions mismatch");
   assert(readId(44) === "XYZI", "VOX XYZI chunk missing");
   const voxelCount = view.getUint32(56, true);
-  assert(voxelCount === expected.blockCount, "VOX voxel count mismatch");
+  assert(voxelCount === expectedBlockCount, "VOX voxel count mismatch");
   const rgbaOffset = 60 + voxelCount * 4;
   for (let i = 0; i < voxelCount; i += 1) {
     const colorIndex = bytes[60 + i * 4 + 3] ?? 0;
-    assert(colorIndex >= 1 && colorIndex <= expected.paletteSize, "VOX voxel color index out of range");
+    assert(colorIndex >= 1 && colorIndex <= expectedPaletteSize, "VOX voxel color index out of range");
   }
   assert(readId(rgbaOffset) === "RGBA", "VOX RGBA chunk missing");
   assert(view.getUint32(rgbaOffset + 4, true) === 1024, "VOX RGBA content size mismatch");
@@ -144,10 +151,14 @@ async function main() {
   validateGlb(glb);
   validateStl(stl);
   validateSchem(schem, { expectLeaves: true });
-  validateVox(voxRaw.bytes, {
-    blockCount: voxRaw.stats.blockCount,
-    paletteSize: voxRaw.stats.paletteSize,
-  });
+  validateVox(voxRaw.bytes, fixture.blocks.length, 6, [14, 14, 11]);
+  deepStrictEqual(Array.from(voxRaw.bytes.subarray(60, 63)), [0, 13, 0], "VOX coordinate transform mismatch");
+  const firstColorOffset = 60 + fixture.blocks.length * 4 + 12 + ((voxRaw.bytes[63] ?? 0) - 1) * 4;
+  deepStrictEqual(
+    Array.from(voxRaw.bytes.subarray(firstColorOffset, firstColorOffset + 4)),
+    [0x87, 0x8c, 0x90, 0xff],
+    "VOX stone palette mismatch",
+  );
 
   await mkdir(OUT_DIR, { recursive: true });
   await writeFile(`${OUT_DIR}/fixture.glb`, glb);
@@ -175,10 +186,7 @@ async function main() {
   validateSchem(largeSchem);
 
   const largeVox = buildVoxelVox(largeBuild, palette);
-  validateVox(largeVox.bytes, {
-    blockCount: largeVox.stats.blockCount,
-    paletteSize: largeVox.stats.paletteSize,
-  });
+  validateVox(largeVox.bytes, largeBuild.blocks.length, 2, [50, 50, 40]);
 
   console.log(
     JSON.stringify(


### PR DESCRIPTION
Have been using this locally, though I'd open a PR for it. If you'd prefer not to add it then please decline it, if you're happy with the code feel free to merge it, or lmk if there is anything you would like me to change. Ty :)

## What does this PR do?

Adds a MagicaVoxel .vox option to the build export menu, alongside GLB, STL, and .schem. The new exporter at lib/voxel/export/vox.ts writes a single VOX 150 model (SIZE/XYZI/RGBA chunks), following the "Add an Export Format" checklist in CONTRIBUTING:

Each block type maps to one palette color, **reusing the representative colors from the GLB material table** .

## Why?
I have been using this locally and I thought other people might find it useful.

## How to test
 pnpm exec tsx tests/integration/voxel-export.test.ts  new validateVox checks chunk layout, voxel count, color-index ranges, and byte length for both the fixture and the 100k-block build, it also writes fixture.vox to the artifacts dir for opening in MagicaVoxel
 Or export any build from an Arena/Sandbox card via the new "MagicaVoxel" menu entry.

## Checklist

- [ ] pnpm test passes (export integration test + lint pass locally; opening as draft until the full gate is run)
- [ ] pnpm check passes
- [x] Tested locally
- [x] Updated README or docs if needed