### PR TITLE
feat(explorer): promote build exploration to production

### DIFF
--- a/app/api/sandbox/explorer-builds/route.ts
+++ b/app/api/sandbox/explorer-builds/route.ts
@@ -6,38 +6,50 @@ import {
   getErrorMessage,
   isDatabaseUnavailableError,
 } from "@/lib/db/errors";
+import { listPublicGalleryExplorerBuilds } from "@/lib/gallery/service";
 import { prisma } from "@/lib/prisma";
 
 export const runtime = "nodejs";
 
 export async function GET() {
   try {
-    const builds = await prisma.build.findMany({
-      where: arenaCohortBuildWhere(),
-      orderBy: [
-        { model: { displayName: "asc" } },
-        { prompt: { text: "asc" } },
-      ],
-      select: {
-        id: true,
-        blockCount: true,
-        model: { select: { displayName: true } },
-        prompt: { select: { text: true } },
-      },
-    });
+    const [builds, galleryBuilds] = await Promise.all([
+      prisma.build.findMany({
+        where: arenaCohortBuildWhere(),
+        orderBy: [
+          { model: { displayName: "asc" } },
+          { prompt: { text: "asc" } },
+        ],
+        select: {
+          id: true,
+          blockCount: true,
+          model: { select: { displayName: true } },
+          prompt: { select: { text: true } },
+        },
+      }),
+      listPublicGalleryExplorerBuilds(),
+    ]);
 
     return NextResponse.json(
       {
-        builds: builds.map((build) => ({
-          id: build.id,
-          model: build.model.displayName,
-          prompt: build.prompt.text,
-          blockCount: build.blockCount,
-        })),
+        builds: [
+          ...galleryBuilds.map((build) => ({
+            ...build,
+            id: `gallery:${build.id}`,
+            source: "gallery" as const,
+          })),
+          ...builds.map((build) => ({
+            id: build.id,
+            model: build.model.displayName,
+            prompt: build.prompt.text,
+            blockCount: build.blockCount,
+            source: "benchmark" as const,
+          })),
+        ],
       },
       {
         headers: {
-          "Cache-Control": "public, max-age=60, s-maxage=300, stale-while-revalidate=3600",
+          "Cache-Control": "public, max-age=30, s-maxage=60",
         },
       },
     );

--- a/app/api/sandbox/explorer-builds/route.ts
+++ b/app/api/sandbox/explorer-builds/route.ts
@@ -1,0 +1,57 @@
+import { NextResponse } from "next/server";
+import { arenaCohortBuildWhere } from "@/lib/arena/eligibility";
+import {
+  databaseUnavailableBody,
+  databaseUnavailableHeaders,
+  getErrorMessage,
+  isDatabaseUnavailableError,
+} from "@/lib/db/errors";
+import { prisma } from "@/lib/prisma";
+
+export const runtime = "nodejs";
+
+export async function GET() {
+  try {
+    const builds = await prisma.build.findMany({
+      where: arenaCohortBuildWhere(),
+      orderBy: [
+        { model: { displayName: "asc" } },
+        { prompt: { text: "asc" } },
+      ],
+      select: {
+        id: true,
+        blockCount: true,
+        model: { select: { displayName: true } },
+        prompt: { select: { text: true } },
+      },
+    });
+
+    return NextResponse.json(
+      {
+        builds: builds.map((build) => ({
+          id: build.id,
+          model: build.model.displayName,
+          prompt: build.prompt.text,
+          blockCount: build.blockCount,
+        })),
+      },
+      {
+        headers: {
+          "Cache-Control": "public, max-age=60, s-maxage=300, stale-while-revalidate=3600",
+        },
+      },
+    );
+  } catch (error) {
+    if (isDatabaseUnavailableError(error)) {
+      console.warn(
+        "explorer build catalog database unavailable",
+        getErrorMessage(error, "unknown error"),
+      );
+      return NextResponse.json(databaseUnavailableBody(), {
+        status: 503,
+        headers: databaseUnavailableHeaders(),
+      });
+    }
+    throw error;
+  }
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -929,6 +929,16 @@
     background-color: hsl(var(--fg) / 0.09);
   }
 
+  .mb-explorer-launch {
+    display: none;
+  }
+
+  @media (hover: hover) and (pointer: fine) {
+    .mb-explorer-launch {
+      display: inline-flex;
+    }
+  }
+
   .mb-btn-danger {
     @apply ring-1 ring-danger/45;
     background-color: hsl(var(--danger) / 0.12);

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -8,6 +8,7 @@ import { PublicPresence } from "@/components/PublicPresence";
 import { SiteFooter } from "@/components/SiteFooter";
 import { SiteHeader } from "@/components/SiteHeader";
 import { SiteHealthBanner } from "@/components/SiteHealthBanner";
+import { VoxelExplorerProvider } from "@/components/voxel/VoxelExplorerLauncher";
 import {
   DEFAULT_OG_IMAGE,
   SEO_KEYWORDS,
@@ -136,21 +137,23 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
           dangerouslySetInnerHTML={{ __html: JSON.stringify(structuredData) }}
         />
 
-        <OfflineBanner />
-        <SiteHealthBanner />
+        <VoxelExplorerProvider>
+          <OfflineBanner />
+          <SiteHealthBanner />
 
-        <div id="mb-shell" className="relative z-10 flex min-h-dvh flex-col">
-          <SiteHeader />
-          <div id="mb-container" className="mx-auto flex w-full max-w-[92rem] flex-1 flex-col px-4 sm:px-6 lg:px-8">
-            <main id="main" className="flex-1 py-4 sm:py-6">
-              {children}
-            </main>
-            <SiteFooter />
+          <div id="mb-shell" className="relative z-10 flex min-h-dvh flex-col">
+            <SiteHeader />
+            <div id="mb-container" className="mx-auto flex w-full max-w-[92rem] flex-1 flex-col px-4 sm:px-6 lg:px-8">
+              <main id="main" className="flex-1 py-4 sm:py-6">
+                {children}
+              </main>
+              <SiteFooter />
+            </div>
           </div>
-        </div>
-        <Analytics />
-        <SpeedInsights />
-        <PublicPresence />
+          <Analytics />
+          <SpeedInsights />
+          <PublicPresence />
+        </VoxelExplorerProvider>
       </body>
     </html>
   );

--- a/app/sandbox/explore/[buildId]/page.tsx
+++ b/app/sandbox/explore/[buildId]/page.tsx
@@ -1,0 +1,18 @@
+import type { Metadata } from "next";
+import { VoxelExplorer } from "@/components/voxel/VoxelExplorer";
+
+export const dynamic = "force-dynamic";
+
+export const metadata: Metadata = {
+  title: "Explore Build",
+  robots: { index: false, follow: false },
+};
+
+export default async function SandboxExplorePage({
+  params,
+}: {
+  params: Promise<{ buildId: string }>;
+}) {
+  const { buildId } = await params;
+  return <VoxelExplorer buildId={buildId} />;
+}

--- a/components/gallery/GalleryDetail.tsx
+++ b/components/gallery/GalleryDetail.tsx
@@ -381,6 +381,13 @@ export function GalleryDetail({ candidate }: { candidate: GalleryDetailPayload }
         enableBuildExport={Boolean(build)}
         exportLabel={example.model.label}
         exportPrompt={candidate.prompt}
+        explorer={build && !loading ? {
+          id: `gallery:${example.id}`,
+          model: example.model.label,
+          prompt: candidate.prompt,
+          source: "gallery",
+          checksum: example.checksum ?? null,
+        } : undefined}
         viewerRef={getViewerRef(example.id)}
         metrics={example.blockCount != null ? {
           blockCount: example.blockCount,

--- a/components/gallery/GalleryYours.tsx
+++ b/components/gallery/GalleryYours.tsx
@@ -205,9 +205,11 @@ function GenerationActions({
 function SavedBuildDialog({
   generation,
   onClose,
+  onExplorerExit,
 }: {
   generation: SavedGenerationPayload;
   onClose: () => void;
+  onExplorerExit: () => void;
 }) {
   const dialogRef = useRef<HTMLDialogElement>(null);
   const viewerRef = useRef<VoxelViewerHandle>(null);
@@ -283,6 +285,15 @@ function SavedBuildDialog({
             enableBuildExport={Boolean(build)}
             exportLabel={generation.model.label}
             exportPrompt={generation.prompt}
+            explorer={build && !loading ? {
+              id: `current:${generation.id}`,
+              model: generation.model.label,
+              prompt: generation.prompt,
+              source: "current",
+              checksum: null,
+              onContinue: onClose,
+              onExit: onExplorerExit,
+            } : undefined}
             viewerRef={viewerRef}
             jsonBytes={generation.expandedBytes}
             metrics={generation.blockCount != null ? {
@@ -441,7 +452,13 @@ export function GalleryYours({
       </div>
       {cursor ? <div className="mt-12 flex justify-center"><button type="button" disabled={loadingMore} className="mb-btn h-11 min-w-36" onClick={() => void loadMore()}>{loadingMore ? "Loading…" : "More"}</button></div> : null}
       {loadError ? <p role="status" className="mt-6 text-center text-sm text-danger">{loadError}</p> : null}
-      {selected ? <SavedBuildDialog generation={selected} onClose={() => setSelectedId(null)} /> : null}
+      {selected ? (
+        <SavedBuildDialog
+          generation={selected}
+          onClose={() => setSelectedId(null)}
+          onExplorerExit={() => setSelectedId(selected.id)}
+        />
+      ) : null}
     </section>
   );
 }

--- a/components/leaderboard/ModelDetail.tsx
+++ b/components/leaderboard/ModelDetail.tsx
@@ -937,6 +937,7 @@ export function ModelDetail({ data }: { data: ModelDetailStats }) {
   const pathname = usePathname();
   const searchParams = useSearchParams();
   const requestedBuildId = searchParams.get("build");
+  const explorerActive = useVoxelExplorerActive();
   const [hoveredCurveIndex, setHoveredCurveIndex] = useState<number | null>(null);
   const [showAllOpponents, setShowAllOpponents] = useState(false);
   const [showAllPrompts, setShowAllPrompts] = useState(false);
@@ -1087,13 +1088,13 @@ export function ModelDetail({ data }: { data: ModelDetailStats }) {
   useEffect(() => {
     if (!activePrompt) return;
     const onKeyDown = (event: KeyboardEvent) => {
-      if (event.key !== "Escape") return;
+      if (event.key !== "Escape" || explorerActive) return;
       event.preventDefault();
       setPromptWithUrl(null);
     };
     window.addEventListener("keydown", onKeyDown);
     return () => window.removeEventListener("keydown", onKeyDown);
-  }, [activePrompt, setPromptWithUrl]);
+  }, [activePrompt, explorerActive, setPromptWithUrl]);
 
   const activePromptIndex = useMemo(() => {
     if (!activePrompt) return -1;
@@ -2016,18 +2017,20 @@ export function ModelDetail({ data }: { data: ModelDetailStats }) {
                   actions={
                     activeLoadedBuild ? (
                       <>
-                        <VoxelExplorerLaunchButton
-                          build={{
-                            id: activeLoadedBuild.buildId,
-                            model: data.model.displayName,
-                            prompt: activePrompt.promptText,
-                            blockCount: activeLoadedBuild.blockCount,
-                            source: "benchmark",
-                            checksum: activeLoadedBuild.checksum ?? null,
-                            palette: activeLoadedBuild.palette,
-                            voxelBuild: activeLoadedBuild.voxelBuild,
-                          }}
-                        />
+                        {activeFullCachedBuild ? (
+                          <VoxelExplorerLaunchButton
+                            build={{
+                              id: activeFullCachedBuild.buildId,
+                              model: data.model.displayName,
+                              prompt: activePrompt.promptText,
+                              blockCount: activeFullCachedBuild.blockCount,
+                              source: "benchmark",
+                              checksum: activeFullCachedBuild.checksum ?? null,
+                              palette: activeFullCachedBuild.palette,
+                              voxelBuild: activeFullCachedBuild.voxelBuild,
+                            }}
+                          />
+                        ) : null}
                         <VoxelBuildExportButton
                           build={activeLoadedBuild.voxelBuild}
                           palette={activeLoadedBuild.palette}

--- a/components/leaderboard/ModelDetail.tsx
+++ b/components/leaderboard/ModelDetail.tsx
@@ -31,6 +31,10 @@ import type {
   VoxelViewerHandle,
 } from "@/components/voxel/VoxelViewer";
 import { VoxelBuildExportButton } from "@/components/voxel/VoxelBuildExportButton";
+import {
+  VoxelExplorerLaunchButton,
+  useVoxelExplorerActive,
+} from "@/components/voxel/VoxelExplorerLauncher";
 import { summarizeArenaVotes } from "@/lib/arena/voteMath";
 import { createPublicMeshCacheKey } from "@/lib/voxel/meshPayloadCache";
 import {
@@ -747,6 +751,7 @@ const PromptBuildPreview = memo(function PromptBuildPreview({
 
   const [viewerReady, setViewerReady] = useState(false);
   const [placementProgress, setPlacementProgress] = useState<PlacementProgressState | null>(null);
+  const explorerActive = useVoxelExplorerActive();
   useEffect(() => {
     setViewerReady(false);
     setPlacementProgress(null);
@@ -815,20 +820,22 @@ const PromptBuildPreview = memo(function PromptBuildPreview({
 
   return (
     <div className={`relative w-full overflow-hidden rounded-md bg-bg/32 ring-1 ring-border/65 ${heightClass}`}>
-      <LazyVoxelViewer
-        ref={viewerRef}
-        voxelBuild={build.voxelBuild}
-        palette={build.palette}
-        meshCacheKey={meshCacheKey}
-        autoRotate
-        showControls={false}
-        onBuildReadyChange={handleBuildReadyChange}
-        onBuildProgressChange={handleBuildProgressChange}
-        onBuildMetrics={(metrics) => {
-          if (!build?.checksum) return;
-          enqueueVoxelMetric("leaderboard", build.variant, metrics);
-        }}
-      />
+      {!explorerActive ? (
+        <LazyVoxelViewer
+          ref={viewerRef}
+          voxelBuild={build.voxelBuild}
+          palette={build.palette}
+          meshCacheKey={meshCacheKey}
+          autoRotate
+          showControls={false}
+          onBuildReadyChange={handleBuildReadyChange}
+          onBuildProgressChange={handleBuildProgressChange}
+          onBuildMetrics={(metrics) => {
+            if (!build?.checksum) return;
+            enqueueVoxelMetric("leaderboard", build.variant, metrics);
+          }}
+        />
+      ) : null}
       {loading || placementLoading ? (
         <VoxelLoadingHud
           label={overlayLabel}
@@ -2009,6 +2016,18 @@ export function ModelDetail({ data }: { data: ModelDetailStats }) {
                   actions={
                     activeLoadedBuild ? (
                       <>
+                        <VoxelExplorerLaunchButton
+                          build={{
+                            id: activeLoadedBuild.buildId,
+                            model: data.model.displayName,
+                            prompt: activePrompt.promptText,
+                            blockCount: activeLoadedBuild.blockCount,
+                            source: "benchmark",
+                            checksum: activeLoadedBuild.checksum ?? null,
+                            palette: activeLoadedBuild.palette,
+                            voxelBuild: activeLoadedBuild.voxelBuild,
+                          }}
+                        />
                         <VoxelBuildExportButton
                           build={activeLoadedBuild.voxelBuild}
                           palette={activeLoadedBuild.palette}

--- a/components/local/LocalLab.tsx
+++ b/components/local/LocalLab.tsx
@@ -854,6 +854,13 @@ export function LocalLab() {
             loadingProgress={rendered.kind === "loading" ? rendered.progress ?? undefined : undefined}
             skipValidation={rendered.kind === "loading"}
             viewerRef={previewViewerRef}
+            explorer={rendered.kind === "ready" ? {
+              id: "current:imported",
+              model: "Imported build",
+              prompt: taskPrompt,
+              source: "current",
+              checksum: null,
+            } : undefined}
             actions={
               <SandboxGifExportButton
                 targets={previewExportTargets}

--- a/components/sandbox/SandboxBenchmark.tsx
+++ b/components/sandbox/SandboxBenchmark.tsx
@@ -1069,6 +1069,13 @@ export function SandboxBenchmark() {
             enableBuildExport={hasRenderableBuild && laneState.phase === "ready" && Boolean(build && model)}
             exportLabel={title}
             exportPrompt={selectedPromptText}
+            explorer={hasRenderableBuild && laneState.phase === "ready" && build && model ? {
+              id: build.buildId,
+              model: model.displayName,
+              prompt: selectedPromptText,
+              source: "benchmark",
+              checksum: build.checksum ?? build.buildRef.checksum ?? null,
+            } : undefined}
             actions={
               hasRenderableBuild && build && model ? (
                 <SandboxGifExportButton

--- a/components/sandbox/SandboxLive.tsx
+++ b/components/sandbox/SandboxLive.tsx
@@ -1609,6 +1609,13 @@ export function SandboxLive({
         enableBuildExport={r?.status === "success" && !isDurableResult}
         exportLabel={modelName}
         exportPrompt={resultPrompt}
+        explorer={r?.status === "success" ? {
+          id: r.customBuildId ?? `generation:${model.id}`,
+          model: modelName,
+          prompt: resultPrompt,
+          source: "current",
+          checksum: null,
+        } : undefined}
         actions={
           <>
             {r?.status === "error" && r.customBuildRetryable ? (

--- a/components/voxel/VoxelExplorer.tsx
+++ b/components/voxel/VoxelExplorer.tsx
@@ -1,10 +1,13 @@
 "use client";
 
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import * as THREE from "three";
 import { PointerLockControls } from "three/examples/jsm/controls/PointerLockControls.js";
+import { Lensflare, LensflareElement } from "three/examples/jsm/objects/Lensflare.js";
 import { Sky } from "three/examples/jsm/objects/Sky.js";
+import { SSAOPass } from "three/examples/jsm/postprocessing/SSAOPass.js";
 import {
   readBuildVariantPayload,
   readBuildVariantStream,
@@ -26,6 +29,10 @@ import {
   type RenderableVoxelBuild,
 } from "@/lib/voxel/packedBlocks";
 import { createPublicMeshCacheKey } from "@/lib/voxel/meshPayloadCache";
+import {
+  setExplorerViewBob,
+  type ExplorerViewBobTransform,
+} from "@/lib/voxel/explorerViewBob";
 
 const WALK_SPEED = 4.3;
 const RUN_SPEED = 7.5;
@@ -36,18 +43,29 @@ const JUMP_VELOCITY = Math.sqrt(GRAVITY * 2 * 1.25);
 const WATER_SPEED_MULTIPLIER = 0.8;
 const WATER_ASCENT_SPEED = 3.5;
 const WATER_SINK_SPEED = 1;
-const VIEW_BOB_VERTICAL = 0.045;
-const VIEW_BOB_LATERAL = 0.018;
+const VIEW_BOB_DISTANCE_SCALE = 0.8;
+const VIEW_BOB_WALK_AMOUNT = 0.075;
+const VIEW_BOB_RUN_AMOUNT = 0.1;
+const SSAO_RENDER_SCALE = 0.5;
 const MAX_FRAME_SECONDS = 0.05;
 const MAX_PHYSICS_STEP_SECONDS = 1 / 60;
 const DAYLIGHT_COLOR = 0xaed4ef;
 const SIMPLE_PALETTE = getPalette("simple");
+const SUN_DIRECTION = new THREE.Vector3(0.55, 0.78, 0.3).normalize();
 
 let explorerAtlasPromise: Promise<THREE.Texture> | null = null;
+let explorerBuildCatalog: ExplorerBuildOption[] | null = null;
 
 type LoadedBuild = {
   checksum: string | null;
   voxelBuild: RenderableVoxelBuild;
+};
+
+type ExplorerBuildOption = {
+  id: string;
+  model: string;
+  prompt: string;
+  blockCount: number;
 };
 
 function loadAtlasTexture(): Promise<THREE.Texture> {
@@ -104,10 +122,171 @@ async function fetchExplorerBuild(buildId: string, signal: AbortSignal): Promise
   return { checksum: payload.checksum, voxelBuild: payload.voxelBuild };
 }
 
+async function fetchExplorerBuildCatalog(signal: AbortSignal): Promise<ExplorerBuildOption[]> {
+  if (explorerBuildCatalog) return explorerBuildCatalog;
+  const response = await fetch("/api/sandbox/explorer-builds", { signal });
+  const body = (await response.json()) as {
+    builds?: ExplorerBuildOption[];
+    error?: string;
+  };
+  if (!response.ok || !Array.isArray(body.builds)) {
+    throw new Error(body.error ?? "Builds unavailable");
+  }
+  explorerBuildCatalog = body.builds;
+  return body.builds;
+}
+
+function createSunHaloTexture(): THREE.Texture {
+  const canvas = document.createElement("canvas");
+  canvas.width = 128;
+  canvas.height = 128;
+  const context = canvas.getContext("2d");
+  if (context) {
+    const gradient = context.createRadialGradient(64, 64, 0, 64, 64, 64);
+    gradient.addColorStop(0, "rgba(255, 250, 224, 0.95)");
+    gradient.addColorStop(0.12, "rgba(255, 235, 178, 0.65)");
+    gradient.addColorStop(0.38, "rgba(255, 213, 128, 0.18)");
+    gradient.addColorStop(1, "rgba(255, 203, 112, 0)");
+    context.fillStyle = gradient;
+    context.fillRect(0, 0, 128, 128);
+  }
+  const texture = new THREE.CanvasTexture(canvas);
+  texture.colorSpace = THREE.SRGBColorSpace;
+  return texture;
+}
+
+function ExplorerBuildMenu({
+  currentBuildId,
+  onClose,
+  onSelect,
+}: {
+  currentBuildId: string;
+  onClose: () => void;
+  onSelect: (buildId: string) => void;
+}) {
+  const [builds, setBuilds] = useState<ExplorerBuildOption[] | null>(explorerBuildCatalog);
+  const [query, setQuery] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [attempt, setAttempt] = useState(0);
+
+  useEffect(() => {
+    if (builds) return;
+    const controller = new AbortController();
+    setError(null);
+    void fetchExplorerBuildCatalog(controller.signal).then(
+      setBuilds,
+      (loadError: unknown) => {
+        if (loadError instanceof DOMException && loadError.name === "AbortError") return;
+        setError(loadError instanceof Error ? loadError.message : "Builds unavailable");
+      },
+    );
+    return () => controller.abort();
+  }, [attempt, builds]);
+
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") onClose();
+    };
+    document.addEventListener("keydown", onKeyDown);
+    return () => document.removeEventListener("keydown", onKeyDown);
+  }, [onClose]);
+
+  const filteredBuilds = useMemo(() => {
+    if (!builds) return [];
+    const tokens = query.trim().toLowerCase().split(/\s+/).filter(Boolean);
+    if (tokens.length === 0) return builds;
+    return builds.filter((build) => {
+      const searchable = `${build.model} ${build.prompt}`.toLowerCase();
+      return tokens.every((token) => searchable.includes(token));
+    });
+  }, [builds, query]);
+
+  return (
+    <aside className="absolute inset-y-3 right-3 flex w-[min(28rem,calc(100%-1.5rem))] flex-col overflow-hidden rounded-md border border-white/10 bg-slate-950/90 text-white shadow-2xl backdrop-blur-md">
+      <div className="flex items-center justify-between gap-4 border-b border-white/10 px-4 py-3">
+        <div>
+          <h2 className="text-sm font-semibold">Builds</h2>
+          {builds ? (
+            <p className="mt-0.5 text-[11px] text-white/50">
+              {filteredBuilds.length === builds.length
+                ? `${builds.length.toLocaleString()} available`
+                : `${filteredBuilds.length.toLocaleString()} matches`}
+            </p>
+          ) : null}
+        </div>
+        <button
+          type="button"
+          onClick={onClose}
+          className="min-h-10 rounded px-3 text-xs font-medium text-white/65 transition-colors hover:bg-white/10 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/65 motion-reduce:transition-none"
+        >
+          Close
+        </button>
+      </div>
+
+      <div className="border-b border-white/10 p-3">
+        <input
+          autoFocus
+          type="search"
+          value={query}
+          onChange={(event) => setQuery(event.target.value)}
+          placeholder="Search builds…"
+          aria-label="Search builds"
+          className="h-10 w-full rounded border border-white/15 bg-white/[0.08] px-3 text-sm text-white outline-none placeholder:text-white/35 focus:border-white/40 focus:ring-2 focus:ring-white/15"
+        />
+      </div>
+
+      <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain p-2">
+        {!builds && !error ? (
+          <p className="px-3 py-8 text-center text-xs text-white/50">Loading</p>
+        ) : null}
+        {error ? (
+          <div className="flex flex-col items-center gap-3 px-3 py-8 text-center">
+            <p className="text-xs text-white/60">{error}</p>
+            <button
+              type="button"
+              onClick={() => setAttempt((value) => value + 1)}
+              className="min-h-10 rounded bg-white/10 px-4 text-xs font-semibold text-white hover:bg-white/15 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/65"
+            >
+              Retry
+            </button>
+          </div>
+        ) : null}
+        {builds && filteredBuilds.length === 0 ? (
+          <p className="px-3 py-8 text-center text-xs text-white/50">No matches</p>
+        ) : null}
+        {filteredBuilds.map((build) => {
+          const current = build.id === currentBuildId;
+          return (
+            <button
+              key={build.id}
+              type="button"
+              aria-current={current ? "page" : undefined}
+              onClick={() => current ? onClose() : onSelect(build.id)}
+              className={`mb-1 block w-full rounded px-3 py-2.5 text-left transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-white/65 motion-reduce:transition-none ${
+                current ? "bg-white/15" : "hover:bg-white/[0.08]"
+              }`}
+            >
+              <span className="flex items-center justify-between gap-3 text-[11px] font-semibold text-white/80">
+                <span className="truncate">{build.model}</span>
+                <span className="shrink-0 tabular-nums text-white/40">
+                  {build.blockCount.toLocaleString()} blocks
+                </span>
+              </span>
+              <span className="mt-1 line-clamp-2 block text-xs leading-relaxed text-white/55">
+                {build.prompt}
+              </span>
+            </button>
+          );
+        })}
+      </div>
+    </aside>
+  );
+}
+
 function configureDaylight(
   scene: THREE.Scene,
   renderer: THREE.WebGLRenderer,
-): { sky: Sky; sun: THREE.DirectionalLight } {
+): { sky: Sky; sun: THREE.DirectionalLight; sunFlare: Lensflare } {
   scene.background = new THREE.Color(DAYLIGHT_COLOR);
   scene.fog = new THREE.Fog(DAYLIGHT_COLOR, 72, 320);
 
@@ -117,8 +296,7 @@ function configureDaylight(
   sky.material.uniforms.rayleigh.value = 1.8;
   sky.material.uniforms.mieCoefficient.value = 0.0035;
   sky.material.uniforms.mieDirectionalG.value = 0.86;
-  const sunDirection = new THREE.Vector3(0.55, 0.78, 0.3).normalize();
-  sky.material.uniforms.sunPosition.value.copy(sunDirection);
+  sky.material.uniforms.sunPosition.value.copy(SUN_DIRECTION);
   scene.add(sky);
 
   scene.add(new THREE.HemisphereLight(0xeaf6ff, 0x39452f, 0.72));
@@ -131,13 +309,19 @@ function configureDaylight(
   sun.shadow.normalBias = 0.025;
   scene.add(sun, sun.target);
 
+  const sunFlare = new Lensflare();
+  sunFlare.addElement(
+    new LensflareElement(createSunHaloTexture(), 220, 0, new THREE.Color(0xffe8b8)),
+  );
+  scene.add(sunFlare);
+
   renderer.shadowMap.enabled = true;
   renderer.shadowMap.type = THREE.PCFSoftShadowMap;
   renderer.shadowMap.autoUpdate = false;
   renderer.toneMapping = THREE.ACESFilmicToneMapping;
   renderer.toneMappingExposure = 1.08;
   renderer.outputColorSpace = THREE.SRGBColorSpace;
-  return { sky, sun };
+  return { sky, sun, sunFlare };
 }
 
 function frameDaylight(
@@ -156,10 +340,9 @@ function frameDaylight(
   camera.updateProjectionMatrix();
   sky.scale.setScalar(camera.far * 0.8);
 
-  const sunDirection = new THREE.Vector3(0.55, 0.78, 0.3).normalize();
   const lightDistance = Math.max(80, radius * 2.2);
   sun.target.position.copy(bounds.center);
-  sun.position.copy(bounds.center).addScaledVector(sunDirection, lightDistance);
+  sun.position.copy(bounds.center).addScaledVector(SUN_DIRECTION, lightDistance);
   const shadowCamera = sun.shadow.camera;
   const shadowRadius = radius * 1.1;
   shadowCamera.left = -shadowRadius;
@@ -177,9 +360,11 @@ function hasKey(keys: Set<string>, left: string, right?: string): boolean {
   return keys.has(left) || Boolean(right && keys.has(right));
 }
 
-function ExplorerScene({ build }: { build: LoadedBuild }) {
+function ExplorerScene({ build, buildId }: { build: LoadedBuild; buildId: string }) {
+  const router = useRouter();
   const mountRef = useRef<HTMLDivElement | null>(null);
   const startRef = useRef<(() => void) | null>(null);
+  const browseButtonRef = useRef<HTMLButtonElement | null>(null);
   const [ready, setReady] = useState(false);
   const [locked, setLocked] = useState(false);
   const [entered, setEntered] = useState(false);
@@ -187,6 +372,7 @@ function ExplorerScene({ build }: { build: LoadedBuild }) {
   const [fps, setFps] = useState(0);
   const [loading, setLoading] = useState("Building");
   const [error, setError] = useState<string | null>(null);
+  const [buildMenuOpen, setBuildMenuOpen] = useState(false);
   const meshCacheKey = useMemo(
     () =>
       createPublicMeshCacheKey({
@@ -199,6 +385,14 @@ function ExplorerScene({ build }: { build: LoadedBuild }) {
   );
 
   const enter = useCallback(() => startRef.current?.(), []);
+  const closeBuildMenu = useCallback(() => {
+    setBuildMenuOpen(false);
+    window.requestAnimationFrame(() => browseButtonRef.current?.focus());
+  }, []);
+  const selectBuild = useCallback((nextBuildId: string) => {
+    setBuildMenuOpen(false);
+    router.push(`/sandbox/explore/${encodeURIComponent(nextBuildId)}`);
+  }, [router]);
 
   useEffect(() => {
     const mount = mountRef.current;
@@ -213,7 +407,7 @@ function ExplorerScene({ build }: { build: LoadedBuild }) {
     let grounded = false;
     let bobWalking = false;
     let bobRunning = false;
-    let bobPhase = 0;
+    let bobDistance = 0;
     let bobBlend = 0;
     const keys = new Set<string>();
 
@@ -240,7 +434,12 @@ function ExplorerScene({ build }: { build: LoadedBuild }) {
     renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, 2));
     renderer.setSize(Math.max(1, mount.clientWidth), Math.max(1, mount.clientHeight), true);
     mount.appendChild(renderer.domElement);
-    const { sky, sun } = configureDaylight(scene, renderer);
+    const { sky, sun, sunFlare } = configureDaylight(scene, renderer);
+    const ssaoPass = new SSAOPass(scene, camera, 1, 1, 16);
+    ssaoPass.renderToScreen = true;
+    ssaoPass.kernelRadius = 12;
+    ssaoPass.minDistance = 0.001;
+    ssaoPass.maxDistance = 0.1;
 
     const controls = new PointerLockControls(camera, renderer.domElement);
     controls.pointerSpeed = 0.9;
@@ -294,10 +493,15 @@ function ExplorerScene({ build }: { build: LoadedBuild }) {
       const width = mount.clientWidth;
       const height = mount.clientHeight;
       if (width <= 0 || height <= 0) return;
-      renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, 2));
+      const pixelRatio = Math.min(window.devicePixelRatio || 1, 2);
+      renderer.setPixelRatio(pixelRatio);
       renderer.setSize(width, height, true);
       camera.aspect = width / height;
       camera.updateProjectionMatrix();
+      ssaoPass.setSize(
+        Math.max(1, Math.round(width * pixelRatio * SSAO_RENDER_SCALE)),
+        Math.max(1, Math.round(height * pixelRatio * SSAO_RENDER_SCALE)),
+      );
     };
     const resizeObserver = new ResizeObserver(resize);
     resizeObserver.observe(mount);
@@ -306,6 +510,9 @@ function ExplorerScene({ build }: { build: LoadedBuild }) {
     const forward = new THREE.Vector3();
     const right = new THREE.Vector3();
     const movement = new THREE.Vector3();
+    const bobUp = new THREE.Vector3();
+    const baseQuaternion = new THREE.Quaternion();
+    const viewBob: ExplorerViewBobTransform = { x: 0, y: 0, roll: 0, pitch: 0 };
     const updatePlayer = (seconds: number) => {
       if (!controls.isLocked || !collisionWorld) {
         bobWalking = false;
@@ -337,6 +544,8 @@ function ExplorerScene({ build }: { build: LoadedBuild }) {
         return;
       }
 
+      const startX = camera.position.x;
+      const startZ = camera.position.z;
       const stepCount = Math.max(1, Math.ceil(seconds / MAX_PHYSICS_STEP_SECONDS));
       const stepSeconds = seconds / stepCount;
       for (let step = 0; step < stepCount; step += 1) {
@@ -368,8 +577,10 @@ function ExplorerScene({ build }: { build: LoadedBuild }) {
         grounded = verticalCollision && verticalVelocity < 0;
         if (verticalCollision) verticalVelocity = 0;
       }
-      bobWalking = grounded && movement.lengthSq() > 0 && !collisionWorld.isInWater(camera.position);
+      const traveled = Math.hypot(camera.position.x - startX, camera.position.z - startZ);
+      bobWalking = grounded && traveled > 1e-6 && !collisionWorld.isInWater(camera.position);
       bobRunning = running;
+      if (bobWalking) bobDistance += traveled * VIEW_BOB_DISTANCE_SCALE;
     };
 
     let animationFrame = 0;
@@ -384,16 +595,31 @@ function ExplorerScene({ build }: { build: LoadedBuild }) {
       if (reducedMotion) {
         bobBlend = 0;
       } else {
-        bobBlend = THREE.MathUtils.damp(bobBlend, bobWalking ? (bobRunning ? 1 : 0.55) : 0, 14, seconds);
-        if (bobWalking) bobPhase += seconds * (bobRunning ? 13 : 9);
+        bobBlend = THREE.MathUtils.damp(
+          bobBlend,
+          bobWalking ? (bobRunning ? VIEW_BOB_RUN_AMOUNT : VIEW_BOB_WALK_AMOUNT) : 0,
+          14,
+          seconds,
+        );
       }
-      const bobY = Math.sin(bobPhase * 2) * VIEW_BOB_VERTICAL * bobBlend;
-      const bobX = Math.cos(bobPhase) * VIEW_BOB_LATERAL * bobBlend;
-      camera.position.y += bobY;
-      camera.position.addScaledVector(right, bobX);
-      renderer.render(scene, camera);
-      camera.position.addScaledVector(right, -bobX);
-      camera.position.y -= bobY;
+      setExplorerViewBob(viewBob, bobDistance, bobBlend);
+      baseQuaternion.copy(camera.quaternion);
+      bobUp.set(0, 1, 0).applyQuaternion(baseQuaternion);
+      camera.position.addScaledVector(right, viewBob.x);
+      camera.position.addScaledVector(bobUp, viewBob.y);
+      camera.rotateZ(viewBob.roll);
+      camera.rotateX(viewBob.pitch);
+      sunFlare.position.copy(camera.position).addScaledVector(SUN_DIRECTION, camera.far * 0.8);
+      try {
+        renderer.render(scene, camera);
+        sunFlare.visible = false;
+        ssaoPass.render(renderer, null!, null!, seconds, false);
+      } finally {
+        sunFlare.visible = true;
+        camera.quaternion.copy(baseQuaternion);
+        camera.position.addScaledVector(bobUp, -viewBob.y);
+        camera.position.addScaledVector(right, -viewBob.x);
+      }
       fpsFrames += 1;
       if (now - fpsWindowAt >= 750) {
         setFps(Math.round((fpsFrames * 1_000) / (now - fpsWindowAt)));
@@ -440,6 +666,7 @@ function ExplorerScene({ build }: { build: LoadedBuild }) {
         });
         scene.add(voxelGroup.group);
         frameDaylight(camera, scene, sky, sun, voxelGroup.bounds);
+        resize();
 
         camera.position.set(0, collisionWorld.height + 8, 0);
         camera.lookAt(0, Math.max(0, collisionWorld.height - 4), -12);
@@ -474,6 +701,10 @@ function ExplorerScene({ build }: { build: LoadedBuild }) {
         scene.remove(voxelGroup.group);
         voxelGroup.dispose();
       }
+      scene.remove(sunFlare);
+      sunFlare.dispose();
+      ssaoPass.noiseTexture.dispose();
+      ssaoPass.dispose();
       sky.geometry.dispose();
       sky.material.dispose();
       try {
@@ -506,30 +737,48 @@ function ExplorerScene({ build }: { build: LoadedBuild }) {
       {ready && locked ? (
         <div className="pointer-events-none absolute inset-x-3 bottom-3 flex justify-center">
           <div className="rounded bg-slate-950/55 px-3 py-1.5 text-[10px] font-medium text-white/75 backdrop-blur-sm">
-            WASD Move · Shift Run · Space {noclip ? "Rise · Control Descend" : "Jump / Swim"} · F Noclip · Esc Exit
+            WASD Move · Shift Run · Space {noclip ? "Rise · Control Descend" : "Jump / Swim"} · F Noclip · Esc Menu
           </div>
         </div>
       ) : null}
 
       {!locked ? (
-        <div className="absolute inset-0 flex items-center justify-center bg-slate-950/20">
-          <div className="flex flex-col items-center gap-3 rounded-md bg-slate-950/70 px-6 py-5 text-white backdrop-blur-sm">
-            {error ? (
-              <p className="max-w-sm text-center text-sm text-white/85">{error}</p>
-            ) : (
-              <button
-                type="button"
-                disabled={!ready}
-                onClick={enter}
-                className="rounded bg-white/90 px-5 py-2 text-sm font-semibold text-slate-950 transition-colors hover:bg-white disabled:cursor-wait disabled:bg-white/20 disabled:text-white/65"
-              >
-                {ready ? (entered ? "Resume" : "Enter") : loading}
-              </button>
-            )}
-            <Link href="/sandbox" className="text-xs font-medium text-white/65 hover:text-white">
-              Exit
-            </Link>
-          </div>
+        <div className="absolute inset-0 bg-slate-950/20">
+          {buildMenuOpen ? (
+            <ExplorerBuildMenu
+              currentBuildId={buildId}
+              onClose={closeBuildMenu}
+              onSelect={selectBuild}
+            />
+          ) : (
+            <div className="flex h-full items-center justify-center">
+              <div className="flex flex-col items-center gap-3 rounded-md bg-slate-950/70 px-6 py-5 text-white backdrop-blur-sm">
+                {error ? (
+                  <p className="max-w-sm text-center text-sm text-white/85">{error}</p>
+                ) : (
+                  <button
+                    type="button"
+                    disabled={!ready}
+                    onClick={enter}
+                    className="rounded bg-white/90 px-5 py-2 text-sm font-semibold text-slate-950 transition-colors hover:bg-white disabled:cursor-wait disabled:bg-white/20 disabled:text-white/65"
+                  >
+                    {ready ? (entered ? "Resume" : "Enter") : loading}
+                  </button>
+                )}
+                <button
+                  ref={browseButtonRef}
+                  type="button"
+                  onClick={() => setBuildMenuOpen(true)}
+                  className="text-xs font-medium text-white/65 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/65"
+                >
+                  Builds
+                </button>
+                <Link href="/sandbox" className="text-xs font-medium text-white/65 hover:text-white">
+                  Exit
+                </Link>
+              </div>
+            </div>
+          )}
         </div>
       ) : null}
     </div>
@@ -557,7 +806,7 @@ export function VoxelExplorer({ buildId }: { buildId: string }) {
   return (
     <main className="fixed inset-0 z-[100] bg-[oklch(0.86_0.055_235)]">
       {build ? (
-        <ExplorerScene build={build} />
+        <ExplorerScene build={build} buildId={buildId} />
       ) : (
         <div className="flex h-full items-center justify-center text-sm font-semibold text-slate-800">
           {error ?? "Loading"}

--- a/components/voxel/VoxelExplorer.tsx
+++ b/components/voxel/VoxelExplorer.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import * as THREE from "three";
@@ -35,13 +34,13 @@ import {
 import { createVoxelGroupAsync, type VoxelGroup } from "@/lib/voxel/mesh";
 import {
   voxelBuildBlockCount,
-  type RenderableVoxelBuild,
 } from "@/lib/voxel/packedBlocks";
 import { createPublicMeshCacheKey } from "@/lib/voxel/meshPayloadCache";
 import {
   setExplorerViewBob,
   type ExplorerViewBobTransform,
 } from "@/lib/voxel/explorerViewBob";
+import type { VoxelExplorerBuild } from "@/components/voxel/VoxelExplorerLauncher";
 
 const WALK_SPEED = 4.3;
 const RUN_SPEED = 7.5;
@@ -81,19 +80,11 @@ const STARS_PER_LAYER = 560;
 let explorerAtlasPromise: Promise<THREE.Texture> | null = null;
 let explorerBuildCatalog: ExplorerBuildOption[] | null = null;
 
-type LoadedBuild = {
-  checksum: string | null;
-  palette: "simple" | "advanced";
-  voxelBuild: RenderableVoxelBuild;
-};
-
-type ExplorerBuildOption = {
-  id: string;
-  model: string;
-  prompt: string;
-  blockCount: number;
-  source: "benchmark" | "gallery";
-};
+type LoadedBuild = Pick<VoxelExplorerBuild, "checksum" | "palette" | "voxelBuild">;
+type ExplorerBuildOption = Pick<
+  VoxelExplorerBuild,
+  "id" | "model" | "prompt" | "blockCount" | "source"
+>;
 
 function loadAtlasTexture(): Promise<THREE.Texture> {
   if (explorerAtlasPromise) return explorerAtlasPromise;
@@ -292,10 +283,12 @@ function deterministicUnit(index: number, salt: number): number {
 
 function ExplorerBuildMenu({
   currentBuildId,
+  pinnedBuild,
   onClose,
   onSelect,
 }: {
   currentBuildId: string;
+  pinnedBuild?: ExplorerBuildOption;
   onClose: () => void;
   onSelect: (buildId: string) => void;
 }) {
@@ -326,25 +319,30 @@ function ExplorerBuildMenu({
     return () => document.removeEventListener("keydown", onKeyDown);
   }, [onClose]);
 
+  const availableBuilds = useMemo(() => {
+    if (!pinnedBuild || builds?.some((build) => build.id === pinnedBuild.id)) return builds;
+    return [pinnedBuild, ...(builds ?? [])];
+  }, [builds, pinnedBuild]);
+
   const filteredBuilds = useMemo(() => {
-    if (!builds) return [];
+    if (!availableBuilds) return [];
     const tokens = query.trim().toLowerCase().split(/\s+/).filter(Boolean);
-    if (tokens.length === 0) return builds;
-    return builds.filter((build) => {
+    if (tokens.length === 0) return availableBuilds;
+    return availableBuilds.filter((build) => {
       const searchable = `${build.source} ${build.model} ${build.prompt}`.toLowerCase();
       return tokens.every((token) => searchable.includes(token));
     });
-  }, [builds, query]);
+  }, [availableBuilds, query]);
 
   return (
     <aside className="absolute inset-y-3 right-3 flex w-[min(28rem,calc(100%-1.5rem))] flex-col overflow-hidden rounded-md border border-white/10 bg-slate-950/90 text-white shadow-2xl backdrop-blur-md">
       <div className="flex items-center justify-between gap-4 border-b border-white/10 px-4 py-3">
         <div>
           <h2 className="text-sm font-semibold">Builds</h2>
-          {builds ? (
+          {availableBuilds ? (
             <p className="mt-0.5 text-[11px] text-white/50">
-              {filteredBuilds.length === builds.length
-                ? `${builds.length.toLocaleString()} available`
+              {filteredBuilds.length === availableBuilds.length
+                ? `${availableBuilds.length.toLocaleString()} available`
                 : `${filteredBuilds.length.toLocaleString()} matches`}
             </p>
           ) : null}
@@ -386,7 +384,7 @@ function ExplorerBuildMenu({
             </button>
           </div>
         ) : null}
-        {builds && filteredBuilds.length === 0 ? (
+        {availableBuilds && filteredBuilds.length === 0 ? (
           <p className="px-3 py-8 text-center text-xs text-white/50">No matches</p>
         ) : null}
         {filteredBuilds.map((build) => {
@@ -404,7 +402,11 @@ function ExplorerBuildMenu({
               <span className="flex items-center justify-between gap-3 text-[11px] font-semibold text-white/80">
                 <span className="truncate">{build.model}</span>
                 <span className="shrink-0 tabular-nums text-white/40">
-                  {build.source === "gallery" ? "Gallery · " : ""}
+                  {build.source === "gallery"
+                    ? "Gallery · "
+                    : build.source === "current"
+                      ? "Current · "
+                      : ""}
                   {build.blockCount.toLocaleString()} blocks
                 </span>
               </span>
@@ -659,8 +661,19 @@ function hasKey(keys: Set<string>, left: string, right?: string): boolean {
   return keys.has(left) || Boolean(right && keys.has(right));
 }
 
-function ExplorerScene({ build, buildId }: { build: LoadedBuild; buildId: string }) {
-  const router = useRouter();
+function ExplorerScene({
+  build,
+  buildId,
+  pinnedBuild,
+  onSelectBuild,
+  onExit,
+}: {
+  build: LoadedBuild;
+  buildId: string;
+  pinnedBuild?: ExplorerBuildOption;
+  onSelectBuild: (buildId: string) => void;
+  onExit: () => void;
+}) {
   const mountRef = useRef<HTMLDivElement | null>(null);
   const startRef = useRef<(() => void) | null>(null);
   const browseButtonRef = useRef<HTMLButtonElement | null>(null);
@@ -691,8 +704,8 @@ function ExplorerScene({ build, buildId }: { build: LoadedBuild; buildId: string
   }, []);
   const selectBuild = useCallback((nextBuildId: string) => {
     setBuildMenuOpen(false);
-    router.push(`/sandbox/explore/${encodeURIComponent(nextBuildId)}`);
-  }, [router]);
+    onSelectBuild(nextBuildId);
+  }, [onSelectBuild]);
 
   useEffect(() => {
     const mount = mountRef.current;
@@ -1352,6 +1365,7 @@ function ExplorerScene({ build, buildId }: { build: LoadedBuild; buildId: string
           {buildMenuOpen ? (
             <ExplorerBuildMenu
               currentBuildId={buildId}
+              pinnedBuild={pinnedBuild}
               onClose={closeBuildMenu}
               onSelect={selectBuild}
             />
@@ -1378,9 +1392,13 @@ function ExplorerScene({ build, buildId }: { build: LoadedBuild; buildId: string
                 >
                   Builds
                 </button>
-                <Link href="/sandbox" className="text-xs font-medium text-white/65 hover:text-white">
+                <button
+                  type="button"
+                  onClick={onExit}
+                  className="text-xs font-medium text-white/65 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/65"
+                >
                   Exit
-                </Link>
+                </button>
               </div>
             </div>
           )}
@@ -1390,11 +1408,17 @@ function ExplorerScene({ build, buildId }: { build: LoadedBuild; buildId: string
   );
 }
 
-export function VoxelExplorer({ buildId }: { buildId: string }) {
-  const [build, setBuild] = useState<LoadedBuild | null>(null);
+function useExplorerBuild(buildId: string, initialBuild?: VoxelExplorerBuild) {
+  const [build, setBuild] = useState<LoadedBuild | null>(
+    buildId === initialBuild?.id ? initialBuild : null,
+  );
   const [error, setError] = useState<string | null>(null);
-
   useEffect(() => {
+    if (buildId === initialBuild?.id) {
+      setBuild(initialBuild);
+      setError(null);
+      return;
+    }
     const controller = new AbortController();
     setBuild(null);
     setError(null);
@@ -1406,17 +1430,80 @@ export function VoxelExplorer({ buildId }: { buildId: string }) {
       },
     );
     return () => controller.abort();
-  }, [buildId]);
+  }, [buildId, initialBuild]);
+  return { build, error };
+}
+
+export function VoxelExplorer({ buildId }: { buildId: string }) {
+  const router = useRouter();
+  const { build, error } = useExplorerBuild(buildId);
+  const selectBuild = useCallback(
+    (nextBuildId: string) => router.push(`/sandbox/explore/${encodeURIComponent(nextBuildId)}`),
+    [router],
+  );
+  const exit = useCallback(() => router.push("/sandbox"), [router]);
 
   return (
-    <main className="fixed inset-0 z-[100] bg-[oklch(0.86_0.055_235)]">
+    <div className="fixed inset-0 z-[100] bg-[oklch(0.86_0.055_235)]">
       {build ? (
-        <ExplorerScene build={build} buildId={buildId} />
+        <ExplorerScene
+          build={build}
+          buildId={buildId}
+          onSelectBuild={selectBuild}
+          onExit={exit}
+        />
       ) : (
         <div className="flex h-full items-center justify-center text-sm font-semibold text-slate-800">
           {error ?? "Loading"}
         </div>
       )}
-    </main>
+    </div>
+  );
+}
+
+export function VoxelExplorerOverlay({
+  initialBuild,
+  onExit,
+}: {
+  initialBuild: VoxelExplorerBuild;
+  onExit: () => void;
+}) {
+  const [buildId, setBuildId] = useState(initialBuild.id);
+  const { build, error } = useExplorerBuild(buildId, initialBuild);
+
+  return (
+    <div className="fixed inset-0 z-[100] bg-[oklch(0.86_0.055_235)]">
+      {build ? (
+        <ExplorerScene
+          build={build}
+          buildId={buildId}
+          pinnedBuild={initialBuild}
+          onSelectBuild={setBuildId}
+          onExit={onExit}
+        />
+      ) : (
+        <div className="flex h-full flex-col items-center justify-center gap-4 text-sm font-semibold text-slate-800">
+          <p>{error ?? "Loading"}</p>
+          {error ? (
+            <div className="flex gap-2">
+              <button
+                type="button"
+                className="rounded bg-slate-900 px-4 py-2 text-xs text-white"
+                onClick={() => setBuildId(initialBuild.id)}
+              >
+                Current build
+              </button>
+              <button
+                type="button"
+                className="rounded border border-slate-400 px-4 py-2 text-xs"
+                onClick={onExit}
+              >
+                Exit
+              </button>
+            </div>
+          ) : null}
+        </div>
+      )}
+    </div>
   );
 }

--- a/components/voxel/VoxelExplorer.tsx
+++ b/components/voxel/VoxelExplorer.tsx
@@ -88,10 +88,14 @@ type ExplorerBuildOption = Pick<
 
 function loadAtlasTexture(): Promise<THREE.Texture> {
   if (explorerAtlasPromise) return explorerAtlasPromise;
-  explorerAtlasPromise = new Promise((resolve, reject) => {
+  const promise = new Promise<THREE.Texture>((resolve, reject) => {
     new THREE.TextureLoader().load("/textures/atlas.png", resolve, undefined, reject);
+  }).catch((error) => {
+    explorerAtlasPromise = null;
+    throw error;
   });
-  return explorerAtlasPromise;
+  explorerAtlasPromise = promise;
+  return promise;
 }
 
 async function fetchStreamBuild(

--- a/components/voxel/VoxelExplorer.tsx
+++ b/components/voxel/VoxelExplorer.tsx
@@ -28,6 +28,7 @@ import {
 import {
   applyExplorerBlockLighting,
   createExplorerBlockLightGrid,
+  getExplorerMeteorOpacity,
   isExplorerSunRayVisible,
   renderExplorerBloomOverlay,
 } from "@/lib/voxel/explorerLighting";
@@ -62,6 +63,20 @@ const MAX_FRAME_SECONDS = 0.05;
 const MAX_PHYSICS_STEP_SECONDS = 1 / 60;
 const DAYLIGHT_COLOR = 0xaed4ef;
 const SUN_DIRECTION = new THREE.Vector3(-0.46, 0.72, -0.52).normalize();
+const MOON_DIRECTION = new THREE.Vector3(0.48, 0.6, -0.64).normalize();
+const DAY_SUN_COLOR = new THREE.Color(0xffe2b3);
+const NIGHT_MOONLIGHT_COLOR = new THREE.Color(0xa9c8ff);
+const DAY_HEMISPHERE_COLOR = new THREE.Color(0xeaf6ff);
+const NIGHT_HEMISPHERE_COLOR = new THREE.Color(0x547bb3);
+const DAY_GROUND_COLOR = new THREE.Color(0x4d5548);
+const NIGHT_GROUND_COLOR = new THREE.Color(0x111b31);
+const DAY_AMBIENT_COLOR = new THREE.Color(0xf4f8ff);
+const NIGHT_AMBIENT_COLOR = new THREE.Color(0x263c68);
+const DAY_FOG_COLOR = new THREE.Color(DAYLIGHT_COLOR);
+const NIGHT_FOG_COLOR = new THREE.Color(0x0b1830);
+const SUN_FLARE_COLOR = new THREE.Color(0xffdf9f);
+const STAR_LAYER_COUNT = 3;
+const STARS_PER_LAYER = 560;
 
 let explorerAtlasPromise: Promise<THREE.Texture> | null = null;
 let explorerBuildCatalog: ExplorerBuildOption[] | null = null;
@@ -186,16 +201,16 @@ function createSunHaloTexture(): THREE.Texture {
   return texture;
 }
 
-function createSkyGradientTexture(): THREE.Texture {
+function createSkyGradientTexture(
+  stops: ReadonlyArray<readonly [number, string]>,
+): THREE.Texture {
   const canvas = document.createElement("canvas");
   canvas.width = 4;
   canvas.height = 256;
   const context = canvas.getContext("2d");
   if (context) {
     const gradient = context.createLinearGradient(0, 0, 0, 256);
-    gradient.addColorStop(0, "#4f97cb");
-    gradient.addColorStop(0.55, "#78add3");
-    gradient.addColorStop(1, "#bfdbea");
+    for (const [offset, color] of stops) gradient.addColorStop(offset, color);
     context.fillStyle = gradient;
     context.fillRect(0, 0, 4, 256);
   }
@@ -204,6 +219,75 @@ function createSkyGradientTexture(): THREE.Texture {
   texture.generateMipmaps = false;
   texture.minFilter = THREE.LinearFilter;
   return texture;
+}
+
+function createMoonTexture(): THREE.Texture {
+  const canvas = document.createElement("canvas");
+  canvas.width = 512;
+  canvas.height = 512;
+  const context = canvas.getContext("2d");
+  if (context) {
+    const halo = context.createRadialGradient(256, 256, 118, 256, 256, 256);
+    halo.addColorStop(0, "rgba(226,238,255,0.38)");
+    halo.addColorStop(0.5, "rgba(154,188,236,0.1)");
+    halo.addColorStop(1, "rgba(120,164,224,0)");
+    context.fillStyle = halo;
+    context.fillRect(0, 0, 512, 512);
+
+    const disc = context.createRadialGradient(214, 204, 24, 256, 256, 132);
+    disc.addColorStop(0, "#fffdf0");
+    disc.addColorStop(0.68, "#e8eef0");
+    disc.addColorStop(1, "#aebed0");
+    context.fillStyle = disc;
+    context.beginPath();
+    context.arc(256, 256, 132, 0, Math.PI * 2);
+    context.fill();
+
+    context.save();
+    context.beginPath();
+    context.arc(256, 256, 130, 0, Math.PI * 2);
+    context.clip();
+    context.fillStyle = "rgba(83,104,128,0.17)";
+    for (const [x, y, radius] of [
+      [205, 204, 25], [306, 225, 18], [276, 302, 29], [191, 284, 14], [330, 278, 11],
+    ] as const) {
+      context.beginPath();
+      context.ellipse(x, y, radius, radius * 0.76, -0.25, 0, Math.PI * 2);
+      context.fill();
+    }
+    context.restore();
+  }
+  const texture = new THREE.CanvasTexture(canvas);
+  texture.colorSpace = THREE.SRGBColorSpace;
+  texture.generateMipmaps = false;
+  texture.minFilter = THREE.LinearFilter;
+  return texture;
+}
+
+function createMeteorTexture(): THREE.Texture {
+  const canvas = document.createElement("canvas");
+  canvas.width = 256;
+  canvas.height = 32;
+  const context = canvas.getContext("2d");
+  if (context) {
+    const streak = context.createLinearGradient(0, 0, 256, 0);
+    streak.addColorStop(0, "rgba(119,171,255,0)");
+    streak.addColorStop(0.72, "rgba(169,207,255,0.38)");
+    streak.addColorStop(0.94, "rgba(240,247,255,0.96)");
+    streak.addColorStop(1, "rgba(255,255,255,0)");
+    context.fillStyle = streak;
+    context.fillRect(0, 10, 256, 12);
+  }
+  const texture = new THREE.CanvasTexture(canvas);
+  texture.colorSpace = THREE.SRGBColorSpace;
+  texture.generateMipmaps = false;
+  texture.minFilter = THREE.LinearFilter;
+  return texture;
+}
+
+function deterministicUnit(index: number, salt: number): number {
+  const value = Math.sin(index * 12.9898 + salt * 78.233) * 43_758.5453;
+  return value - Math.floor(value);
 }
 
 function ExplorerBuildMenu({
@@ -335,21 +419,30 @@ function ExplorerBuildMenu({
   );
 }
 
-function configureDaylight(
+type ExplorerMeteor = {
+  sprite: THREE.Sprite;
+  material: THREE.SpriteMaterial;
+  start: THREE.Vector3;
+  end: THREE.Vector3;
+  delay: number;
+  duration: number;
+};
+
+function configureAtmosphere(
   scene: THREE.Scene,
   renderer: THREE.WebGLRenderer,
-): {
-  sky: THREE.Mesh<THREE.SphereGeometry, THREE.MeshBasicMaterial>;
-  sun: THREE.DirectionalLight;
-  sunFlare: Lensflare;
-} {
+) {
   scene.background = new THREE.Color(DAYLIGHT_COLOR);
   scene.fog = new THREE.Fog(DAYLIGHT_COLOR, 72, 320);
 
   const sky = new THREE.Mesh(
     new THREE.SphereGeometry(1, 32, 16),
     new THREE.MeshBasicMaterial({
-      map: createSkyGradientTexture(),
+      map: createSkyGradientTexture([
+        [0, "#4f97cb"],
+        [0.55, "#78add3"],
+        [1, "#bfdbea"],
+      ]),
       side: THREE.BackSide,
       depthWrite: false,
       fog: false,
@@ -358,12 +451,132 @@ function configureDaylight(
   );
   sky.scale.setScalar(800);
   sky.frustumCulled = false;
-  scene.add(sky);
+  sky.renderOrder = -100;
 
-  scene.add(new THREE.HemisphereLight(0xeaf6ff, 0x4d5548, 0.98));
-  scene.add(new THREE.AmbientLight(0xf4f8ff, 0.14));
+  const nightSky = new THREE.Mesh(
+    sky.geometry,
+    new THREE.MeshBasicMaterial({
+      map: createSkyGradientTexture([
+        [0, "#020513"],
+        [0.52, "#07132d"],
+        [1, "#172c53"],
+      ]),
+      side: THREE.BackSide,
+      depthWrite: false,
+      fog: false,
+      toneMapped: false,
+      transparent: true,
+      opacity: 0,
+    }),
+  );
+  nightSky.scale.copy(sky.scale);
+  nightSky.frustumCulled = false;
+  nightSky.renderOrder = -99;
+  nightSky.visible = false;
 
-  const sun = new THREE.DirectionalLight(0xffe2b3, 3.5);
+  const starMaterials: THREE.PointsMaterial[] = [];
+  const stars = new THREE.Group();
+  const starColors = [
+    new THREE.Color(0xffffff),
+    new THREE.Color(0xbfd7ff),
+    new THREE.Color(0xffe2bf),
+  ];
+  for (let layer = 0; layer < STAR_LAYER_COUNT; layer += 1) {
+    const positions = new Float32Array(STARS_PER_LAYER * 3);
+    const colors = new Float32Array(STARS_PER_LAYER * 3);
+    for (let star = 0; star < STARS_PER_LAYER; star += 1) {
+      const index = layer * STARS_PER_LAYER + star;
+      const y = THREE.MathUtils.lerp(-0.18, 1, deterministicUnit(index, 1));
+      const radius = Math.sqrt(Math.max(0, 1 - y * y));
+      const theta = deterministicUnit(index, 2) * Math.PI * 2;
+      const offset = star * 3;
+      positions[offset] = Math.cos(theta) * radius;
+      positions[offset + 1] = y;
+      positions[offset + 2] = Math.sin(theta) * radius;
+      starColors[Math.floor(deterministicUnit(index, 3) * starColors.length)]
+        .toArray(colors, offset);
+    }
+    const geometry = new THREE.BufferGeometry();
+    geometry.setAttribute("position", new THREE.BufferAttribute(positions, 3));
+    geometry.setAttribute("color", new THREE.BufferAttribute(colors, 3));
+    const material = new THREE.PointsMaterial({
+      size: 0.85 + layer * 0.42,
+      sizeAttenuation: false,
+      vertexColors: true,
+      transparent: true,
+      opacity: 0,
+      depthWrite: false,
+      fog: false,
+      toneMapped: false,
+      blending: THREE.AdditiveBlending,
+    });
+    const points = new THREE.Points(geometry, material);
+    points.frustumCulled = false;
+    points.renderOrder = -80;
+    stars.add(points);
+    starMaterials.push(material);
+  }
+
+  const moonTexture = createMoonTexture();
+  const moonMaterial = new THREE.SpriteMaterial({
+    map: moonTexture,
+    color: 0xe4efff,
+    transparent: true,
+    opacity: 0,
+    depthWrite: false,
+    fog: false,
+    toneMapped: false,
+  });
+  const moon = new THREE.Sprite(moonMaterial);
+  moon.renderOrder = -60;
+
+  const meteorTexture = createMeteorTexture();
+  const meteorGroup = new THREE.Group();
+  const meteorConfigs = [
+    [[-0.72, 0.65, -0.24], [-0.2, 0.32, -0.68], 0, -0.55],
+    [[0.02, 0.9, -0.36], [0.48, 0.54, -0.7], 0.42, -0.48],
+    [[0.56, 0.72, -0.18], [0.82, 0.38, -0.42], 0.86, -0.62],
+  ] as const;
+  const meteors: ExplorerMeteor[] = meteorConfigs.map(([start, end, delay, rotation]) => {
+    const material = new THREE.SpriteMaterial({
+      map: meteorTexture,
+      color: 0xcfe4ff,
+      transparent: true,
+      opacity: 0,
+      depthWrite: false,
+      fog: false,
+      toneMapped: false,
+      rotation,
+      blending: THREE.AdditiveBlending,
+    });
+    const sprite = new THREE.Sprite(material);
+    sprite.scale.set(0.18, 0.012, 1);
+    sprite.visible = false;
+    sprite.renderOrder = -50;
+    meteorGroup.add(sprite);
+    return {
+      sprite,
+      material,
+      start: new THREE.Vector3(...start).normalize(),
+      end: new THREE.Vector3(...end).normalize(),
+      delay,
+      duration: 1.15,
+    };
+  });
+
+  const atmosphereRoot = new THREE.Group();
+  atmosphereRoot.add(sky, nightSky, stars, moon, meteorGroup);
+  scene.add(atmosphereRoot);
+
+  const hemisphere = new THREE.HemisphereLight(
+    DAY_HEMISPHERE_COLOR,
+    DAY_GROUND_COLOR,
+    0.98,
+  );
+  const ambient = new THREE.AmbientLight(DAY_AMBIENT_COLOR, 0.14);
+  scene.add(hemisphere, ambient);
+
+  const sun = new THREE.DirectionalLight(DAY_SUN_COLOR, 3.5);
   sun.castShadow = true;
   sun.shadow.mapSize.set(2048, 2048);
   sun.shadow.bias = -0.00015;
@@ -372,10 +585,14 @@ function configureDaylight(
   scene.add(sun, sun.target);
 
   const sunFlare = new Lensflare();
-  sunFlare.addElement(
-    new LensflareElement(createSunHaloTexture(), 440, 0, new THREE.Color(0xffdf9f)),
+  const sunFlareElement = new LensflareElement(
+    createSunHaloTexture(),
+    440,
+    0,
+    SUN_FLARE_COLOR,
   );
-  scene.add(sunFlare);
+  sunFlare.addElement(sunFlareElement);
+  atmosphereRoot.add(sunFlare);
 
   renderer.shadowMap.enabled = true;
   renderer.shadowMap.type = THREE.PCFSoftShadowMap;
@@ -383,15 +600,32 @@ function configureDaylight(
   renderer.toneMapping = THREE.ACESFilmicToneMapping;
   renderer.toneMappingExposure = 1.1;
   renderer.outputColorSpace = THREE.SRGBColorSpace;
-  return { sky, sun, sunFlare };
+  return {
+    root: atmosphereRoot,
+    sky,
+    nightSky,
+    stars,
+    starMaterials,
+    moon,
+    moonMaterial,
+    moonTexture,
+    meteorGroup,
+    meteors,
+    meteorTexture,
+    hemisphere,
+    ambient,
+    sun,
+    sunFlare,
+    sunFlareElement,
+  };
 }
 
-function frameDaylight(
+function frameAtmosphere(
   camera: THREE.PerspectiveCamera,
   scene: THREE.Scene,
-  sky: THREE.Mesh,
-  sun: THREE.DirectionalLight,
+  atmosphere: ReturnType<typeof configureAtmosphere>,
   bounds: VoxelGroup["bounds"],
+  lightDirection: THREE.Vector3,
 ) {
   const size = bounds.box.getSize(new THREE.Vector3());
   const radius = Math.max(8, bounds.radius);
@@ -400,12 +634,15 @@ function frameDaylight(
   fog.far = THREE.MathUtils.clamp(Math.max(size.x, size.z) * 1.5, 160, 512);
   camera.far = Math.max(1_000, fog.far * 3);
   camera.updateProjectionMatrix();
-  sky.scale.setScalar(camera.far * 0.8);
+  atmosphere.sky.scale.setScalar(camera.far * 0.96);
+  atmosphere.nightSky.scale.copy(atmosphere.sky.scale);
+  atmosphere.stars.scale.setScalar(camera.far * 0.88);
+  atmosphere.meteorGroup.scale.setScalar(camera.far * 0.84);
 
   const lightDistance = Math.max(80, radius * 2.2);
-  sun.target.position.copy(bounds.center);
-  sun.position.copy(bounds.center).addScaledVector(SUN_DIRECTION, lightDistance);
-  const shadowCamera = sun.shadow.camera;
+  atmosphere.sun.target.position.copy(bounds.center);
+  atmosphere.sun.position.copy(bounds.center).addScaledVector(lightDirection, lightDistance);
+  const shadowCamera = atmosphere.sun.shadow.camera;
   const shadowRadius = radius * 1.1;
   shadowCamera.left = -shadowRadius;
   shadowCamera.right = shadowRadius;
@@ -414,8 +651,8 @@ function frameDaylight(
   shadowCamera.near = 0.1;
   shadowCamera.far = lightDistance + radius * 2;
   shadowCamera.updateProjectionMatrix();
-  sun.target.updateMatrixWorld();
-  sun.shadow.needsUpdate = true;
+  atmosphere.sun.target.updateMatrixWorld();
+  atmosphere.sun.shadow.needsUpdate = true;
 }
 
 function hasKey(keys: Set<string>, left: string, right?: string): boolean {
@@ -431,6 +668,7 @@ function ExplorerScene({ build, buildId }: { build: LoadedBuild; buildId: string
   const [locked, setLocked] = useState(false);
   const [entered, setEntered] = useState(false);
   const [noclip, setNoclip] = useState(true);
+  const [night, setNight] = useState(false);
   const [fps, setFps] = useState(0);
   const [loading, setLoading] = useState("Building");
   const [error, setError] = useState<string | null>(null);
@@ -471,12 +709,22 @@ function ExplorerScene({ build, buildId }: { build: LoadedBuild; buildId: string
     let bobRunning = false;
     let bobDistance = 0;
     let bobBlend = 0;
+    let nightTarget = false;
+    let nightBlend = 0;
+    let moonLightActive = false;
+    let atmosphereTime = 0;
+    let nightElapsed = 0;
+    let nextShowerAt = 10;
+    let showerStartedAt = -1;
+    let showerCount = 0;
+    let sunVisibility = 1;
     const keys = new Set<string>();
 
     setReady(false);
     setLocked(false);
     setEntered(false);
     setNoclip(true);
+    setNight(false);
     setFps(0);
     setLoading("Building");
     setError(null);
@@ -496,7 +744,8 @@ function ExplorerScene({ build, buildId }: { build: LoadedBuild; buildId: string
     renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, 2));
     renderer.setSize(Math.max(1, mount.clientWidth), Math.max(1, mount.clientHeight), true);
     mount.appendChild(renderer.domElement);
-    const { sky, sun, sunFlare } = configureDaylight(scene, renderer);
+    const atmosphere = configureAtmosphere(scene, renderer);
+    const { sun, sunFlare } = atmosphere;
     const bloomTarget = new THREE.WebGLRenderTarget(1, 1, {
       type: THREE.HalfFloatType,
       depthBuffer: true,
@@ -599,7 +848,7 @@ function ExplorerScene({ build, buildId }: { build: LoadedBuild; buildId: string
         event.code === "KeyD" || event.code === "Space" ||
         event.code === "ShiftLeft" || event.code === "ShiftRight" ||
         event.code === "ControlLeft" || event.code === "ControlRight" ||
-        event.code === "KeyF"
+        event.code === "KeyF" || event.code === "KeyT"
       ) {
         event.preventDefault();
       }
@@ -609,6 +858,16 @@ function ExplorerScene({ build, buildId }: { build: LoadedBuild; buildId: string
         verticalVelocity = 0;
         grounded = false;
         setNoclip(isNoclip);
+      }
+      if (event.code === "KeyT" && !event.repeat) {
+        nightTarget = !nightTarget;
+        setNight(nightTarget);
+        if (nightTarget) {
+          nightElapsed = 0;
+          nextShowerAt = 10;
+          showerStartedAt = -1;
+          showerCount = 0;
+        }
       }
     };
     const onKeyUp = (event: KeyboardEvent) => keys.delete(event.code);
@@ -650,7 +909,7 @@ function ExplorerScene({ build, buildId }: { build: LoadedBuild; buildId: string
     const sunRayScreenPosition = new THREE.Vector3();
     const renderPostEffects = (seconds: number) => {
       sunRayScreenPosition.copy(sunRaySprite.position).project(camera);
-      const hasSunRays = isExplorerSunRayVisible(
+      const hasSunRays = sunVisibility > 0.01 && isExplorerSunRayVisible(
         sunRayScreenPosition.x,
         sunRayScreenPosition.y,
         sunRayScreenPosition.z,
@@ -660,16 +919,14 @@ function ExplorerScene({ build, buildId }: { build: LoadedBuild; buildId: string
       const background = scene.background;
       const fog = scene.fog;
       const overrideMaterial = scene.overrideMaterial;
-      const skyVisible = sky.visible;
-      const sunFlareVisible = sunFlare.visible;
+      const atmosphereVisible = atmosphere.root.visible;
       const layerMask = camera.layers.mask;
       renderer.getClearColor(bloomClearColor);
       const clearAlpha = renderer.getClearAlpha();
       try {
         scene.background = null;
         scene.fog = null;
-        sky.visible = false;
-        sunFlare.visible = false;
+        atmosphere.root.visible = false;
         renderer.setClearColor(0x000000, 0);
         renderer.setRenderTarget(bloomTarget);
         camera.layers.set(0);
@@ -699,8 +956,7 @@ function ExplorerScene({ build, buildId }: { build: LoadedBuild; buildId: string
         scene.background = background;
         scene.fog = fog;
         scene.overrideMaterial = overrideMaterial;
-        sky.visible = skyVisible;
-        sunFlare.visible = sunFlareVisible;
+        atmosphere.root.visible = atmosphereVisible;
         renderer.setClearColor(bloomClearColor, clearAlpha);
         renderer.setRenderTarget(null);
       }
@@ -708,6 +964,105 @@ function ExplorerScene({ build, buildId }: { build: LoadedBuild; buildId: string
       bloomPass.render(renderer, bloomTarget, bloomTarget, seconds, false);
       renderer.setRenderTarget(null);
       renderExplorerBloomOverlay(renderer, () => bloomOverlay.render(renderer));
+    };
+    const updateAtmosphere = (seconds: number) => {
+      nightBlend = reducedMotion
+        ? Number(nightTarget)
+        : THREE.MathUtils.damp(nightBlend, Number(nightTarget), 2.4, seconds);
+      if (Math.abs(nightBlend - Number(nightTarget)) < 0.001) {
+        nightBlend = Number(nightTarget);
+      }
+
+      const dayLight = 1 - THREE.MathUtils.smoothstep(nightBlend, 0, 0.54);
+      const moonLight = THREE.MathUtils.smoothstep(nightBlend, 0.46, 1);
+      sunVisibility = 1 - THREE.MathUtils.smoothstep(nightBlend, 0, 0.72);
+      atmosphere.sky.visible = nightBlend < 0.999;
+      atmosphere.nightSky.visible = nightBlend > 0.001;
+      atmosphere.nightSky.material.opacity = nightBlend;
+      atmosphere.hemisphere.color.lerpColors(
+        DAY_HEMISPHERE_COLOR,
+        NIGHT_HEMISPHERE_COLOR,
+        nightBlend,
+      );
+      atmosphere.hemisphere.groundColor.lerpColors(
+        DAY_GROUND_COLOR,
+        NIGHT_GROUND_COLOR,
+        nightBlend,
+      );
+      atmosphere.hemisphere.intensity = THREE.MathUtils.lerp(0.98, 0.42, nightBlend);
+      atmosphere.ambient.color.lerpColors(DAY_AMBIENT_COLOR, NIGHT_AMBIENT_COLOR, nightBlend);
+      atmosphere.ambient.intensity = THREE.MathUtils.lerp(0.14, 0.11, nightBlend);
+      sun.color.lerpColors(DAY_SUN_COLOR, NIGHT_MOONLIGHT_COLOR, moonLight);
+      sun.intensity = 3.5 * dayLight + 0.42 * moonLight;
+      (scene.background as THREE.Color).lerpColors(DAY_FOG_COLOR, NIGHT_FOG_COLOR, nightBlend);
+      (scene.fog as THREE.Fog).color.lerpColors(DAY_FOG_COLOR, NIGHT_FOG_COLOR, nightBlend);
+      renderer.toneMappingExposure = THREE.MathUtils.lerp(1.1, 1.04, nightBlend);
+
+      atmosphere.moonMaterial.opacity =
+        THREE.MathUtils.smoothstep(nightBlend, 0.22, 0.86) * 0.96;
+      atmosphere.sunFlareElement.color
+        .copy(SUN_FLARE_COLOR)
+        .multiplyScalar(sunVisibility);
+      sunFlare.visible = sunVisibility > 0.01;
+      sunRaySpriteMaterial.opacity = sunVisibility;
+
+      if (!reducedMotion) {
+        atmosphereTime += seconds;
+        atmosphere.stars.rotation.y += seconds * 0.00045;
+      }
+      for (let layer = 0; layer < atmosphere.starMaterials.length; layer += 1) {
+        const twinkle = 0.65 + Math.sin(atmosphereTime * (0.72 + layer * 0.17) + layer * 2.1) * 0.13;
+        atmosphere.starMaterials[layer].opacity = nightBlend * twinkle;
+      }
+
+      const shouldUseMoonLight = nightBlend >= 0.5;
+      if (shouldUseMoonLight !== moonLightActive && voxelGroup) {
+        moonLightActive = shouldUseMoonLight;
+        frameAtmosphere(
+          camera,
+          scene,
+          atmosphere,
+          voxelGroup.bounds,
+          moonLightActive ? MOON_DIRECTION : SUN_DIRECTION,
+        );
+      }
+
+      if (reducedMotion || !nightTarget || nightBlend < 0.9) {
+        atmosphere.meteorGroup.visible = false;
+        for (const meteor of atmosphere.meteors) meteor.sprite.visible = false;
+        return;
+      }
+      nightElapsed += seconds;
+      if (showerStartedAt < 0 && nightElapsed >= nextShowerAt) {
+        showerStartedAt = nightElapsed;
+      }
+      let meteorVisible = false;
+      if (showerStartedAt >= 0) {
+        const showerAge = nightElapsed - showerStartedAt;
+        for (const meteor of atmosphere.meteors) {
+          const opacity = getExplorerMeteorOpacity(
+            showerAge,
+            meteor.delay,
+            meteor.duration,
+          );
+          const progress = THREE.MathUtils.clamp(
+            (showerAge - meteor.delay) / meteor.duration,
+            0,
+            1,
+          );
+          meteor.sprite.position.lerpVectors(meteor.start, meteor.end, progress).normalize();
+          meteor.material.opacity = opacity * 0.88 * nightBlend;
+          meteor.sprite.visible = opacity > 0;
+          meteorVisible ||= meteor.sprite.visible;
+        }
+        const lastMeteor = atmosphere.meteors[atmosphere.meteors.length - 1];
+        if (showerAge > lastMeteor.delay + lastMeteor.duration) {
+          showerStartedAt = -1;
+          showerCount += 1;
+          nextShowerAt = nightElapsed + 38 + (showerCount % 3) * 9;
+        }
+      }
+      atmosphere.meteorGroup.visible = meteorVisible;
     };
     const updatePlayer = (seconds: number) => {
       if (!controls.isLocked || !collisionWorld) {
@@ -790,6 +1145,7 @@ function ExplorerScene({ build, buildId }: { build: LoadedBuild; buildId: string
       const seconds = Math.min(MAX_FRAME_SECONDS, Math.max(0, (now - lastFrameAt) / 1_000));
       lastFrameAt = now;
       updatePlayer(seconds);
+      updateAtmosphere(seconds);
 
       if (reducedMotion) {
         bobBlend = 0;
@@ -808,19 +1164,21 @@ function ExplorerScene({ build, buildId }: { build: LoadedBuild; buildId: string
       camera.position.addScaledVector(bobUp, viewBob.y);
       camera.rotateZ(viewBob.roll);
       camera.rotateX(viewBob.pitch);
-      const sunDistance = camera.far * 0.45;
-      sky.position.copy(camera.position);
-      sunFlare.position.copy(camera.position).addScaledVector(SUN_DIRECTION, sunDistance);
-      sunRaySprite.position.copy(sunFlare.position);
+      const sunDistance = camera.far * 0.9;
+      atmosphere.root.position.copy(camera.position);
+      sunFlare.position.copy(SUN_DIRECTION).multiplyScalar(sunDistance);
+      atmosphere.moon.position.copy(MOON_DIRECTION).multiplyScalar(sunDistance);
+      sunRaySprite.position.copy(camera.position).addScaledVector(SUN_DIRECTION, sunDistance);
       const sunRaySize =
         2 * sunDistance * Math.tan(THREE.MathUtils.degToRad(camera.fov * 0.5)) * 0.18;
       sunRaySprite.scale.set(sunRaySize, sunRaySize, 1);
+      const moonSize =
+        2 * sunDistance * Math.tan(THREE.MathUtils.degToRad(camera.fov * 0.5)) * 0.075;
+      atmosphere.moon.scale.set(moonSize, moonSize, 1);
       try {
         renderer.render(scene, camera);
         renderPostEffects(seconds);
-        sunFlare.visible = false;
       } finally {
-        sunFlare.visible = true;
         camera.quaternion.copy(baseQuaternion);
         camera.position.addScaledVector(bobUp, -viewBob.y);
         camera.position.addScaledVector(right, -viewBob.x);
@@ -893,7 +1251,7 @@ function ExplorerScene({ build, buildId }: { build: LoadedBuild; buildId: string
           child.layers.enable(EMISSIVE_LAYER);
         });
         scene.add(voxelGroup.group);
-        frameDaylight(camera, scene, sky, sun, voxelGroup.bounds);
+        frameAtmosphere(camera, scene, atmosphere, voxelGroup.bounds, SUN_DIRECTION);
         resize();
 
         camera.position.set(0, collisionWorld.height + 8, 0);
@@ -929,7 +1287,7 @@ function ExplorerScene({ build, buildId }: { build: LoadedBuild; buildId: string
         scene.remove(voxelGroup.group);
         voxelGroup.dispose();
       }
-      scene.remove(sunFlare);
+      scene.remove(atmosphere.root);
       sunFlare.dispose();
       scene.remove(sunRaySprite);
       sunRayTexture.dispose();
@@ -941,9 +1299,19 @@ function ExplorerScene({ build, buildId }: { build: LoadedBuild; buildId: string
       bloomOverlay.dispose();
       bloomPass.dispose();
       bloomTarget.dispose();
-      sky.material.map?.dispose();
-      sky.geometry.dispose();
-      sky.material.dispose();
+      atmosphere.sky.material.map?.dispose();
+      atmosphere.nightSky.material.map?.dispose();
+      atmosphere.sky.geometry.dispose();
+      atmosphere.sky.material.dispose();
+      atmosphere.nightSky.material.dispose();
+      atmosphere.stars.traverse((child) => {
+        if (child instanceof THREE.Points) child.geometry.dispose();
+      });
+      for (const material of atmosphere.starMaterials) material.dispose();
+      atmosphere.moonTexture.dispose();
+      atmosphere.moonMaterial.dispose();
+      atmosphere.meteorTexture.dispose();
+      for (const meteor of atmosphere.meteors) meteor.material.dispose();
       try {
         renderer.forceContextLoss();
       } catch {}
@@ -974,7 +1342,7 @@ function ExplorerScene({ build, buildId }: { build: LoadedBuild; buildId: string
       {ready && locked ? (
         <div className="pointer-events-none absolute inset-x-3 bottom-3 flex justify-center">
           <div className="rounded bg-slate-950/55 px-3 py-1.5 text-[10px] font-medium text-white/75 backdrop-blur-sm">
-            WASD Move · Shift Run · Space {noclip ? "Rise · Control Descend" : "Jump / Swim"} · F Noclip · Esc Menu
+            WASD Move · Shift Run · Space {noclip ? "Rise · Control Descend" : "Jump / Swim"} · F Noclip · T {night ? "Day" : "Night"} · Esc Menu
           </div>
         </div>
       ) : null}

--- a/components/voxel/VoxelExplorer.tsx
+++ b/components/voxel/VoxelExplorer.tsx
@@ -59,10 +59,11 @@ const VIEW_BOB_RUN_AMOUNT = 0.1;
 const SSAO_RENDER_SCALE = 0.5;
 const BLOOM_RENDER_SCALE = 0.25;
 const EMISSIVE_LAYER = 1;
-const EMISSIVE_LIGHT_COUNT = 6;
-const EMISSIVE_LIGHT_DISTANCE = 18;
-const EMISSIVE_LIGHT_SELECTION_RADIUS = 32;
-const EMISSIVE_LIGHT_INTENSITY = 42;
+const EMISSIVE_LIGHT_COUNT = 2;
+const EMISSIVE_LIGHT_DISTANCE = 14;
+const EMISSIVE_LIGHT_SELECTION_RADIUS = 28;
+const EMISSIVE_LIGHT_INTENSITY = 24;
+const EMISSIVE_LIGHT_SURFACE_OFFSET = 0.55;
 const EMISSIVE_LIGHT_UPDATE_MS = 180;
 const MAX_FRAME_SECONDS = 0.05;
 const MAX_PHYSICS_STEP_SECONDS = 1 / 60;
@@ -337,14 +338,15 @@ function configureDaylight(
   sky.material.uniforms.sunPosition.value.copy(SUN_DIRECTION);
   scene.add(sky);
 
-  scene.add(new THREE.HemisphereLight(0xeaf6ff, 0x39452f, 0.78));
-  scene.add(new THREE.AmbientLight(0xffffff, 0.08));
+  scene.add(new THREE.HemisphereLight(0xeaf6ff, 0x4d5548, 0.98));
+  scene.add(new THREE.AmbientLight(0xf4f8ff, 0.14));
 
   const sun = new THREE.DirectionalLight(0xffe2b3, 3.2);
   sun.castShadow = true;
   sun.shadow.mapSize.set(2048, 2048);
   sun.shadow.bias = -0.00015;
   sun.shadow.normalBias = 0.025;
+  sun.shadow.autoUpdate = false;
   scene.add(sun, sun.target);
 
   const sunFlare = new Lensflare();
@@ -487,7 +489,7 @@ function ExplorerScene({ build, buildId }: { build: LoadedBuild; buildId: string
     const bloomPass = new BloomPass(1, 13, 2);
     const bloomOverlayUniforms = THREE.UniformsUtils.clone(CopyShader.uniforms);
     bloomOverlayUniforms.tDiffuse.value = bloomTarget.texture;
-    bloomOverlayUniforms.opacity.value = 0.78;
+    bloomOverlayUniforms.opacity.value = 0.62;
     const bloomOverlayMaterial = new THREE.ShaderMaterial({
       uniforms: bloomOverlayUniforms,
       vertexShader: CopyShader.vertexShader,
@@ -499,6 +501,7 @@ function ExplorerScene({ build, buildId }: { build: LoadedBuild; buildId: string
       toneMapped: false,
     });
     const bloomOverlay = new FullScreenQuad(bloomOverlayMaterial);
+    const bloomDepthMaterial = new THREE.MeshBasicMaterial({ colorWrite: false });
     const emissiveLights = Array.from({ length: EMISSIVE_LIGHT_COUNT }, () => {
       const light = new THREE.PointLight(
         0xffb45c,
@@ -507,6 +510,15 @@ function ExplorerScene({ build, buildId }: { build: LoadedBuild; buildId: string
         2,
       );
       light.visible = false;
+      light.castShadow = true;
+      light.shadow.mapSize.set(256, 256);
+      light.shadow.camera.near = 0.1;
+      light.shadow.camera.far = EMISSIVE_LIGHT_DISTANCE;
+      light.shadow.camera.updateProjectionMatrix();
+      light.shadow.bias = -0.0005;
+      light.shadow.normalBias = 0.035;
+      light.shadow.radius = 2;
+      light.shadow.autoUpdate = false;
       scene.add(light);
       return light;
     });
@@ -598,38 +610,60 @@ function ExplorerScene({ build, buildId }: { build: LoadedBuild; buildId: string
         EMISSIVE_LIGHT_COUNT,
         EMISSIVE_LIGHT_SELECTION_RADIUS,
       );
-      const active = selected.length > 0;
+      let shadowChanged = false;
       for (let i = 0; i < emissiveLights.length; i += 1) {
         const light = emissiveLights[i];
         const cluster = selected[i];
-        light.visible = active;
         if (!cluster) {
+          light.visible = false;
           light.intensity = 0;
           continue;
         }
-        light.position.set(cluster.x, cluster.y, cluster.z);
+        const x = cluster.x + cluster.nx * EMISSIVE_LIGHT_SURFACE_OFFSET;
+        const y = cluster.y + cluster.ny * EMISSIVE_LIGHT_SURFACE_OFFSET;
+        const z = cluster.z + cluster.nz * EMISSIVE_LIGHT_SURFACE_OFFSET;
+        const moved =
+          !light.visible ||
+          Math.abs(light.position.x - x) > 1e-4 ||
+          Math.abs(light.position.y - y) > 1e-4 ||
+          Math.abs(light.position.z - z) > 1e-4;
+        light.visible = true;
+        light.position.set(x, y, z);
         light.intensity =
-          EMISSIVE_LIGHT_INTENSITY * Math.min(1.45, 0.65 + Math.sqrt(cluster.faces) * 0.16);
+          EMISSIVE_LIGHT_INTENSITY * Math.min(1.25, 0.7 + Math.sqrt(cluster.faces) * 0.12);
+        if (moved) {
+          light.shadow.needsUpdate = true;
+          shadowChanged = true;
+        }
       }
+      if (shadowChanged) renderer.shadowMap.needsUpdate = true;
     };
     const renderEmissiveBloom = (seconds: number) => {
       const background = scene.background;
       const fog = scene.fog;
+      const overrideMaterial = scene.overrideMaterial;
+      const skyVisible = sky.visible;
       const layerMask = camera.layers.mask;
       renderer.getClearColor(bloomClearColor);
       const clearAlpha = renderer.getClearAlpha();
       try {
-        camera.layers.set(EMISSIVE_LAYER);
         scene.background = null;
         scene.fog = null;
+        sky.visible = false;
         renderer.setClearColor(0x000000, 0);
         renderer.setRenderTarget(bloomTarget);
-        renderer.clear();
+        camera.layers.set(0);
+        scene.overrideMaterial = bloomDepthMaterial;
         renderer.render(scene, camera);
+        camera.layers.set(EMISSIVE_LAYER);
+        scene.overrideMaterial = null;
+        renderExplorerBloomOverlay(renderer, () => renderer.render(scene, camera));
       } finally {
         camera.layers.mask = layerMask;
         scene.background = background;
         scene.fog = fog;
+        scene.overrideMaterial = overrideMaterial;
+        sky.visible = skyVisible;
         renderer.setClearColor(bloomClearColor, clearAlpha);
         renderer.setRenderTarget(null);
       }
@@ -841,7 +875,11 @@ function ExplorerScene({ build, buildId }: { build: LoadedBuild; buildId: string
       }
       scene.remove(sunFlare);
       sunFlare.dispose();
-      for (const light of emissiveLights) scene.remove(light);
+      for (const light of emissiveLights) {
+        scene.remove(light);
+        light.shadow.dispose();
+      }
+      bloomDepthMaterial.dispose();
       bloomOverlayMaterial.dispose();
       bloomOverlay.dispose();
       bloomPass.dispose();

--- a/components/voxel/VoxelExplorer.tsx
+++ b/components/voxel/VoxelExplorer.tsx
@@ -9,7 +9,6 @@ import { Lensflare, LensflareElement } from "three/examples/jsm/objects/Lensflar
 import { Sky } from "three/examples/jsm/objects/Sky.js";
 import { BloomPass } from "three/examples/jsm/postprocessing/BloomPass.js";
 import { FullScreenQuad } from "three/examples/jsm/postprocessing/Pass.js";
-import { SSAOPass } from "three/examples/jsm/postprocessing/SSAOPass.js";
 import { CopyShader } from "three/examples/jsm/shaders/CopyShader.js";
 import {
   readBuildVariantPayload,
@@ -28,10 +27,10 @@ import {
   type ExplorerCollisionWorld,
 } from "@/lib/voxel/explorerCollision";
 import {
-  clusterExplorerEmissiveFaces,
+  applyExplorerBlockLighting,
+  createExplorerBlockLightGrid,
+  isExplorerSunRayVisible,
   renderExplorerBloomOverlay,
-  selectNearestExplorerLightClusters,
-  type ExplorerLightCluster,
 } from "@/lib/voxel/explorerLighting";
 import { createVoxelGroupAsync, type VoxelGroup } from "@/lib/voxel/mesh";
 import {
@@ -46,25 +45,20 @@ import {
 
 const WALK_SPEED = 4.3;
 const RUN_SPEED = 7.5;
-const FLY_SPEED = 10.9;
-const FLY_RUN_SPEED = 21.8;
-const GRAVITY = 32;
+const FLY_SPEED = 14;
+const FLY_RUN_SPEED = 28;
+const GRAVITY = 36;
 const JUMP_VELOCITY = Math.sqrt(GRAVITY * 2 * 1.25);
+const MAX_FALL_SPEED = 78.4;
 const WATER_SPEED_MULTIPLIER = 0.8;
 const WATER_ASCENT_SPEED = 3.5;
 const WATER_SINK_SPEED = 1;
-const VIEW_BOB_DISTANCE_SCALE = 0.8;
-const VIEW_BOB_WALK_AMOUNT = 0.075;
-const VIEW_BOB_RUN_AMOUNT = 0.1;
-const SSAO_RENDER_SCALE = 0.5;
+const VIEW_BOB_DISTANCE_SCALE = 0.6;
+const VIEW_BOB_WALK_AMOUNT = 0.065;
+const VIEW_BOB_RUN_AMOUNT = 0.088;
 const BLOOM_RENDER_SCALE = 0.25;
 const EMISSIVE_LAYER = 1;
-const EMISSIVE_LIGHT_COUNT = 2;
-const EMISSIVE_LIGHT_DISTANCE = 14;
-const EMISSIVE_LIGHT_SELECTION_RADIUS = 28;
-const EMISSIVE_LIGHT_INTENSITY = 24;
-const EMISSIVE_LIGHT_SURFACE_OFFSET = 0.55;
-const EMISSIVE_LIGHT_UPDATE_MS = 180;
+const SUN_RAY_LAYER = 2;
 const MAX_FRAME_SECONDS = 0.05;
 const MAX_PHYSICS_STEP_SECONDS = 1 / 60;
 const DAYLIGHT_COLOR = 0xaed4ef;
@@ -180,10 +174,10 @@ function createSunHaloTexture(): THREE.Texture {
   if (context) {
     const gradient = context.createRadialGradient(128, 128, 0, 128, 128, 128);
     gradient.addColorStop(0, "rgba(255, 253, 235, 1)");
-    gradient.addColorStop(0.055, "rgba(255, 245, 201, 0.98)");
-    gradient.addColorStop(0.14, "rgba(255, 224, 151, 0.68)");
-    gradient.addColorStop(0.34, "rgba(255, 193, 102, 0.24)");
-    gradient.addColorStop(0.68, "rgba(255, 174, 76, 0.07)");
+    gradient.addColorStop(0.085, "rgba(255, 249, 220, 1)");
+    gradient.addColorStop(0.13, "rgba(255, 231, 168, 0.9)");
+    gradient.addColorStop(0.3, "rgba(255, 199, 108, 0.3)");
+    gradient.addColorStop(0.68, "rgba(255, 174, 76, 0.06)");
     gradient.addColorStop(1, "rgba(255, 165, 64, 0)");
     context.fillStyle = gradient;
     context.fillRect(0, 0, 256, 256);
@@ -331,17 +325,17 @@ function configureDaylight(
 
   const sky = new Sky();
   sky.scale.setScalar(1_000);
-  sky.material.uniforms.turbidity.value = 4.5;
-  sky.material.uniforms.rayleigh.value = 1.8;
-  sky.material.uniforms.mieCoefficient.value = 0.0035;
-  sky.material.uniforms.mieDirectionalG.value = 0.86;
+  sky.material.uniforms.turbidity.value = 3.2;
+  sky.material.uniforms.rayleigh.value = 2.1;
+  sky.material.uniforms.mieCoefficient.value = 0.006;
+  sky.material.uniforms.mieDirectionalG.value = 0.9;
   sky.material.uniforms.sunPosition.value.copy(SUN_DIRECTION);
   scene.add(sky);
 
   scene.add(new THREE.HemisphereLight(0xeaf6ff, 0x4d5548, 0.98));
   scene.add(new THREE.AmbientLight(0xf4f8ff, 0.14));
 
-  const sun = new THREE.DirectionalLight(0xffe2b3, 3.2);
+  const sun = new THREE.DirectionalLight(0xffe2b3, 3.5);
   sun.castShadow = true;
   sun.shadow.mapSize.set(2048, 2048);
   sun.shadow.bias = -0.00015;
@@ -351,7 +345,7 @@ function configureDaylight(
 
   const sunFlare = new Lensflare();
   sunFlare.addElement(
-    new LensflareElement(createSunHaloTexture(), 360, 0, new THREE.Color(0xffd18a)),
+    new LensflareElement(createSunHaloTexture(), 440, 0, new THREE.Color(0xffdf9f)),
   );
   scene.add(sunFlare);
 
@@ -475,16 +469,11 @@ function ExplorerScene({ build, buildId }: { build: LoadedBuild; buildId: string
     renderer.setSize(Math.max(1, mount.clientWidth), Math.max(1, mount.clientHeight), true);
     mount.appendChild(renderer.domElement);
     const { sky, sun, sunFlare } = configureDaylight(scene, renderer);
-    const ssaoPass = new SSAOPass(scene, camera, 1, 1, 16);
-    ssaoPass.renderToScreen = true;
-    ssaoPass.kernelRadius = 12;
-    ssaoPass.minDistance = 0.001;
-    ssaoPass.maxDistance = 0.1;
     const bloomTarget = new THREE.WebGLRenderTarget(1, 1, {
       type: THREE.HalfFloatType,
       depthBuffer: true,
     });
-    bloomTarget.texture.name = "Explorer.emissiveBloom";
+    bloomTarget.texture.name = "Explorer.postEffects";
     bloomTarget.texture.generateMipmaps = false;
     const bloomPass = new BloomPass(1, 13, 2);
     const bloomOverlayUniforms = THREE.UniformsUtils.clone(CopyShader.uniforms);
@@ -502,29 +491,60 @@ function ExplorerScene({ build, buildId }: { build: LoadedBuild; buildId: string
     });
     const bloomOverlay = new FullScreenQuad(bloomOverlayMaterial);
     const bloomDepthMaterial = new THREE.MeshBasicMaterial({ colorWrite: false });
-    const emissiveLights = Array.from({ length: EMISSIVE_LIGHT_COUNT }, () => {
-      const light = new THREE.PointLight(
-        0xffb45c,
-        0,
-        EMISSIVE_LIGHT_DISTANCE,
-        2,
-      );
-      light.visible = false;
-      light.castShadow = true;
-      light.shadow.mapSize.set(256, 256);
-      light.shadow.camera.near = 0.1;
-      light.shadow.camera.far = EMISSIVE_LIGHT_DISTANCE;
-      light.shadow.camera.updateProjectionMatrix();
-      light.shadow.bias = -0.0005;
-      light.shadow.normalBias = 0.035;
-      light.shadow.radius = 2;
-      light.shadow.autoUpdate = false;
-      scene.add(light);
-      return light;
+    const sunRayTexture = createSunHaloTexture();
+    const sunRaySpriteMaterial = new THREE.SpriteMaterial({
+      map: sunRayTexture,
+      color: 0xffffff,
+      transparent: true,
+      depthTest: true,
+      depthWrite: false,
+      fog: false,
+      toneMapped: false,
     });
-    let emissiveClusters: ExplorerLightCluster[] = [];
+    const sunRaySprite = new THREE.Sprite(sunRaySpriteMaterial);
+    sunRaySprite.layers.set(SUN_RAY_LAYER);
+    scene.add(sunRaySprite);
+    const sunRayMaterial = new THREE.ShaderMaterial({
+      uniforms: {
+        tDiffuse: { value: bloomTarget.texture },
+        lightPosition: { value: new THREE.Vector2(0.5, 0.5) },
+        rayColor: { value: new THREE.Color(0xffd2a3) },
+      },
+      vertexShader: `
+        varying vec2 vUv;
+        void main() {
+          vUv = uv;
+          gl_Position = vec4(position.xy, 0.0, 1.0);
+        }
+      `,
+      fragmentShader: `
+        uniform sampler2D tDiffuse;
+        uniform vec2 lightPosition;
+        uniform vec3 rayColor;
+        varying vec2 vUv;
+
+        void main() {
+          vec2 sampleUv = vUv;
+          vec2 stepUv = (vUv - lightPosition) * 0.88 / 24.0;
+          float illumination = 1.0;
+          float rays = 0.0;
+          for (int i = 0; i < 24; i++) {
+            sampleUv -= stepUv;
+            vec3 sampleColor = texture2D(tDiffuse, sampleUv).rgb;
+            rays += max(max(sampleColor.r, sampleColor.g), sampleColor.b) * illumination * 0.1;
+            illumination *= 0.94;
+          }
+          gl_FragColor = vec4(rayColor * rays * 0.28, 1.0);
+        }
+      `,
+      blending: THREE.AdditiveBlending,
+      transparent: true,
+      depthTest: false,
+      depthWrite: false,
+      toneMapped: false,
+    });
+    const sunRayOverlay = new FullScreenQuad(sunRayMaterial);
     let hasEmissiveMeshes = false;
-    let nextEmissiveLightUpdateAt = 0;
 
     const controls = new PointerLockControls(camera, renderer.domElement);
     controls.pointerSpeed = 0.9;
@@ -583,10 +603,6 @@ function ExplorerScene({ build, buildId }: { build: LoadedBuild; buildId: string
       renderer.setSize(width, height, true);
       camera.aspect = width / height;
       camera.updateProjectionMatrix();
-      ssaoPass.setSize(
-        Math.max(1, Math.round(width * pixelRatio * SSAO_RENDER_SCALE)),
-        Math.max(1, Math.round(height * pixelRatio * SSAO_RENDER_SCALE)),
-      );
       const bloomWidth = Math.max(1, Math.round(width * pixelRatio * BLOOM_RENDER_SCALE));
       const bloomHeight = Math.max(1, Math.round(height * pixelRatio * BLOOM_RENDER_SCALE));
       bloomTarget.setSize(bloomWidth, bloomHeight);
@@ -603,46 +619,21 @@ function ExplorerScene({ build, buildId }: { build: LoadedBuild; buildId: string
     const baseQuaternion = new THREE.Quaternion();
     const viewBob: ExplorerViewBobTransform = { x: 0, y: 0, roll: 0, pitch: 0 };
     const bloomClearColor = new THREE.Color();
-    const updateEmissiveLights = () => {
-      const selected = selectNearestExplorerLightClusters(
-        emissiveClusters,
-        camera.position,
-        EMISSIVE_LIGHT_COUNT,
-        EMISSIVE_LIGHT_SELECTION_RADIUS,
+    const sunRayScreenPosition = new THREE.Vector3();
+    const renderPostEffects = (seconds: number) => {
+      sunRayScreenPosition.copy(sunRaySprite.position).project(camera);
+      const hasSunRays = isExplorerSunRayVisible(
+        sunRayScreenPosition.x,
+        sunRayScreenPosition.y,
+        sunRayScreenPosition.z,
       );
-      let shadowChanged = false;
-      for (let i = 0; i < emissiveLights.length; i += 1) {
-        const light = emissiveLights[i];
-        const cluster = selected[i];
-        if (!cluster) {
-          light.visible = false;
-          light.intensity = 0;
-          continue;
-        }
-        const x = cluster.x + cluster.nx * EMISSIVE_LIGHT_SURFACE_OFFSET;
-        const y = cluster.y + cluster.ny * EMISSIVE_LIGHT_SURFACE_OFFSET;
-        const z = cluster.z + cluster.nz * EMISSIVE_LIGHT_SURFACE_OFFSET;
-        const moved =
-          !light.visible ||
-          Math.abs(light.position.x - x) > 1e-4 ||
-          Math.abs(light.position.y - y) > 1e-4 ||
-          Math.abs(light.position.z - z) > 1e-4;
-        light.visible = true;
-        light.position.set(x, y, z);
-        light.intensity =
-          EMISSIVE_LIGHT_INTENSITY * Math.min(1.25, 0.7 + Math.sqrt(cluster.faces) * 0.12);
-        if (moved) {
-          light.shadow.needsUpdate = true;
-          shadowChanged = true;
-        }
-      }
-      if (shadowChanged) renderer.shadowMap.needsUpdate = true;
-    };
-    const renderEmissiveBloom = (seconds: number) => {
+      if (!hasSunRays && !hasEmissiveMeshes) return;
+
       const background = scene.background;
       const fog = scene.fog;
       const overrideMaterial = scene.overrideMaterial;
       const skyVisible = sky.visible;
+      const sunFlareVisible = sunFlare.visible;
       const layerMask = camera.layers.mask;
       renderer.getClearColor(bloomClearColor);
       const clearAlpha = renderer.getClearAlpha();
@@ -650,23 +641,42 @@ function ExplorerScene({ build, buildId }: { build: LoadedBuild; buildId: string
         scene.background = null;
         scene.fog = null;
         sky.visible = false;
+        sunFlare.visible = false;
         renderer.setClearColor(0x000000, 0);
         renderer.setRenderTarget(bloomTarget);
         camera.layers.set(0);
         scene.overrideMaterial = bloomDepthMaterial;
         renderer.render(scene, camera);
-        camera.layers.set(EMISSIVE_LAYER);
         scene.overrideMaterial = null;
-        renderExplorerBloomOverlay(renderer, () => renderer.render(scene, camera));
+
+        if (hasSunRays) {
+          camera.layers.set(SUN_RAY_LAYER);
+          renderExplorerBloomOverlay(renderer, () => renderer.render(scene, camera));
+          renderer.setRenderTarget(null);
+          sunRayMaterial.uniforms.lightPosition.value.set(
+            sunRayScreenPosition.x * 0.5 + 0.5,
+            sunRayScreenPosition.y * 0.5 + 0.5,
+          );
+          renderExplorerBloomOverlay(renderer, () => sunRayOverlay.render(renderer));
+        }
+
+        if (hasEmissiveMeshes) {
+          renderer.setRenderTarget(bloomTarget);
+          renderer.clear(true, false, false);
+          camera.layers.set(EMISSIVE_LAYER);
+          renderExplorerBloomOverlay(renderer, () => renderer.render(scene, camera));
+        }
       } finally {
         camera.layers.mask = layerMask;
         scene.background = background;
         scene.fog = fog;
         scene.overrideMaterial = overrideMaterial;
         sky.visible = skyVisible;
+        sunFlare.visible = sunFlareVisible;
         renderer.setClearColor(bloomClearColor, clearAlpha);
         renderer.setRenderTarget(null);
       }
+      if (!hasEmissiveMeshes) return;
       bloomPass.render(renderer, bloomTarget, bloomTarget, seconds, false);
       renderer.setRenderTarget(null);
       renderExplorerBloomOverlay(renderer, () => bloomOverlay.render(renderer));
@@ -724,7 +734,10 @@ function ExplorerScene({ build, buildId }: { build: LoadedBuild; buildId: string
             verticalVelocity = JUMP_VELOCITY;
             grounded = false;
           }
-          verticalVelocity -= GRAVITY * stepSeconds;
+          verticalVelocity = Math.max(
+            verticalVelocity - GRAVITY * stepSeconds,
+            -MAX_FALL_SPEED,
+          );
         }
         const verticalCollision = moveExplorerPlayerAxis(
           collisionWorld,
@@ -749,10 +762,6 @@ function ExplorerScene({ build, buildId }: { build: LoadedBuild; buildId: string
       const seconds = Math.min(MAX_FRAME_SECONDS, Math.max(0, (now - lastFrameAt) / 1_000));
       lastFrameAt = now;
       updatePlayer(seconds);
-      if (hasEmissiveMeshes && now >= nextEmissiveLightUpdateAt) {
-        updateEmissiveLights();
-        nextEmissiveLightUpdateAt = now + EMISSIVE_LIGHT_UPDATE_MS;
-      }
 
       if (reducedMotion) {
         bobBlend = 0;
@@ -771,12 +780,16 @@ function ExplorerScene({ build, buildId }: { build: LoadedBuild; buildId: string
       camera.position.addScaledVector(bobUp, viewBob.y);
       camera.rotateZ(viewBob.roll);
       camera.rotateX(viewBob.pitch);
-      sunFlare.position.copy(camera.position).addScaledVector(SUN_DIRECTION, camera.far * 0.8);
+      const sunDistance = camera.far * 0.45;
+      sunFlare.position.copy(camera.position).addScaledVector(SUN_DIRECTION, sunDistance);
+      sunRaySprite.position.copy(sunFlare.position);
+      const sunRaySize =
+        2 * sunDistance * Math.tan(THREE.MathUtils.degToRad(camera.fov * 0.5)) * 0.18;
+      sunRaySprite.scale.set(sunRaySize, sunRaySize, 1);
       try {
         renderer.render(scene, camera);
+        renderPostEffects(seconds);
         sunFlare.visible = false;
-        ssaoPass.render(renderer, null!, null!, seconds, false);
-        if (hasEmissiveMeshes) renderEmissiveBloom(seconds);
       } finally {
         sunFlare.visible = true;
         camera.quaternion.copy(baseQuaternion);
@@ -802,6 +815,12 @@ function ExplorerScene({ build, buildId }: { build: LoadedBuild; buildId: string
             if (!disposed) setLoading("Preparing collision");
           },
         });
+        const blockLightPromise = createExplorerBlockLightGrid(build.voxelBuild, {
+          signal: abortController.signal,
+          onProgress(stage) {
+            if (!disposed) setLoading(stage);
+          },
+        });
         const atlas = await atlasPromise;
         const groupPromise = createVoxelGroupAsync(build.voxelBuild, getPalette(build.palette), atlas, {
           signal: abortController.signal,
@@ -810,9 +829,10 @@ function ExplorerScene({ build, buildId }: { build: LoadedBuild; buildId: string
             if (!disposed) setLoading(progress.stageLabel ?? "Building");
           },
         });
-        const [nextCollisionWorld, nextVoxelGroup] = await Promise.all([
+        const [nextCollisionWorld, nextVoxelGroup, blockLightGrid] = await Promise.all([
           collisionPromise,
           groupPromise,
+          blockLightPromise,
         ]);
         if (disposed || abortController.signal.aborted) {
           nextVoxelGroup.dispose();
@@ -821,6 +841,19 @@ function ExplorerScene({ build, buildId }: { build: LoadedBuild; buildId: string
 
         collisionWorld = nextCollisionWorld;
         voxelGroup = nextVoxelGroup;
+        if (blockLightGrid) {
+          await applyExplorerBlockLighting(
+            voxelGroup.group,
+            voxelGroup.bounds.box,
+            blockLightGrid,
+            {
+              signal: abortController.signal,
+              onProgress(stage) {
+                if (!disposed) setLoading(stage);
+              },
+            },
+          );
+        }
         voxelGroup.group.traverse((child) => {
           if (!(child instanceof THREE.Mesh)) return;
           const materials = Array.isArray(child.material) ? child.material : [child.material];
@@ -829,11 +862,6 @@ function ExplorerScene({ build, buildId }: { build: LoadedBuild; buildId: string
           if (!materials.some((material) => material instanceof THREE.MeshBasicMaterial)) return;
           hasEmissiveMeshes = true;
           child.layers.enable(EMISSIVE_LAYER);
-          const positions = child.geometry.getAttribute("position");
-          if (positions?.itemSize !== 3) return;
-          for (const cluster of clusterExplorerEmissiveFaces(positions.array)) {
-            emissiveClusters.push(cluster);
-          }
         });
         scene.add(voxelGroup.group);
         frameDaylight(camera, scene, sky, sun, voxelGroup.bounds);
@@ -841,7 +869,6 @@ function ExplorerScene({ build, buildId }: { build: LoadedBuild; buildId: string
 
         camera.position.set(0, collisionWorld.height + 8, 0);
         camera.lookAt(0, Math.max(0, collisionWorld.height - 4), -12);
-        updateEmissiveLights();
         renderer.shadowMap.needsUpdate = true;
         worldReady = true;
         setLoading("");
@@ -875,17 +902,16 @@ function ExplorerScene({ build, buildId }: { build: LoadedBuild; buildId: string
       }
       scene.remove(sunFlare);
       sunFlare.dispose();
-      for (const light of emissiveLights) {
-        scene.remove(light);
-        light.shadow.dispose();
-      }
+      scene.remove(sunRaySprite);
+      sunRayTexture.dispose();
+      sunRaySpriteMaterial.dispose();
+      sunRayMaterial.dispose();
+      sunRayOverlay.dispose();
       bloomDepthMaterial.dispose();
       bloomOverlayMaterial.dispose();
       bloomOverlay.dispose();
       bloomPass.dispose();
       bloomTarget.dispose();
-      ssaoPass.noiseTexture.dispose();
-      ssaoPass.dispose();
       sky.geometry.dispose();
       sky.material.dispose();
       try {

--- a/components/voxel/VoxelExplorer.tsx
+++ b/components/voxel/VoxelExplorer.tsx
@@ -1454,8 +1454,17 @@ export function VoxelExplorer({ buildId }: { buildId: string }) {
           onExit={exit}
         />
       ) : (
-        <div className="flex h-full items-center justify-center text-sm font-semibold text-slate-800">
-          {error ?? "Loading"}
+        <div className="flex h-full flex-col items-center justify-center gap-4 text-sm font-semibold text-slate-800">
+          <p>{error ?? "Loading"}</p>
+          {error ? (
+            <button
+              type="button"
+              className="rounded border border-slate-400 px-4 py-2 text-xs"
+              onClick={exit}
+            >
+              Exit
+            </button>
+          ) : null}
         </div>
       )}
     </div>

--- a/components/voxel/VoxelExplorer.tsx
+++ b/components/voxel/VoxelExplorer.tsx
@@ -19,6 +19,7 @@ import {
 import { readClientErrorResponse } from "@/lib/clientErrorResponse";
 import { getPalette } from "@/lib/blocks/palettes";
 import { VOXEL_VIEWER_WEBGL_ERROR } from "@/lib/voxel/errors";
+import { parseExplorerBuildId } from "@/lib/voxel/explorerBuildId";
 import {
   EXPLORER_EYE_HEIGHT,
   createExplorerCollisionWorld,
@@ -28,6 +29,7 @@ import {
 } from "@/lib/voxel/explorerCollision";
 import {
   clusterExplorerEmissiveFaces,
+  renderExplorerBloomOverlay,
   selectNearestExplorerLightClusters,
   type ExplorerLightCluster,
 } from "@/lib/voxel/explorerLighting";
@@ -65,7 +67,6 @@ const EMISSIVE_LIGHT_UPDATE_MS = 180;
 const MAX_FRAME_SECONDS = 0.05;
 const MAX_PHYSICS_STEP_SECONDS = 1 / 60;
 const DAYLIGHT_COLOR = 0xaed4ef;
-const GALLERY_BUILD_PREFIX = "gallery:";
 const SUN_DIRECTION = new THREE.Vector3(-0.46, 0.72, -0.52).normalize();
 
 let explorerAtlasPromise: Promise<THREE.Texture> | null = null;
@@ -117,12 +118,10 @@ async function fetchStreamBuild(
 }
 
 async function fetchExplorerBuild(buildId: string, signal: AbortSignal): Promise<LoadedBuild> {
-  const galleryExampleId = buildId.startsWith(GALLERY_BUILD_PREFIX)
-    ? buildId.slice(GALLERY_BUILD_PREFIX.length)
-    : null;
-  if (galleryExampleId) {
+  const target = parseExplorerBuildId(buildId);
+  if (target.source === "gallery") {
     const response = await fetch(
-      `/api/gallery/examples/${encodeURIComponent(galleryExampleId)}/viewer`,
+      `/api/gallery/examples/${encodeURIComponent(target.id)}/viewer`,
       { signal },
     );
     if (!response.ok) {
@@ -137,7 +136,7 @@ async function fetchExplorerBuild(buildId: string, signal: AbortSignal): Promise
   }
 
   const url = new URL(
-    `/api/arena/builds/${encodeURIComponent(buildId)}`,
+    `/api/arena/builds/${encodeURIComponent(target.id)}`,
     window.location.origin,
   );
   url.searchParams.set("variant", "full");
@@ -151,7 +150,7 @@ async function fetchExplorerBuild(buildId: string, signal: AbortSignal): Promise
       })
     ).payload;
   } else if (response.status === 503) {
-    payload = await fetchStreamBuild(buildId, signal);
+    payload = await fetchStreamBuild(target.id, signal);
   } else {
     throw new Error(await readClientErrorResponse(response, "Failed to load build"));
   }
@@ -636,7 +635,7 @@ function ExplorerScene({ build, buildId }: { build: LoadedBuild; buildId: string
       }
       bloomPass.render(renderer, bloomTarget, bloomTarget, seconds, false);
       renderer.setRenderTarget(null);
-      bloomOverlay.render(renderer);
+      renderExplorerBloomOverlay(renderer, () => bloomOverlay.render(renderer));
     };
     const updatePlayer = (seconds: number) => {
       if (!controls.isLocked || !collisionWorld) {

--- a/components/voxel/VoxelExplorer.tsx
+++ b/components/voxel/VoxelExplorer.tsx
@@ -78,7 +78,6 @@ const STAR_LAYER_COUNT = 3;
 const STARS_PER_LAYER = 560;
 
 let explorerAtlasPromise: Promise<THREE.Texture> | null = null;
-let explorerBuildCatalog: ExplorerBuildOption[] | null = null;
 
 type LoadedBuild = Pick<VoxelExplorerBuild, "checksum" | "palette" | "voxelBuild">;
 type ExplorerBuildOption = Pick<
@@ -162,7 +161,6 @@ async function fetchExplorerBuild(buildId: string, signal: AbortSignal): Promise
 }
 
 async function fetchExplorerBuildCatalog(signal: AbortSignal): Promise<ExplorerBuildOption[]> {
-  if (explorerBuildCatalog) return explorerBuildCatalog;
   const response = await fetch("/api/sandbox/explorer-builds", { signal });
   const body = (await response.json()) as {
     builds?: ExplorerBuildOption[];
@@ -171,7 +169,6 @@ async function fetchExplorerBuildCatalog(signal: AbortSignal): Promise<ExplorerB
   if (!response.ok || !Array.isArray(body.builds)) {
     throw new Error(body.error ?? "Builds unavailable");
   }
-  explorerBuildCatalog = body.builds;
   return body.builds;
 }
 
@@ -296,7 +293,7 @@ function ExplorerBuildMenu({
   onClose: () => void;
   onSelect: (buildId: string) => void;
 }) {
-  const [builds, setBuilds] = useState<ExplorerBuildOption[] | null>(explorerBuildCatalog);
+  const [builds, setBuilds] = useState<ExplorerBuildOption[] | null>(null);
   const [query, setQuery] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [attempt, setAttempt] = useState(0);

--- a/components/voxel/VoxelExplorer.tsx
+++ b/components/voxel/VoxelExplorer.tsx
@@ -1,0 +1,531 @@
+"use client";
+
+import Link from "next/link";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import * as THREE from "three";
+import { PointerLockControls } from "three/examples/jsm/controls/PointerLockControls.js";
+import { Sky } from "three/examples/jsm/objects/Sky.js";
+import {
+  readBuildVariantPayload,
+  readBuildVariantStream,
+  type BuildVariantStreamResponse,
+} from "@/lib/arena/clientBuildResponse";
+import { readClientErrorResponse } from "@/lib/clientErrorResponse";
+import { getPalette } from "@/lib/blocks/palettes";
+import { VOXEL_VIEWER_WEBGL_ERROR } from "@/lib/voxel/errors";
+import {
+  EXPLORER_EYE_HEIGHT,
+  createExplorerCollisionWorld,
+  moveExplorerPlayerAxis,
+  type ExplorerCollisionWorld,
+} from "@/lib/voxel/explorerCollision";
+import { createVoxelGroupAsync, type VoxelGroup } from "@/lib/voxel/mesh";
+import {
+  voxelBuildBlockCount,
+  type RenderableVoxelBuild,
+} from "@/lib/voxel/packedBlocks";
+import { createPublicMeshCacheKey } from "@/lib/voxel/meshPayloadCache";
+
+const WALK_SPEED = 4.3;
+const RUN_SPEED = 5.6;
+const FLY_SPEED = 10.9;
+const GRAVITY = 32;
+const JUMP_VELOCITY = Math.sqrt(GRAVITY * 2 * 1.25);
+const WATER_SPEED_MULTIPLIER = 0.8;
+const MAX_FRAME_SECONDS = 0.05;
+const MAX_PHYSICS_STEP_SECONDS = 1 / 60;
+const DAYLIGHT_COLOR = 0xbfdcf2;
+const SIMPLE_PALETTE = getPalette("simple");
+
+let explorerAtlasPromise: Promise<THREE.Texture> | null = null;
+
+type LoadedBuild = {
+  checksum: string | null;
+  voxelBuild: RenderableVoxelBuild;
+};
+
+function loadAtlasTexture(): Promise<THREE.Texture> {
+  if (explorerAtlasPromise) return explorerAtlasPromise;
+  explorerAtlasPromise = new Promise((resolve, reject) => {
+    new THREE.TextureLoader().load("/textures/atlas.png", resolve, undefined, reject);
+  });
+  return explorerAtlasPromise;
+}
+
+async function fetchStreamBuild(
+  buildId: string,
+  signal: AbortSignal,
+): Promise<BuildVariantStreamResponse> {
+  const url = new URL(
+    `/api/arena/builds/${encodeURIComponent(buildId)}/stream`,
+    window.location.origin,
+  );
+  url.searchParams.set("variant", "full");
+  const response = await fetch(url, { signal });
+  if (!response.ok) {
+    throw new Error(await readClientErrorResponse(response, "Failed to load build"));
+  }
+  if ((response.headers.get("content-type") ?? "").includes("application/x-ndjson")) {
+    return readBuildVariantStream(response, { signal });
+  }
+  return (
+    await readBuildVariantPayload(response, {
+      fallbackIdentity: { buildId, variant: "full", checksum: null },
+    })
+  ).payload;
+}
+
+async function fetchExplorerBuild(buildId: string, signal: AbortSignal): Promise<LoadedBuild> {
+  const url = new URL(
+    `/api/arena/builds/${encodeURIComponent(buildId)}`,
+    window.location.origin,
+  );
+  url.searchParams.set("variant", "full");
+  url.searchParams.set("format", "mbf1");
+  const response = await fetch(url, { signal });
+  let payload: BuildVariantStreamResponse;
+  if (response.ok) {
+    payload = (
+      await readBuildVariantPayload(response, {
+        fallbackIdentity: { buildId, variant: "full", checksum: null },
+      })
+    ).payload;
+  } else if (response.status === 503) {
+    payload = await fetchStreamBuild(buildId, signal);
+  } else {
+    throw new Error(await readClientErrorResponse(response, "Failed to load build"));
+  }
+  return { checksum: payload.checksum, voxelBuild: payload.voxelBuild };
+}
+
+function configureDaylight(
+  scene: THREE.Scene,
+  renderer: THREE.WebGLRenderer,
+): { sky: Sky; sun: THREE.DirectionalLight } {
+  scene.background = new THREE.Color(DAYLIGHT_COLOR);
+  scene.fog = new THREE.Fog(DAYLIGHT_COLOR, 72, 320);
+
+  const sky = new Sky();
+  sky.scale.setScalar(1_000);
+  sky.material.uniforms.turbidity.value = 6;
+  sky.material.uniforms.rayleigh.value = 2.2;
+  sky.material.uniforms.mieCoefficient.value = 0.004;
+  sky.material.uniforms.mieDirectionalG.value = 0.8;
+  const sunDirection = new THREE.Vector3(0.55, 0.78, 0.3).normalize();
+  sky.material.uniforms.sunPosition.value.copy(sunDirection);
+  scene.add(sky);
+
+  scene.add(new THREE.HemisphereLight(0xeaf6ff, 0x65724d, 1.15));
+  scene.add(new THREE.AmbientLight(0xffffff, 0.3));
+
+  const sun = new THREE.DirectionalLight(0xfff3d6, 2.1);
+  sun.castShadow = true;
+  sun.shadow.mapSize.set(2048, 2048);
+  sun.shadow.bias = -0.00015;
+  sun.shadow.normalBias = 0.025;
+  scene.add(sun, sun.target);
+
+  renderer.shadowMap.enabled = true;
+  renderer.shadowMap.type = THREE.PCFSoftShadowMap;
+  renderer.shadowMap.autoUpdate = false;
+  renderer.toneMapping = THREE.ACESFilmicToneMapping;
+  renderer.toneMappingExposure = 1;
+  renderer.outputColorSpace = THREE.SRGBColorSpace;
+  return { sky, sun };
+}
+
+function frameDaylight(
+  camera: THREE.PerspectiveCamera,
+  scene: THREE.Scene,
+  sky: Sky,
+  sun: THREE.DirectionalLight,
+  bounds: VoxelGroup["bounds"],
+) {
+  const size = bounds.box.getSize(new THREE.Vector3());
+  const radius = Math.max(8, bounds.radius);
+  const fog = scene.fog as THREE.Fog;
+  fog.near = THREE.MathUtils.clamp(Math.max(size.x, size.z) * 0.35, 48, 96);
+  fog.far = THREE.MathUtils.clamp(Math.max(size.x, size.z) * 1.5, 160, 512);
+  camera.far = Math.max(1_000, fog.far * 3);
+  camera.updateProjectionMatrix();
+  sky.scale.setScalar(camera.far * 0.8);
+
+  const sunDirection = new THREE.Vector3(0.55, 0.78, 0.3).normalize();
+  const lightDistance = Math.max(80, radius * 2.2);
+  sun.target.position.copy(bounds.center);
+  sun.position.copy(bounds.center).addScaledVector(sunDirection, lightDistance);
+  const shadowCamera = sun.shadow.camera;
+  const shadowRadius = radius * 1.1;
+  shadowCamera.left = -shadowRadius;
+  shadowCamera.right = shadowRadius;
+  shadowCamera.top = shadowRadius;
+  shadowCamera.bottom = -shadowRadius;
+  shadowCamera.near = 0.1;
+  shadowCamera.far = lightDistance + radius * 2;
+  shadowCamera.updateProjectionMatrix();
+  sun.target.updateMatrixWorld();
+  sun.shadow.needsUpdate = true;
+}
+
+function hasKey(keys: Set<string>, left: string, right?: string): boolean {
+  return keys.has(left) || Boolean(right && keys.has(right));
+}
+
+function ExplorerScene({ build }: { build: LoadedBuild }) {
+  const mountRef = useRef<HTMLDivElement | null>(null);
+  const startRef = useRef<(() => void) | null>(null);
+  const [ready, setReady] = useState(false);
+  const [locked, setLocked] = useState(false);
+  const [entered, setEntered] = useState(false);
+  const [noclip, setNoclip] = useState(true);
+  const [fps, setFps] = useState(0);
+  const [loading, setLoading] = useState("Building");
+  const [error, setError] = useState<string | null>(null);
+  const meshCacheKey = useMemo(
+    () =>
+      createPublicMeshCacheKey({
+        checksum: build.checksum,
+        variant: "full",
+        palette: "simple",
+        blockCount: voxelBuildBlockCount(build.voxelBuild),
+      }),
+    [build],
+  );
+
+  const enter = useCallback(() => startRef.current?.(), []);
+
+  useEffect(() => {
+    const mount = mountRef.current;
+    if (!mount) return;
+    const abortController = new AbortController();
+    let disposed = false;
+    let voxelGroup: VoxelGroup | null = null;
+    let collisionWorld: ExplorerCollisionWorld | null = null;
+    let worldReady = false;
+    let isNoclip = true;
+    let verticalVelocity = 0;
+    let grounded = false;
+    let jumpQueued = false;
+    const keys = new Set<string>();
+
+    setReady(false);
+    setLocked(false);
+    setEntered(false);
+    setNoclip(true);
+    setFps(0);
+    setLoading("Building");
+    setError(null);
+
+    const scene = new THREE.Scene();
+    const camera = new THREE.PerspectiveCamera(70, 1, 0.05, 1_000);
+    let renderer: THREE.WebGLRenderer;
+    try {
+      renderer = new THREE.WebGLRenderer({
+        antialias: true,
+        powerPreference: "high-performance",
+      });
+    } catch {
+      setError(VOXEL_VIEWER_WEBGL_ERROR);
+      return;
+    }
+    renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, 2));
+    renderer.setSize(Math.max(1, mount.clientWidth), Math.max(1, mount.clientHeight), true);
+    mount.appendChild(renderer.domElement);
+    const { sky, sun } = configureDaylight(scene, renderer);
+
+    const controls = new PointerLockControls(camera, renderer.domElement);
+    controls.pointerSpeed = 0.9;
+    const clearKeys = () => {
+      keys.clear();
+      jumpQueued = false;
+    };
+    const onLock = () => {
+      clearKeys();
+      setLocked(true);
+      setEntered(true);
+    };
+    const onUnlock = () => {
+      clearKeys();
+      setLocked(false);
+    };
+    controls.addEventListener("lock", onLock);
+    controls.addEventListener("unlock", onUnlock);
+    startRef.current = () => {
+      if (worldReady && !controls.isLocked) controls.lock();
+    };
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (!controls.isLocked) return;
+      if (
+        event.code === "KeyW" || event.code === "KeyA" || event.code === "KeyS" ||
+        event.code === "KeyD" || event.code === "Space" ||
+        event.code === "ShiftLeft" || event.code === "ShiftRight" ||
+        event.code === "ControlLeft" || event.code === "ControlRight" ||
+        event.code === "KeyF"
+      ) {
+        event.preventDefault();
+      }
+      keys.add(event.code);
+      if (event.code === "Space" && !event.repeat) jumpQueued = true;
+      if (event.code === "KeyF" && !event.repeat) {
+        isNoclip = !isNoclip;
+        verticalVelocity = 0;
+        grounded = false;
+        setNoclip(isNoclip);
+      }
+    };
+    const onKeyUp = (event: KeyboardEvent) => keys.delete(event.code);
+    document.addEventListener("keydown", onKeyDown);
+    document.addEventListener("keyup", onKeyUp);
+    window.addEventListener("blur", clearKeys);
+
+    const resize = () => {
+      const width = mount.clientWidth;
+      const height = mount.clientHeight;
+      if (width <= 0 || height <= 0) return;
+      renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, 2));
+      renderer.setSize(width, height, true);
+      camera.aspect = width / height;
+      camera.updateProjectionMatrix();
+    };
+    const resizeObserver = new ResizeObserver(resize);
+    resizeObserver.observe(mount);
+    resize();
+
+    const forward = new THREE.Vector3();
+    const right = new THREE.Vector3();
+    const movement = new THREE.Vector3();
+    const updatePlayer = (seconds: number) => {
+      if (!controls.isLocked || !collisionWorld) return;
+      const stepCount = Math.max(1, Math.ceil(seconds / MAX_PHYSICS_STEP_SECONDS));
+      const stepSeconds = seconds / stepCount;
+
+      controls.getDirection(forward);
+      forward.y = 0;
+      if (forward.lengthSq() < 1e-8) forward.set(0, 0, -1);
+      else forward.normalize();
+      right.crossVectors(forward, camera.up).normalize();
+      movement.set(0, 0, 0);
+      if (keys.has("KeyW")) movement.add(forward);
+      if (keys.has("KeyS")) movement.sub(forward);
+      if (keys.has("KeyD")) movement.add(right);
+      if (keys.has("KeyA")) movement.sub(right);
+      if (movement.lengthSq() > 1) movement.normalize();
+
+      for (let step = 0; step < stepCount; step += 1) {
+        const running = hasKey(keys, "ShiftLeft", "ShiftRight");
+        if (isNoclip) {
+          const speed = FLY_SPEED * (running ? RUN_SPEED / WALK_SPEED : 1);
+          camera.position.addScaledVector(movement, speed * stepSeconds);
+          const verticalInput = Number(keys.has("Space")) - Number(
+            hasKey(keys, "ControlLeft", "ControlRight"),
+          );
+          camera.position.y += verticalInput * speed * stepSeconds;
+          jumpQueued = false;
+          continue;
+        }
+
+        const waterMultiplier = collisionWorld.isInWater(camera.position)
+          ? WATER_SPEED_MULTIPLIER
+          : 1;
+        const speed = (running ? RUN_SPEED : WALK_SPEED) * waterMultiplier;
+        moveExplorerPlayerAxis(collisionWorld, camera.position, "x", movement.x * speed * stepSeconds);
+        moveExplorerPlayerAxis(collisionWorld, camera.position, "z", movement.z * speed * stepSeconds);
+
+        if (jumpQueued && grounded) {
+          verticalVelocity = JUMP_VELOCITY;
+          grounded = false;
+        }
+        jumpQueued = false;
+        verticalVelocity -= GRAVITY * stepSeconds;
+        const verticalCollision = moveExplorerPlayerAxis(
+          collisionWorld,
+          camera.position,
+          "y",
+          verticalVelocity * stepSeconds,
+        );
+        grounded = verticalCollision && verticalVelocity < 0;
+        if (verticalCollision) verticalVelocity = 0;
+      }
+    };
+
+    let animationFrame = 0;
+    let lastFrameAt = performance.now();
+    let fpsWindowAt = lastFrameAt;
+    let fpsFrames = 0;
+    const render = (now: number) => {
+      const seconds = Math.min(MAX_FRAME_SECONDS, Math.max(0, (now - lastFrameAt) / 1_000));
+      lastFrameAt = now;
+      updatePlayer(seconds);
+      renderer.render(scene, camera);
+      fpsFrames += 1;
+      if (now - fpsWindowAt >= 750) {
+        setFps(Math.round((fpsFrames * 1_000) / (now - fpsWindowAt)));
+        fpsFrames = 0;
+        fpsWindowAt = now;
+      }
+      animationFrame = window.requestAnimationFrame(render);
+    };
+    animationFrame = window.requestAnimationFrame(render);
+
+    void (async () => {
+      try {
+        const atlasPromise = loadAtlasTexture();
+        const collisionPromise = createExplorerCollisionWorld(build.voxelBuild, {
+          signal: abortController.signal,
+          onProgress() {
+            if (!disposed) setLoading("Preparing collision");
+          },
+        });
+        const atlas = await atlasPromise;
+        const groupPromise = createVoxelGroupAsync(build.voxelBuild, SIMPLE_PALETTE, atlas, {
+          signal: abortController.signal,
+          cacheKey: meshCacheKey,
+          onProgress(progress) {
+            if (!disposed) setLoading(progress.stageLabel ?? "Building");
+          },
+        });
+        const [nextCollisionWorld, nextVoxelGroup] = await Promise.all([
+          collisionPromise,
+          groupPromise,
+        ]);
+        if (disposed || abortController.signal.aborted) {
+          nextVoxelGroup.dispose();
+          return;
+        }
+
+        collisionWorld = nextCollisionWorld;
+        voxelGroup = nextVoxelGroup;
+        voxelGroup.group.traverse((child) => {
+          if (!(child instanceof THREE.Mesh)) return;
+          const materials = Array.isArray(child.material) ? child.material : [child.material];
+          child.castShadow = materials.every((material) => !material.transparent);
+          child.receiveShadow = true;
+        });
+        scene.add(voxelGroup.group);
+        frameDaylight(camera, scene, sky, sun, voxelGroup.bounds);
+
+        camera.position.set(0, collisionWorld.height + 8, 0);
+        camera.lookAt(0, Math.max(0, collisionWorld.height - 4), -12);
+        renderer.shadowMap.needsUpdate = true;
+        worldReady = true;
+        setLoading("");
+        setReady(true);
+      } catch (loadError) {
+        if (loadError instanceof DOMException && loadError.name === "AbortError") return;
+        console.warn("Voxel explorer setup failed", loadError);
+        if (!disposed) {
+          setError(loadError instanceof Error ? loadError.message : "Explorer failed to start");
+        }
+      }
+    })();
+
+    return () => {
+      disposed = true;
+      abortController.abort();
+      startRef.current = null;
+      resizeObserver.disconnect();
+      document.removeEventListener("keydown", onKeyDown);
+      document.removeEventListener("keyup", onKeyUp);
+      window.removeEventListener("blur", clearKeys);
+      controls.removeEventListener("lock", onLock);
+      controls.removeEventListener("unlock", onUnlock);
+      if (controls.isLocked) controls.unlock();
+      controls.dispose();
+      window.cancelAnimationFrame(animationFrame);
+      if (voxelGroup) {
+        scene.remove(voxelGroup.group);
+        voxelGroup.dispose();
+      }
+      sky.geometry.dispose();
+      sky.material.dispose();
+      try {
+        renderer.forceContextLoss();
+      } catch {}
+      renderer.dispose();
+      renderer.domElement.remove();
+    };
+  }, [build, meshCacheKey]);
+
+  return (
+    <div className="relative h-full w-full overflow-hidden bg-[oklch(0.86_0.055_235)] text-slate-950">
+      <div ref={mountRef} className="absolute inset-0" />
+
+      {ready && locked ? (
+        <div aria-hidden="true" className="pointer-events-none absolute left-1/2 top-1/2 h-4 w-4 -translate-x-1/2 -translate-y-1/2">
+          <span className="absolute left-1/2 top-0 h-4 w-px -translate-x-1/2 bg-white/85 shadow-[0_0_1px_rgba(0,0,0,0.9)]" />
+          <span className="absolute left-0 top-1/2 h-px w-4 -translate-y-1/2 bg-white/85 shadow-[0_0_1px_rgba(0,0,0,0.9)]" />
+        </div>
+      ) : null}
+
+      {ready ? (
+        <div className="pointer-events-none absolute left-3 top-3 flex items-center gap-2 rounded bg-slate-950/55 px-2.5 py-1.5 text-[11px] font-semibold text-white backdrop-blur-sm">
+          <span>{noclip ? "Noclip" : "Walking"}</span>
+          <span className="text-white/45">·</span>
+          <span className="tabular-nums text-white/75">{fps} FPS</span>
+        </div>
+      ) : null}
+
+      {ready && locked ? (
+        <div className="pointer-events-none absolute inset-x-3 bottom-3 flex justify-center">
+          <div className="rounded bg-slate-950/55 px-3 py-1.5 text-[10px] font-medium text-white/75 backdrop-blur-sm">
+            WASD Move · Shift Run · Space {noclip ? "Rise" : "Jump"} · Control Descend · F Noclip · Esc Exit
+          </div>
+        </div>
+      ) : null}
+
+      {!locked ? (
+        <div className="absolute inset-0 flex items-center justify-center bg-slate-950/20">
+          <div className="flex flex-col items-center gap-3 rounded-md bg-slate-950/70 px-6 py-5 text-white backdrop-blur-sm">
+            {error ? (
+              <p className="max-w-sm text-center text-sm text-white/85">{error}</p>
+            ) : (
+              <button
+                type="button"
+                disabled={!ready}
+                onClick={enter}
+                className="rounded bg-white/90 px-5 py-2 text-sm font-semibold text-slate-950 transition-colors hover:bg-white disabled:cursor-wait disabled:bg-white/20 disabled:text-white/65"
+              >
+                {ready ? (entered ? "Resume" : "Enter") : loading}
+              </button>
+            )}
+            <Link href="/sandbox" className="text-xs font-medium text-white/65 hover:text-white">
+              Exit
+            </Link>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+export function VoxelExplorer({ buildId }: { buildId: string }) {
+  const [build, setBuild] = useState<LoadedBuild | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    setBuild(null);
+    setError(null);
+    void fetchExplorerBuild(buildId, controller.signal).then(
+      setBuild,
+      (loadError: unknown) => {
+        if (loadError instanceof DOMException && loadError.name === "AbortError") return;
+        setError(loadError instanceof Error ? loadError.message : "Failed to load build");
+      },
+    );
+    return () => controller.abort();
+  }, [buildId]);
+
+  return (
+    <main className="fixed inset-0 z-[100] bg-[oklch(0.86_0.055_235)]">
+      {build ? (
+        <ExplorerScene build={build} />
+      ) : (
+        <div className="flex h-full items-center justify-center text-sm font-semibold text-slate-800">
+          {error ?? "Loading"}
+        </div>
+      )}
+    </main>
+  );
+}

--- a/components/voxel/VoxelExplorer.tsx
+++ b/components/voxel/VoxelExplorer.tsx
@@ -17,6 +17,7 @@ import {
   EXPLORER_EYE_HEIGHT,
   createExplorerCollisionWorld,
   moveExplorerPlayerAxis,
+  setExplorerMoveDirection,
   type ExplorerCollisionWorld,
 } from "@/lib/voxel/explorerCollision";
 import { createVoxelGroupAsync, type VoxelGroup } from "@/lib/voxel/mesh";
@@ -27,14 +28,19 @@ import {
 import { createPublicMeshCacheKey } from "@/lib/voxel/meshPayloadCache";
 
 const WALK_SPEED = 4.3;
-const RUN_SPEED = 5.6;
+const RUN_SPEED = 7.5;
 const FLY_SPEED = 10.9;
+const FLY_RUN_SPEED = 21.8;
 const GRAVITY = 32;
 const JUMP_VELOCITY = Math.sqrt(GRAVITY * 2 * 1.25);
 const WATER_SPEED_MULTIPLIER = 0.8;
+const WATER_ASCENT_SPEED = 3.5;
+const WATER_SINK_SPEED = 1;
+const VIEW_BOB_VERTICAL = 0.045;
+const VIEW_BOB_LATERAL = 0.018;
 const MAX_FRAME_SECONDS = 0.05;
 const MAX_PHYSICS_STEP_SECONDS = 1 / 60;
-const DAYLIGHT_COLOR = 0xbfdcf2;
+const DAYLIGHT_COLOR = 0xaed4ef;
 const SIMPLE_PALETTE = getPalette("simple");
 
 let explorerAtlasPromise: Promise<THREE.Texture> | null = null;
@@ -107,18 +113,18 @@ function configureDaylight(
 
   const sky = new Sky();
   sky.scale.setScalar(1_000);
-  sky.material.uniforms.turbidity.value = 6;
-  sky.material.uniforms.rayleigh.value = 2.2;
-  sky.material.uniforms.mieCoefficient.value = 0.004;
-  sky.material.uniforms.mieDirectionalG.value = 0.8;
+  sky.material.uniforms.turbidity.value = 4.5;
+  sky.material.uniforms.rayleigh.value = 1.8;
+  sky.material.uniforms.mieCoefficient.value = 0.0035;
+  sky.material.uniforms.mieDirectionalG.value = 0.86;
   const sunDirection = new THREE.Vector3(0.55, 0.78, 0.3).normalize();
   sky.material.uniforms.sunPosition.value.copy(sunDirection);
   scene.add(sky);
 
-  scene.add(new THREE.HemisphereLight(0xeaf6ff, 0x65724d, 1.15));
-  scene.add(new THREE.AmbientLight(0xffffff, 0.3));
+  scene.add(new THREE.HemisphereLight(0xeaf6ff, 0x39452f, 0.72));
+  scene.add(new THREE.AmbientLight(0xffffff, 0.08));
 
-  const sun = new THREE.DirectionalLight(0xfff3d6, 2.1);
+  const sun = new THREE.DirectionalLight(0xffedc2, 3);
   sun.castShadow = true;
   sun.shadow.mapSize.set(2048, 2048);
   sun.shadow.bias = -0.00015;
@@ -129,7 +135,7 @@ function configureDaylight(
   renderer.shadowMap.type = THREE.PCFSoftShadowMap;
   renderer.shadowMap.autoUpdate = false;
   renderer.toneMapping = THREE.ACESFilmicToneMapping;
-  renderer.toneMappingExposure = 1;
+  renderer.toneMappingExposure = 1.08;
   renderer.outputColorSpace = THREE.SRGBColorSpace;
   return { sky, sun };
 }
@@ -205,7 +211,10 @@ function ExplorerScene({ build }: { build: LoadedBuild }) {
     let isNoclip = true;
     let verticalVelocity = 0;
     let grounded = false;
-    let jumpQueued = false;
+    let bobWalking = false;
+    let bobRunning = false;
+    let bobPhase = 0;
+    let bobBlend = 0;
     const keys = new Set<string>();
 
     setReady(false);
@@ -235,10 +244,7 @@ function ExplorerScene({ build }: { build: LoadedBuild }) {
 
     const controls = new PointerLockControls(camera, renderer.domElement);
     controls.pointerSpeed = 0.9;
-    const clearKeys = () => {
-      keys.clear();
-      jumpQueued = false;
-    };
+    const clearKeys = () => keys.clear();
     const onLock = () => {
       clearKeys();
       setLocked(true);
@@ -266,7 +272,6 @@ function ExplorerScene({ build }: { build: LoadedBuild }) {
         event.preventDefault();
       }
       keys.add(event.code);
-      if (event.code === "Space" && !event.repeat) jumpQueued = true;
       if (event.code === "KeyF" && !event.repeat) {
         isNoclip = !isNoclip;
         verticalVelocity = 0;
@@ -278,6 +283,12 @@ function ExplorerScene({ build }: { build: LoadedBuild }) {
     document.addEventListener("keydown", onKeyDown);
     document.addEventListener("keyup", onKeyUp);
     window.addEventListener("blur", clearKeys);
+    const reducedMotionQuery = window.matchMedia("(prefers-reduced-motion: reduce)");
+    let reducedMotion = reducedMotionQuery.matches;
+    const onReducedMotionChange = (event: MediaQueryListEvent) => {
+      reducedMotion = event.matches;
+    };
+    reducedMotionQuery.addEventListener("change", onReducedMotionChange);
 
     const resize = () => {
       const width = mount.clientWidth;
@@ -296,48 +307,58 @@ function ExplorerScene({ build }: { build: LoadedBuild }) {
     const right = new THREE.Vector3();
     const movement = new THREE.Vector3();
     const updatePlayer = (seconds: number) => {
-      if (!controls.isLocked || !collisionWorld) return;
-      const stepCount = Math.max(1, Math.ceil(seconds / MAX_PHYSICS_STEP_SECONDS));
-      const stepSeconds = seconds / stepCount;
+      if (!controls.isLocked || !collisionWorld) {
+        bobWalking = false;
+        return;
+      }
 
       controls.getDirection(forward);
-      forward.y = 0;
-      if (forward.lengthSq() < 1e-8) forward.set(0, 0, -1);
-      else forward.normalize();
-      right.crossVectors(forward, camera.up).normalize();
-      movement.set(0, 0, 0);
-      if (keys.has("KeyW")) movement.add(forward);
-      if (keys.has("KeyS")) movement.sub(forward);
-      if (keys.has("KeyD")) movement.add(right);
-      if (keys.has("KeyA")) movement.sub(right);
-      if (movement.lengthSq() > 1) movement.normalize();
+      right.set(1, 0, 0).applyQuaternion(camera.quaternion).normalize();
+      if (!isNoclip) {
+        forward.y = 0;
+        if (forward.lengthSq() < 1e-8) forward.set(0, 0, -1);
+        else forward.normalize();
+      }
+      setExplorerMoveDirection(
+        movement,
+        forward,
+        right,
+        Number(keys.has("KeyW")) - Number(keys.has("KeyS")),
+        Number(keys.has("KeyD")) - Number(keys.has("KeyA")),
+        isNoclip
+          ? Number(keys.has("Space")) - Number(hasKey(keys, "ControlLeft", "ControlRight"))
+          : 0,
+      );
 
+      const running = hasKey(keys, "ShiftLeft", "ShiftRight");
+      if (isNoclip) {
+        camera.position.addScaledVector(movement, (running ? FLY_RUN_SPEED : FLY_SPEED) * seconds);
+        bobWalking = false;
+        return;
+      }
+
+      const stepCount = Math.max(1, Math.ceil(seconds / MAX_PHYSICS_STEP_SECONDS));
+      const stepSeconds = seconds / stepCount;
       for (let step = 0; step < stepCount; step += 1) {
-        const running = hasKey(keys, "ShiftLeft", "ShiftRight");
-        if (isNoclip) {
-          const speed = FLY_SPEED * (running ? RUN_SPEED / WALK_SPEED : 1);
-          camera.position.addScaledVector(movement, speed * stepSeconds);
-          const verticalInput = Number(keys.has("Space")) - Number(
-            hasKey(keys, "ControlLeft", "ControlRight"),
-          );
-          camera.position.y += verticalInput * speed * stepSeconds;
-          jumpQueued = false;
-          continue;
-        }
-
-        const waterMultiplier = collisionWorld.isInWater(camera.position)
+        let inWater = collisionWorld.isInWater(camera.position);
+        const waterMultiplier = inWater
           ? WATER_SPEED_MULTIPLIER
           : 1;
         const speed = (running ? RUN_SPEED : WALK_SPEED) * waterMultiplier;
         moveExplorerPlayerAxis(collisionWorld, camera.position, "x", movement.x * speed * stepSeconds);
         moveExplorerPlayerAxis(collisionWorld, camera.position, "z", movement.z * speed * stepSeconds);
 
-        if (jumpQueued && grounded) {
-          verticalVelocity = JUMP_VELOCITY;
+        inWater = collisionWorld.isInWater(camera.position);
+        if (inWater) {
+          verticalVelocity = keys.has("Space") ? WATER_ASCENT_SPEED : -WATER_SINK_SPEED;
           grounded = false;
+        } else {
+          if (keys.has("Space") && grounded) {
+            verticalVelocity = JUMP_VELOCITY;
+            grounded = false;
+          }
+          verticalVelocity -= GRAVITY * stepSeconds;
         }
-        jumpQueued = false;
-        verticalVelocity -= GRAVITY * stepSeconds;
         const verticalCollision = moveExplorerPlayerAxis(
           collisionWorld,
           camera.position,
@@ -347,6 +368,8 @@ function ExplorerScene({ build }: { build: LoadedBuild }) {
         grounded = verticalCollision && verticalVelocity < 0;
         if (verticalCollision) verticalVelocity = 0;
       }
+      bobWalking = grounded && movement.lengthSq() > 0 && !collisionWorld.isInWater(camera.position);
+      bobRunning = running;
     };
 
     let animationFrame = 0;
@@ -357,7 +380,20 @@ function ExplorerScene({ build }: { build: LoadedBuild }) {
       const seconds = Math.min(MAX_FRAME_SECONDS, Math.max(0, (now - lastFrameAt) / 1_000));
       lastFrameAt = now;
       updatePlayer(seconds);
+
+      if (reducedMotion) {
+        bobBlend = 0;
+      } else {
+        bobBlend = THREE.MathUtils.damp(bobBlend, bobWalking ? (bobRunning ? 1 : 0.55) : 0, 14, seconds);
+        if (bobWalking) bobPhase += seconds * (bobRunning ? 13 : 9);
+      }
+      const bobY = Math.sin(bobPhase * 2) * VIEW_BOB_VERTICAL * bobBlend;
+      const bobX = Math.cos(bobPhase) * VIEW_BOB_LATERAL * bobBlend;
+      camera.position.y += bobY;
+      camera.position.addScaledVector(right, bobX);
       renderer.render(scene, camera);
+      camera.position.addScaledVector(right, -bobX);
+      camera.position.y -= bobY;
       fpsFrames += 1;
       if (now - fpsWindowAt >= 750) {
         setFps(Math.round((fpsFrames * 1_000) / (now - fpsWindowAt)));
@@ -428,6 +464,7 @@ function ExplorerScene({ build }: { build: LoadedBuild }) {
       document.removeEventListener("keydown", onKeyDown);
       document.removeEventListener("keyup", onKeyUp);
       window.removeEventListener("blur", clearKeys);
+      reducedMotionQuery.removeEventListener("change", onReducedMotionChange);
       controls.removeEventListener("lock", onLock);
       controls.removeEventListener("unlock", onUnlock);
       if (controls.isLocked) controls.unlock();
@@ -469,7 +506,7 @@ function ExplorerScene({ build }: { build: LoadedBuild }) {
       {ready && locked ? (
         <div className="pointer-events-none absolute inset-x-3 bottom-3 flex justify-center">
           <div className="rounded bg-slate-950/55 px-3 py-1.5 text-[10px] font-medium text-white/75 backdrop-blur-sm">
-            WASD Move · Shift Run · Space {noclip ? "Rise" : "Jump"} · Control Descend · F Noclip · Esc Exit
+            WASD Move · Shift Run · Space {noclip ? "Rise · Control Descend" : "Jump / Swim"} · F Noclip · Esc Exit
           </div>
         </div>
       ) : null}

--- a/components/voxel/VoxelExplorer.tsx
+++ b/components/voxel/VoxelExplorer.tsx
@@ -6,7 +6,6 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import * as THREE from "three";
 import { PointerLockControls } from "three/examples/jsm/controls/PointerLockControls.js";
 import { Lensflare, LensflareElement } from "three/examples/jsm/objects/Lensflare.js";
-import { Sky } from "three/examples/jsm/objects/Sky.js";
 import { BloomPass } from "three/examples/jsm/postprocessing/BloomPass.js";
 import { FullScreenQuad } from "three/examples/jsm/postprocessing/Pass.js";
 import { CopyShader } from "three/examples/jsm/shaders/CopyShader.js";
@@ -173,10 +172,10 @@ function createSunHaloTexture(): THREE.Texture {
   const context = canvas.getContext("2d");
   if (context) {
     const gradient = context.createRadialGradient(128, 128, 0, 128, 128, 128);
-    gradient.addColorStop(0, "rgba(255, 253, 235, 1)");
-    gradient.addColorStop(0.085, "rgba(255, 249, 220, 1)");
-    gradient.addColorStop(0.13, "rgba(255, 231, 168, 0.9)");
-    gradient.addColorStop(0.3, "rgba(255, 199, 108, 0.3)");
+    gradient.addColorStop(0, "rgba(255, 254, 240, 1)");
+    gradient.addColorStop(0.16, "rgba(255, 251, 222, 1)");
+    gradient.addColorStop(0.2, "rgba(255, 225, 155, 0.95)");
+    gradient.addColorStop(0.34, "rgba(255, 196, 99, 0.3)");
     gradient.addColorStop(0.68, "rgba(255, 174, 76, 0.06)");
     gradient.addColorStop(1, "rgba(255, 165, 64, 0)");
     context.fillStyle = gradient;
@@ -184,6 +183,26 @@ function createSunHaloTexture(): THREE.Texture {
   }
   const texture = new THREE.CanvasTexture(canvas);
   texture.colorSpace = THREE.SRGBColorSpace;
+  return texture;
+}
+
+function createSkyGradientTexture(): THREE.Texture {
+  const canvas = document.createElement("canvas");
+  canvas.width = 4;
+  canvas.height = 256;
+  const context = canvas.getContext("2d");
+  if (context) {
+    const gradient = context.createLinearGradient(0, 0, 0, 256);
+    gradient.addColorStop(0, "#4f97cb");
+    gradient.addColorStop(0.55, "#78add3");
+    gradient.addColorStop(1, "#bfdbea");
+    context.fillStyle = gradient;
+    context.fillRect(0, 0, 4, 256);
+  }
+  const texture = new THREE.CanvasTexture(canvas);
+  texture.colorSpace = THREE.SRGBColorSpace;
+  texture.generateMipmaps = false;
+  texture.minFilter = THREE.LinearFilter;
   return texture;
 }
 
@@ -319,17 +338,26 @@ function ExplorerBuildMenu({
 function configureDaylight(
   scene: THREE.Scene,
   renderer: THREE.WebGLRenderer,
-): { sky: Sky; sun: THREE.DirectionalLight; sunFlare: Lensflare } {
+): {
+  sky: THREE.Mesh<THREE.SphereGeometry, THREE.MeshBasicMaterial>;
+  sun: THREE.DirectionalLight;
+  sunFlare: Lensflare;
+} {
   scene.background = new THREE.Color(DAYLIGHT_COLOR);
   scene.fog = new THREE.Fog(DAYLIGHT_COLOR, 72, 320);
 
-  const sky = new Sky();
-  sky.scale.setScalar(1_000);
-  sky.material.uniforms.turbidity.value = 3.2;
-  sky.material.uniforms.rayleigh.value = 2.1;
-  sky.material.uniforms.mieCoefficient.value = 0.006;
-  sky.material.uniforms.mieDirectionalG.value = 0.9;
-  sky.material.uniforms.sunPosition.value.copy(SUN_DIRECTION);
+  const sky = new THREE.Mesh(
+    new THREE.SphereGeometry(1, 32, 16),
+    new THREE.MeshBasicMaterial({
+      map: createSkyGradientTexture(),
+      side: THREE.BackSide,
+      depthWrite: false,
+      fog: false,
+      toneMapped: false,
+    }),
+  );
+  sky.scale.setScalar(800);
+  sky.frustumCulled = false;
   scene.add(sky);
 
   scene.add(new THREE.HemisphereLight(0xeaf6ff, 0x4d5548, 0.98));
@@ -361,7 +389,7 @@ function configureDaylight(
 function frameDaylight(
   camera: THREE.PerspectiveCamera,
   scene: THREE.Scene,
-  sky: Sky,
+  sky: THREE.Mesh,
   sun: THREE.DirectionalLight,
   bounds: VoxelGroup["bounds"],
 ) {
@@ -781,6 +809,7 @@ function ExplorerScene({ build, buildId }: { build: LoadedBuild; buildId: string
       camera.rotateZ(viewBob.roll);
       camera.rotateX(viewBob.pitch);
       const sunDistance = camera.far * 0.45;
+      sky.position.copy(camera.position);
       sunFlare.position.copy(camera.position).addScaledVector(SUN_DIRECTION, sunDistance);
       sunRaySprite.position.copy(sunFlare.position);
       const sunRaySize =
@@ -912,6 +941,7 @@ function ExplorerScene({ build, buildId }: { build: LoadedBuild; buildId: string
       bloomOverlay.dispose();
       bloomPass.dispose();
       bloomTarget.dispose();
+      sky.material.map?.dispose();
       sky.geometry.dispose();
       sky.material.dispose();
       try {

--- a/components/voxel/VoxelExplorer.tsx
+++ b/components/voxel/VoxelExplorer.tsx
@@ -7,7 +7,10 @@ import * as THREE from "three";
 import { PointerLockControls } from "three/examples/jsm/controls/PointerLockControls.js";
 import { Lensflare, LensflareElement } from "three/examples/jsm/objects/Lensflare.js";
 import { Sky } from "three/examples/jsm/objects/Sky.js";
+import { BloomPass } from "three/examples/jsm/postprocessing/BloomPass.js";
+import { FullScreenQuad } from "three/examples/jsm/postprocessing/Pass.js";
 import { SSAOPass } from "three/examples/jsm/postprocessing/SSAOPass.js";
+import { CopyShader } from "three/examples/jsm/shaders/CopyShader.js";
 import {
   readBuildVariantPayload,
   readBuildVariantStream,
@@ -23,6 +26,11 @@ import {
   setExplorerMoveDirection,
   type ExplorerCollisionWorld,
 } from "@/lib/voxel/explorerCollision";
+import {
+  clusterExplorerEmissiveFaces,
+  selectNearestExplorerLightClusters,
+  type ExplorerLightCluster,
+} from "@/lib/voxel/explorerLighting";
 import { createVoxelGroupAsync, type VoxelGroup } from "@/lib/voxel/mesh";
 import {
   voxelBuildBlockCount,
@@ -47,17 +55,25 @@ const VIEW_BOB_DISTANCE_SCALE = 0.8;
 const VIEW_BOB_WALK_AMOUNT = 0.075;
 const VIEW_BOB_RUN_AMOUNT = 0.1;
 const SSAO_RENDER_SCALE = 0.5;
+const BLOOM_RENDER_SCALE = 0.25;
+const EMISSIVE_LAYER = 1;
+const EMISSIVE_LIGHT_COUNT = 6;
+const EMISSIVE_LIGHT_DISTANCE = 18;
+const EMISSIVE_LIGHT_SELECTION_RADIUS = 32;
+const EMISSIVE_LIGHT_INTENSITY = 42;
+const EMISSIVE_LIGHT_UPDATE_MS = 180;
 const MAX_FRAME_SECONDS = 0.05;
 const MAX_PHYSICS_STEP_SECONDS = 1 / 60;
 const DAYLIGHT_COLOR = 0xaed4ef;
-const SIMPLE_PALETTE = getPalette("simple");
-const SUN_DIRECTION = new THREE.Vector3(0.55, 0.78, 0.3).normalize();
+const GALLERY_BUILD_PREFIX = "gallery:";
+const SUN_DIRECTION = new THREE.Vector3(-0.46, 0.72, -0.52).normalize();
 
 let explorerAtlasPromise: Promise<THREE.Texture> | null = null;
 let explorerBuildCatalog: ExplorerBuildOption[] | null = null;
 
 type LoadedBuild = {
   checksum: string | null;
+  palette: "simple" | "advanced";
   voxelBuild: RenderableVoxelBuild;
 };
 
@@ -66,6 +82,7 @@ type ExplorerBuildOption = {
   model: string;
   prompt: string;
   blockCount: number;
+  source: "benchmark" | "gallery";
 };
 
 function loadAtlasTexture(): Promise<THREE.Texture> {
@@ -100,6 +117,25 @@ async function fetchStreamBuild(
 }
 
 async function fetchExplorerBuild(buildId: string, signal: AbortSignal): Promise<LoadedBuild> {
+  const galleryExampleId = buildId.startsWith(GALLERY_BUILD_PREFIX)
+    ? buildId.slice(GALLERY_BUILD_PREFIX.length)
+    : null;
+  if (galleryExampleId) {
+    const response = await fetch(
+      `/api/gallery/examples/${encodeURIComponent(galleryExampleId)}/viewer`,
+      { signal },
+    );
+    if (!response.ok) {
+      throw new Error(await readClientErrorResponse(response, "Failed to load build"));
+    }
+    const payload = (
+      await readBuildVariantPayload(response, {
+        fallbackIdentity: { buildId, variant: "full", checksum: null },
+      })
+    ).payload;
+    return { checksum: payload.checksum, palette: "advanced", voxelBuild: payload.voxelBuild };
+  }
+
   const url = new URL(
     `/api/arena/builds/${encodeURIComponent(buildId)}`,
     window.location.origin,
@@ -119,7 +155,7 @@ async function fetchExplorerBuild(buildId: string, signal: AbortSignal): Promise
   } else {
     throw new Error(await readClientErrorResponse(response, "Failed to load build"));
   }
-  return { checksum: payload.checksum, voxelBuild: payload.voxelBuild };
+  return { checksum: payload.checksum, palette: "simple", voxelBuild: payload.voxelBuild };
 }
 
 async function fetchExplorerBuildCatalog(signal: AbortSignal): Promise<ExplorerBuildOption[]> {
@@ -138,17 +174,19 @@ async function fetchExplorerBuildCatalog(signal: AbortSignal): Promise<ExplorerB
 
 function createSunHaloTexture(): THREE.Texture {
   const canvas = document.createElement("canvas");
-  canvas.width = 128;
-  canvas.height = 128;
+  canvas.width = 256;
+  canvas.height = 256;
   const context = canvas.getContext("2d");
   if (context) {
-    const gradient = context.createRadialGradient(64, 64, 0, 64, 64, 64);
-    gradient.addColorStop(0, "rgba(255, 250, 224, 0.95)");
-    gradient.addColorStop(0.12, "rgba(255, 235, 178, 0.65)");
-    gradient.addColorStop(0.38, "rgba(255, 213, 128, 0.18)");
-    gradient.addColorStop(1, "rgba(255, 203, 112, 0)");
+    const gradient = context.createRadialGradient(128, 128, 0, 128, 128, 128);
+    gradient.addColorStop(0, "rgba(255, 253, 235, 1)");
+    gradient.addColorStop(0.055, "rgba(255, 245, 201, 0.98)");
+    gradient.addColorStop(0.14, "rgba(255, 224, 151, 0.68)");
+    gradient.addColorStop(0.34, "rgba(255, 193, 102, 0.24)");
+    gradient.addColorStop(0.68, "rgba(255, 174, 76, 0.07)");
+    gradient.addColorStop(1, "rgba(255, 165, 64, 0)");
     context.fillStyle = gradient;
-    context.fillRect(0, 0, 128, 128);
+    context.fillRect(0, 0, 256, 256);
   }
   const texture = new THREE.CanvasTexture(canvas);
   texture.colorSpace = THREE.SRGBColorSpace;
@@ -196,7 +234,7 @@ function ExplorerBuildMenu({
     const tokens = query.trim().toLowerCase().split(/\s+/).filter(Boolean);
     if (tokens.length === 0) return builds;
     return builds.filter((build) => {
-      const searchable = `${build.model} ${build.prompt}`.toLowerCase();
+      const searchable = `${build.source} ${build.model} ${build.prompt}`.toLowerCase();
       return tokens.every((token) => searchable.includes(token));
     });
   }, [builds, query]);
@@ -269,6 +307,7 @@ function ExplorerBuildMenu({
               <span className="flex items-center justify-between gap-3 text-[11px] font-semibold text-white/80">
                 <span className="truncate">{build.model}</span>
                 <span className="shrink-0 tabular-nums text-white/40">
+                  {build.source === "gallery" ? "Gallery · " : ""}
                   {build.blockCount.toLocaleString()} blocks
                 </span>
               </span>
@@ -299,10 +338,10 @@ function configureDaylight(
   sky.material.uniforms.sunPosition.value.copy(SUN_DIRECTION);
   scene.add(sky);
 
-  scene.add(new THREE.HemisphereLight(0xeaf6ff, 0x39452f, 0.72));
+  scene.add(new THREE.HemisphereLight(0xeaf6ff, 0x39452f, 0.78));
   scene.add(new THREE.AmbientLight(0xffffff, 0.08));
 
-  const sun = new THREE.DirectionalLight(0xffedc2, 3);
+  const sun = new THREE.DirectionalLight(0xffe2b3, 3.2);
   sun.castShadow = true;
   sun.shadow.mapSize.set(2048, 2048);
   sun.shadow.bias = -0.00015;
@@ -311,7 +350,7 @@ function configureDaylight(
 
   const sunFlare = new Lensflare();
   sunFlare.addElement(
-    new LensflareElement(createSunHaloTexture(), 220, 0, new THREE.Color(0xffe8b8)),
+    new LensflareElement(createSunHaloTexture(), 360, 0, new THREE.Color(0xffd18a)),
   );
   scene.add(sunFlare);
 
@@ -319,7 +358,7 @@ function configureDaylight(
   renderer.shadowMap.type = THREE.PCFSoftShadowMap;
   renderer.shadowMap.autoUpdate = false;
   renderer.toneMapping = THREE.ACESFilmicToneMapping;
-  renderer.toneMappingExposure = 1.08;
+  renderer.toneMappingExposure = 1.1;
   renderer.outputColorSpace = THREE.SRGBColorSpace;
   return { sky, sun, sunFlare };
 }
@@ -378,7 +417,7 @@ function ExplorerScene({ build, buildId }: { build: LoadedBuild; buildId: string
       createPublicMeshCacheKey({
         checksum: build.checksum,
         variant: "full",
-        palette: "simple",
+        palette: build.palette,
         blockCount: voxelBuildBlockCount(build.voxelBuild),
       }),
     [build],
@@ -440,6 +479,41 @@ function ExplorerScene({ build, buildId }: { build: LoadedBuild; buildId: string
     ssaoPass.kernelRadius = 12;
     ssaoPass.minDistance = 0.001;
     ssaoPass.maxDistance = 0.1;
+    const bloomTarget = new THREE.WebGLRenderTarget(1, 1, {
+      type: THREE.HalfFloatType,
+      depthBuffer: true,
+    });
+    bloomTarget.texture.name = "Explorer.emissiveBloom";
+    bloomTarget.texture.generateMipmaps = false;
+    const bloomPass = new BloomPass(1, 13, 2);
+    const bloomOverlayUniforms = THREE.UniformsUtils.clone(CopyShader.uniforms);
+    bloomOverlayUniforms.tDiffuse.value = bloomTarget.texture;
+    bloomOverlayUniforms.opacity.value = 0.78;
+    const bloomOverlayMaterial = new THREE.ShaderMaterial({
+      uniforms: bloomOverlayUniforms,
+      vertexShader: CopyShader.vertexShader,
+      fragmentShader: CopyShader.fragmentShader,
+      blending: THREE.AdditiveBlending,
+      transparent: true,
+      depthTest: false,
+      depthWrite: false,
+      toneMapped: false,
+    });
+    const bloomOverlay = new FullScreenQuad(bloomOverlayMaterial);
+    const emissiveLights = Array.from({ length: EMISSIVE_LIGHT_COUNT }, () => {
+      const light = new THREE.PointLight(
+        0xffb45c,
+        0,
+        EMISSIVE_LIGHT_DISTANCE,
+        2,
+      );
+      light.visible = false;
+      scene.add(light);
+      return light;
+    });
+    let emissiveClusters: ExplorerLightCluster[] = [];
+    let hasEmissiveMeshes = false;
+    let nextEmissiveLightUpdateAt = 0;
 
     const controls = new PointerLockControls(camera, renderer.domElement);
     controls.pointerSpeed = 0.9;
@@ -502,6 +576,10 @@ function ExplorerScene({ build, buildId }: { build: LoadedBuild; buildId: string
         Math.max(1, Math.round(width * pixelRatio * SSAO_RENDER_SCALE)),
         Math.max(1, Math.round(height * pixelRatio * SSAO_RENDER_SCALE)),
       );
+      const bloomWidth = Math.max(1, Math.round(width * pixelRatio * BLOOM_RENDER_SCALE));
+      const bloomHeight = Math.max(1, Math.round(height * pixelRatio * BLOOM_RENDER_SCALE));
+      bloomTarget.setSize(bloomWidth, bloomHeight);
+      bloomPass.setSize(bloomWidth, bloomHeight);
     };
     const resizeObserver = new ResizeObserver(resize);
     resizeObserver.observe(mount);
@@ -513,6 +591,53 @@ function ExplorerScene({ build, buildId }: { build: LoadedBuild; buildId: string
     const bobUp = new THREE.Vector3();
     const baseQuaternion = new THREE.Quaternion();
     const viewBob: ExplorerViewBobTransform = { x: 0, y: 0, roll: 0, pitch: 0 };
+    const bloomClearColor = new THREE.Color();
+    const updateEmissiveLights = () => {
+      const selected = selectNearestExplorerLightClusters(
+        emissiveClusters,
+        camera.position,
+        EMISSIVE_LIGHT_COUNT,
+        EMISSIVE_LIGHT_SELECTION_RADIUS,
+      );
+      const active = selected.length > 0;
+      for (let i = 0; i < emissiveLights.length; i += 1) {
+        const light = emissiveLights[i];
+        const cluster = selected[i];
+        light.visible = active;
+        if (!cluster) {
+          light.intensity = 0;
+          continue;
+        }
+        light.position.set(cluster.x, cluster.y, cluster.z);
+        light.intensity =
+          EMISSIVE_LIGHT_INTENSITY * Math.min(1.45, 0.65 + Math.sqrt(cluster.faces) * 0.16);
+      }
+    };
+    const renderEmissiveBloom = (seconds: number) => {
+      const background = scene.background;
+      const fog = scene.fog;
+      const layerMask = camera.layers.mask;
+      renderer.getClearColor(bloomClearColor);
+      const clearAlpha = renderer.getClearAlpha();
+      try {
+        camera.layers.set(EMISSIVE_LAYER);
+        scene.background = null;
+        scene.fog = null;
+        renderer.setClearColor(0x000000, 0);
+        renderer.setRenderTarget(bloomTarget);
+        renderer.clear();
+        renderer.render(scene, camera);
+      } finally {
+        camera.layers.mask = layerMask;
+        scene.background = background;
+        scene.fog = fog;
+        renderer.setClearColor(bloomClearColor, clearAlpha);
+        renderer.setRenderTarget(null);
+      }
+      bloomPass.render(renderer, bloomTarget, bloomTarget, seconds, false);
+      renderer.setRenderTarget(null);
+      bloomOverlay.render(renderer);
+    };
     const updatePlayer = (seconds: number) => {
       if (!controls.isLocked || !collisionWorld) {
         bobWalking = false;
@@ -591,6 +716,10 @@ function ExplorerScene({ build, buildId }: { build: LoadedBuild; buildId: string
       const seconds = Math.min(MAX_FRAME_SECONDS, Math.max(0, (now - lastFrameAt) / 1_000));
       lastFrameAt = now;
       updatePlayer(seconds);
+      if (hasEmissiveMeshes && now >= nextEmissiveLightUpdateAt) {
+        updateEmissiveLights();
+        nextEmissiveLightUpdateAt = now + EMISSIVE_LIGHT_UPDATE_MS;
+      }
 
       if (reducedMotion) {
         bobBlend = 0;
@@ -614,6 +743,7 @@ function ExplorerScene({ build, buildId }: { build: LoadedBuild; buildId: string
         renderer.render(scene, camera);
         sunFlare.visible = false;
         ssaoPass.render(renderer, null!, null!, seconds, false);
+        if (hasEmissiveMeshes) renderEmissiveBloom(seconds);
       } finally {
         sunFlare.visible = true;
         camera.quaternion.copy(baseQuaternion);
@@ -640,7 +770,7 @@ function ExplorerScene({ build, buildId }: { build: LoadedBuild; buildId: string
           },
         });
         const atlas = await atlasPromise;
-        const groupPromise = createVoxelGroupAsync(build.voxelBuild, SIMPLE_PALETTE, atlas, {
+        const groupPromise = createVoxelGroupAsync(build.voxelBuild, getPalette(build.palette), atlas, {
           signal: abortController.signal,
           cacheKey: meshCacheKey,
           onProgress(progress) {
@@ -663,6 +793,14 @@ function ExplorerScene({ build, buildId }: { build: LoadedBuild; buildId: string
           const materials = Array.isArray(child.material) ? child.material : [child.material];
           child.castShadow = materials.every((material) => !material.transparent);
           child.receiveShadow = true;
+          if (!materials.some((material) => material instanceof THREE.MeshBasicMaterial)) return;
+          hasEmissiveMeshes = true;
+          child.layers.enable(EMISSIVE_LAYER);
+          const positions = child.geometry.getAttribute("position");
+          if (positions?.itemSize !== 3) return;
+          for (const cluster of clusterExplorerEmissiveFaces(positions.array)) {
+            emissiveClusters.push(cluster);
+          }
         });
         scene.add(voxelGroup.group);
         frameDaylight(camera, scene, sky, sun, voxelGroup.bounds);
@@ -670,6 +808,7 @@ function ExplorerScene({ build, buildId }: { build: LoadedBuild; buildId: string
 
         camera.position.set(0, collisionWorld.height + 8, 0);
         camera.lookAt(0, Math.max(0, collisionWorld.height - 4), -12);
+        updateEmissiveLights();
         renderer.shadowMap.needsUpdate = true;
         worldReady = true;
         setLoading("");
@@ -703,6 +842,11 @@ function ExplorerScene({ build, buildId }: { build: LoadedBuild; buildId: string
       }
       scene.remove(sunFlare);
       sunFlare.dispose();
+      for (const light of emissiveLights) scene.remove(light);
+      bloomOverlayMaterial.dispose();
+      bloomOverlay.dispose();
+      bloomPass.dispose();
+      bloomTarget.dispose();
       ssaoPass.noiseTexture.dispose();
       ssaoPass.dispose();
       sky.geometry.dispose();

--- a/components/voxel/VoxelExplorerLauncher.tsx
+++ b/components/voxel/VoxelExplorerLauncher.tsx
@@ -93,6 +93,7 @@ export function VoxelExplorerProvider({ children }: { children: ReactNode }) {
             event.preventDefault();
             setPending(null);
           }}
+          onKeyDown={(event) => event.stopPropagation()}
           onClose={() => setPending(null)}
         >
           <div className="space-y-6 p-6 sm:p-7">

--- a/components/voxel/VoxelExplorerLauncher.tsx
+++ b/components/voxel/VoxelExplorerLauncher.tsx
@@ -1,0 +1,166 @@
+"use client";
+
+import dynamic from "next/dynamic";
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
+import type { RenderableVoxelBuild } from "@/lib/voxel/packedBlocks";
+
+export type VoxelExplorerBuild = {
+  id: string;
+  model: string;
+  prompt: string;
+  blockCount: number;
+  source: "benchmark" | "gallery" | "current";
+  checksum: string | null;
+  palette: "simple" | "advanced";
+  voxelBuild: RenderableVoxelBuild;
+};
+
+type ExplorerRequest = {
+  build: VoxelExplorerBuild;
+  onContinue?: () => void;
+  onExit?: () => void;
+};
+
+type ExplorerContextValue = {
+  active: boolean;
+  launch: (request: ExplorerRequest) => void;
+};
+
+const ExplorerContext = createContext<ExplorerContextValue | null>(null);
+const VoxelExplorerOverlay = dynamic(
+  () => import("@/components/voxel/VoxelExplorer").then((module) => module.VoxelExplorerOverlay),
+  {
+    ssr: false,
+    loading: () => (
+      <div className="fixed inset-0 z-[100] flex items-center justify-center bg-[oklch(0.86_0.055_235)] text-sm font-semibold text-slate-800">
+        Loading
+      </div>
+    ),
+  },
+);
+
+export function VoxelExplorerProvider({ children }: { children: ReactNode }) {
+  const dialogRef = useRef<HTMLDialogElement>(null);
+  const [pending, setPending] = useState<ExplorerRequest | null>(null);
+  const [active, setActive] = useState<ExplorerRequest | null>(null);
+  const launch = useCallback((request: ExplorerRequest) => setPending(request), []);
+  const context = useMemo(() => ({ active: Boolean(active), launch }), [active, launch]);
+
+  useEffect(() => {
+    const dialog = dialogRef.current;
+    if (pending && dialog && !dialog.open) dialog.showModal();
+  }, [pending]);
+
+  useEffect(() => {
+    if (!active) return;
+    const overflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = overflow;
+    };
+  }, [active]);
+
+  const continueToExplorer = () => {
+    if (!pending) return;
+    pending.onContinue?.();
+    setActive(pending);
+    setPending(null);
+  };
+
+  const exitExplorer = () => {
+    active?.onExit?.();
+    setActive(null);
+  };
+
+  return (
+    <ExplorerContext.Provider value={context}>
+      {children}
+      {pending ? (
+        <dialog
+          ref={dialogRef}
+          aria-labelledby="voxel-explorer-confirm-title"
+          className="mb-dialog m-auto w-[min(28rem,calc(100%-2rem))] rounded-md border-0 bg-card p-0 text-fg ring-1 ring-border-xl backdrop:bg-bg/60 backdrop:backdrop-blur-sm"
+          onCancel={(event) => {
+            event.preventDefault();
+            setPending(null);
+          }}
+          onClose={() => setPending(null)}
+        >
+          <div className="space-y-6 p-6 sm:p-7">
+            <div>
+              <p className="mb-eyebrow">Explorer</p>
+              <h2
+                id="voxel-explorer-confirm-title"
+                className="mt-2 text-2xl font-semibold tracking-tight"
+              >
+                Explore this build?
+              </h2>
+              <p className="mt-2 text-sm leading-6 text-muted">
+                Step inside at block scale with keyboard and mouse.
+              </p>
+            </div>
+            <div className="grid gap-2 sm:grid-cols-2">
+              <button
+                type="button"
+                autoFocus
+                className="mb-btn mb-btn-primary h-11"
+                onClick={continueToExplorer}
+              >
+                Continue
+              </button>
+              <button type="button" className="mb-btn h-11" onClick={() => setPending(null)}>
+                Cancel
+              </button>
+            </div>
+          </div>
+        </dialog>
+      ) : null}
+      {active ? <VoxelExplorerOverlay initialBuild={active.build} onExit={exitExplorer} /> : null}
+    </ExplorerContext.Provider>
+  );
+}
+
+export function useVoxelExplorerActive(): boolean {
+  return useContext(ExplorerContext)?.active ?? false;
+}
+
+export function VoxelExplorerLaunchButton({
+  build,
+  onContinue,
+  onExit,
+}: ExplorerRequest) {
+  const context = useContext(ExplorerContext);
+  if (!context) return null;
+  return (
+    <button
+      type="button"
+      aria-label="Explore build"
+      title="Explore build"
+      className="mb-explorer-launch mb-btn mb-btn-ghost h-8 w-8 border border-border/70 bg-bg/55 p-0 text-muted shadow-sm backdrop-blur-sm hover:border-accent/60 hover:bg-accent/10 hover:text-fg"
+      onClick={() => context.launch({ build, onContinue, onExit })}
+    >
+      <svg
+        aria-hidden="true"
+        viewBox="0 0 24 24"
+        className="h-[18px] w-[18px]"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      >
+        <path d="M7.5 7h9a4.5 4.5 0 0 1 4.3 3.2l1 3.4a3.4 3.4 0 0 1-5.7 3.3l-1.2-1.2a2 2 0 0 0-1.4-.6h-3a2 2 0 0 0-1.4.6l-1.2 1.2a3.4 3.4 0 0 1-5.7-3.3l1-3.4A4.5 4.5 0 0 1 7.5 7Z" />
+        <path d="M7.5 10v4M5.5 12h4M16.5 11h.01M18.5 13h.01" />
+      </svg>
+    </button>
+  );
+}

--- a/components/voxel/VoxelViewerCard.tsx
+++ b/components/voxel/VoxelViewerCard.tsx
@@ -14,6 +14,11 @@ import {
 } from "@/components/voxel/VoxelViewer";
 import { VoxelBuildExportButton } from "@/components/voxel/VoxelBuildExportButton";
 import { VoxelEmptyState } from "@/components/voxel/VoxelEmptyState";
+import {
+  VoxelExplorerLaunchButton,
+  useVoxelExplorerActive,
+  type VoxelExplorerBuild,
+} from "@/components/voxel/VoxelExplorerLauncher";
 import { MAX_BLOCKS_BY_GRID } from "@/lib/ai/limits";
 import { getPalette } from "@/lib/blocks/palettes";
 import { formatBuildDuration, formatBuildJsonSize } from "@/lib/buildMetrics";
@@ -60,6 +65,7 @@ export function VoxelViewerCard({
   exportPrompt,
   exportDisabled,
   exportDisabledReason,
+  explorer,
   actions,
   jsonBytes,
   viewerRef,
@@ -100,6 +106,10 @@ export function VoxelViewerCard({
   exportPrompt?: string;
   exportDisabled?: boolean;
   exportDisabledReason?: string;
+  explorer?: Omit<VoxelExplorerBuild, "blockCount" | "palette" | "voxelBuild"> & {
+    onContinue?: () => void;
+    onExit?: () => void;
+  };
   actions?: ReactNode;
   jsonBytes?: number | null;
   viewerRef?: RefObject<VoxelViewerHandle | null>;
@@ -148,6 +158,10 @@ export function VoxelViewerCard({
   const buildBlocksRef = build ? voxelBuildBlocksRef(build) : null;
   const warnings = metrics?.warnings ?? rendered.warnings;
   const blockCount = metrics?.blockCount ?? voxelBuildBlockCount(build);
+  const explorerActive = useVoxelExplorerActive();
+  const explorerBuild = explorer && build
+    ? { ...explorer, blockCount, palette, voxelBuild: build }
+    : null;
   const isThinking = Boolean(isLoading && attempt && attempt > 0 && !debugRawText);
   const [preferredView, setPreferredView] = useState<"build" | "json">("build");
   const [showRawBuildJson, setShowRawBuildJson] = useState(false);
@@ -369,8 +383,15 @@ export function VoxelViewerCard({
                   </button>
                 </div>
               ) : null}
-              {enableBuildExport || actions ? (
+              {enableBuildExport || explorerBuild || actions ? (
                 <div className="flex items-center gap-1.5">
+                  {explorerBuild ? (
+                    <VoxelExplorerLaunchButton
+                      build={explorerBuild}
+                      onContinue={explorer?.onContinue}
+                      onExit={explorer?.onExit}
+                    />
+                  ) : null}
                   {enableBuildExport ? (
                     <VoxelBuildExportButton
                       build={build}
@@ -389,7 +410,7 @@ export function VoxelViewerCard({
         </div>
 
         <div className={viewerHeightClass}>
-          {showBuildView ? (
+          {showBuildView && !explorerActive ? (
             <VoxelViewer
               ref={viewerRef}
               voxelBuild={build}

--- a/lib/gallery/service.ts
+++ b/lib/gallery/service.ts
@@ -1225,6 +1225,41 @@ export async function getPublicGalleryExampleArtifact(
   });
 }
 
+export async function listPublicGalleryExplorerBuilds() {
+  const examples = await prisma.galleryExample.findMany({
+    where: {
+      AND: [
+        publicExampleWhere,
+        {
+          candidate: publicCandidateWhere,
+          customBuild: {
+            blockCount: { gt: 0 },
+            artifacts: { some: { kind: { in: ["viewer_mbf1", "viewer_mbv4"] } } },
+          },
+        },
+      ],
+    },
+    orderBy: [{ createdAt: "desc" }, { id: "desc" }],
+    select: {
+      id: true,
+      candidate: { select: { promptText: true } },
+      customBuild: {
+        select: {
+          blockCount: true,
+          ...galleryModelSelect,
+        },
+      },
+    },
+  });
+
+  return examples.map((example) => ({
+    id: example.id,
+    model: publicGalleryModel(example.customBuild).label,
+    prompt: example.candidate.promptText,
+    blockCount: example.customBuild.blockCount ?? 0,
+  }));
+}
+
 export async function setGalleryCandidateHidden(
   adminId: string,
   publicId: string,

--- a/lib/voxel/explorerBuildId.ts
+++ b/lib/voxel/explorerBuildId.ts
@@ -1,0 +1,17 @@
+const GALLERY_BUILD_PREFIX = "gallery:";
+
+export function parseExplorerBuildId(value: string):
+  | { source: "gallery"; id: string }
+  | { source: "benchmark"; id: string } {
+  let id = value;
+  try {
+    id = decodeURIComponent(value);
+  } catch {
+    // Keep malformed benchmark IDs unchanged so the API can reject them normally
+  }
+
+  if (id.startsWith(GALLERY_BUILD_PREFIX) && id.length > GALLERY_BUILD_PREFIX.length) {
+    return { source: "gallery", id: id.slice(GALLERY_BUILD_PREFIX.length) };
+  }
+  return { source: "benchmark", id };
+}

--- a/lib/voxel/explorerCollision.ts
+++ b/lib/voxel/explorerCollision.ts
@@ -15,6 +15,25 @@ const YIELD_EVERY_BLOCKS = 262_144;
 export type ExplorerPosition = { x: number; y: number; z: number };
 export type ExplorerAxis = "x" | "y" | "z";
 
+export function setExplorerMoveDirection(
+  target: ExplorerPosition,
+  forward: ExplorerPosition,
+  right: ExplorerPosition,
+  forwardInput: number,
+  rightInput: number,
+  verticalInput: number,
+) {
+  target.x = forward.x * forwardInput + right.x * rightInput;
+  target.y = forward.y * forwardInput + right.y * rightInput + verticalInput;
+  target.z = forward.z * forwardInput + right.z * rightInput;
+  const lengthSquared = target.x ** 2 + target.y ** 2 + target.z ** 2;
+  if (lengthSquared <= 1) return;
+  const scale = 1 / Math.sqrt(lengthSquared);
+  target.x *= scale;
+  target.y *= scale;
+  target.z *= scale;
+}
+
 export type ExplorerCollisionWorld = {
   height: number;
   collides: (position: ExplorerPosition) => boolean;

--- a/lib/voxel/explorerCollision.ts
+++ b/lib/voxel/explorerCollision.ts
@@ -1,0 +1,205 @@
+import {
+  voxelBuildBlockCount,
+  type RenderableVoxelBuild,
+} from "@/lib/voxel/packedBlocks";
+
+export const EXPLORER_PLAYER_WIDTH = 0.6;
+export const EXPLORER_PLAYER_HEIGHT = 1.8;
+export const EXPLORER_EYE_HEIGHT = 1.62;
+
+const PLAYER_HALF_WIDTH = EXPLORER_PLAYER_WIDTH / 2;
+const MAX_COLLISION_AXIS = 512;
+const COLLISION_EPSILON = 1e-5;
+const YIELD_EVERY_BLOCKS = 262_144;
+
+export type ExplorerPosition = { x: number; y: number; z: number };
+export type ExplorerAxis = "x" | "y" | "z";
+
+export type ExplorerCollisionWorld = {
+  height: number;
+  collides: (position: ExplorerPosition) => boolean;
+  isInWater: (position: ExplorerPosition) => boolean;
+};
+
+type BuildProgress = {
+  processedBlocks: number;
+  totalBlocks: number;
+};
+
+function throwIfAborted(signal?: AbortSignal) {
+  if (signal?.aborted) throw new DOMException("Aborted", "AbortError");
+}
+
+async function yieldToMainThread() {
+  const schedulerApi = (globalThis as typeof globalThis & {
+    scheduler?: { yield?: () => Promise<void> };
+  }).scheduler;
+  if (typeof schedulerApi?.yield === "function") {
+    await schedulerApi.yield();
+    return;
+  }
+  await new Promise<void>((resolve) => setTimeout(resolve, 0));
+}
+
+function setBit(bits: Uint8Array, index: number) {
+  bits[index >>> 3] |= 1 << (index & 7);
+}
+
+function hasBit(bits: Uint8Array | null, index: number): boolean {
+  return Boolean(bits && (bits[index >>> 3] & (1 << (index & 7))));
+}
+
+export async function createExplorerCollisionWorld(
+  build: RenderableVoxelBuild,
+  opts?: {
+    signal?: AbortSignal;
+    onProgress?: (progress: BuildProgress) => void;
+  },
+): Promise<ExplorerCollisionWorld> {
+  const blockCount = voxelBuildBlockCount(build);
+  if (blockCount === 0) throw new Error("Build has no blocks");
+
+  const packed = build.packed;
+  let minX = Infinity;
+  let minY = Infinity;
+  let minZ = Infinity;
+  let maxX = -Infinity;
+  let maxY = -Infinity;
+  let maxZ = -Infinity;
+  let hasWaterBlocks = false;
+
+  for (let i = 0; i < blockCount; i += 1) {
+    const block = packed ? null : build.blocks[i];
+    const x = packed ? packed.positions[i * 3] : block?.x;
+    const y = packed ? packed.positions[i * 3 + 1] : block?.y;
+    const z = packed ? packed.positions[i * 3 + 2] : block?.z;
+    const type = packed ? packed.typeNames[packed.typeIds[i]] : block?.type;
+    if (
+      typeof x !== "number" || !Number.isInteger(x) ||
+      typeof y !== "number" || !Number.isInteger(y) ||
+      typeof z !== "number" || !Number.isInteger(z) ||
+      typeof type !== "string" || !type
+    ) {
+      throw new Error("Build contains invalid collision data");
+    }
+    minX = Math.min(minX, x);
+    minY = Math.min(minY, y);
+    minZ = Math.min(minZ, z);
+    maxX = Math.max(maxX, x);
+    maxY = Math.max(maxY, y);
+    maxZ = Math.max(maxZ, z);
+    hasWaterBlocks ||= type === "water";
+
+    if ((i + 1) % YIELD_EVERY_BLOCKS === 0) {
+      opts?.onProgress?.({ processedBlocks: i + 1, totalBlocks: blockCount * 2 });
+      throwIfAborted(opts?.signal);
+      await yieldToMainThread();
+    }
+  }
+
+  const width = maxX - minX + 1;
+  const height = maxY - minY + 1;
+  const depth = maxZ - minZ + 1;
+  if (
+    width > MAX_COLLISION_AXIS ||
+    height > MAX_COLLISION_AXIS ||
+    depth > MAX_COLLISION_AXIS
+  ) {
+    throw new Error("Build collision bounds exceed the supported grid");
+  }
+
+  const cellCount = width * height * depth;
+  const byteCount = Math.ceil(cellCount / 8);
+  const solids = new Uint8Array(byteCount);
+  const water = hasWaterBlocks ? new Uint8Array(byteCount) : null;
+
+  for (let i = 0; i < blockCount; i += 1) {
+    const block = packed ? null : build.blocks[i];
+    const x = (packed ? packed.positions[i * 3] : block?.x) as number;
+    const y = (packed ? packed.positions[i * 3 + 1] : block?.y) as number;
+    const z = (packed ? packed.positions[i * 3 + 2] : block?.z) as number;
+    const type = packed ? packed.typeNames[packed.typeIds[i]] : block?.type;
+    const index = x - minX + width * (z - minZ + depth * (y - minY));
+    if (type === "water") setBit(water as Uint8Array, index);
+    else if (type !== "lava") setBit(solids, index);
+
+    if ((i + 1) % YIELD_EVERY_BLOCKS === 0) {
+      opts?.onProgress?.({
+        processedBlocks: blockCount + i + 1,
+        totalBlocks: blockCount * 2,
+      });
+      throwIfAborted(opts?.signal);
+      await yieldToMainThread();
+    }
+  }
+  throwIfAborted(opts?.signal);
+  opts?.onProgress?.({ processedBlocks: blockCount * 2, totalBlocks: blockCount * 2 });
+
+  const worldMinX = -width / 2;
+  const worldMinZ = -depth / 2;
+
+  const intersects = (position: ExplorerPosition, bits: Uint8Array | null): boolean => {
+    if (!bits) return false;
+    const feetY = position.y - EXPLORER_EYE_HEIGHT;
+    const minCellX = Math.floor(position.x - PLAYER_HALF_WIDTH - worldMinX + COLLISION_EPSILON);
+    const maxCellX = Math.floor(position.x + PLAYER_HALF_WIDTH - worldMinX - COLLISION_EPSILON);
+    const minCellY = Math.floor(feetY + COLLISION_EPSILON);
+    const maxCellY = Math.floor(feetY + EXPLORER_PLAYER_HEIGHT - COLLISION_EPSILON);
+    const minCellZ = Math.floor(position.z - PLAYER_HALF_WIDTH - worldMinZ + COLLISION_EPSILON);
+    const maxCellZ = Math.floor(position.z + PLAYER_HALF_WIDTH - worldMinZ - COLLISION_EPSILON);
+
+    if (
+      maxCellX < 0 || minCellX >= width ||
+      maxCellY < 0 || minCellY >= height ||
+      maxCellZ < 0 || minCellZ >= depth
+    ) {
+      return false;
+    }
+
+    for (let y = Math.max(0, minCellY); y <= Math.min(height - 1, maxCellY); y += 1) {
+      for (let z = Math.max(0, minCellZ); z <= Math.min(depth - 1, maxCellZ); z += 1) {
+        for (let x = Math.max(0, minCellX); x <= Math.min(width - 1, maxCellX); x += 1) {
+          if (hasBit(bits, x + width * (z + depth * y))) return true;
+        }
+      }
+    }
+    return false;
+  };
+
+  return {
+    height,
+    collides(position) {
+      const feetY = position.y - EXPLORER_EYE_HEIGHT;
+      return feetY < -COLLISION_EPSILON || intersects(position, solids);
+    },
+    isInWater(position) {
+      return intersects(position, water);
+    },
+  };
+}
+
+export function moveExplorerPlayerAxis(
+  world: ExplorerCollisionWorld,
+  position: ExplorerPosition,
+  axis: ExplorerAxis,
+  distance: number,
+): boolean {
+  if (!Number.isFinite(distance) || distance === 0) return false;
+  const start = position[axis];
+  position[axis] = start + distance;
+  if (!world.collides(position)) return false;
+
+  position[axis] = start;
+  if (world.collides(position)) return true;
+
+  let clear = 0;
+  let blocked = 1;
+  for (let i = 0; i < 12; i += 1) {
+    const fraction = (clear + blocked) / 2;
+    position[axis] = start + distance * fraction;
+    if (world.collides(position)) blocked = fraction;
+    else clear = fraction;
+  }
+  position[axis] = start + distance * clear;
+  return true;
+}

--- a/lib/voxel/explorerLighting.ts
+++ b/lib/voxel/explorerLighting.ts
@@ -2,6 +2,9 @@ export type ExplorerLightCluster = {
   x: number;
   y: number;
   z: number;
+  nx: number;
+  ny: number;
+  nz: number;
   faces: number;
 };
 
@@ -30,7 +33,21 @@ export function clusterExplorerEmissiveFaces(
     const y = (positions[i + 1] + positions[i + 4] + positions[i + 7] + positions[i + 10]) / 4;
     const z = (positions[i + 2] + positions[i + 5] + positions[i + 8] + positions[i + 11]) / 4;
     if (!Number.isFinite(x) || !Number.isFinite(y) || !Number.isFinite(z)) continue;
-    const key = `${Math.floor(x / cellSize)},${Math.floor(y / cellSize)},${Math.floor(z / cellSize)}`;
+    const ax = positions[i + 3] - positions[i];
+    const ay = positions[i + 4] - positions[i + 1];
+    const az = positions[i + 5] - positions[i + 2];
+    const bx = positions[i + 6] - positions[i];
+    const by = positions[i + 7] - positions[i + 1];
+    const bz = positions[i + 8] - positions[i + 2];
+    const normalX = ay * bz - az * by;
+    const normalY = az * bx - ax * bz;
+    const normalZ = ax * by - ay * bx;
+    const normalLength = Math.hypot(normalX, normalY, normalZ);
+    if (normalLength < 1e-6) continue;
+    const nx = Math.round(normalX / normalLength);
+    const ny = Math.round(normalY / normalLength);
+    const nz = Math.round(normalZ / normalLength);
+    const key = `${Math.floor(x / cellSize)},${Math.floor(y / cellSize)},${Math.floor(z / cellSize)},${nx},${ny},${nz}`;
     const cluster = clusters.get(key);
     if (cluster) {
       cluster.x += x;
@@ -38,7 +55,7 @@ export function clusterExplorerEmissiveFaces(
       cluster.z += z;
       cluster.faces += 1;
     } else {
-      clusters.set(key, { x, y, z, faces: 1 });
+      clusters.set(key, { x, y, z, nx, ny, nz, faces: 1 });
     }
   }
 
@@ -46,6 +63,9 @@ export function clusterExplorerEmissiveFaces(
     x: cluster.x / cluster.faces,
     y: cluster.y / cluster.faces,
     z: cluster.z / cluster.faces,
+    nx: cluster.nx,
+    ny: cluster.ny,
+    nz: cluster.nz,
     faces: cluster.faces,
   }));
 }

--- a/lib/voxel/explorerLighting.ts
+++ b/lib/voxel/explorerLighting.ts
@@ -110,7 +110,9 @@ export async function createExplorerBlockLightGrid(
   const width = buildWidth + padding * 2;
   const height = buildHeight + padding * 2;
   const depth = buildDepth + padding * 2;
-  const cells = new Uint8Array(width * height * depth);
+  const cellCount = width * height * depth;
+  if (cellCount > MAX_BLOCK_LIGHT_CELLS) return null;
+  const cells = new Uint8Array(cellCount);
   const plane = width * depth;
   const queue: Array<Uint32Array | null> = [new Uint32Array(QUEUE_CHUNK_SIZE)];
   let readChunk = 0;

--- a/lib/voxel/explorerLighting.ts
+++ b/lib/voxel/explorerLighting.ts
@@ -10,6 +10,7 @@ const BLOCK_LIGHT_MAX_LEVEL = 15;
 const BLOCK_LIGHT_OCCLUDER = 0x80;
 const BLOCK_LIGHT_SOURCE = 0x40;
 const BLOCK_LIGHT_PADDING = BLOCK_LIGHT_MAX_LEVEL;
+const BLOCK_LIGHT_BYTE_SCALE = 255 / BLOCK_LIGHT_MAX_LEVEL;
 const MAX_BLOCK_LIGHT_CELLS = 32_000_000;
 const QUEUE_CHUNK_SIZE = 65_536;
 const YIELD_EVERY = 262_144;
@@ -260,7 +261,8 @@ export async function applyExplorerBlockLighting(
   const worldMinX = bounds.min.x - grid.padding;
   const worldMinY = bounds.min.y - grid.padding;
   const worldMinZ = bounds.min.z - grid.padding;
-  const plane = grid.width * grid.depth;
+  const { cells, width, height, depth } = grid;
+  const plane = width * depth;
   let processed = 0;
 
   for (const mesh of meshes) {
@@ -273,25 +275,26 @@ export async function applyExplorerBlockLighting(
 
     for (let vertex = 0; vertex + 3 < positions.count; vertex += 4) {
       const offset = vertex * 3;
-      const centerX =
-        (positionArray[offset] + positionArray[offset + 3] +
-          positionArray[offset + 6] + positionArray[offset + 9]) / 4;
-      const centerY =
-        (positionArray[offset + 1] + positionArray[offset + 4] +
-          positionArray[offset + 7] + positionArray[offset + 10]) / 4;
-      const centerZ =
-        (positionArray[offset + 2] + positionArray[offset + 5] +
-          positionArray[offset + 8] + positionArray[offset + 11]) / 4;
-      const x = Math.floor(centerX + Math.sign(normalArray[offset]) * 0.01 - worldMinX);
-      const y = Math.floor(centerY + Math.sign(normalArray[offset + 1]) * 0.01 - worldMinY);
-      const z = Math.floor(centerZ + Math.sign(normalArray[offset + 2]) * 0.01 - worldMinZ);
-      const level =
-        x >= 0 && x < grid.width &&
-        y >= 0 && y < grid.height &&
-        z >= 0 && z < grid.depth
-          ? grid.cells[x + grid.width * (z + grid.depth * y)] & BLOCK_LIGHT_MAX_LEVEL
-          : 0;
-      values.fill(Math.round((level / BLOCK_LIGHT_MAX_LEVEL) * 255), vertex, vertex + 4);
+      const normalX = Math.sign(normalArray[offset]);
+      const normalY = Math.sign(normalArray[offset + 1]);
+      const normalZ = Math.sign(normalArray[offset + 2]);
+      const sampleOffsetX = normalX === 0 ? -0.001 : normalX * 0.01;
+      const sampleOffsetY = normalY === 0 ? -0.001 : normalY * 0.01;
+      const sampleOffsetZ = normalZ === 0 ? -0.001 : normalZ * 0.01;
+
+      for (let corner = 0; corner < 4; corner += 1) {
+        const cornerOffset = offset + corner * 3;
+        const x = Math.floor(positionArray[cornerOffset] + sampleOffsetX - worldMinX);
+        const y = Math.floor(positionArray[cornerOffset + 1] + sampleOffsetY - worldMinY);
+        const z = Math.floor(positionArray[cornerOffset + 2] + sampleOffsetZ - worldMinZ);
+        const level =
+          x >= 0 && x < width &&
+          y >= 0 && y < height &&
+          z >= 0 && z < depth
+            ? cells[x + width * z + plane * y] & BLOCK_LIGHT_MAX_LEVEL
+            : 0;
+        values[vertex + corner] = level * BLOCK_LIGHT_BYTE_SCALE;
+      }
       processed += 4;
       if (processed % YIELD_EVERY === 0) await yieldToMainThread(opts?.signal);
     }

--- a/lib/voxel/explorerLighting.ts
+++ b/lib/voxel/explorerLighting.ts
@@ -5,6 +5,19 @@ export type ExplorerLightCluster = {
   faces: number;
 };
 
+export function renderExplorerBloomOverlay(
+  renderer: { autoClear: boolean },
+  render: () => void,
+): void {
+  const autoClear = renderer.autoClear;
+  renderer.autoClear = false;
+  try {
+    render();
+  } finally {
+    renderer.autoClear = autoClear;
+  }
+}
+
 export function clusterExplorerEmissiveFaces(
   positions: ArrayLike<number>,
   cellSize = 8,

--- a/lib/voxel/explorerLighting.ts
+++ b/lib/voxel/explorerLighting.ts
@@ -320,6 +320,16 @@ export function renderExplorerBloomOverlay(
   }
 }
 
+export function getExplorerMeteorOpacity(
+  elapsed: number,
+  delay: number,
+  duration: number,
+): number {
+  if (![elapsed, delay, duration].every(Number.isFinite) || duration <= 0) return 0;
+  const progress = (elapsed - delay) / duration;
+  return progress > 0 && progress < 1 ? Math.sin(Math.PI * progress) : 0;
+}
+
 export function isExplorerSunRayVisible(
   x: number,
   y: number,

--- a/lib/voxel/explorerLighting.ts
+++ b/lib/voxel/explorerLighting.ts
@@ -1,12 +1,308 @@
-export type ExplorerLightCluster = {
-  x: number;
-  y: number;
-  z: number;
-  nx: number;
-  ny: number;
-  nz: number;
-  faces: number;
+import * as THREE from "three";
+import { getRenderKind } from "@/lib/blocks/registry";
+import {
+  voxelBuildBlockCount,
+  type RenderableVoxelBuild,
+} from "@/lib/voxel/packedBlocks";
+import { isVoxelOccluder } from "@/lib/voxel/renderVisibility";
+
+const BLOCK_LIGHT_MAX_LEVEL = 15;
+const BLOCK_LIGHT_OCCLUDER = 0x80;
+const BLOCK_LIGHT_SOURCE = 0x40;
+const BLOCK_LIGHT_PADDING = BLOCK_LIGHT_MAX_LEVEL;
+const MAX_BLOCK_LIGHT_CELLS = 32_000_000;
+const QUEUE_CHUNK_SIZE = 65_536;
+const YIELD_EVERY = 262_144;
+
+export type ExplorerBlockLightGrid = {
+  cells: Uint8Array;
+  width: number;
+  height: number;
+  depth: number;
+  minX: number;
+  minY: number;
+  minZ: number;
+  padding: number;
 };
+
+type ExplorerLightingOptions = {
+  signal?: AbortSignal;
+  onProgress?: (stage: string) => void;
+};
+
+function throwIfAborted(signal?: AbortSignal) {
+  if (signal?.aborted) throw new DOMException("Aborted", "AbortError");
+}
+
+async function yieldToMainThread(signal?: AbortSignal) {
+  throwIfAborted(signal);
+  const schedulerApi = (globalThis as typeof globalThis & {
+    scheduler?: { yield?: () => Promise<void> };
+  }).scheduler;
+  if (typeof schedulerApi?.yield === "function") await schedulerApi.yield();
+  else await new Promise<void>((resolve) => setTimeout(resolve, 0));
+  throwIfAborted(signal);
+}
+
+function blockFlags(type: string): number {
+  return (
+    (isVoxelOccluder(type) ? BLOCK_LIGHT_OCCLUDER : 0) |
+    (getRenderKind(type) === "emissive" ? BLOCK_LIGHT_SOURCE : 0)
+  );
+}
+
+export async function createExplorerBlockLightGrid(
+  build: RenderableVoxelBuild,
+  opts?: ExplorerLightingOptions,
+): Promise<ExplorerBlockLightGrid | null> {
+  const blockCount = voxelBuildBlockCount(build);
+  if (blockCount === 0) return null;
+
+  const packed = build.packed;
+  const packedFlags = packed ? Uint8Array.from(packed.typeNames, blockFlags) : null;
+  const objectFlags = new Map<string, number>();
+  const flagsFor = (type: string) => {
+    const cached = objectFlags.get(type);
+    if (cached !== undefined) return cached;
+    const flags = blockFlags(type);
+    objectFlags.set(type, flags);
+    return flags;
+  };
+
+  let minX = Infinity;
+  let minY = Infinity;
+  let minZ = Infinity;
+  let maxX = -Infinity;
+  let maxY = -Infinity;
+  let maxZ = -Infinity;
+  let sourceCount = 0;
+
+  for (let i = 0; i < blockCount; i += 1) {
+    const block = packed ? null : build.blocks[i];
+    const x = packed ? packed.positions[i * 3] : block!.x;
+    const y = packed ? packed.positions[i * 3 + 1] : block!.y;
+    const z = packed ? packed.positions[i * 3 + 2] : block!.z;
+    const flags = packed ? packedFlags?.[packed.typeIds[i]] ?? 0 : flagsFor(block!.type);
+    minX = Math.min(minX, x);
+    minY = Math.min(minY, y);
+    minZ = Math.min(minZ, z);
+    maxX = Math.max(maxX, x);
+    maxY = Math.max(maxY, y);
+    maxZ = Math.max(maxZ, z);
+    if ((flags & BLOCK_LIGHT_SOURCE) !== 0) sourceCount += 1;
+    if ((i + 1) % YIELD_EVERY === 0) await yieldToMainThread(opts?.signal);
+  }
+  if (sourceCount === 0) return null;
+
+  const buildWidth = maxX - minX + 1;
+  const buildHeight = maxY - minY + 1;
+  const buildDepth = maxZ - minZ + 1;
+  let padding = BLOCK_LIGHT_PADDING;
+  while (
+    padding > 1 &&
+    (buildWidth + padding * 2) *
+      (buildHeight + padding * 2) *
+      (buildDepth + padding * 2) > MAX_BLOCK_LIGHT_CELLS
+  ) {
+    padding -= 1;
+  }
+  const width = buildWidth + padding * 2;
+  const height = buildHeight + padding * 2;
+  const depth = buildDepth + padding * 2;
+  const cells = new Uint8Array(width * height * depth);
+  const plane = width * depth;
+  const queue: Array<Uint32Array | null> = [new Uint32Array(QUEUE_CHUNK_SIZE)];
+  let readChunk = 0;
+  let readOffset = 0;
+  let writeChunk = 0;
+  let writeOffset = 0;
+  let queued = 0;
+  const enqueue = (index: number) => {
+    if (writeOffset === QUEUE_CHUNK_SIZE) {
+      writeChunk += 1;
+      writeOffset = 0;
+      queue.push(new Uint32Array(QUEUE_CHUNK_SIZE));
+    }
+    (queue[writeChunk] as Uint32Array)[writeOffset] = index;
+    writeOffset += 1;
+    queued += 1;
+  };
+  const dequeue = () => {
+    if (queued === 0) return -1;
+    const index = (queue[readChunk] as Uint32Array)[readOffset];
+    readOffset += 1;
+    queued -= 1;
+    if (readOffset === QUEUE_CHUNK_SIZE) {
+      queue[readChunk] = null;
+      readChunk += 1;
+      readOffset = 0;
+    }
+    return index;
+  };
+  const spread = (neighbor: number, nextLevel: number) => {
+    const cell = cells[neighbor];
+    if ((cell & BLOCK_LIGHT_OCCLUDER) !== 0 || (cell & BLOCK_LIGHT_MAX_LEVEL) >= nextLevel) {
+      return;
+    }
+    cells[neighbor] = nextLevel;
+    enqueue(neighbor);
+  };
+
+  opts?.onProgress?.("Lighting glowstone");
+  for (let i = 0; i < blockCount; i += 1) {
+    const block = packed ? null : build.blocks[i];
+    const x = packed ? packed.positions[i * 3] : block!.x;
+    const y = packed ? packed.positions[i * 3 + 1] : block!.y;
+    const z = packed ? packed.positions[i * 3 + 2] : block!.z;
+    const flags = packed ? packedFlags?.[packed.typeIds[i]] ?? 0 : flagsFor(block!.type);
+    const index =
+      x - minX + padding +
+      width * (z - minZ + padding + depth * (y - minY + padding));
+    if ((flags & BLOCK_LIGHT_OCCLUDER) !== 0) cells[index] |= BLOCK_LIGHT_OCCLUDER;
+    if ((flags & BLOCK_LIGHT_SOURCE) !== 0 && (cells[index] & BLOCK_LIGHT_MAX_LEVEL) === 0) {
+      cells[index] |= BLOCK_LIGHT_MAX_LEVEL;
+      enqueue(index);
+    }
+    if ((i + 1) % YIELD_EVERY === 0) await yieldToMainThread(opts?.signal);
+  }
+
+  let processed = 0;
+  while (queued > 0) {
+    const index = dequeue();
+    const nextLevel = (cells[index] & BLOCK_LIGHT_MAX_LEVEL) - 1;
+    if (nextLevel > 0) {
+      const y = Math.floor(index / plane);
+      const remainder = index - y * plane;
+      const z = Math.floor(remainder / width);
+      const x = remainder - z * width;
+      if (x > 0) spread(index - 1, nextLevel);
+      if (x + 1 < width) spread(index + 1, nextLevel);
+      if (z > 0) spread(index - width, nextLevel);
+      if (z + 1 < depth) spread(index + width, nextLevel);
+      if (y > 0) spread(index - plane, nextLevel);
+      if (y + 1 < height) spread(index + plane, nextLevel);
+    }
+    processed += 1;
+    if (processed % YIELD_EVERY === 0) await yieldToMainThread(opts?.signal);
+  }
+
+  return {
+    cells,
+    width,
+    height,
+    depth,
+    minX: minX - padding,
+    minY: minY - padding,
+    minZ: minZ - padding,
+    padding,
+  };
+}
+
+export function getExplorerBlockLight(
+  grid: ExplorerBlockLightGrid,
+  x: number,
+  y: number,
+  z: number,
+): number {
+  const localX = x - grid.minX;
+  const localY = y - grid.minY;
+  const localZ = z - grid.minZ;
+  if (
+    localX < 0 || localX >= grid.width ||
+    localY < 0 || localY >= grid.height ||
+    localZ < 0 || localZ >= grid.depth
+  ) {
+    return 0;
+  }
+  return grid.cells[localX + grid.width * (localZ + grid.depth * localY)] & BLOCK_LIGHT_MAX_LEVEL;
+}
+
+function enableExplorerBlockLight(material: THREE.MeshLambertMaterial) {
+  material.onBeforeCompile = (shader) => {
+    shader.vertexShader = shader.vertexShader
+      .replace(
+        "#include <color_pars_vertex>",
+        "#include <color_pars_vertex>\nattribute float explorerBlockLight;\nvarying float vExplorerBlockLight;",
+      )
+      .replace(
+        "#include <color_vertex>",
+        "#include <color_vertex>\nvExplorerBlockLight = explorerBlockLight;",
+      );
+    shader.fragmentShader = shader.fragmentShader
+      .replace(
+        "#include <color_pars_fragment>",
+        "#include <color_pars_fragment>\nvarying float vExplorerBlockLight;",
+      )
+      .replace(
+        "#include <emissivemap_fragment>",
+        "#include <emissivemap_fragment>\ntotalEmissiveRadiance += diffuseColor.rgb * vec3(1.0, 0.62, 0.32) * pow(vExplorerBlockLight, 1.6) * 1.2;",
+      );
+  };
+  material.customProgramCacheKey = () => "explorer-block-light-v1";
+  material.needsUpdate = true;
+}
+
+export async function applyExplorerBlockLighting(
+  root: THREE.Object3D,
+  bounds: THREE.Box3,
+  grid: ExplorerBlockLightGrid,
+  opts?: ExplorerLightingOptions,
+): Promise<void> {
+  const meshes: Array<THREE.Mesh<THREE.BufferGeometry, THREE.MeshLambertMaterial>> = [];
+  root.traverse((child) => {
+    if (child instanceof THREE.Mesh && child.material instanceof THREE.MeshLambertMaterial) {
+      meshes.push(child as THREE.Mesh<THREE.BufferGeometry, THREE.MeshLambertMaterial>);
+    }
+  });
+  if (meshes.length === 0) return;
+
+  opts?.onProgress?.("Applying glowstone light");
+  const worldMinX = bounds.min.x - grid.padding;
+  const worldMinY = bounds.min.y - grid.padding;
+  const worldMinZ = bounds.min.z - grid.padding;
+  const plane = grid.width * grid.depth;
+  let processed = 0;
+
+  for (const mesh of meshes) {
+    const positions = mesh.geometry.getAttribute("position");
+    const normals = mesh.geometry.getAttribute("normal");
+    if (!positions || !normals || positions.itemSize !== 3 || normals.itemSize !== 3) continue;
+    const positionArray = positions.array;
+    const normalArray = normals.array;
+    const values = new Uint8Array(positions.count);
+
+    for (let vertex = 0; vertex + 3 < positions.count; vertex += 4) {
+      const offset = vertex * 3;
+      const centerX =
+        (positionArray[offset] + positionArray[offset + 3] +
+          positionArray[offset + 6] + positionArray[offset + 9]) / 4;
+      const centerY =
+        (positionArray[offset + 1] + positionArray[offset + 4] +
+          positionArray[offset + 7] + positionArray[offset + 10]) / 4;
+      const centerZ =
+        (positionArray[offset + 2] + positionArray[offset + 5] +
+          positionArray[offset + 8] + positionArray[offset + 11]) / 4;
+      const x = Math.floor(centerX + Math.sign(normalArray[offset]) * 0.01 - worldMinX);
+      const y = Math.floor(centerY + Math.sign(normalArray[offset + 1]) * 0.01 - worldMinY);
+      const z = Math.floor(centerZ + Math.sign(normalArray[offset + 2]) * 0.01 - worldMinZ);
+      const level =
+        x >= 0 && x < grid.width &&
+        y >= 0 && y < grid.height &&
+        z >= 0 && z < grid.depth
+          ? grid.cells[x + grid.width * (z + grid.depth * y)] & BLOCK_LIGHT_MAX_LEVEL
+          : 0;
+      values.fill(Math.round((level / BLOCK_LIGHT_MAX_LEVEL) * 255), vertex, vertex + 4);
+      processed += 4;
+      if (processed % YIELD_EVERY === 0) await yieldToMainThread(opts?.signal);
+    }
+
+    mesh.geometry.setAttribute(
+      "explorerBlockLight",
+      new THREE.Uint8BufferAttribute(values, 1, true),
+    );
+    enableExplorerBlockLight(mesh.material);
+  }
+}
 
 export function renderExplorerBloomOverlay(
   renderer: { autoClear: boolean },
@@ -21,80 +317,18 @@ export function renderExplorerBloomOverlay(
   }
 }
 
-export function clusterExplorerEmissiveFaces(
-  positions: ArrayLike<number>,
-  cellSize = 8,
-): ExplorerLightCluster[] {
-  if (!Number.isFinite(cellSize) || cellSize <= 0) return [];
-  const clusters = new Map<string, ExplorerLightCluster>();
-
-  for (let i = 0; i + 11 < positions.length; i += 12) {
-    const x = (positions[i] + positions[i + 3] + positions[i + 6] + positions[i + 9]) / 4;
-    const y = (positions[i + 1] + positions[i + 4] + positions[i + 7] + positions[i + 10]) / 4;
-    const z = (positions[i + 2] + positions[i + 5] + positions[i + 8] + positions[i + 11]) / 4;
-    if (!Number.isFinite(x) || !Number.isFinite(y) || !Number.isFinite(z)) continue;
-    const ax = positions[i + 3] - positions[i];
-    const ay = positions[i + 4] - positions[i + 1];
-    const az = positions[i + 5] - positions[i + 2];
-    const bx = positions[i + 6] - positions[i];
-    const by = positions[i + 7] - positions[i + 1];
-    const bz = positions[i + 8] - positions[i + 2];
-    const normalX = ay * bz - az * by;
-    const normalY = az * bx - ax * bz;
-    const normalZ = ax * by - ay * bx;
-    const normalLength = Math.hypot(normalX, normalY, normalZ);
-    if (normalLength < 1e-6) continue;
-    const nx = Math.round(normalX / normalLength);
-    const ny = Math.round(normalY / normalLength);
-    const nz = Math.round(normalZ / normalLength);
-    const key = `${Math.floor(x / cellSize)},${Math.floor(y / cellSize)},${Math.floor(z / cellSize)},${nx},${ny},${nz}`;
-    const cluster = clusters.get(key);
-    if (cluster) {
-      cluster.x += x;
-      cluster.y += y;
-      cluster.z += z;
-      cluster.faces += 1;
-    } else {
-      clusters.set(key, { x, y, z, nx, ny, nz, faces: 1 });
-    }
-  }
-
-  return Array.from(clusters.values(), (cluster) => ({
-    x: cluster.x / cluster.faces,
-    y: cluster.y / cluster.faces,
-    z: cluster.z / cluster.faces,
-    nx: cluster.nx,
-    ny: cluster.ny,
-    nz: cluster.nz,
-    faces: cluster.faces,
-  }));
-}
-
-export function selectNearestExplorerLightClusters(
-  clusters: readonly ExplorerLightCluster[],
-  position: { x: number; y: number; z: number },
-  limit: number,
-  maxDistance: number,
-): ExplorerLightCluster[] {
-  const count = Math.max(0, Math.floor(limit));
-  if (count === 0 || !Number.isFinite(maxDistance) || maxDistance <= 0) return [];
-  const maxDistanceSquared = maxDistance * maxDistance;
-  const nearest: Array<{ cluster: ExplorerLightCluster; distanceSquared: number }> = [];
-
-  for (const cluster of clusters) {
-    const distanceSquared =
-      (cluster.x - position.x) ** 2 +
-      (cluster.y - position.y) ** 2 +
-      (cluster.z - position.z) ** 2;
-    if (distanceSquared > maxDistanceSquared) continue;
-    const index = nearest.findIndex((candidate) => distanceSquared < candidate.distanceSquared);
-    if (index < 0) {
-      if (nearest.length < count) nearest.push({ cluster, distanceSquared });
-    } else {
-      nearest.splice(index, 0, { cluster, distanceSquared });
-      if (nearest.length > count) nearest.pop();
-    }
-  }
-
-  return nearest.map(({ cluster }) => cluster);
+export function isExplorerSunRayVisible(
+  x: number,
+  y: number,
+  z: number,
+  margin = 1.2,
+): boolean {
+  return (
+    [x, y, z, margin].every(Number.isFinite) &&
+    margin > 0 &&
+    Math.abs(x) <= margin &&
+    Math.abs(y) <= margin &&
+    z >= -1 &&
+    z <= 1
+  );
 }

--- a/lib/voxel/explorerLighting.ts
+++ b/lib/voxel/explorerLighting.ts
@@ -1,0 +1,67 @@
+export type ExplorerLightCluster = {
+  x: number;
+  y: number;
+  z: number;
+  faces: number;
+};
+
+export function clusterExplorerEmissiveFaces(
+  positions: ArrayLike<number>,
+  cellSize = 8,
+): ExplorerLightCluster[] {
+  if (!Number.isFinite(cellSize) || cellSize <= 0) return [];
+  const clusters = new Map<string, ExplorerLightCluster>();
+
+  for (let i = 0; i + 11 < positions.length; i += 12) {
+    const x = (positions[i] + positions[i + 3] + positions[i + 6] + positions[i + 9]) / 4;
+    const y = (positions[i + 1] + positions[i + 4] + positions[i + 7] + positions[i + 10]) / 4;
+    const z = (positions[i + 2] + positions[i + 5] + positions[i + 8] + positions[i + 11]) / 4;
+    if (!Number.isFinite(x) || !Number.isFinite(y) || !Number.isFinite(z)) continue;
+    const key = `${Math.floor(x / cellSize)},${Math.floor(y / cellSize)},${Math.floor(z / cellSize)}`;
+    const cluster = clusters.get(key);
+    if (cluster) {
+      cluster.x += x;
+      cluster.y += y;
+      cluster.z += z;
+      cluster.faces += 1;
+    } else {
+      clusters.set(key, { x, y, z, faces: 1 });
+    }
+  }
+
+  return Array.from(clusters.values(), (cluster) => ({
+    x: cluster.x / cluster.faces,
+    y: cluster.y / cluster.faces,
+    z: cluster.z / cluster.faces,
+    faces: cluster.faces,
+  }));
+}
+
+export function selectNearestExplorerLightClusters(
+  clusters: readonly ExplorerLightCluster[],
+  position: { x: number; y: number; z: number },
+  limit: number,
+  maxDistance: number,
+): ExplorerLightCluster[] {
+  const count = Math.max(0, Math.floor(limit));
+  if (count === 0 || !Number.isFinite(maxDistance) || maxDistance <= 0) return [];
+  const maxDistanceSquared = maxDistance * maxDistance;
+  const nearest: Array<{ cluster: ExplorerLightCluster; distanceSquared: number }> = [];
+
+  for (const cluster of clusters) {
+    const distanceSquared =
+      (cluster.x - position.x) ** 2 +
+      (cluster.y - position.y) ** 2 +
+      (cluster.z - position.z) ** 2;
+    if (distanceSquared > maxDistanceSquared) continue;
+    const index = nearest.findIndex((candidate) => distanceSquared < candidate.distanceSquared);
+    if (index < 0) {
+      if (nearest.length < count) nearest.push({ cluster, distanceSquared });
+    } else {
+      nearest.splice(index, 0, { cluster, distanceSquared });
+      if (nearest.length > count) nearest.pop();
+    }
+  }
+
+  return nearest.map(({ cluster }) => cluster);
+}

--- a/lib/voxel/explorerViewBob.ts
+++ b/lib/voxel/explorerViewBob.ts
@@ -1,0 +1,21 @@
+const DEG_TO_RAD = Math.PI / 180;
+
+export type ExplorerViewBobTransform = {
+  x: number;
+  y: number;
+  roll: number;
+  pitch: number;
+};
+
+export function setExplorerViewBob(
+  target: ExplorerViewBobTransform,
+  walkDistance: number,
+  amount: number,
+) {
+  const phase = walkDistance * Math.PI;
+  const sway = Math.sin(phase);
+  target.x = sway * amount * 0.5;
+  target.y = -Math.abs(Math.cos(phase) * amount);
+  target.roll = sway * amount * 3 * DEG_TO_RAD;
+  target.pitch = Math.abs(Math.cos(phase - 0.2) * amount) * 5 * DEG_TO_RAD;
+}

--- a/tests/unit/voxel-explorer-build-id.test.ts
+++ b/tests/unit/voxel-explorer-build-id.test.ts
@@ -1,0 +1,15 @@
+import assert from "node:assert/strict";
+import { parseExplorerBuildId } from "@/lib/voxel/explorerBuildId";
+
+assert.deepEqual(parseExplorerBuildId("benchmark-build"), {
+  source: "benchmark",
+  id: "benchmark-build",
+});
+assert.deepEqual(parseExplorerBuildId("gallery:example-id"), {
+  source: "gallery",
+  id: "example-id",
+});
+assert.deepEqual(parseExplorerBuildId("gallery%3Aexample-id"), {
+  source: "gallery",
+  id: "example-id",
+});

--- a/tests/unit/voxel-explorer-collision.test.ts
+++ b/tests/unit/voxel-explorer-collision.test.ts
@@ -1,0 +1,50 @@
+import assert from "node:assert/strict";
+import {
+  EXPLORER_EYE_HEIGHT,
+  createExplorerCollisionWorld,
+  moveExplorerPlayerAxis,
+} from "@/lib/voxel/explorerCollision";
+import {
+  packVoxelBlocks,
+  type RenderableVoxelBuild,
+} from "@/lib/voxel/packedBlocks";
+
+const build: RenderableVoxelBuild = {
+  version: "1.0",
+  blocks: [
+    { x: 0, y: 0, z: 0, type: "stone" },
+    { x: 1, y: 0, z: 0, type: "water" },
+    { x: 2, y: 0, z: 0, type: "lava" },
+  ],
+};
+
+async function main() {
+  const world = await createExplorerCollisionWorld(build);
+
+  assert.equal(world.collides({ x: -1, y: EXPLORER_EYE_HEIGHT, z: 0 }), true);
+  assert.equal(world.collides({ x: 0, y: EXPLORER_EYE_HEIGHT, z: 0 }), false);
+  assert.equal(world.isInWater({ x: 0, y: EXPLORER_EYE_HEIGHT, z: 0 }), true);
+  assert.equal(world.collides({ x: 1, y: EXPLORER_EYE_HEIGHT, z: 0 }), false);
+  assert.equal(world.collides({ x: 3, y: EXPLORER_EYE_HEIGHT - 0.01, z: 0 }), true);
+
+  const packedWorld = await createExplorerCollisionWorld({
+    version: "1.0",
+    blocks: [],
+    packed: packVoxelBlocks(build.blocks),
+  });
+  assert.equal(packedWorld.collides({ x: -1, y: EXPLORER_EYE_HEIGHT, z: 0 }), true);
+  assert.equal(packedWorld.isInWater({ x: 0, y: EXPLORER_EYE_HEIGHT, z: 0 }), true);
+
+  const falling = { x: 3, y: EXPLORER_EYE_HEIGHT + 1, z: 0 };
+  assert.equal(moveExplorerPlayerAxis(world, falling, "y", -2), true);
+  assert.ok(Math.abs(falling.y - EXPLORER_EYE_HEIGHT) < 0.001);
+
+  const embedded = { x: -1, y: EXPLORER_EYE_HEIGHT, z: 0 };
+  assert.equal(moveExplorerPlayerAxis(world, embedded, "x", 0.2), true);
+  assert.equal(embedded.x, -1);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/tests/unit/voxel-explorer-collision.test.ts
+++ b/tests/unit/voxel-explorer-collision.test.ts
@@ -3,6 +3,7 @@ import {
   EXPLORER_EYE_HEIGHT,
   createExplorerCollisionWorld,
   moveExplorerPlayerAxis,
+  setExplorerMoveDirection,
 } from "@/lib/voxel/explorerCollision";
 import {
   packVoxelBlocks,
@@ -19,6 +20,15 @@ const build: RenderableVoxelBuild = {
 };
 
 async function main() {
+  const movement = { x: 0, y: 0, z: 0 };
+  const pitchedForward = { x: 0, y: 0.6, z: -0.8 };
+  setExplorerMoveDirection(movement, pitchedForward, { x: 1, y: 0, z: 0 }, 1, 0, 0);
+  assert.deepEqual(movement, pitchedForward);
+
+  setExplorerMoveDirection(movement, pitchedForward, { x: 1, y: 0, z: 0 }, 1, 0, 1);
+  assert.ok(Math.abs(Math.hypot(movement.x, movement.y, movement.z) - 1) < 1e-12);
+  assert.ok(movement.y > pitchedForward.y);
+
   const world = await createExplorerCollisionWorld(build);
 
   assert.equal(world.collides({ x: -1, y: EXPLORER_EYE_HEIGHT, z: 0 }), true);

--- a/tests/unit/voxel-explorer-integration.test.ts
+++ b/tests/unit/voxel-explorer-integration.test.ts
@@ -9,6 +9,7 @@ const leaderboard = read("components/leaderboard/ModelDetail.tsx");
 assert.match(read("app/layout.tsx"), /<VoxelExplorerProvider>/);
 assert.match(launcher, /Explore this build\?/);
 assert.match(launcher, /Step inside at block scale with keyboard and mouse\./);
+assert.match(launcher, /onKeyDown=\{\(event\) => event\.stopPropagation\(\)\}/);
 assert.match(viewerCard, /showBuildView && !explorerActive/);
 
 for (const path of [

--- a/tests/unit/voxel-explorer-integration.test.ts
+++ b/tests/unit/voxel-explorer-integration.test.ts
@@ -10,6 +10,7 @@ assert.match(read("app/layout.tsx"), /<VoxelExplorerProvider>/);
 assert.match(launcher, /Explore this build\?/);
 assert.match(launcher, /Step inside at block scale with keyboard and mouse\./);
 assert.match(launcher, /onKeyDown=\{\(event\) => event\.stopPropagation\(\)\}/);
+assert.match(read("components/voxel/VoxelExplorer.tsx"), /onClick=\{exit\}[\s\S]*?>\s*Exit\s*</);
 assert.match(viewerCard, /showBuildView && !explorerActive/);
 
 for (const path of [

--- a/tests/unit/voxel-explorer-integration.test.ts
+++ b/tests/unit/voxel-explorer-integration.test.ts
@@ -1,0 +1,25 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const read = (path: string) => readFileSync(path, "utf8");
+const launcher = read("components/voxel/VoxelExplorerLauncher.tsx");
+const viewerCard = read("components/voxel/VoxelViewerCard.tsx");
+
+assert.match(read("app/layout.tsx"), /<VoxelExplorerProvider>/);
+assert.match(launcher, /Explore this build\?/);
+assert.match(launcher, /Step inside at block scale with keyboard and mouse\./);
+assert.match(viewerCard, /showBuildView && !explorerActive/);
+
+for (const path of [
+  "components/sandbox/SandboxBenchmark.tsx",
+  "components/sandbox/SandboxLive.tsx",
+  "components/local/LocalLab.tsx",
+  "components/gallery/GalleryDetail.tsx",
+  "components/gallery/GalleryYours.tsx",
+]) {
+  assert.match(read(path), /explorer=/, `${path} must offer Explorer`);
+}
+
+assert.match(read("components/leaderboard/ModelDetail.tsx"), /VoxelExplorerLaunchButton/);
+assert.doesNotMatch(read("components/arena/Arena.tsx"), /explorer=|VoxelExplorerLaunchButton/);
+assert.doesNotMatch(read("components/lab/ProtectedBuildInspector.tsx"), /explorer=|VoxelExplorerLaunchButton/);

--- a/tests/unit/voxel-explorer-integration.test.ts
+++ b/tests/unit/voxel-explorer-integration.test.ts
@@ -4,6 +4,7 @@ import { readFileSync } from "node:fs";
 const read = (path: string) => readFileSync(path, "utf8");
 const launcher = read("components/voxel/VoxelExplorerLauncher.tsx");
 const viewerCard = read("components/voxel/VoxelViewerCard.tsx");
+const leaderboard = read("components/leaderboard/ModelDetail.tsx");
 
 assert.match(read("app/layout.tsx"), /<VoxelExplorerProvider>/);
 assert.match(launcher, /Explore this build\?/);
@@ -20,6 +21,7 @@ for (const path of [
   assert.match(read(path), /explorer=/, `${path} must offer Explorer`);
 }
 
-assert.match(read("components/leaderboard/ModelDetail.tsx"), /VoxelExplorerLaunchButton/);
+assert.match(leaderboard, /activeFullCachedBuild \? \(\s*<VoxelExplorerLaunchButton/);
+assert.match(leaderboard, /event\.key !== "Escape" \|\| explorerActive/);
 assert.doesNotMatch(read("components/arena/Arena.tsx"), /explorer=|VoxelExplorerLaunchButton/);
 assert.doesNotMatch(read("components/lab/ProtectedBuildInspector.tsx"), /explorer=|VoxelExplorerLaunchButton/);

--- a/tests/unit/voxel-explorer-lighting.test.ts
+++ b/tests/unit/voxel-explorer-lighting.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import {
   clusterExplorerEmissiveFaces,
+  renderExplorerBloomOverlay,
   selectNearestExplorerLightClusters,
 } from "@/lib/voxel/explorerLighting";
 
@@ -20,3 +21,9 @@ assert.deepEqual(
   [clusters[1]],
 );
 assert.deepEqual(selectNearestExplorerLightClusters(clusters, { x: 40, y: 0, z: 0 }, 2, 8), []);
+
+const renderer = { autoClear: true };
+renderExplorerBloomOverlay(renderer, () => assert.equal(renderer.autoClear, false));
+assert.equal(renderer.autoClear, true);
+assert.throws(() => renderExplorerBloomOverlay(renderer, () => { throw new Error("draw failed"); }));
+assert.equal(renderer.autoClear, true);

--- a/tests/unit/voxel-explorer-lighting.test.ts
+++ b/tests/unit/voxel-explorer-lighting.test.ts
@@ -1,5 +1,7 @@
 import assert from "node:assert/strict";
+import * as THREE from "three";
 import {
+  applyExplorerBlockLighting,
   createExplorerBlockLightGrid,
   getExplorerBlockLight,
   isExplorerSunRayVisible,
@@ -66,6 +68,32 @@ async function main() {
   assert.equal(renderer.autoClear, true);
   assert.throws(() => renderExplorerBloomOverlay(renderer, () => { throw new Error("draw failed"); }));
   assert.equal(renderer.autoClear, true);
+
+  const geometry = new THREE.BufferGeometry();
+  geometry.setAttribute("position", new THREE.Float32BufferAttribute([
+    2.5, -0.5, 0.5,
+    3.5, -0.5, 0.5,
+    3.5, 0.5, 0.5,
+    2.5, 0.5, 0.5,
+  ], 3));
+  geometry.setAttribute("normal", new THREE.Float32BufferAttribute([
+    0, 0, 1,
+    0, 0, 1,
+    0, 0, 1,
+    0, 0, 1,
+  ], 3));
+  const mesh = new THREE.Mesh(geometry, new THREE.MeshLambertMaterial());
+  await applyExplorerBlockLighting(
+    mesh,
+    new THREE.Box3(new THREE.Vector3(-0.5, -0.5, -0.5), new THREE.Vector3(20.5, 0.5, 0.5)),
+    open,
+  );
+  assert.deepEqual(
+    Array.from(mesh.geometry.getAttribute("explorerBlockLight").array),
+    [187, 170, 187, 204],
+  );
+  geometry.dispose();
+  mesh.material.dispose();
 }
 
 main().catch((error) => {

--- a/tests/unit/voxel-explorer-lighting.test.ts
+++ b/tests/unit/voxel-explorer-lighting.test.ts
@@ -60,6 +60,16 @@ async function main() {
     }),
     null,
   );
+  assert.equal(
+    await createExplorerBlockLightGrid({
+      version: "1.0",
+      blocks: [
+        { x: 0, y: 0, z: 0, type: "glowstone" },
+        { x: 511, y: 511, z: 511, type: "glowstone" },
+      ],
+    }),
+    null,
+  );
   assert.equal(isExplorerSunRayVisible(0, 0, 0), true);
   assert.equal(isExplorerSunRayVisible(1.3, 0, 0), false);
   assert.equal(isExplorerSunRayVisible(0, 0, 2), false);

--- a/tests/unit/voxel-explorer-lighting.test.ts
+++ b/tests/unit/voxel-explorer-lighting.test.ts
@@ -8,17 +8,19 @@ import {
 const positions = new Float32Array([
   0, 0, 0, 0, 1, 0, 0, 1, 1, 0, 0, 1,
   2, 0, 0, 2, 1, 0, 2, 1, 1, 2, 0, 1,
+  4, 0, 1, 4, 1, 1, 4, 1, 0, 4, 0, 0,
   16, 0, 0, 16, 1, 0, 16, 1, 1, 16, 0, 1,
 ]);
 
 const clusters = clusterExplorerEmissiveFaces(positions, 8);
-assert.equal(clusters.length, 2);
-assert.deepEqual(clusters[0], { x: 1, y: 0.5, z: 0.5, faces: 2 });
-assert.deepEqual(clusters[1], { x: 16, y: 0.5, z: 0.5, faces: 1 });
+assert.equal(clusters.length, 3);
+assert.deepEqual(clusters[0], { x: 1, y: 0.5, z: 0.5, nx: 1, ny: 0, nz: 0, faces: 2 });
+assert.deepEqual(clusters[1], { x: 4, y: 0.5, z: 0.5, nx: -1, ny: 0, nz: 0, faces: 1 });
+assert.deepEqual(clusters[2], { x: 16, y: 0.5, z: 0.5, nx: 1, ny: 0, nz: 0, faces: 1 });
 
 assert.deepEqual(
   selectNearestExplorerLightClusters(clusters, { x: 15, y: 0, z: 0 }, 1, 20),
-  [clusters[1]],
+  [clusters[2]],
 );
 assert.deepEqual(selectNearestExplorerLightClusters(clusters, { x: 40, y: 0, z: 0 }, 2, 8), []);
 

--- a/tests/unit/voxel-explorer-lighting.test.ts
+++ b/tests/unit/voxel-explorer-lighting.test.ts
@@ -3,6 +3,7 @@ import * as THREE from "three";
 import {
   applyExplorerBlockLighting,
   createExplorerBlockLightGrid,
+  getExplorerMeteorOpacity,
   getExplorerBlockLight,
   isExplorerSunRayVisible,
   renderExplorerBloomOverlay,
@@ -62,6 +63,10 @@ async function main() {
   assert.equal(isExplorerSunRayVisible(0, 0, 0), true);
   assert.equal(isExplorerSunRayVisible(1.3, 0, 0), false);
   assert.equal(isExplorerSunRayVisible(0, 0, 2), false);
+  assert.equal(getExplorerMeteorOpacity(0, 0, 1), 0);
+  assert.equal(getExplorerMeteorOpacity(0.5, 0, 1), 1);
+  assert.equal(getExplorerMeteorOpacity(1, 0, 1), 0);
+  assert.equal(getExplorerMeteorOpacity(1, 0, 0), 0);
 
   const renderer = { autoClear: true };
   renderExplorerBloomOverlay(renderer, () => assert.equal(renderer.autoClear, false));

--- a/tests/unit/voxel-explorer-lighting.test.ts
+++ b/tests/unit/voxel-explorer-lighting.test.ts
@@ -1,0 +1,22 @@
+import assert from "node:assert/strict";
+import {
+  clusterExplorerEmissiveFaces,
+  selectNearestExplorerLightClusters,
+} from "@/lib/voxel/explorerLighting";
+
+const positions = new Float32Array([
+  0, 0, 0, 0, 1, 0, 0, 1, 1, 0, 0, 1,
+  2, 0, 0, 2, 1, 0, 2, 1, 1, 2, 0, 1,
+  16, 0, 0, 16, 1, 0, 16, 1, 1, 16, 0, 1,
+]);
+
+const clusters = clusterExplorerEmissiveFaces(positions, 8);
+assert.equal(clusters.length, 2);
+assert.deepEqual(clusters[0], { x: 1, y: 0.5, z: 0.5, faces: 2 });
+assert.deepEqual(clusters[1], { x: 16, y: 0.5, z: 0.5, faces: 1 });
+
+assert.deepEqual(
+  selectNearestExplorerLightClusters(clusters, { x: 15, y: 0, z: 0 }, 1, 20),
+  [clusters[1]],
+);
+assert.deepEqual(selectNearestExplorerLightClusters(clusters, { x: 40, y: 0, z: 0 }, 2, 8), []);

--- a/tests/unit/voxel-explorer-lighting.test.ts
+++ b/tests/unit/voxel-explorer-lighting.test.ts
@@ -1,31 +1,74 @@
 import assert from "node:assert/strict";
 import {
-  clusterExplorerEmissiveFaces,
+  createExplorerBlockLightGrid,
+  getExplorerBlockLight,
+  isExplorerSunRayVisible,
   renderExplorerBloomOverlay,
-  selectNearestExplorerLightClusters,
 } from "@/lib/voxel/explorerLighting";
+import {
+  packVoxelBlocks,
+  type RenderableVoxelBuild,
+} from "@/lib/voxel/packedBlocks";
 
-const positions = new Float32Array([
-  0, 0, 0, 0, 1, 0, 0, 1, 1, 0, 0, 1,
-  2, 0, 0, 2, 1, 0, 2, 1, 1, 2, 0, 1,
-  4, 0, 1, 4, 1, 1, 4, 1, 0, 4, 0, 0,
-  16, 0, 0, 16, 1, 0, 16, 1, 1, 16, 0, 1,
-]);
+const openBuild: RenderableVoxelBuild = {
+  version: "1.0",
+  blocks: [
+    { x: 0, y: 0, z: 0, type: "glowstone" },
+    { x: 20, y: 0, z: 0, type: "glowstone" },
+    { x: 1, y: 0, z: 0, type: "glass" },
+  ],
+};
 
-const clusters = clusterExplorerEmissiveFaces(positions, 8);
-assert.equal(clusters.length, 3);
-assert.deepEqual(clusters[0], { x: 1, y: 0.5, z: 0.5, nx: 1, ny: 0, nz: 0, faces: 2 });
-assert.deepEqual(clusters[1], { x: 4, y: 0.5, z: 0.5, nx: -1, ny: 0, nz: 0, faces: 1 });
-assert.deepEqual(clusters[2], { x: 16, y: 0.5, z: 0.5, nx: 1, ny: 0, nz: 0, faces: 1 });
+async function main() {
+  const open = await createExplorerBlockLightGrid(openBuild);
+  assert.ok(open);
+  assert.equal(getExplorerBlockLight(open, 0, 0, 0), 15);
+  assert.equal(getExplorerBlockLight(open, 1, 0, 0), 14);
+  assert.equal(getExplorerBlockLight(open, 2, 0, 0), 13);
+  assert.equal(getExplorerBlockLight(open, 20, 0, 0), 15);
 
-assert.deepEqual(
-  selectNearestExplorerLightClusters(clusters, { x: 15, y: 0, z: 0 }, 1, 20),
-  [clusters[2]],
-);
-assert.deepEqual(selectNearestExplorerLightClusters(clusters, { x: 40, y: 0, z: 0 }, 2, 8), []);
+  const enclosure = await createExplorerBlockLightGrid({
+    version: "1.0",
+    blocks: [
+      { x: 0, y: 0, z: 0, type: "glowstone" },
+      { x: -1, y: 0, z: 0, type: "stone" },
+      { x: 1, y: 0, z: 0, type: "stone" },
+      { x: 0, y: -1, z: 0, type: "stone" },
+      { x: 0, y: 1, z: 0, type: "stone" },
+      { x: 0, y: 0, z: -1, type: "stone" },
+      { x: 0, y: 0, z: 1, type: "stone" },
+    ],
+  });
+  assert.ok(enclosure);
+  assert.equal(getExplorerBlockLight(enclosure, 2, 0, 0), 0);
 
-const renderer = { autoClear: true };
-renderExplorerBloomOverlay(renderer, () => assert.equal(renderer.autoClear, false));
-assert.equal(renderer.autoClear, true);
-assert.throws(() => renderExplorerBloomOverlay(renderer, () => { throw new Error("draw failed"); }));
-assert.equal(renderer.autoClear, true);
+  const packed = await createExplorerBlockLightGrid({
+    version: "1.0",
+    blocks: [],
+    packed: packVoxelBlocks(openBuild.blocks),
+  });
+  assert.ok(packed);
+  assert.equal(getExplorerBlockLight(packed, 2, 0, 0), 13);
+
+  assert.equal(
+    await createExplorerBlockLightGrid({
+      version: "1.0",
+      blocks: [{ x: 0, y: 0, z: 0, type: "stone" }],
+    }),
+    null,
+  );
+  assert.equal(isExplorerSunRayVisible(0, 0, 0), true);
+  assert.equal(isExplorerSunRayVisible(1.3, 0, 0), false);
+  assert.equal(isExplorerSunRayVisible(0, 0, 2), false);
+
+  const renderer = { autoClear: true };
+  renderExplorerBloomOverlay(renderer, () => assert.equal(renderer.autoClear, false));
+  assert.equal(renderer.autoClear, true);
+  assert.throws(() => renderExplorerBloomOverlay(renderer, () => { throw new Error("draw failed"); }));
+  assert.equal(renderer.autoClear, true);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/tests/unit/voxel-explorer-view-bob.test.ts
+++ b/tests/unit/voxel-explorer-view-bob.test.ts
@@ -1,0 +1,21 @@
+import assert from "node:assert/strict";
+import {
+  setExplorerViewBob,
+  type ExplorerViewBobTransform,
+} from "@/lib/voxel/explorerViewBob";
+
+const bob: ExplorerViewBobTransform = { x: 0, y: 0, roll: 0, pitch: 0 };
+
+setExplorerViewBob(bob, 0, 0.1);
+assert.equal(bob.x, 0);
+assert.equal(bob.y, -0.1);
+assert.equal(bob.roll, 0);
+assert.ok(bob.pitch > 0);
+
+setExplorerViewBob(bob, 0.5, 0.1);
+assert.ok(Math.abs(bob.x - 0.05) < 1e-12);
+assert.ok(Math.abs(bob.y) < 1e-12);
+assert.ok(bob.roll > 0);
+
+setExplorerViewBob(bob, 1, 0);
+assert.equal(Math.hypot(bob.x, bob.y, bob.roll, bob.pitch), 0);


### PR DESCRIPTION
## Summary

- add Minecraft-scale build exploration with grounded movement, noclip, and cinematic day and night lighting
- expose the shared Explore launch flow in ordinary build viewers while keeping Arena unchanged
- support benchmark, Gallery, saved, imported, and local builds

## Validation

- TypeScript typecheck
- targeted ESLint
- five focused Explorer test files
- production build
- final tree matches the Alpha-tested tree

*PR written by Codex*