### PR TITLE
feat(explorer): integrate build exploration

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -929,6 +929,16 @@
     background-color: hsl(var(--fg) / 0.09);
   }
 
+  .mb-explorer-launch {
+    display: none;
+  }
+
+  @media (hover: hover) and (pointer: fine) {
+    .mb-explorer-launch {
+      display: inline-flex;
+    }
+  }
+
   .mb-btn-danger {
     @apply ring-1 ring-danger/45;
     background-color: hsl(var(--danger) / 0.12);

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -8,6 +8,7 @@ import { PublicPresence } from "@/components/PublicPresence";
 import { SiteFooter } from "@/components/SiteFooter";
 import { SiteHeader } from "@/components/SiteHeader";
 import { SiteHealthBanner } from "@/components/SiteHealthBanner";
+import { VoxelExplorerProvider } from "@/components/voxel/VoxelExplorerLauncher";
 import {
   DEFAULT_OG_IMAGE,
   SEO_KEYWORDS,
@@ -136,21 +137,23 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
           dangerouslySetInnerHTML={{ __html: JSON.stringify(structuredData) }}
         />
 
-        <OfflineBanner />
-        <SiteHealthBanner />
+        <VoxelExplorerProvider>
+          <OfflineBanner />
+          <SiteHealthBanner />
 
-        <div id="mb-shell" className="relative z-10 flex min-h-dvh flex-col">
-          <SiteHeader />
-          <div id="mb-container" className="mx-auto flex w-full max-w-[92rem] flex-1 flex-col px-4 sm:px-6 lg:px-8">
-            <main id="main" className="flex-1 py-4 sm:py-6">
-              {children}
-            </main>
-            <SiteFooter />
+          <div id="mb-shell" className="relative z-10 flex min-h-dvh flex-col">
+            <SiteHeader />
+            <div id="mb-container" className="mx-auto flex w-full max-w-[92rem] flex-1 flex-col px-4 sm:px-6 lg:px-8">
+              <main id="main" className="flex-1 py-4 sm:py-6">
+                {children}
+              </main>
+              <SiteFooter />
+            </div>
           </div>
-        </div>
-        <Analytics />
-        <SpeedInsights />
-        <PublicPresence />
+          <Analytics />
+          <SpeedInsights />
+          <PublicPresence />
+        </VoxelExplorerProvider>
       </body>
     </html>
   );

--- a/components/gallery/GalleryDetail.tsx
+++ b/components/gallery/GalleryDetail.tsx
@@ -381,6 +381,13 @@ export function GalleryDetail({ candidate }: { candidate: GalleryDetailPayload }
         enableBuildExport={Boolean(build)}
         exportLabel={example.model.label}
         exportPrompt={candidate.prompt}
+        explorer={build && !loading ? {
+          id: `gallery:${example.id}`,
+          model: example.model.label,
+          prompt: candidate.prompt,
+          source: "gallery",
+          checksum: example.checksum ?? null,
+        } : undefined}
         viewerRef={getViewerRef(example.id)}
         metrics={example.blockCount != null ? {
           blockCount: example.blockCount,

--- a/components/gallery/GalleryYours.tsx
+++ b/components/gallery/GalleryYours.tsx
@@ -205,9 +205,11 @@ function GenerationActions({
 function SavedBuildDialog({
   generation,
   onClose,
+  onExplorerExit,
 }: {
   generation: SavedGenerationPayload;
   onClose: () => void;
+  onExplorerExit: () => void;
 }) {
   const dialogRef = useRef<HTMLDialogElement>(null);
   const viewerRef = useRef<VoxelViewerHandle>(null);
@@ -283,6 +285,15 @@ function SavedBuildDialog({
             enableBuildExport={Boolean(build)}
             exportLabel={generation.model.label}
             exportPrompt={generation.prompt}
+            explorer={build && !loading ? {
+              id: `current:${generation.id}`,
+              model: generation.model.label,
+              prompt: generation.prompt,
+              source: "current",
+              checksum: null,
+              onContinue: onClose,
+              onExit: onExplorerExit,
+            } : undefined}
             viewerRef={viewerRef}
             jsonBytes={generation.expandedBytes}
             metrics={generation.blockCount != null ? {
@@ -441,7 +452,13 @@ export function GalleryYours({
       </div>
       {cursor ? <div className="mt-12 flex justify-center"><button type="button" disabled={loadingMore} className="mb-btn h-11 min-w-36" onClick={() => void loadMore()}>{loadingMore ? "Loading…" : "More"}</button></div> : null}
       {loadError ? <p role="status" className="mt-6 text-center text-sm text-danger">{loadError}</p> : null}
-      {selected ? <SavedBuildDialog generation={selected} onClose={() => setSelectedId(null)} /> : null}
+      {selected ? (
+        <SavedBuildDialog
+          generation={selected}
+          onClose={() => setSelectedId(null)}
+          onExplorerExit={() => setSelectedId(selected.id)}
+        />
+      ) : null}
     </section>
   );
 }

--- a/components/leaderboard/ModelDetail.tsx
+++ b/components/leaderboard/ModelDetail.tsx
@@ -937,6 +937,7 @@ export function ModelDetail({ data }: { data: ModelDetailStats }) {
   const pathname = usePathname();
   const searchParams = useSearchParams();
   const requestedBuildId = searchParams.get("build");
+  const explorerActive = useVoxelExplorerActive();
   const [hoveredCurveIndex, setHoveredCurveIndex] = useState<number | null>(null);
   const [showAllOpponents, setShowAllOpponents] = useState(false);
   const [showAllPrompts, setShowAllPrompts] = useState(false);
@@ -1087,13 +1088,13 @@ export function ModelDetail({ data }: { data: ModelDetailStats }) {
   useEffect(() => {
     if (!activePrompt) return;
     const onKeyDown = (event: KeyboardEvent) => {
-      if (event.key !== "Escape") return;
+      if (event.key !== "Escape" || explorerActive) return;
       event.preventDefault();
       setPromptWithUrl(null);
     };
     window.addEventListener("keydown", onKeyDown);
     return () => window.removeEventListener("keydown", onKeyDown);
-  }, [activePrompt, setPromptWithUrl]);
+  }, [activePrompt, explorerActive, setPromptWithUrl]);
 
   const activePromptIndex = useMemo(() => {
     if (!activePrompt) return -1;
@@ -2016,18 +2017,20 @@ export function ModelDetail({ data }: { data: ModelDetailStats }) {
                   actions={
                     activeLoadedBuild ? (
                       <>
-                        <VoxelExplorerLaunchButton
-                          build={{
-                            id: activeLoadedBuild.buildId,
-                            model: data.model.displayName,
-                            prompt: activePrompt.promptText,
-                            blockCount: activeLoadedBuild.blockCount,
-                            source: "benchmark",
-                            checksum: activeLoadedBuild.checksum ?? null,
-                            palette: activeLoadedBuild.palette,
-                            voxelBuild: activeLoadedBuild.voxelBuild,
-                          }}
-                        />
+                        {activeFullCachedBuild ? (
+                          <VoxelExplorerLaunchButton
+                            build={{
+                              id: activeFullCachedBuild.buildId,
+                              model: data.model.displayName,
+                              prompt: activePrompt.promptText,
+                              blockCount: activeFullCachedBuild.blockCount,
+                              source: "benchmark",
+                              checksum: activeFullCachedBuild.checksum ?? null,
+                              palette: activeFullCachedBuild.palette,
+                              voxelBuild: activeFullCachedBuild.voxelBuild,
+                            }}
+                          />
+                        ) : null}
                         <VoxelBuildExportButton
                           build={activeLoadedBuild.voxelBuild}
                           palette={activeLoadedBuild.palette}

--- a/components/leaderboard/ModelDetail.tsx
+++ b/components/leaderboard/ModelDetail.tsx
@@ -31,6 +31,10 @@ import type {
   VoxelViewerHandle,
 } from "@/components/voxel/VoxelViewer";
 import { VoxelBuildExportButton } from "@/components/voxel/VoxelBuildExportButton";
+import {
+  VoxelExplorerLaunchButton,
+  useVoxelExplorerActive,
+} from "@/components/voxel/VoxelExplorerLauncher";
 import { summarizeArenaVotes } from "@/lib/arena/voteMath";
 import { createPublicMeshCacheKey } from "@/lib/voxel/meshPayloadCache";
 import {
@@ -747,6 +751,7 @@ const PromptBuildPreview = memo(function PromptBuildPreview({
 
   const [viewerReady, setViewerReady] = useState(false);
   const [placementProgress, setPlacementProgress] = useState<PlacementProgressState | null>(null);
+  const explorerActive = useVoxelExplorerActive();
   useEffect(() => {
     setViewerReady(false);
     setPlacementProgress(null);
@@ -815,20 +820,22 @@ const PromptBuildPreview = memo(function PromptBuildPreview({
 
   return (
     <div className={`relative w-full overflow-hidden rounded-md bg-bg/32 ring-1 ring-border/65 ${heightClass}`}>
-      <LazyVoxelViewer
-        ref={viewerRef}
-        voxelBuild={build.voxelBuild}
-        palette={build.palette}
-        meshCacheKey={meshCacheKey}
-        autoRotate
-        showControls={false}
-        onBuildReadyChange={handleBuildReadyChange}
-        onBuildProgressChange={handleBuildProgressChange}
-        onBuildMetrics={(metrics) => {
-          if (!build?.checksum) return;
-          enqueueVoxelMetric("leaderboard", build.variant, metrics);
-        }}
-      />
+      {!explorerActive ? (
+        <LazyVoxelViewer
+          ref={viewerRef}
+          voxelBuild={build.voxelBuild}
+          palette={build.palette}
+          meshCacheKey={meshCacheKey}
+          autoRotate
+          showControls={false}
+          onBuildReadyChange={handleBuildReadyChange}
+          onBuildProgressChange={handleBuildProgressChange}
+          onBuildMetrics={(metrics) => {
+            if (!build?.checksum) return;
+            enqueueVoxelMetric("leaderboard", build.variant, metrics);
+          }}
+        />
+      ) : null}
       {loading || placementLoading ? (
         <VoxelLoadingHud
           label={overlayLabel}
@@ -2009,6 +2016,18 @@ export function ModelDetail({ data }: { data: ModelDetailStats }) {
                   actions={
                     activeLoadedBuild ? (
                       <>
+                        <VoxelExplorerLaunchButton
+                          build={{
+                            id: activeLoadedBuild.buildId,
+                            model: data.model.displayName,
+                            prompt: activePrompt.promptText,
+                            blockCount: activeLoadedBuild.blockCount,
+                            source: "benchmark",
+                            checksum: activeLoadedBuild.checksum ?? null,
+                            palette: activeLoadedBuild.palette,
+                            voxelBuild: activeLoadedBuild.voxelBuild,
+                          }}
+                        />
                         <VoxelBuildExportButton
                           build={activeLoadedBuild.voxelBuild}
                           palette={activeLoadedBuild.palette}

--- a/components/local/LocalLab.tsx
+++ b/components/local/LocalLab.tsx
@@ -854,6 +854,13 @@ export function LocalLab() {
             loadingProgress={rendered.kind === "loading" ? rendered.progress ?? undefined : undefined}
             skipValidation={rendered.kind === "loading"}
             viewerRef={previewViewerRef}
+            explorer={rendered.kind === "ready" ? {
+              id: "current:imported",
+              model: "Imported build",
+              prompt: taskPrompt,
+              source: "current",
+              checksum: null,
+            } : undefined}
             actions={
               <SandboxGifExportButton
                 targets={previewExportTargets}

--- a/components/sandbox/SandboxBenchmark.tsx
+++ b/components/sandbox/SandboxBenchmark.tsx
@@ -1069,6 +1069,13 @@ export function SandboxBenchmark() {
             enableBuildExport={hasRenderableBuild && laneState.phase === "ready" && Boolean(build && model)}
             exportLabel={title}
             exportPrompt={selectedPromptText}
+            explorer={hasRenderableBuild && laneState.phase === "ready" && build && model ? {
+              id: build.buildId,
+              model: model.displayName,
+              prompt: selectedPromptText,
+              source: "benchmark",
+              checksum: build.checksum ?? build.buildRef.checksum ?? null,
+            } : undefined}
             actions={
               hasRenderableBuild && build && model ? (
                 <SandboxGifExportButton

--- a/components/sandbox/SandboxLive.tsx
+++ b/components/sandbox/SandboxLive.tsx
@@ -1609,6 +1609,13 @@ export function SandboxLive({
         enableBuildExport={r?.status === "success" && !isDurableResult}
         exportLabel={modelName}
         exportPrompt={resultPrompt}
+        explorer={r?.status === "success" ? {
+          id: r.customBuildId ?? `generation:${model.id}`,
+          model: modelName,
+          prompt: resultPrompt,
+          source: "current",
+          checksum: null,
+        } : undefined}
         actions={
           <>
             {r?.status === "error" && r.customBuildRetryable ? (

--- a/components/voxel/VoxelExplorer.tsx
+++ b/components/voxel/VoxelExplorer.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import * as THREE from "three";
@@ -35,13 +34,13 @@ import {
 import { createVoxelGroupAsync, type VoxelGroup } from "@/lib/voxel/mesh";
 import {
   voxelBuildBlockCount,
-  type RenderableVoxelBuild,
 } from "@/lib/voxel/packedBlocks";
 import { createPublicMeshCacheKey } from "@/lib/voxel/meshPayloadCache";
 import {
   setExplorerViewBob,
   type ExplorerViewBobTransform,
 } from "@/lib/voxel/explorerViewBob";
+import type { VoxelExplorerBuild } from "@/components/voxel/VoxelExplorerLauncher";
 
 const WALK_SPEED = 4.3;
 const RUN_SPEED = 7.5;
@@ -81,19 +80,11 @@ const STARS_PER_LAYER = 560;
 let explorerAtlasPromise: Promise<THREE.Texture> | null = null;
 let explorerBuildCatalog: ExplorerBuildOption[] | null = null;
 
-type LoadedBuild = {
-  checksum: string | null;
-  palette: "simple" | "advanced";
-  voxelBuild: RenderableVoxelBuild;
-};
-
-type ExplorerBuildOption = {
-  id: string;
-  model: string;
-  prompt: string;
-  blockCount: number;
-  source: "benchmark" | "gallery";
-};
+type LoadedBuild = Pick<VoxelExplorerBuild, "checksum" | "palette" | "voxelBuild">;
+type ExplorerBuildOption = Pick<
+  VoxelExplorerBuild,
+  "id" | "model" | "prompt" | "blockCount" | "source"
+>;
 
 function loadAtlasTexture(): Promise<THREE.Texture> {
   if (explorerAtlasPromise) return explorerAtlasPromise;
@@ -292,10 +283,12 @@ function deterministicUnit(index: number, salt: number): number {
 
 function ExplorerBuildMenu({
   currentBuildId,
+  pinnedBuild,
   onClose,
   onSelect,
 }: {
   currentBuildId: string;
+  pinnedBuild?: ExplorerBuildOption;
   onClose: () => void;
   onSelect: (buildId: string) => void;
 }) {
@@ -326,25 +319,30 @@ function ExplorerBuildMenu({
     return () => document.removeEventListener("keydown", onKeyDown);
   }, [onClose]);
 
+  const availableBuilds = useMemo(() => {
+    if (!pinnedBuild || builds?.some((build) => build.id === pinnedBuild.id)) return builds;
+    return [pinnedBuild, ...(builds ?? [])];
+  }, [builds, pinnedBuild]);
+
   const filteredBuilds = useMemo(() => {
-    if (!builds) return [];
+    if (!availableBuilds) return [];
     const tokens = query.trim().toLowerCase().split(/\s+/).filter(Boolean);
-    if (tokens.length === 0) return builds;
-    return builds.filter((build) => {
+    if (tokens.length === 0) return availableBuilds;
+    return availableBuilds.filter((build) => {
       const searchable = `${build.source} ${build.model} ${build.prompt}`.toLowerCase();
       return tokens.every((token) => searchable.includes(token));
     });
-  }, [builds, query]);
+  }, [availableBuilds, query]);
 
   return (
     <aside className="absolute inset-y-3 right-3 flex w-[min(28rem,calc(100%-1.5rem))] flex-col overflow-hidden rounded-md border border-white/10 bg-slate-950/90 text-white shadow-2xl backdrop-blur-md">
       <div className="flex items-center justify-between gap-4 border-b border-white/10 px-4 py-3">
         <div>
           <h2 className="text-sm font-semibold">Builds</h2>
-          {builds ? (
+          {availableBuilds ? (
             <p className="mt-0.5 text-[11px] text-white/50">
-              {filteredBuilds.length === builds.length
-                ? `${builds.length.toLocaleString()} available`
+              {filteredBuilds.length === availableBuilds.length
+                ? `${availableBuilds.length.toLocaleString()} available`
                 : `${filteredBuilds.length.toLocaleString()} matches`}
             </p>
           ) : null}
@@ -386,7 +384,7 @@ function ExplorerBuildMenu({
             </button>
           </div>
         ) : null}
-        {builds && filteredBuilds.length === 0 ? (
+        {availableBuilds && filteredBuilds.length === 0 ? (
           <p className="px-3 py-8 text-center text-xs text-white/50">No matches</p>
         ) : null}
         {filteredBuilds.map((build) => {
@@ -404,7 +402,11 @@ function ExplorerBuildMenu({
               <span className="flex items-center justify-between gap-3 text-[11px] font-semibold text-white/80">
                 <span className="truncate">{build.model}</span>
                 <span className="shrink-0 tabular-nums text-white/40">
-                  {build.source === "gallery" ? "Gallery · " : ""}
+                  {build.source === "gallery"
+                    ? "Gallery · "
+                    : build.source === "current"
+                      ? "Current · "
+                      : ""}
                   {build.blockCount.toLocaleString()} blocks
                 </span>
               </span>
@@ -659,8 +661,19 @@ function hasKey(keys: Set<string>, left: string, right?: string): boolean {
   return keys.has(left) || Boolean(right && keys.has(right));
 }
 
-function ExplorerScene({ build, buildId }: { build: LoadedBuild; buildId: string }) {
-  const router = useRouter();
+function ExplorerScene({
+  build,
+  buildId,
+  pinnedBuild,
+  onSelectBuild,
+  onExit,
+}: {
+  build: LoadedBuild;
+  buildId: string;
+  pinnedBuild?: ExplorerBuildOption;
+  onSelectBuild: (buildId: string) => void;
+  onExit: () => void;
+}) {
   const mountRef = useRef<HTMLDivElement | null>(null);
   const startRef = useRef<(() => void) | null>(null);
   const browseButtonRef = useRef<HTMLButtonElement | null>(null);
@@ -691,8 +704,8 @@ function ExplorerScene({ build, buildId }: { build: LoadedBuild; buildId: string
   }, []);
   const selectBuild = useCallback((nextBuildId: string) => {
     setBuildMenuOpen(false);
-    router.push(`/sandbox/explore/${encodeURIComponent(nextBuildId)}`);
-  }, [router]);
+    onSelectBuild(nextBuildId);
+  }, [onSelectBuild]);
 
   useEffect(() => {
     const mount = mountRef.current;
@@ -1352,6 +1365,7 @@ function ExplorerScene({ build, buildId }: { build: LoadedBuild; buildId: string
           {buildMenuOpen ? (
             <ExplorerBuildMenu
               currentBuildId={buildId}
+              pinnedBuild={pinnedBuild}
               onClose={closeBuildMenu}
               onSelect={selectBuild}
             />
@@ -1378,9 +1392,13 @@ function ExplorerScene({ build, buildId }: { build: LoadedBuild; buildId: string
                 >
                   Builds
                 </button>
-                <Link href="/sandbox" className="text-xs font-medium text-white/65 hover:text-white">
+                <button
+                  type="button"
+                  onClick={onExit}
+                  className="text-xs font-medium text-white/65 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/65"
+                >
                   Exit
-                </Link>
+                </button>
               </div>
             </div>
           )}
@@ -1390,11 +1408,17 @@ function ExplorerScene({ build, buildId }: { build: LoadedBuild; buildId: string
   );
 }
 
-export function VoxelExplorer({ buildId }: { buildId: string }) {
-  const [build, setBuild] = useState<LoadedBuild | null>(null);
+function useExplorerBuild(buildId: string, initialBuild?: VoxelExplorerBuild) {
+  const [build, setBuild] = useState<LoadedBuild | null>(
+    buildId === initialBuild?.id ? initialBuild : null,
+  );
   const [error, setError] = useState<string | null>(null);
-
   useEffect(() => {
+    if (buildId === initialBuild?.id) {
+      setBuild(initialBuild);
+      setError(null);
+      return;
+    }
     const controller = new AbortController();
     setBuild(null);
     setError(null);
@@ -1406,17 +1430,80 @@ export function VoxelExplorer({ buildId }: { buildId: string }) {
       },
     );
     return () => controller.abort();
-  }, [buildId]);
+  }, [buildId, initialBuild]);
+  return { build, error };
+}
+
+export function VoxelExplorer({ buildId }: { buildId: string }) {
+  const router = useRouter();
+  const { build, error } = useExplorerBuild(buildId);
+  const selectBuild = useCallback(
+    (nextBuildId: string) => router.push(`/sandbox/explore/${encodeURIComponent(nextBuildId)}`),
+    [router],
+  );
+  const exit = useCallback(() => router.push("/sandbox"), [router]);
 
   return (
-    <main className="fixed inset-0 z-[100] bg-[oklch(0.86_0.055_235)]">
+    <div className="fixed inset-0 z-[100] bg-[oklch(0.86_0.055_235)]">
       {build ? (
-        <ExplorerScene build={build} buildId={buildId} />
+        <ExplorerScene
+          build={build}
+          buildId={buildId}
+          onSelectBuild={selectBuild}
+          onExit={exit}
+        />
       ) : (
         <div className="flex h-full items-center justify-center text-sm font-semibold text-slate-800">
           {error ?? "Loading"}
         </div>
       )}
-    </main>
+    </div>
+  );
+}
+
+export function VoxelExplorerOverlay({
+  initialBuild,
+  onExit,
+}: {
+  initialBuild: VoxelExplorerBuild;
+  onExit: () => void;
+}) {
+  const [buildId, setBuildId] = useState(initialBuild.id);
+  const { build, error } = useExplorerBuild(buildId, initialBuild);
+
+  return (
+    <div className="fixed inset-0 z-[100] bg-[oklch(0.86_0.055_235)]">
+      {build ? (
+        <ExplorerScene
+          build={build}
+          buildId={buildId}
+          pinnedBuild={initialBuild}
+          onSelectBuild={setBuildId}
+          onExit={onExit}
+        />
+      ) : (
+        <div className="flex h-full flex-col items-center justify-center gap-4 text-sm font-semibold text-slate-800">
+          <p>{error ?? "Loading"}</p>
+          {error ? (
+            <div className="flex gap-2">
+              <button
+                type="button"
+                className="rounded bg-slate-900 px-4 py-2 text-xs text-white"
+                onClick={() => setBuildId(initialBuild.id)}
+              >
+                Current build
+              </button>
+              <button
+                type="button"
+                className="rounded border border-slate-400 px-4 py-2 text-xs"
+                onClick={onExit}
+              >
+                Exit
+              </button>
+            </div>
+          ) : null}
+        </div>
+      )}
+    </div>
   );
 }

--- a/components/voxel/VoxelExplorerLauncher.tsx
+++ b/components/voxel/VoxelExplorerLauncher.tsx
@@ -93,6 +93,7 @@ export function VoxelExplorerProvider({ children }: { children: ReactNode }) {
             event.preventDefault();
             setPending(null);
           }}
+          onKeyDown={(event) => event.stopPropagation()}
           onClose={() => setPending(null)}
         >
           <div className="space-y-6 p-6 sm:p-7">

--- a/components/voxel/VoxelExplorerLauncher.tsx
+++ b/components/voxel/VoxelExplorerLauncher.tsx
@@ -1,0 +1,166 @@
+"use client";
+
+import dynamic from "next/dynamic";
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
+import type { RenderableVoxelBuild } from "@/lib/voxel/packedBlocks";
+
+export type VoxelExplorerBuild = {
+  id: string;
+  model: string;
+  prompt: string;
+  blockCount: number;
+  source: "benchmark" | "gallery" | "current";
+  checksum: string | null;
+  palette: "simple" | "advanced";
+  voxelBuild: RenderableVoxelBuild;
+};
+
+type ExplorerRequest = {
+  build: VoxelExplorerBuild;
+  onContinue?: () => void;
+  onExit?: () => void;
+};
+
+type ExplorerContextValue = {
+  active: boolean;
+  launch: (request: ExplorerRequest) => void;
+};
+
+const ExplorerContext = createContext<ExplorerContextValue | null>(null);
+const VoxelExplorerOverlay = dynamic(
+  () => import("@/components/voxel/VoxelExplorer").then((module) => module.VoxelExplorerOverlay),
+  {
+    ssr: false,
+    loading: () => (
+      <div className="fixed inset-0 z-[100] flex items-center justify-center bg-[oklch(0.86_0.055_235)] text-sm font-semibold text-slate-800">
+        Loading
+      </div>
+    ),
+  },
+);
+
+export function VoxelExplorerProvider({ children }: { children: ReactNode }) {
+  const dialogRef = useRef<HTMLDialogElement>(null);
+  const [pending, setPending] = useState<ExplorerRequest | null>(null);
+  const [active, setActive] = useState<ExplorerRequest | null>(null);
+  const launch = useCallback((request: ExplorerRequest) => setPending(request), []);
+  const context = useMemo(() => ({ active: Boolean(active), launch }), [active, launch]);
+
+  useEffect(() => {
+    const dialog = dialogRef.current;
+    if (pending && dialog && !dialog.open) dialog.showModal();
+  }, [pending]);
+
+  useEffect(() => {
+    if (!active) return;
+    const overflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = overflow;
+    };
+  }, [active]);
+
+  const continueToExplorer = () => {
+    if (!pending) return;
+    pending.onContinue?.();
+    setActive(pending);
+    setPending(null);
+  };
+
+  const exitExplorer = () => {
+    active?.onExit?.();
+    setActive(null);
+  };
+
+  return (
+    <ExplorerContext.Provider value={context}>
+      {children}
+      {pending ? (
+        <dialog
+          ref={dialogRef}
+          aria-labelledby="voxel-explorer-confirm-title"
+          className="mb-dialog m-auto w-[min(28rem,calc(100%-2rem))] rounded-md border-0 bg-card p-0 text-fg ring-1 ring-border-xl backdrop:bg-bg/60 backdrop:backdrop-blur-sm"
+          onCancel={(event) => {
+            event.preventDefault();
+            setPending(null);
+          }}
+          onClose={() => setPending(null)}
+        >
+          <div className="space-y-6 p-6 sm:p-7">
+            <div>
+              <p className="mb-eyebrow">Explorer</p>
+              <h2
+                id="voxel-explorer-confirm-title"
+                className="mt-2 text-2xl font-semibold tracking-tight"
+              >
+                Explore this build?
+              </h2>
+              <p className="mt-2 text-sm leading-6 text-muted">
+                Step inside at block scale with keyboard and mouse.
+              </p>
+            </div>
+            <div className="grid gap-2 sm:grid-cols-2">
+              <button
+                type="button"
+                autoFocus
+                className="mb-btn mb-btn-primary h-11"
+                onClick={continueToExplorer}
+              >
+                Continue
+              </button>
+              <button type="button" className="mb-btn h-11" onClick={() => setPending(null)}>
+                Cancel
+              </button>
+            </div>
+          </div>
+        </dialog>
+      ) : null}
+      {active ? <VoxelExplorerOverlay initialBuild={active.build} onExit={exitExplorer} /> : null}
+    </ExplorerContext.Provider>
+  );
+}
+
+export function useVoxelExplorerActive(): boolean {
+  return useContext(ExplorerContext)?.active ?? false;
+}
+
+export function VoxelExplorerLaunchButton({
+  build,
+  onContinue,
+  onExit,
+}: ExplorerRequest) {
+  const context = useContext(ExplorerContext);
+  if (!context) return null;
+  return (
+    <button
+      type="button"
+      aria-label="Explore build"
+      title="Explore build"
+      className="mb-explorer-launch mb-btn mb-btn-ghost h-8 w-8 border border-border/70 bg-bg/55 p-0 text-muted shadow-sm backdrop-blur-sm hover:border-accent/60 hover:bg-accent/10 hover:text-fg"
+      onClick={() => context.launch({ build, onContinue, onExit })}
+    >
+      <svg
+        aria-hidden="true"
+        viewBox="0 0 24 24"
+        className="h-[18px] w-[18px]"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      >
+        <path d="M7.5 7h9a4.5 4.5 0 0 1 4.3 3.2l1 3.4a3.4 3.4 0 0 1-5.7 3.3l-1.2-1.2a2 2 0 0 0-1.4-.6h-3a2 2 0 0 0-1.4.6l-1.2 1.2a3.4 3.4 0 0 1-5.7-3.3l1-3.4A4.5 4.5 0 0 1 7.5 7Z" />
+        <path d="M7.5 10v4M5.5 12h4M16.5 11h.01M18.5 13h.01" />
+      </svg>
+    </button>
+  );
+}

--- a/components/voxel/VoxelViewerCard.tsx
+++ b/components/voxel/VoxelViewerCard.tsx
@@ -14,6 +14,11 @@ import {
 } from "@/components/voxel/VoxelViewer";
 import { VoxelBuildExportButton } from "@/components/voxel/VoxelBuildExportButton";
 import { VoxelEmptyState } from "@/components/voxel/VoxelEmptyState";
+import {
+  VoxelExplorerLaunchButton,
+  useVoxelExplorerActive,
+  type VoxelExplorerBuild,
+} from "@/components/voxel/VoxelExplorerLauncher";
 import { MAX_BLOCKS_BY_GRID } from "@/lib/ai/limits";
 import { getPalette } from "@/lib/blocks/palettes";
 import { formatBuildDuration, formatBuildJsonSize } from "@/lib/buildMetrics";
@@ -60,6 +65,7 @@ export function VoxelViewerCard({
   exportPrompt,
   exportDisabled,
   exportDisabledReason,
+  explorer,
   actions,
   jsonBytes,
   viewerRef,
@@ -100,6 +106,10 @@ export function VoxelViewerCard({
   exportPrompt?: string;
   exportDisabled?: boolean;
   exportDisabledReason?: string;
+  explorer?: Omit<VoxelExplorerBuild, "blockCount" | "palette" | "voxelBuild"> & {
+    onContinue?: () => void;
+    onExit?: () => void;
+  };
   actions?: ReactNode;
   jsonBytes?: number | null;
   viewerRef?: RefObject<VoxelViewerHandle | null>;
@@ -148,6 +158,10 @@ export function VoxelViewerCard({
   const buildBlocksRef = build ? voxelBuildBlocksRef(build) : null;
   const warnings = metrics?.warnings ?? rendered.warnings;
   const blockCount = metrics?.blockCount ?? voxelBuildBlockCount(build);
+  const explorerActive = useVoxelExplorerActive();
+  const explorerBuild = explorer && build
+    ? { ...explorer, blockCount, palette, voxelBuild: build }
+    : null;
   const isThinking = Boolean(isLoading && attempt && attempt > 0 && !debugRawText);
   const [preferredView, setPreferredView] = useState<"build" | "json">("build");
   const [showRawBuildJson, setShowRawBuildJson] = useState(false);
@@ -369,8 +383,15 @@ export function VoxelViewerCard({
                   </button>
                 </div>
               ) : null}
-              {enableBuildExport || actions ? (
+              {enableBuildExport || explorerBuild || actions ? (
                 <div className="flex items-center gap-1.5">
+                  {explorerBuild ? (
+                    <VoxelExplorerLaunchButton
+                      build={explorerBuild}
+                      onContinue={explorer?.onContinue}
+                      onExit={explorer?.onExit}
+                    />
+                  ) : null}
                   {enableBuildExport ? (
                     <VoxelBuildExportButton
                       build={build}
@@ -389,7 +410,7 @@ export function VoxelViewerCard({
         </div>
 
         <div className={viewerHeightClass}>
-          {showBuildView ? (
+          {showBuildView && !explorerActive ? (
             <VoxelViewer
               ref={viewerRef}
               voxelBuild={build}

--- a/tests/unit/voxel-explorer-integration.test.ts
+++ b/tests/unit/voxel-explorer-integration.test.ts
@@ -9,6 +9,7 @@ const leaderboard = read("components/leaderboard/ModelDetail.tsx");
 assert.match(read("app/layout.tsx"), /<VoxelExplorerProvider>/);
 assert.match(launcher, /Explore this build\?/);
 assert.match(launcher, /Step inside at block scale with keyboard and mouse\./);
+assert.match(launcher, /onKeyDown=\{\(event\) => event\.stopPropagation\(\)\}/);
 assert.match(viewerCard, /showBuildView && !explorerActive/);
 
 for (const path of [

--- a/tests/unit/voxel-explorer-integration.test.ts
+++ b/tests/unit/voxel-explorer-integration.test.ts
@@ -1,0 +1,25 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const read = (path: string) => readFileSync(path, "utf8");
+const launcher = read("components/voxel/VoxelExplorerLauncher.tsx");
+const viewerCard = read("components/voxel/VoxelViewerCard.tsx");
+
+assert.match(read("app/layout.tsx"), /<VoxelExplorerProvider>/);
+assert.match(launcher, /Explore this build\?/);
+assert.match(launcher, /Step inside at block scale with keyboard and mouse\./);
+assert.match(viewerCard, /showBuildView && !explorerActive/);
+
+for (const path of [
+  "components/sandbox/SandboxBenchmark.tsx",
+  "components/sandbox/SandboxLive.tsx",
+  "components/local/LocalLab.tsx",
+  "components/gallery/GalleryDetail.tsx",
+  "components/gallery/GalleryYours.tsx",
+]) {
+  assert.match(read(path), /explorer=/, `${path} must offer Explorer`);
+}
+
+assert.match(read("components/leaderboard/ModelDetail.tsx"), /VoxelExplorerLaunchButton/);
+assert.doesNotMatch(read("components/arena/Arena.tsx"), /explorer=|VoxelExplorerLaunchButton/);
+assert.doesNotMatch(read("components/lab/ProtectedBuildInspector.tsx"), /explorer=|VoxelExplorerLaunchButton/);

--- a/tests/unit/voxel-explorer-integration.test.ts
+++ b/tests/unit/voxel-explorer-integration.test.ts
@@ -4,6 +4,7 @@ import { readFileSync } from "node:fs";
 const read = (path: string) => readFileSync(path, "utf8");
 const launcher = read("components/voxel/VoxelExplorerLauncher.tsx");
 const viewerCard = read("components/voxel/VoxelViewerCard.tsx");
+const leaderboard = read("components/leaderboard/ModelDetail.tsx");
 
 assert.match(read("app/layout.tsx"), /<VoxelExplorerProvider>/);
 assert.match(launcher, /Explore this build\?/);
@@ -20,6 +21,7 @@ for (const path of [
   assert.match(read(path), /explorer=/, `${path} must offer Explorer`);
 }
 
-assert.match(read("components/leaderboard/ModelDetail.tsx"), /VoxelExplorerLaunchButton/);
+assert.match(leaderboard, /activeFullCachedBuild \? \(\s*<VoxelExplorerLaunchButton/);
+assert.match(leaderboard, /event\.key !== "Escape" \|\| explorerActive/);
 assert.doesNotMatch(read("components/arena/Arena.tsx"), /explorer=|VoxelExplorerLaunchButton/);
 assert.doesNotMatch(read("components/lab/ProtectedBuildInspector.tsx"), /explorer=|VoxelExplorerLaunchButton/);


### PR DESCRIPTION
## Summary

- adds a shared Explore launch flow to ordinary build viewers across Sandbox, Gallery, saved generations, imports, and Leaderboard
- opens the existing Explorer engine in a full-screen overlay while preserving the originating page and supporting in-Explorer build switching
- keeps Arena and Lab inspectors excluded, limits launch controls to desktop pointers, and suspends background voxel canvases while Explorer is active
- polishes the launch hierarchy, confirmation copy, and simplified gamepad icon

## Testing

- `pnpm test:unit` — 104 test files passed
- `pnpm build`
- `git diff --cached --check`

*(PR written by Codex)*