### PR TITLE
feat(gallery): publish official prompt retests

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ The full FAQ is available at **[minebench.ai/faq](https://minebench.ai/faq)**. E
 * [How do grid size, block limits, and different leaderboard settings work?](https://minebench.ai/faq#how-do-grid-size-block-limits-and-leaderboard-settings-work)
 * [Why not add more prompts, grid sizes, block-limited settings, and other evaluation modes?](https://minebench.ai/faq#why-not-add-more-evaluation-modes)
 * [Are generations one-shot?](https://minebench.ai/faq#are-generations-one-shot)
+* [How does MineBench account for nondeterminism?](https://minebench.ai/faq#how-does-minebench-account-for-nondeterminism)
 * [How does the Gallery shape the benchmark?](https://minebench.ai/faq#how-does-the-gallery-shape-the-benchmark)
 
 ### Using MineBench

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ The full FAQ is available at **[minebench.ai/faq](https://minebench.ai/faq)**. E
 * [How do grid size, block limits, and different leaderboard settings work?](https://minebench.ai/faq#how-do-grid-size-block-limits-and-leaderboard-settings-work)
 * [Why not add more prompts, grid sizes, block-limited settings, and other evaluation modes?](https://minebench.ai/faq#why-not-add-more-evaluation-modes)
 * [Are generations one-shot?](https://minebench.ai/faq#are-generations-one-shot)
+* [How does the Gallery shape the benchmark?](https://minebench.ai/faq#how-does-the-gallery-shape-the-benchmark)
 
 ### Using MineBench
 

--- a/app/api/gallery/candidates/[publicId]/route.ts
+++ b/app/api/gallery/candidates/[publicId]/route.ts
@@ -1,7 +1,7 @@
 import { getAuthenticatedUserId } from "@/lib/auth/request";
 import { readArenaSessionId } from "@/lib/arena/session";
 import { apiJson, apiServiceError } from "@/lib/gallery/api";
-import { GalleryServiceError, getGalleryCandidate, removeGalleryCandidate } from "@/lib/gallery/service";
+import { GalleryServiceError, getGalleryCandidate, normalizeGallerySort, removeGalleryCandidate } from "@/lib/gallery/service";
 
 export const runtime = "nodejs";
 
@@ -11,7 +11,7 @@ export async function GET(request: Request, context: { params: Promise<{ publicI
     sessionId: readArenaSessionId(request.headers.get("cookie")),
     userId: await getAuthenticatedUserId(request),
     examplesCursor: url.searchParams.get("examplesCursor"),
-    navigationSort: url.searchParams.get("sort") === "new" ? "new" : "top",
+    navigationSort: normalizeGallerySort(url.searchParams.get("sort")),
   });
   return candidate
     ? apiJson({ candidate })

--- a/app/api/gallery/candidates/route.ts
+++ b/app/api/gallery/candidates/route.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 import { getAuthenticatedUserId } from "@/lib/auth/request";
 import { readArenaSessionId } from "@/lib/arena/session";
 import { apiJson, apiServiceError } from "@/lib/gallery/api";
-import { listGalleryCandidates, submitGalleryCandidate } from "@/lib/gallery/service";
+import { listGalleryCandidates, normalizeGallerySort, submitGalleryCandidate } from "@/lib/gallery/service";
 
 export const runtime = "nodejs";
 
@@ -19,7 +19,7 @@ export async function GET(request: Request) {
   const limit = Number.parseInt(url.searchParams.get("limit") ?? "24", 10);
   try {
     return apiJson(await listGalleryCandidates({
-      sort: url.searchParams.get("sort") === "new" ? "new" : "top",
+      sort: normalizeGallerySort(url.searchParams.get("sort")),
       cursor: url.searchParams.get("cursor"),
       limit: Number.isFinite(limit) ? limit : 24,
       query: url.searchParams.get("q"),

--- a/app/gallery/[publicId]/page.tsx
+++ b/app/gallery/[publicId]/page.tsx
@@ -3,7 +3,7 @@ import { cookies } from "next/headers";
 import { notFound } from "next/navigation";
 import { GalleryDetail } from "@/components/gallery/GalleryDetail";
 import { ARENA_SESSION_COOKIE } from "@/lib/arena/session";
-import { getGalleryCandidate } from "@/lib/gallery/service";
+import { getGalleryCandidate, normalizeGallerySort } from "@/lib/gallery/service";
 import { getCurrentAccount } from "@/lib/auth/account";
 
 export const dynamic = "force-dynamic";
@@ -33,7 +33,7 @@ export default async function GalleryDetailPage({
     cookies(),
     getCurrentAccount().catch(() => null),
   ]);
-  const sort = query.sort === "new" ? "new" : "top";
+  const sort = normalizeGallerySort(query.sort);
   const candidate = await getGalleryCandidate(route.publicId, {
     sessionId: cookieStore.get(ARENA_SESSION_COOKIE)?.value ?? null,
     userId: account?.id,

--- a/app/gallery/loading.tsx
+++ b/app/gallery/loading.tsx
@@ -22,15 +22,16 @@ export default function GalleryLoading() {
       </header>
 
       <div className="mt-10 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-        <nav className="flex items-center gap-7" aria-label="Gallery sorting">
+        <nav className="flex items-center gap-7" aria-label="Gallery views">
+          <span className="relative inline-flex min-h-11 items-center text-sm capitalize text-muted">
+            Official
+          </span>
+          <span aria-hidden="true" className="h-5 w-px bg-border" />
           <span className="relative inline-flex min-h-11 items-center text-sm font-semibold capitalize text-fg after:absolute after:inset-x-0 after:bottom-0 after:h-0.5 after:bg-fg">
             Top
           </span>
           <span className="relative inline-flex min-h-11 items-center text-sm capitalize text-muted">
             New
-          </span>
-          <span className="relative inline-flex min-h-11 items-center text-sm capitalize text-muted">
-            Official
           </span>
         </nav>
 

--- a/app/gallery/loading.tsx
+++ b/app/gallery/loading.tsx
@@ -29,6 +29,9 @@ export default function GalleryLoading() {
           <span className="relative inline-flex min-h-11 items-center text-sm capitalize text-muted">
             New
           </span>
+          <span className="relative inline-flex min-h-11 items-center text-sm capitalize text-muted">
+            Official
+          </span>
         </nav>
 
         <div className="relative w-full sm:w-80 lg:w-96">

--- a/app/gallery/page.tsx
+++ b/app/gallery/page.tsx
@@ -3,7 +3,7 @@ import { cookies } from "next/headers";
 import { GalleryExplore } from "@/components/gallery/GalleryExplore";
 import { ARENA_SESSION_COOKIE } from "@/lib/arena/session";
 import { getCurrentAccount } from "@/lib/auth/account";
-import { listGalleryCandidates } from "@/lib/gallery/service";
+import { listGalleryCandidates, normalizeGallerySort } from "@/lib/gallery/service";
 
 export const dynamic = "force-dynamic";
 
@@ -19,7 +19,7 @@ export const metadata: Metadata = {
 };
 
 export default async function GalleryPage({ searchParams }: { searchParams: Promise<{ sort?: string }> }) {
-  const sort = (await searchParams).sort === "new" ? "new" : "top";
+  const sort = normalizeGallerySort((await searchParams).sort);
   const [cookieStore, account] = await Promise.all([
     cookies(),
     getCurrentAccount().catch(() => null),

--- a/components/gallery/GalleryDetail.tsx
+++ b/components/gallery/GalleryDetail.tsx
@@ -39,6 +39,10 @@ type ExampleViewerState = {
 };
 
 const MAX_COMPARISON_EXAMPLES = 4;
+const RUN_DATE_FORMAT = new Intl.DateTimeFormat("en-US", {
+  dateStyle: "medium",
+  timeZone: "UTC",
+});
 
 function galleryDetailHref(publicId: string, sort: "top" | "new") {
   return `/gallery/${publicId}${sort === "new" ? "?sort=new" : ""}`;
@@ -368,7 +372,7 @@ export function GalleryDetail({ candidate }: { candidate: GalleryDetailPayload }
     return (
       <VoxelViewerCard
         title={example.model.label}
-        subtitle={`By ${example.attribution}`}
+        subtitle={`${example.attribution} · ${RUN_DATE_FORMAT.format(new Date(example.runAt))}`}
         voxelBuild={build}
         expectedBlockCount={example.blockCount ?? undefined}
         jsonBytes={example.jsonBytes}
@@ -441,7 +445,7 @@ export function GalleryDetail({ candidate }: { candidate: GalleryDetailPayload }
       </nav>
 
       <header className="mt-6 max-w-5xl sm:mt-8">
-        <div className="flex flex-wrap items-center gap-3 text-xs uppercase tracking-[0.12em] text-muted"><span>By {candidate.attribution}</span>{candidate.selected ? <span className="text-accent">Selected</span> : null}</div>
+        <div className="flex flex-wrap items-center gap-3 text-xs uppercase tracking-[0.12em] text-muted"><span>By {candidate.attribution}</span>{candidate.selected ? <span className="text-accent">Official prompt</span> : null}</div>
         <h1 className="mt-3 text-balance font-display text-3xl font-semibold leading-tight tracking-tight text-fg sm:text-4xl lg:text-5xl">{candidate.prompt}</h1>
         <div className="mt-6 flex flex-wrap items-center gap-2">
           <GalleryVoteButton candidateId={candidate.id} initialCount={candidate.upvoteCount} initialUpvoted={candidate.upvoted} />
@@ -578,7 +582,9 @@ export function GalleryDetail({ candidate }: { candidate: GalleryDetailPayload }
                       ) : null}
                       <div className="p-3">
                         <p className="truncate text-sm font-medium text-fg">{example.model.label}</p>
-                        <p className="mt-1 truncate text-xs text-muted">{example.attribution}</p>
+                        <p className="mt-1 truncate text-xs text-muted">
+                          {example.attribution} · <time dateTime={example.runAt}>{RUN_DATE_FORMAT.format(new Date(example.runAt))}</time>
+                        </p>
                         <p className="mt-2 flex flex-wrap gap-x-2 font-mono text-[10px] text-muted">
                           {example.blockCount != null ? <span>{example.blockCount.toLocaleString()} blocks</span> : null}
                           {formatBuildJsonSize(example.jsonBytes) ? <span>{formatBuildJsonSize(example.jsonBytes)} JSON</span> : null}

--- a/components/gallery/GalleryDetail.tsx
+++ b/components/gallery/GalleryDetail.tsx
@@ -14,6 +14,8 @@ import { readBuildVariantPayload } from "@/lib/arena/clientBuildResponse";
 import type { GalleryCandidatePayload, GalleryExamplePayload } from "@/lib/gallery/service";
 import { formatBuildDuration, formatBuildJsonSize } from "@/lib/buildMetrics";
 
+type GallerySort = "top" | "new" | "official";
+
 const SandboxGifExportButton = dynamic(
   () => import("@/components/sandbox/SandboxGifExportButton").then((module) => module.SandboxGifExportButton),
   {
@@ -26,7 +28,7 @@ type GalleryDetailPayload = GalleryCandidatePayload & {
   examples: GalleryExamplePayload[];
   nextExamplesCursor: string | null;
   navigation: {
-    sort: "top" | "new";
+    sort: GallerySort;
     previousId: string | null;
     nextId: string | null;
   } | null;
@@ -44,8 +46,12 @@ const RUN_DATE_FORMAT = new Intl.DateTimeFormat("en-US", {
   timeZone: "UTC",
 });
 
-function galleryDetailHref(publicId: string, sort: "top" | "new") {
-  return `/gallery/${publicId}${sort === "new" ? "?sort=new" : ""}`;
+function gallerySortHref(sort?: GallerySort) {
+  return sort === "top" || !sort ? "/gallery" : `/gallery?sort=${sort}`;
+}
+
+function galleryDetailHref(publicId: string, sort: GallerySort) {
+  return `/gallery/${publicId}${sort === "top" ? "" : `?sort=${sort}`}`;
 }
 
 function GalleryNavigationArrow({
@@ -55,7 +61,7 @@ function GalleryNavigationArrow({
 }: {
   direction: "previous" | "next";
   publicId: string | null;
-  sort: "top" | "new";
+  sort: GallerySort;
 }) {
   const previous = direction === "previous";
   const label = previous ? "Previous build" : "Next build";
@@ -428,11 +434,12 @@ export function GalleryDetail({ candidate }: { candidate: GalleryDetailPayload }
         jsonBytes: example.jsonBytes,
       }))
     : [];
+  const longPrompt = candidate.prompt.length > 140;
 
   return (
     <article className="mb-fade-in mx-auto w-full max-w-7xl py-4 sm:py-8">
       <nav aria-label="Gallery navigation" className="flex items-center justify-between gap-4">
-        <Link href={navigation?.sort === "new" ? "/gallery?sort=new" : "/gallery"} className="group inline-flex min-h-11 items-center gap-2 text-sm font-medium text-muted transition-colors hover:text-fg motion-reduce:transition-none">
+        <Link href={gallerySortHref(navigation?.sort)} className="group inline-flex min-h-11 items-center gap-2 text-sm font-medium text-muted transition-colors hover:text-fg motion-reduce:transition-none">
           <span aria-hidden="true" className="transition-transform duration-200 group-hover:-translate-x-0.5 motion-reduce:transform-none motion-reduce:transition-none">←</span>
           Gallery
         </Link>
@@ -444,9 +451,9 @@ export function GalleryDetail({ candidate }: { candidate: GalleryDetailPayload }
         ) : null}
       </nav>
 
-      <header className="mt-6 max-w-5xl sm:mt-8">
+      <header className="mt-6 max-w-4xl sm:mt-8">
         <div className="flex flex-wrap items-center gap-3 text-xs uppercase tracking-[0.12em] text-muted"><span>By {candidate.attribution}</span>{candidate.selected ? <span className="text-accent">Official prompt</span> : null}</div>
-        <h1 className="mt-3 text-balance font-display text-3xl font-semibold leading-tight tracking-tight text-fg sm:text-4xl lg:text-5xl">{candidate.prompt}</h1>
+        <h1 className={`mt-3 text-balance font-display font-semibold leading-tight tracking-tight text-fg ${longPrompt ? "text-2xl sm:text-3xl lg:text-4xl" : "text-3xl sm:text-4xl lg:text-5xl"}`}>{candidate.prompt}</h1>
         <div className="mt-6 flex flex-wrap items-center gap-2">
           <GalleryVoteButton candidateId={candidate.id} initialCount={candidate.upvoteCount} initialUpvoted={candidate.upvoted} />
           <Link href={`/sandbox?mode=live&prompt=${encodeURIComponent(candidate.prompt)}`} className="mb-btn mb-btn-primary h-11">Use prompt</Link>
@@ -456,7 +463,7 @@ export function GalleryDetail({ candidate }: { candidate: GalleryDetailPayload }
       {actionError ? <p role="alert" className="mt-5 text-sm text-danger">{actionError}</p> : null}
 
       {selected ? (
-        <section className="mt-10 grid gap-6 sm:mt-12 lg:grid-cols-[minmax(0,1fr)_18rem] lg:items-start" aria-labelledby="viewer-title">
+        <section className="mt-8 grid gap-6 sm:mt-10 lg:grid-cols-[minmax(0,1fr)_18rem] lg:items-start" aria-labelledby="viewer-title">
           {selectedExamples.length > 1 ? (
             <div className="min-w-0 self-start">
               <div className="mb-3 flex min-h-9 flex-wrap items-center justify-between gap-3">

--- a/components/gallery/GalleryExplore.tsx
+++ b/components/gallery/GalleryExplore.tsx
@@ -9,6 +9,8 @@ import { GalleryVoteButton } from "@/components/gallery/GalleryVoteButton";
 import { VoxelEmptyState } from "@/components/voxel/VoxelEmptyState";
 import { formatBuildDuration, formatBuildJsonSize } from "@/lib/buildMetrics";
 
+type GallerySort = "top" | "new" | "official";
+
 export function GalleryCardSkeleton({ delayed = false }: { delayed?: boolean }) {
   return (
     <article
@@ -53,7 +55,7 @@ export function GallerySkeletonGrid({ count = 8 }: { count?: number }) {
   );
 }
 
-function galleryCandidatesUrl(sort: "top" | "new", query: string, cursor?: string) {
+function galleryCandidatesUrl(sort: GallerySort, query: string, cursor?: string) {
   const params = new URLSearchParams({ sort });
   if (query) params.set("q", query);
   if (cursor) params.set("cursor", cursor);
@@ -145,7 +147,7 @@ function GalleryCard({
 }: {
   candidate: GalleryCandidatePayload;
   delayed: boolean;
-  sort: "top" | "new";
+  sort: GallerySort;
 }) {
   const modelsTooltipId = useId();
   const [coverLoaded, setCoverLoaded] = useState(false);
@@ -170,7 +172,7 @@ function GalleryCard({
         aria-hidden={!previewsReady || undefined}
         className={`group [grid-area:1/1] flex min-w-0 flex-col overflow-hidden rounded-md border border-border/80 bg-card/10 transition-[border-color,background-color] duration-200 ease-out hover:border-accent/35 hover:bg-card/20 motion-reduce:transition-none ${previewsReady ? `mb-card-enter ${delayed ? "mb-card-enter-delay" : ""}` : "invisible pointer-events-none"}`}
       >
-      <Link href={`/gallery/${candidate.id}${sort === "new" ? "?sort=new" : ""}`} className="block focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-accent/50">
+      <Link href={`/gallery/${candidate.id}${sort === "top" ? "" : `?sort=${sort}`}`} className="block focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-accent/50">
         {candidate.cover?.previewUrl ? (
           <div className="relative aspect-[4/3] overflow-hidden bg-bg/45">
             <Image
@@ -246,7 +248,7 @@ export function GalleryExplore({
 }: {
   initialItems: GalleryCandidatePayload[];
   initialCursor: string | null;
-  sort: "top" | "new";
+  sort: GallerySort;
   signedIn: boolean;
   hasNickname: boolean;
   suspended: boolean;
@@ -304,7 +306,7 @@ export function GalleryExplore({
         loadedSortRef.current = requestSort;
         loadedQueryRef.current = normalizedQuery;
         if (sortChanged) {
-          window.history.replaceState(window.history.state, "", requestSort === "new" ? "/gallery?sort=new" : "/gallery");
+          window.history.replaceState(window.history.state, "", requestSort === "top" ? "/gallery" : `/gallery?sort=${requestSort}`);
         }
       } catch {
         if (!controller.signal.aborted && requestId === firstPageRequestRef.current) {
@@ -343,7 +345,7 @@ export function GalleryExplore({
     return () => window.removeEventListener("keydown", handleKeyDown);
   }, []);
 
-  async function changeSort(nextSort: "top" | "new") {
+  async function changeSort(nextSort: GallerySort) {
     if (nextSort === activeSort || loading || loadingMore) return;
     requestedSortRef.current = nextSort;
     const requestId = ++firstPageRequestRef.current;
@@ -361,7 +363,7 @@ export function GalleryExplore({
       activeSortRef.current = nextSort;
       loadedSortRef.current = nextSort;
       loadedQueryRef.current = query;
-      window.history.replaceState(window.history.state, "", nextSort === "new" ? "/gallery?sort=new" : "/gallery");
+      window.history.replaceState(window.history.state, "", nextSort === "top" ? "/gallery" : `/gallery?sort=${nextSort}`);
     } catch {
       if (requestId === firstPageRequestRef.current) {
         requestedSortRef.current = activeSortRef.current;
@@ -415,7 +417,7 @@ export function GalleryExplore({
 
       <div className="mt-10 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
         <nav className="flex items-center gap-7" aria-label="Gallery sorting">
-          {(["top", "new"] as const).map((option) => (
+          {(["top", "new", "official"] as const).map((option) => (
             <button
               key={option}
               type="button"

--- a/components/gallery/GalleryExplore.tsx
+++ b/components/gallery/GalleryExplore.tsx
@@ -3,7 +3,7 @@
 import Image from "next/image";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { useEffect, useDeferredValue, useId, useRef, useState } from "react";
+import { Fragment, useEffect, useDeferredValue, useId, useRef, useState } from "react";
 import type { GalleryCandidatePayload } from "@/lib/gallery/service";
 import { GalleryVoteButton } from "@/components/gallery/GalleryVoteButton";
 import { VoxelEmptyState } from "@/components/voxel/VoxelEmptyState";
@@ -416,18 +416,20 @@ export function GalleryExplore({
       </header>
 
       <div className="mt-10 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-        <nav className="flex items-center gap-7" aria-label="Gallery sorting">
-          {(["top", "new", "official"] as const).map((option) => (
-            <button
-              key={option}
-              type="button"
-              disabled={loading || loadingMore}
-              aria-current={activeSort === option ? "page" : undefined}
-              className={`relative inline-flex min-h-11 items-center text-sm capitalize transition-colors after:absolute after:inset-x-0 after:bottom-0 after:h-0.5 after:origin-left after:bg-fg after:transition-transform after:duration-200 after:ease-out motion-reduce:transition-none motion-reduce:after:transition-none ${activeSort === option ? "font-semibold text-fg after:scale-x-100" : "text-muted after:scale-x-0 hover:text-fg"}`}
-              onClick={() => void changeSort(option)}
-            >
-              {option}
-            </button>
+        <nav className="flex items-center gap-7" aria-label="Gallery views">
+          {(["official", "top", "new"] as const).map((option) => (
+            <Fragment key={option}>
+              {option === "top" ? <span aria-hidden="true" className="h-5 w-px bg-border" /> : null}
+              <button
+                type="button"
+                disabled={loading || loadingMore}
+                aria-current={activeSort === option ? "page" : undefined}
+                className={`relative inline-flex min-h-11 items-center text-sm capitalize transition-colors after:absolute after:inset-x-0 after:bottom-0 after:h-0.5 after:origin-left after:bg-fg after:transition-transform after:duration-200 after:ease-out motion-reduce:transition-none motion-reduce:after:transition-none ${activeSort === option ? "font-semibold text-fg after:scale-x-100" : "text-muted after:scale-x-0 hover:text-fg"}`}
+                onClick={() => void changeSort(option)}
+              >
+                {option}
+              </button>
+            </Fragment>
           ))}
         </nav>
 
@@ -471,6 +473,15 @@ export function GalleryExplore({
           )}
         </div>
       </div>
+
+      {activeSort === "official" ? (
+        <p className="mt-3 max-w-3xl text-sm leading-6 text-muted">
+          Official prompts are part of the benchmark. Rerun one and share the result to reveal run-to-run variation and track how models change over time.{" "}
+          <Link href="/faq#how-does-minebench-account-for-nondeterminism" className="font-medium text-fg underline decoration-border underline-offset-4 transition-colors hover:decoration-fg motion-reduce:transition-none">
+            Why reruns matter
+          </Link>
+        </p>
+      ) : null}
 
       <div
         key={activeSort}

--- a/components/gallery/GalleryExplore.tsx
+++ b/components/gallery/GalleryExplore.tsx
@@ -193,7 +193,7 @@ function GalleryCard({
         <div className="flex flex-col gap-3 p-5 pb-0">
           <div className="flex items-center justify-between gap-3 text-xs text-muted">
             <span>{candidate.attribution}</span>
-            {candidate.selected ? <span className="font-medium uppercase tracking-[0.12em] text-accent">Selected</span> : null}
+            {candidate.selected ? <span className="font-medium uppercase tracking-[0.12em] text-accent">Official prompt</span> : null}
           </div>
           <h2 className="line-clamp-3 text-balance text-xl font-semibold leading-snug tracking-tight text-fg transition-colors group-hover:text-accent motion-reduce:transition-none">{candidate.prompt}</h2>
         </div>

--- a/docs/gallery.md
+++ b/docs/gallery.md
@@ -9,5 +9,12 @@ Gallery is MineBench's public collection of community prompts and builds.
 
 Saved builds remain private until their owner adds them to Gallery. Gallery
 votes and examples are separate from Arena rankings and benchmark results.
+MineBench reviews the highest-voted prompt proposals and can promote them into
+the official benchmark; votes guide that editorial decision rather than
+changing the benchmark automatically.
+
+The MineBench account also publishes new runs of existing official prompts.
+Each example keeps its original run date, so the Gallery can show later retests
+and run-to-run variation without replacing the canonical benchmark build.
 
 See [Architecture](./architecture.md) for the data and generation flow.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -190,6 +190,17 @@ Saved generations are private, account-owned Sandbox results. Gallery metadata a
 
 `GET /api/admin/status` includes queue age, failed jobs, stored bytes, pending object deletions, purge backlog, and email delivery failures. `GET /api/admin/gallery/purge` accepts `ADMIN_TOKEN` or `CRON_SECRET` and is scheduled daily.
 
+To publish an existing finalized official-prompt rerun under the MineBench
+account, validate the local artifact and benchmark ledger first:
+
+```bash
+pnpm gallery:import --prompt steampunk --model gemini-3-1-pro
+```
+
+The command is read-only unless `--yes` is added. A confirmed import creates or
+reuses a saved generation, publishes it as a dated Gallery example, and marks
+the candidate as an official prompt. It does not replace the benchmark build.
+
 ### Admin Routes
 
 Bearer `ADMIN_TOKEN` required.

--- a/lib/custom-builds/generateJob.ts
+++ b/lib/custom-builds/generateJob.ts
@@ -45,7 +45,14 @@ type GeneratedBuildResult = {
   warnings: string[];
   blockCount: number;
   generationTimeMs: number | null;
+  completedAt?: Date;
+  sourceArtifactSha256?: string;
 };
+
+export type ImportedCustomBuildResult = Required<Pick<
+  GeneratedBuildResult,
+  "build" | "warnings" | "blockCount" | "generationTimeMs" | "completedAt" | "sourceArtifactSha256"
+>>;
 
 const CUSTOM_BUILD_MODEL_MAX_ATTEMPTS = 2;
 const CUSTOM_BUILD_PROVIDER_TIMEOUT_MS = 90 * 60 * 1000;
@@ -397,6 +404,7 @@ export async function runCustomBuildGenerateJob(
     signal?: AbortSignal;
     acquireBuildProcessing?: () => Promise<() => void>;
     beforeSynchronousArtifactPackaging?: () => Promise<void> | void;
+    importedBuild?: ImportedCustomBuildResult;
   } = {},
 ): Promise<void> {
   const customBuild = await prisma.customBuild.findUnique({
@@ -415,11 +423,13 @@ export async function runCustomBuildGenerateJob(
     data: {
       status: "running",
       startedAt: customBuild.startedAt ?? new Date(),
-      currentStage: "generating",
+      currentStage: opts.importedBuild ? "finalizing" : "generating",
     },
   });
   if (started.count !== 1) throw new CustomBuildLeaseLostError();
-  emitCustomBuildEvent(customBuild.id, "started", { stage: "generating" });
+  emitCustomBuildEvent(customBuild.id, "started", {
+    stage: opts.importedBuild ? "finalizing" : "generating",
+  });
 
   let artifactsPersisted = false;
   try {
@@ -428,8 +438,8 @@ export async function runCustomBuildGenerateJob(
     } catch (error) {
       throw new CustomBuildArtifactPersistenceError(error);
     }
-    const recovered = await recoverStoredBuild(customBuild, opts);
-    const generated = recovered ?? await generateBuild(customBuild, job, opts);
+    const recovered = opts.importedBuild ? null : await recoverStoredBuild(customBuild, opts);
+    const generated = opts.importedBuild ?? recovered ?? await generateBuild(customBuild, job, opts);
     if (recovered) emitCustomBuildEvent(customBuild.id, "recovered", { stage: "finalizing" });
     throwIfCustomBuildLeaseLost(opts.signal);
     await opts.beforeSynchronousArtifactPackaging?.();
@@ -551,7 +561,7 @@ export async function runCustomBuildGenerateJob(
         data: {
           status: "succeeded",
           currentStage: "complete",
-          completedAt: new Date(),
+          completedAt: generated.completedAt ?? new Date(),
           blockCount: generated.blockCount,
           generationTimeMs: generated.generationTimeMs,
           warnings: generated.warnings,
@@ -559,6 +569,9 @@ export async function runCustomBuildGenerateJob(
             blockCount: generated.blockCount,
             generationTimeMs: generated.generationTimeMs,
             warnings: generated.warnings,
+            ...(generated.sourceArtifactSha256
+              ? { sourceArtifactSha256: generated.sourceArtifactSha256 }
+              : {}),
           },
           buildSha256: fullSha,
           buildByteSize,
@@ -585,11 +598,13 @@ export async function runCustomBuildGenerateJob(
     throwIfCustomBuildLeaseLost(opts.signal);
     throwIfCustomBuildLeaseLost(opts.signal);
     emitCustomBuildEvent(customBuild.id, "complete", { stage: "complete" });
-    recordGenerationSuccess({
-      jobType: "worker",
-      model: customBuild.modelKey || customBuild.modelDisplayName || customBuild.modelId,
-      durationMs: generated.generationTimeMs ?? (Date.now() - (customBuild.startedAt?.getTime() ?? Date.now())),
-    });
+    if (!opts.importedBuild) {
+      recordGenerationSuccess({
+        jobType: "worker",
+        model: customBuild.modelKey || customBuild.modelDisplayName || customBuild.modelId,
+        durationMs: generated.generationTimeMs ?? (Date.now() - (customBuild.startedAt?.getTime() ?? Date.now())),
+      });
+    }
   } catch (error) {
     if (isCustomBuildLeaseLostError(error)) throw error;
     const effectiveError =
@@ -597,11 +612,13 @@ export async function runCustomBuildGenerateJob(
         ? new CustomBuildArtifactBookkeepingError(error)
         : error;
     const message = redactSensitiveText(effectiveError);
-    recordGenerationError({
-      jobType: "worker",
-      model: customBuild.modelKey || customBuild.modelDisplayName || customBuild.modelId,
-      errorType: message,
-    });
+    if (!opts.importedBuild) {
+      recordGenerationError({
+        jobType: "worker",
+        model: customBuild.modelKey || customBuild.modelDisplayName || customBuild.modelId,
+        errorType: message,
+      });
+    }
     const manuallyRetryable =
       effectiveError instanceof CustomBuildGenerationFailedError &&
       !isTerminalCustomBuildGenerateError(message);

--- a/lib/faq.ts
+++ b/lib/faq.ts
@@ -131,6 +131,17 @@ export const FAQ_SECTIONS: readonly FaqSection[] = [
           "A workflow where models repeatedly inspect renders and modify their builds would test an agentic 3D-editing system and would need to be evaluated separately.",
         ],
       },
+      {
+        id: "how-does-the-gallery-shape-the-benchmark",
+        question: "How does the Gallery shape the benchmark?",
+        navLabel: "Gallery & official prompts",
+        answer: [
+          "The Gallery is where the community proposes prompts, shares builds, and votes on what MineBench should test next.",
+          "MineBench reviews the highest-voted prompts and promotes the strongest into the official benchmark. Votes guide curation rather than changing the benchmark automatically.",
+          "The MineBench account also publishes repeated runs of official prompts, whether to revisit a model later or show run-to-run variation. These examples do not replace the benchmark build or affect Arena rankings.",
+        ],
+        links: [{ label: "Open Gallery", href: "/gallery" }],
+      },
     ],
   },
   {

--- a/lib/faq.ts
+++ b/lib/faq.ts
@@ -140,7 +140,7 @@ export const FAQ_SECTIONS: readonly FaqSection[] = [
           "MineBench currently evaluates one accepted generation for each model and prompt. With a larger evaluation budget, MineBench would run every model-prompt pair three times and publish the strongest result, but doing that across the full benchmark would roughly triple provider API costs.",
           "For now, the Gallery makes this variation visible. MineBench publishes dated reruns of official prompts. Anyone can use an official Gallery prompt in Sandbox, and signed-in users can add successful builds as new examples. These reruns add evidence without silently replacing the benchmark result or changing Arena rankings.",
         ],
-        links: [{ label: "Explore official prompts", href: "/gallery" }],
+        links: [{ label: "Explore official prompts", href: "/gallery?sort=official" }],
       },
       {
         id: "how-does-the-gallery-shape-the-benchmark",

--- a/lib/faq.ts
+++ b/lib/faq.ts
@@ -132,6 +132,17 @@ export const FAQ_SECTIONS: readonly FaqSection[] = [
         ],
       },
       {
+        id: "how-does-minebench-account-for-nondeterminism",
+        question: "How does MineBench account for nondeterminism?",
+        navLabel: "Nondeterminism",
+        answer: [
+          "Generative models are nondeterministic, so the same model and prompt can produce different builds.",
+          "MineBench currently evaluates one accepted generation for each model and prompt. With a larger evaluation budget, MineBench would run every model-prompt pair three times and publish the strongest result, but doing that across the full benchmark would roughly triple provider API costs.",
+          "For now, the Gallery makes this variation visible. MineBench publishes dated reruns of official prompts. Anyone can use an official Gallery prompt in Sandbox, and signed-in users can add successful builds as new examples. These reruns add evidence without silently replacing the benchmark result or changing Arena rankings.",
+        ],
+        links: [{ label: "Explore official prompts", href: "/gallery" }],
+      },
+      {
         id: "how-does-the-gallery-shape-the-benchmark",
         question: "How does the Gallery shape the benchmark?",
         navLabel: "Gallery & official prompts",

--- a/lib/gallery/service.ts
+++ b/lib/gallery/service.ts
@@ -883,6 +883,7 @@ export async function setGalleryCandidateSelected(adminId: string, publicId: str
       return {
         promptId: candidate.officialPromptId,
         promptText: candidate.promptText,
+        uploaderId: candidate.uploaderId,
         uploaderEmail: candidate.uploader.email,
         transitioned: false,
       };
@@ -922,11 +923,12 @@ export async function setGalleryCandidateSelected(adminId: string, publicId: str
     return {
       promptId: prompt?.id ?? null,
       promptText: candidate.promptText,
+      uploaderId: candidate.uploaderId,
       uploaderEmail: candidate.uploader.email,
       transitioned: true,
     };
   });
-  if (selected && result.transitioned) {
+  if (selected && result.transitioned && result.uploaderId !== adminId) {
     await deliverGalleryEmail(
       sendGalleryAccountNotification(result.uploaderEmail, {
         heading: "Your prompt was selected",

--- a/lib/gallery/service.ts
+++ b/lib/gallery/service.ts
@@ -113,6 +113,7 @@ const exampleSelect = {
   customBuild: {
     select: {
       publicId: true,
+      completedAt: true,
       gridSize: true,
       palette: true,
       blockCount: true,
@@ -172,6 +173,7 @@ function publicExample(example: ExampleRow) {
       publicNickname: example.contributor.publicNickname,
     }),
     createdAt: example.createdAt.toISOString(),
+    runAt: (example.customBuild.completedAt ?? example.createdAt).toISOString(),
     model: publicGalleryModel(example.customBuild),
     gridSize: example.customBuild.gridSize,
     palette: example.customBuild.palette === "advanced" ? "advanced" as const : "simple" as const,

--- a/lib/gallery/service.ts
+++ b/lib/gallery/service.ts
@@ -233,12 +233,20 @@ function publicCandidate(
 export type GalleryCandidatePayload = ReturnType<typeof publicCandidate>;
 export type GalleryExamplePayload = ReturnType<typeof publicExample>;
 
-type GallerySort = "top" | "new";
+export type GallerySort = "top" | "new" | "official";
+
+export function normalizeGallerySort(sort?: string | null): GallerySort {
+  return sort === "new" || sort === "official" ? sort : "top";
+}
 
 function galleryCandidateOrder(sort: GallerySort): Prisma.GalleryCandidateOrderByWithRelationInput[] {
-  return sort === "top"
-    ? [{ upvoteCount: "desc" }, { publishedAt: "desc" }, { id: "desc" }]
-    : [{ publishedAt: "desc" }, { id: "desc" }];
+  if (sort === "top") return [{ upvoteCount: "desc" }, { publishedAt: "desc" }, { id: "desc" }];
+  if (sort === "official") return [{ selectedAt: "desc" }, { id: "desc" }];
+  return [{ publishedAt: "desc" }, { id: "desc" }];
+}
+
+function galleryCandidateScope(sort: GallerySort): Prisma.GalleryCandidateWhereInput {
+  return sort === "official" ? { AND: [publicCandidateWhere, { selectedAt: { not: null } }] } : publicCandidateWhere;
 }
 
 export async function listGalleryCandidates(options: {
@@ -267,6 +275,13 @@ export async function listGalleryCandidates(options: {
             },
           ],
         }
+      : options.sort === "official"
+        ? {
+            OR: [
+              { selectedAt: { lt: cursor.publishedAt } },
+              { selectedAt: cursor.publishedAt, id: { lt: cursor.id } },
+            ],
+          }
       : {
           OR: [
             { publishedAt: { lt: cursor.publishedAt } },
@@ -297,7 +312,7 @@ export async function listGalleryCandidates(options: {
       }
     : {};
   const rows = await prisma.galleryCandidate.findMany({
-    where: { AND: [publicCandidateWhere, cursorWhere, queryWhere] },
+    where: { AND: [galleryCandidateScope(options.sort), cursorWhere, queryWhere] },
     select: candidateListSelect,
     orderBy: galleryCandidateOrder(options.sort),
     take: limit + 1,
@@ -355,7 +370,7 @@ export async function listGalleryCandidates(options: {
     nextCursor: rows.length > limit && last
       ? encodeGalleryCursor({
           score: options.sort === "top" ? last.upvoteCount : 0,
-          publishedAt: last.publishedAt,
+          publishedAt: options.sort === "official" ? last.selectedAt ?? last.publishedAt : last.publishedAt,
           id: last.id,
         })
       : null,
@@ -379,6 +394,9 @@ export async function getGalleryCandidate(
   if (!candidate) return null;
   const limit = Math.max(1, Math.min(options.examplesLimit ?? 24, 48));
   const cursor = decodeGalleryCursor(options.examplesCursor);
+  const navigationSort = options.navigationSort === "official" && !candidate.selectedAt
+    ? null
+    : options.navigationSort;
   const [cover, exampleCount, upvoted, previousCandidates, nextCandidates] = await Promise.all([
     prisma.galleryExample.findFirst({
       where: { candidateId: candidate.id, ...publicExampleWhere },
@@ -398,24 +416,24 @@ export async function getGalleryCandidate(
         select: { id: true },
       })
       : null,
-    options.navigationSort
+    navigationSort
       ? prisma.galleryCandidate.findMany({
-          where: publicCandidateWhere,
+          where: galleryCandidateScope(navigationSort),
           cursor: { id: candidate.id },
           skip: 1,
           take: -1,
           select: { publicId: true },
-          orderBy: galleryCandidateOrder(options.navigationSort),
+          orderBy: galleryCandidateOrder(navigationSort),
         })
       : [],
-    options.navigationSort
+    navigationSort
       ? prisma.galleryCandidate.findMany({
-          where: publicCandidateWhere,
+          where: galleryCandidateScope(navigationSort),
           cursor: { id: candidate.id },
           skip: 1,
           take: 1,
           select: { publicId: true },
-          orderBy: galleryCandidateOrder(options.navigationSort),
+          orderBy: galleryCandidateOrder(navigationSort),
         })
       : [],
   ]);
@@ -447,9 +465,9 @@ export async function getGalleryCandidate(
     nextExamplesCursor: additional.length > limit && last
       ? encodeGalleryCursor({ score: 0, publishedAt: last.createdAt, id: last.id })
       : null,
-    navigation: options.navigationSort
+    navigation: navigationSort
       ? {
-          sort: options.navigationSort,
+          sort: navigationSort,
           previousId: previousCandidates[0]?.publicId ?? null,
           nextId: nextCandidates[0]?.publicId ?? null,
         }

--- a/lib/generations/service.ts
+++ b/lib/generations/service.ts
@@ -169,18 +169,10 @@ function dayKey(now: Date): Date {
   return new Date(now.toISOString().slice(0, 10));
 }
 
-export async function createSavedGenerations(input: CreateSavedGenerationsInput) {
-  const prompt = input.prompt.trim();
-  if (!prompt || prompt.length > 800 || input.models.length < 1 || input.models.length > 8) {
-    throw new GenerationServiceError("invalid_request", "Check the prompt and model selection.");
-  }
-  if (new Set(input.models.map((model) => model.id)).size !== input.models.length) {
-    throw new GenerationServiceError("invalid_request", "Model selections must be unique.");
-  }
-
+export async function assertSavedGenerationStorageAvailable(ownerId: string): Promise<void> {
   const retained = await prisma.customBuild.aggregate({
     where: {
-      ownerId: input.ownerId,
+      ownerId,
       storedByteSize: { gt: 0 },
     },
     _sum: { storedByteSize: true },
@@ -191,6 +183,18 @@ export async function createSavedGenerations(input: CreateSavedGenerationsInput)
       "Remove a saved generation before starting another.",
     );
   }
+}
+
+export async function createSavedGenerations(input: CreateSavedGenerationsInput) {
+  const prompt = input.prompt.trim();
+  if (!prompt || prompt.length > 800 || input.models.length < 1 || input.models.length > 8) {
+    throw new GenerationServiceError("invalid_request", "Check the prompt and model selection.");
+  }
+  if (new Set(input.models.map((model) => model.id)).size !== input.models.length) {
+    throw new GenerationServiceError("invalid_request", "Model selections must be unique.");
+  }
+
+  await assertSavedGenerationStorageAvailable(input.ownerId);
 
   const hostedOpenRouterKey = process.env.MINEBENCH_FREE_OPENROUTER_API_KEY?.trim();
   const hasUserGeminiCredential = Boolean(

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "batch:generate": "tsx scripts/batch-generate.ts",
     "batch:status": "tsx scripts/batch-generate.ts",
     "model:publish": "tsx scripts/model-publish.ts",
+    "gallery:import": "tsx scripts/import-gallery-retest.ts",
     "tool:convert": "tsx scripts/convert-voxel-tool-call.ts",
     "uploads:sync": "tsx scripts/sync-uploads-from-db.ts",
     "prompt": "tsx scripts/prompt.ts",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "batch:status": "tsx scripts/batch-generate.ts",
     "model:publish": "tsx scripts/model-publish.ts",
     "gallery:import": "tsx scripts/import-gallery-retest.ts",
+    "gallery:seed-official": "tsx scripts/seed-gallery-official-prompts.ts",
     "tool:convert": "tsx scripts/convert-voxel-tool-call.ts",
     "uploads:sync": "tsx scripts/sync-uploads-from-db.ts",
     "prompt": "tsx scripts/prompt.ts",

--- a/scripts/benchmarkMetrics.ts
+++ b/scripts/benchmarkMetrics.ts
@@ -42,6 +42,11 @@ export type BenchmarkSample = {
   configuration?: BenchmarkRunConfiguration;
 };
 
+export type SucceededBenchmarkSample = {
+  sample: BenchmarkSample;
+  completedAt: Date;
+};
+
 type BenchmarkJobState = "running" | "finalizing" | "succeeded" | "failed" | "interrupted";
 
 // Counters accumulating across every invocation of a job, including runs that
@@ -554,6 +559,17 @@ export class BenchmarkMetricsStore {
   getSample(job: BenchmarkMetricJob): BenchmarkSample | undefined {
     const sample = this.readLedger().jobs[jobKey(job)]?.sample;
     return isBenchmarkSample(sample) ? sample : undefined;
+  }
+
+  getSucceededSample(job: BenchmarkMetricJob): SucceededBenchmarkSample | undefined {
+    const record = this.readLedger().jobs[jobKey(job)];
+    const completedAt = record?.endedAt ? new Date(record.endedAt) : null;
+    return record?.state === "succeeded" &&
+      isBenchmarkSample(record.sample) &&
+      completedAt &&
+      !Number.isNaN(completedAt.getTime())
+      ? { sample: record.sample, completedAt }
+      : undefined;
   }
 
   private updateRecord(

--- a/scripts/gallery-cli.ts
+++ b/scripts/gallery-cli.ts
@@ -1,0 +1,38 @@
+import { normalizeGalleryNickname } from "../lib/gallery/policy";
+import { prisma } from "../lib/prisma";
+
+const MINEBENCH_NICKNAME = "minebench";
+
+export function galleryDatabaseTarget(): string {
+  try {
+    const url = new URL(process.env.DATABASE_URL ?? "");
+    return `${url.hostname}${url.pathname}`;
+  } catch {
+    return "unconfigured";
+  }
+}
+
+export async function loadMineBenchGalleryPublisher() {
+  const publisher = await prisma.user.findUnique({
+    where: { publicNicknameNormalized: MINEBENCH_NICKNAME },
+    select: {
+      id: true,
+      publicNickname: true,
+      isMineBenchAdmin: true,
+      gallerySuspendedAt: true,
+      deletedAt: true,
+      authDeletedAt: true,
+    },
+  });
+  if (
+    !publisher?.publicNickname ||
+    !publisher.isMineBenchAdmin ||
+    publisher.gallerySuspendedAt ||
+    publisher.deletedAt ||
+    publisher.authDeletedAt ||
+    normalizeGalleryNickname(publisher.publicNickname).normalized !== MINEBENCH_NICKNAME
+  ) {
+    throw new Error("An active MineBench Gallery admin account is required.");
+  }
+  return publisher;
+}

--- a/scripts/import-gallery-retest.ts
+++ b/scripts/import-gallery-retest.ts
@@ -19,15 +19,14 @@ import {
   setGalleryCandidateSelected,
   submitGalleryCandidate,
 } from "../lib/gallery/service";
-import { normalizeGalleryNickname } from "../lib/gallery/policy";
 import { prisma } from "../lib/prisma";
 import { sha256Hex } from "../lib/custom-builds/hash";
 import { BenchmarkMetricsStore, type BenchmarkMetricJob } from "./benchmarkMetrics";
+import { galleryDatabaseTarget, loadMineBenchGalleryPublisher } from "./gallery-cli";
 import { BENCHMARK_PROMPT_MAP, UPLOADS_DIR } from "./uploadsCatalog";
 
 const GRID_SIZE = 256;
 const PALETTE = "simple";
-const MINEBENCH_NICKNAME = "minebench";
 const IMPORT_LEASE_MS = 60 * 60 * 1000;
 
 export type GalleryImportArgs = {
@@ -116,15 +115,6 @@ export function galleryRetestPublicId(parts: {
   return `cb_${digest.slice(0, 24)}`;
 }
 
-function databaseTarget(): string {
-  try {
-    const url = new URL(process.env.DATABASE_URL ?? "");
-    return `${url.hostname}${url.pathname}`;
-  } catch {
-    return "unconfigured";
-  }
-}
-
 function readPreparedBuild(spec: ReturnType<typeof resolveGalleryImportSpec>): {
   importedBuild: ImportedCustomBuildResult;
   sourceBytes: number;
@@ -183,31 +173,6 @@ function readPreparedBuild(spec: ReturnType<typeof resolveGalleryImportSpec>): {
     providerRoute: configuration.providerRoute,
     reasoning: configuration.reasoningOverride,
   };
-}
-
-async function loadMineBenchPublisher() {
-  const publisher = await prisma.user.findUnique({
-    where: { publicNicknameNormalized: MINEBENCH_NICKNAME },
-    select: {
-      id: true,
-      publicNickname: true,
-      isMineBenchAdmin: true,
-      gallerySuspendedAt: true,
-      deletedAt: true,
-      authDeletedAt: true,
-    },
-  });
-  if (
-    !publisher?.publicNickname ||
-    !publisher.isMineBenchAdmin ||
-    publisher.gallerySuspendedAt ||
-    publisher.deletedAt ||
-    publisher.authDeletedAt ||
-    normalizeGalleryNickname(publisher.publicNickname).normalized !== MINEBENCH_NICKNAME
-  ) {
-    throw new Error("An active MineBench Gallery admin account is required.");
-  }
-  return publisher;
 }
 
 async function createOrReuseGeneration(args: {
@@ -368,7 +333,7 @@ async function main(): Promise<void> {
   }
   const spec = resolveGalleryImportSpec(parsed);
   const prepared = readPreparedBuild(spec);
-  const publisher = await loadMineBenchPublisher();
+  const publisher = await loadMineBenchGalleryPublisher();
   assertCustomBuildStorageConfigured();
   const publicId = galleryRetestPublicId({
     publisherId: publisher.id,
@@ -386,7 +351,7 @@ async function main(): Promise<void> {
   console.log(`- source bytes: ${prepared.sourceBytes.toLocaleString()}`);
   console.log(`- source sha256: ${prepared.importedBuild.sourceArtifactSha256}`);
   console.log(`- saved generation: ${publicId}`);
-  console.log(`- database: ${databaseTarget()}`);
+  console.log(`- database: ${galleryDatabaseTarget()}`);
   console.log(`- storage bucket: ${getCustomBuildStorageBucket()}`);
 
   if (!parsed.confirmed) {

--- a/scripts/import-gallery-retest.ts
+++ b/scripts/import-gallery-retest.ts
@@ -1,0 +1,436 @@
+#!/usr/bin/env -S tsx
+
+import "dotenv/config";
+import { createHash, randomUUID } from "node:crypto";
+import { readFileSync, statSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { findCatalogEntryBySlugOrKey } from "../lib/ai/modelCatalog";
+import {
+  runCustomBuildGenerateJob,
+  validateGeneratedBuildForArtifacts,
+  type ImportedCustomBuildResult,
+} from "../lib/custom-builds/generateJob";
+import { completeCustomBuildJob, failCustomBuildJob } from "../lib/custom-builds/jobs";
+import { assertCustomBuildStorageConfigured, getCustomBuildStorageBucket } from "../lib/custom-builds/storage";
+import { assertSavedGenerationStorageAvailable } from "../lib/generations/service";
+import {
+  addGalleryExample,
+  setGalleryCandidateSelected,
+  submitGalleryCandidate,
+} from "../lib/gallery/service";
+import { normalizeGalleryNickname } from "../lib/gallery/policy";
+import { prisma } from "../lib/prisma";
+import { sha256Hex } from "../lib/custom-builds/hash";
+import { BenchmarkMetricsStore, type BenchmarkMetricJob } from "./benchmarkMetrics";
+import { BENCHMARK_PROMPT_MAP, UPLOADS_DIR } from "./uploadsCatalog";
+
+const GRID_SIZE = 256;
+const PALETTE = "simple";
+const MINEBENCH_NICKNAME = "minebench";
+const IMPORT_LEASE_MS = 60 * 60 * 1000;
+
+export type GalleryImportArgs = {
+  help: false;
+  promptSlug: string;
+  model: string;
+  confirmed: boolean;
+};
+
+function optionValue(argv: string[], index: number, flag: string): string {
+  const value = argv[index + 1]?.trim();
+  if (!value || value.startsWith("--")) throw new Error(`${flag} needs a value.`);
+  return value;
+}
+
+export function parseGalleryImportArgs(argv: string[]): GalleryImportArgs | { help: true } {
+  if (argv.includes("--help") || argv.includes("-h")) {
+    if (argv.length !== 1) throw new Error("Use --help by itself.");
+    return { help: true };
+  }
+
+  let promptSlug: string | null = null;
+  let model: string | null = null;
+  let confirmed = false;
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--prompt") {
+      if (promptSlug) throw new Error("Pass --prompt once.");
+      promptSlug = optionValue(argv, index, "--prompt");
+      index += 1;
+    } else if (arg === "--model") {
+      if (model) throw new Error("Pass --model once.");
+      model = optionValue(argv, index, "--model");
+      index += 1;
+    } else if (arg === "--yes") {
+      if (confirmed) throw new Error("Pass --yes once.");
+      confirmed = true;
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+  if (!promptSlug || !model) {
+    throw new Error("Pass one official --prompt and one catalog --model.");
+  }
+  return { help: false, promptSlug, model, confirmed };
+}
+
+export function resolveGalleryImportSpec(
+  args: GalleryImportArgs,
+  uploadsDir = UPLOADS_DIR,
+) {
+  if (!Object.hasOwn(BENCHMARK_PROMPT_MAP, args.promptSlug)) {
+    throw new Error(`Unknown official prompt: ${args.promptSlug}`);
+  }
+  const model = findCatalogEntryBySlugOrKey(args.model);
+  if (!model) throw new Error(`Unknown catalog model: ${args.model}`);
+  return {
+    promptSlug: args.promptSlug,
+    promptText: BENCHMARK_PROMPT_MAP[args.promptSlug]!,
+    model,
+    filePath: path.join(
+      uploadsDir,
+      args.promptSlug,
+      `${args.promptSlug}-${model.slug}.json`,
+    ),
+  };
+}
+
+export function galleryRetestPublicId(parts: {
+  publisherId: string;
+  promptSlug: string;
+  modelKey: string;
+  sourceArtifactSha256: string;
+  completedAt: string;
+}): string {
+  const digest = createHash("sha256")
+    .update([
+      "gallery-retest-v1",
+      parts.publisherId,
+      parts.promptSlug,
+      parts.modelKey,
+      parts.sourceArtifactSha256,
+      parts.completedAt,
+    ].join("\0"))
+    .digest("base64url");
+  return `cb_${digest.slice(0, 24)}`;
+}
+
+function databaseTarget(): string {
+  try {
+    const url = new URL(process.env.DATABASE_URL ?? "");
+    return `${url.hostname}${url.pathname}`;
+  } catch {
+    return "unconfigured";
+  }
+}
+
+function readPreparedBuild(spec: ReturnType<typeof resolveGalleryImportSpec>): {
+  importedBuild: ImportedCustomBuildResult;
+  sourceBytes: number;
+  providerRoute: "direct" | "openrouter";
+  reasoning: string | null;
+} {
+  const file = statSync(spec.filePath);
+  if (!file.isFile()) throw new Error(`Build artifact is not a file: ${spec.filePath}`);
+  const bytes = readFileSync(spec.filePath);
+  const sourceArtifactSha256 = sha256Hex(bytes);
+  const metricJob: BenchmarkMetricJob = {
+    promptSlug: spec.promptSlug,
+    promptText: spec.promptText,
+    modelKey: spec.model.key,
+    modelSlug: spec.model.slug,
+    filePath: spec.filePath,
+  };
+  const completed = new BenchmarkMetricsStore().getSucceededSample(metricJob);
+  if (!completed) {
+    throw new Error(`No succeeded benchmark record for ${spec.promptSlug} × ${spec.model.displayName}.`);
+  }
+  if (
+    completed.sample.artifactSha256 !== sourceArtifactSha256 ||
+    completed.sample.jsonBytes !== bytes.byteLength
+  ) {
+    throw new Error("Build artifact does not match its finalized benchmark record.");
+  }
+  const configuration = completed.sample.configuration;
+  if (
+    configuration?.promptSha256 !== sha256Hex(spec.promptText) ||
+    !configuration.toolsEnabled
+  ) {
+    throw new Error("Benchmark record does not match the official prompt and tool configuration.");
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(bytes.toString("utf8"));
+  } catch {
+    throw new Error(`Build artifact is not valid JSON: ${spec.filePath}`);
+  }
+  const validated = validateGeneratedBuildForArtifacts(parsed, {
+    gridSize: GRID_SIZE,
+    palette: PALETTE,
+  });
+  return {
+    importedBuild: {
+      build: validated.build,
+      warnings: validated.warnings,
+      blockCount: validated.build.blocks.length,
+      generationTimeMs: completed.sample.inferenceTimeMs,
+      completedAt: completed.completedAt,
+      sourceArtifactSha256,
+    },
+    sourceBytes: bytes.byteLength,
+    providerRoute: configuration.providerRoute,
+    reasoning: configuration.reasoningOverride,
+  };
+}
+
+async function loadMineBenchPublisher() {
+  const publisher = await prisma.user.findUnique({
+    where: { publicNicknameNormalized: MINEBENCH_NICKNAME },
+    select: {
+      id: true,
+      publicNickname: true,
+      isMineBenchAdmin: true,
+      gallerySuspendedAt: true,
+      deletedAt: true,
+      authDeletedAt: true,
+    },
+  });
+  if (
+    !publisher?.publicNickname ||
+    !publisher.isMineBenchAdmin ||
+    publisher.gallerySuspendedAt ||
+    publisher.deletedAt ||
+    publisher.authDeletedAt ||
+    normalizeGalleryNickname(publisher.publicNickname).normalized !== MINEBENCH_NICKNAME
+  ) {
+    throw new Error("An active MineBench Gallery admin account is required.");
+  }
+  return publisher;
+}
+
+async function createOrReuseGeneration(args: {
+  publisherId: string;
+  spec: ReturnType<typeof resolveGalleryImportSpec>;
+  prepared: ReturnType<typeof readPreparedBuild>;
+}) {
+  const publicId = galleryRetestPublicId({
+    publisherId: args.publisherId,
+    promptSlug: args.spec.promptSlug,
+    modelKey: args.spec.model.key,
+    sourceArtifactSha256: args.prepared.importedBuild.sourceArtifactSha256,
+    completedAt: args.prepared.importedBuild.completedAt.toISOString(),
+  });
+  const proposedId = randomUUID();
+  const jobId = randomUUID();
+  const workerId = `gallery-import-${process.pid}-${randomUUID()}`;
+  const now = new Date();
+  const startedAt = new Date(
+    args.prepared.importedBuild.completedAt.getTime() -
+      (args.prepared.importedBuild.generationTimeMs ?? 0),
+  );
+
+  const generation = await prisma.$transaction(async (tx) => {
+    const row = await tx.customBuild.upsert({
+      where: { publicId },
+      create: {
+        id: proposedId,
+        publicId,
+        ownerId: args.publisherId,
+        status: "queued",
+        currentStage: "queued",
+        startedAt,
+        promptText: args.spec.promptText,
+        promptSha256: sha256Hex(args.spec.promptText),
+        gridSize: GRID_SIZE,
+        palette: PALETTE,
+        mode: "precise",
+        generationMode: "tool",
+        modelKind: "catalog",
+        modelKey: args.spec.model.key,
+        modelProvider: args.spec.model.provider,
+        modelId: args.spec.model.modelId,
+        modelDisplayName: args.spec.model.displayName,
+        openRouterModelId: args.spec.model.openRouterModelId,
+        preferOpenRouter: args.prepared.providerRoute === "openrouter",
+        reasoning: args.prepared.reasoning,
+        metrics: {
+          sourceArtifactSha256: args.prepared.importedBuild.sourceArtifactSha256,
+        },
+        jobs: {
+          create: {
+            id: jobId,
+            type: "generate",
+            status: "running",
+            attempts: 1,
+            maxAttempts: 1,
+            lockedBy: workerId,
+            lockedAt: now,
+            leaseExpiresAt: new Date(now.getTime() + IMPORT_LEASE_MS),
+            startedAt: now,
+          },
+        },
+        events: {
+          create: {
+            seq: 1,
+            type: "queued",
+            data: { stage: "queued", source: "official_retest" },
+          },
+        },
+      },
+      update: {},
+      select: {
+        id: true,
+        publicId: true,
+        ownerId: true,
+        promptText: true,
+        modelKey: true,
+        status: true,
+        objectsDeletedAt: true,
+        artifacts: {
+          where: { kind: "build_json" },
+          select: { id: true },
+          take: 1,
+        },
+      },
+    });
+    if (row.id === proposedId) {
+      await tx.user.update({
+        where: { id: args.publisherId },
+        data: { totalGenerationCount: { increment: 1 } },
+      });
+      const day = new Date(now.toISOString().slice(0, 10));
+      await tx.customBuildStatsDaily.upsert({
+        where: { day },
+        create: { day, created: 1 },
+        update: { created: { increment: 1 } },
+      });
+    }
+    return row;
+  });
+
+  if (
+    generation.ownerId !== args.publisherId ||
+    generation.promptText !== args.spec.promptText ||
+    generation.modelKey !== args.spec.model.key
+  ) {
+    throw new Error("Existing Gallery retest identity does not match this import.");
+  }
+  if (generation.id !== proposedId) {
+    if (
+      generation.status !== "succeeded" ||
+      generation.objectsDeletedAt ||
+      generation.artifacts.length === 0
+    ) {
+      throw new Error(`Existing Gallery retest is ${generation.status}; review it before retrying.`);
+    }
+    return { publicId: generation.publicId, created: false };
+  }
+
+  const job = await prisma.customBuildJob.findUniqueOrThrow({ where: { id: jobId } });
+  try {
+    await runCustomBuildGenerateJob(job, { importedBuild: args.prepared.importedBuild });
+    await completeCustomBuildJob(job.id, workerId);
+  } catch (error) {
+    await failCustomBuildJob(
+      job.id,
+      workerId,
+      {
+        code: "gallery_import_failed",
+        message: error instanceof Error ? error.message : "Gallery import failed.",
+      },
+      prisma,
+      { forceTerminal: true },
+    );
+    throw error;
+  }
+  return { publicId: generation.publicId, created: true };
+}
+
+function printHelp(): void {
+  console.log(`
+Import a finalized benchmark rerun as an official Gallery example.
+
+Usage:
+  pnpm gallery:import --prompt steampunk --model gemini-3-1-pro
+  pnpm gallery:import --prompt steampunk --model gemini-3-1-pro --yes
+
+Without --yes, the command validates and prints the import plan without writing.
+`);
+}
+
+async function main(): Promise<void> {
+  const parsed = parseGalleryImportArgs(process.argv.slice(2));
+  if (parsed.help) {
+    printHelp();
+    return;
+  }
+  const spec = resolveGalleryImportSpec(parsed);
+  const prepared = readPreparedBuild(spec);
+  const publisher = await loadMineBenchPublisher();
+  assertCustomBuildStorageConfigured();
+  const publicId = galleryRetestPublicId({
+    publisherId: publisher.id,
+    promptSlug: spec.promptSlug,
+    modelKey: spec.model.key,
+    sourceArtifactSha256: prepared.importedBuild.sourceArtifactSha256,
+    completedAt: prepared.importedBuild.completedAt.toISOString(),
+  });
+
+  console.log(`Gallery retest: ${spec.promptSlug} × ${spec.model.displayName}`);
+  console.log(`- publisher: ${publisher.publicNickname}`);
+  console.log(`- completed: ${prepared.importedBuild.completedAt.toISOString()}`);
+  console.log(`- blocks: ${prepared.importedBuild.blockCount.toLocaleString()}`);
+  console.log(`- source: ${spec.filePath}`);
+  console.log(`- source bytes: ${prepared.sourceBytes.toLocaleString()}`);
+  console.log(`- source sha256: ${prepared.importedBuild.sourceArtifactSha256}`);
+  console.log(`- saved generation: ${publicId}`);
+  console.log(`- database: ${databaseTarget()}`);
+  console.log(`- storage bucket: ${getCustomBuildStorageBucket()}`);
+
+  if (!parsed.confirmed) {
+    console.log("\nValidated only. Add --yes to import and publish.");
+    return;
+  }
+
+  const existing = await prisma.customBuild.findUnique({
+    where: { publicId },
+    select: { status: true },
+  });
+  if (!existing) await assertSavedGenerationStorageAvailable(publisher.id);
+  const generation = await createOrReuseGeneration({
+    publisherId: publisher.id,
+    spec,
+    prepared,
+  });
+  const submission = await submitGalleryCandidate(publisher.id, {
+    generationId: generation.publicId,
+    postAnonymously: false,
+  });
+  if (submission.candidate.prompt !== spec.promptText) {
+    throw new Error("Existing Gallery candidate does not exactly match the official prompt.");
+  }
+  await addGalleryExample(publisher.id, submission.candidate.id, {
+    generationId: generation.publicId,
+    postAnonymously: false,
+  });
+  await setGalleryCandidateSelected(publisher.id, submission.candidate.id, true);
+
+  const siteUrl = (process.env.MINEBENCH_SITE_URL?.trim() || "https://minebench.ai").replace(/\/+$/, "");
+  console.log(`\n${generation.created ? "Imported" : "Reused"}: ${generation.publicId}`);
+  console.log(`Gallery: ${siteUrl}/gallery/${submission.candidate.id}`);
+}
+
+const isDirectRun = process.argv[1]
+  ? path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)
+  : false;
+
+if (isDirectRun) {
+  main()
+    .finally(() => prisma.$disconnect())
+    .catch((error) => {
+      console.error(error instanceof Error ? error.message : error);
+      process.exitCode = 1;
+    });
+}

--- a/scripts/seed-gallery-official-prompts.ts
+++ b/scripts/seed-gallery-official-prompts.ts
@@ -1,0 +1,112 @@
+#!/usr/bin/env -S tsx
+
+import "dotenv/config";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  setGalleryCandidateSelected,
+  submitGalleryCandidate,
+} from "../lib/gallery/service";
+import { prisma } from "../lib/prisma";
+import { galleryDatabaseTarget, loadMineBenchGalleryPublisher } from "./gallery-cli";
+import { BENCHMARK_PROMPT_MAP } from "./uploadsCatalog";
+
+export type GalleryOfficialSeedArgs = { help: false; confirmed: boolean } | { help: true };
+
+export function parseGalleryOfficialSeedArgs(argv: string[]): GalleryOfficialSeedArgs {
+  if (argv.includes("--help") || argv.includes("-h")) {
+    if (argv.length !== 1) throw new Error("Use --help by itself.");
+    return { help: true };
+  }
+  let confirmed = false;
+  for (const arg of argv) {
+    if (arg !== "--yes") throw new Error(`Unknown argument: ${arg}`);
+    if (confirmed) throw new Error("Pass --yes once.");
+    confirmed = true;
+  }
+  return { help: false, confirmed };
+}
+
+export async function seedGalleryOfficialPrompts(
+  publisherId: string,
+  promptMap: Readonly<Record<string, string>>,
+) {
+  const results: Array<{
+    slug: string;
+    candidateId: string;
+    status: "created" | "selected" | "already_official";
+  }> = [];
+  for (const [slug, promptText] of Object.entries(promptMap)) {
+    const submission = await submitGalleryCandidate(publisherId, {
+      prompt: promptText,
+      postAnonymously: false,
+    });
+    if (submission.candidate.prompt !== promptText) {
+      throw new Error(`${slug}: Existing Gallery candidate does not exactly match the official prompt.`);
+    }
+    const status = submission.candidate.selected
+      ? "already_official" as const
+      : submission.created
+        ? "created" as const
+        : "selected" as const;
+    await setGalleryCandidateSelected(publisherId, submission.candidate.id, true);
+    results.push({ slug, candidateId: submission.candidate.id, status });
+  }
+  return results;
+}
+
+function printHelp(): void {
+  console.log(`
+Seed every canonical benchmark prompt into the official Gallery.
+
+Usage:
+  pnpm gallery:seed-official
+  pnpm gallery:seed-official --yes
+
+Without --yes, the command validates and prints the seed plan without writing.
+Re-running adds new registry prompts and leaves existing official prompts unchanged.
+Prompts removed from the registry are not unselected.
+`);
+}
+
+async function main(): Promise<void> {
+  const parsed = parseGalleryOfficialSeedArgs(process.argv.slice(2));
+  if (parsed.help) {
+    printHelp();
+    return;
+  }
+  const publisher = await loadMineBenchGalleryPublisher();
+  const promptEntries = Object.entries(BENCHMARK_PROMPT_MAP);
+  console.log(`Official Gallery seed: ${promptEntries.length} prompts`);
+  console.log(`- publisher: ${publisher.publicNickname}`);
+  console.log(`- database: ${galleryDatabaseTarget()}`);
+  console.log(`- prompts: ${promptEntries.map(([slug]) => slug).join(", ")}`);
+
+  if (!parsed.confirmed) {
+    console.log("\nValidated only. Add --yes to seed official prompts.");
+    return;
+  }
+
+  const results = await seedGalleryOfficialPrompts(publisher.id, BENCHMARK_PROMPT_MAP);
+  for (const result of results) {
+    console.log(`- ${result.slug}: ${result.status.replaceAll("_", " ")}`);
+  }
+  const count = (status: (typeof results)[number]["status"]) =>
+    results.filter((result) => result.status === status).length;
+  console.log(
+    `\nSeeded ${results.length} official prompts: ${count("created")} created, ${count("selected")} selected, ${count("already_official")} already official.`,
+  );
+}
+
+const isDirectRun = process.argv[1]
+  ? path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)
+  : false;
+
+if (isDirectRun) {
+  main()
+    .finally(() => prisma.$disconnect())
+    .catch((error) => {
+      console.error(error instanceof Error ? error.message : error);
+      process.exitCode = 1;
+    });
+}

--- a/tests/integration/gallery/gallery-service.test.ts
+++ b/tests/integration/gallery/gallery-service.test.ts
@@ -15,6 +15,7 @@ async function main() {
   const buildId = randomUUID();
   const buildPublicId = `cb_${suffix}saved`;
   const prompt = "A lantern-lit cliff observatory";
+  const runAt = new Date("2026-08-31T04:35:00.000Z");
   const legacyPrompt = `A legacy-key Gallery prompt ${suffix}`;
   const racePrompt = `A selection and removal race ${suffix}`;
   const {
@@ -52,6 +53,7 @@ async function main() {
         ownerId: uploaderId,
         status: "succeeded",
         currentStage: "complete",
+        completedAt: runAt,
         promptText: prompt,
         promptSha256: "a".repeat(64),
         gridSize: 64,
@@ -123,6 +125,7 @@ async function main() {
     assert.equal(created.candidate.cover?.blockCount, 4);
     assert.equal(created.candidate.cover?.jsonBytes, 100);
     assert.equal(created.candidate.cover?.generationTimeMs, 125_000);
+    assert.equal(created.candidate.cover?.runAt, runAt.toISOString());
     assert.equal(created.candidate.cover?.buildId, buildPublicId);
     assert.equal(
       created.candidate.cover?.thumbnailUrl,

--- a/tests/integration/gallery/gallery-service.test.ts
+++ b/tests/integration/gallery/gallery-service.test.ts
@@ -208,6 +208,32 @@ async function main() {
       { sort: "top", previousId: navigationIds.highest, nextId: navigationIds.newest },
       "Top navigation should follow visible vote order",
     );
+    await setGalleryCandidateSelected(adminId, navigationIds.middle, true);
+    await setGalleryCandidateSelected(adminId, navigationIds.highest, true);
+    await db.galleryCandidate.update({
+      where: { publicId: navigationIds.middle },
+      data: { selectedAt: new Date("2035-01-02T00:00:00.000Z") },
+    });
+    await db.galleryCandidate.update({
+      where: { publicId: navigationIds.highest },
+      data: { selectedAt: new Date("2035-01-03T00:00:00.000Z") },
+    });
+    const official = await listGalleryCandidates({ sort: "official", limit: 10 });
+    assert.deepEqual(
+      official.items.map((item) => item.id).filter((id) => Object.values(navigationIds).includes(id)),
+      [navigationIds.highest, navigationIds.middle],
+      "Official sorting should include only selected prompts in selection order",
+    );
+    assert.deepEqual(
+      (await getGalleryCandidate(navigationIds.highest, { navigationSort: "official" }))?.navigation,
+      { sort: "official", previousId: null, nextId: navigationIds.middle },
+      "Official navigation should stay within selected prompts",
+    );
+    assert.equal(
+      (await getGalleryCandidate(navigationIds.newest, { navigationSort: "official" }))?.navigation,
+      null,
+      "Non-official prompts should ignore official navigation",
+    );
     await db.galleryCandidate.deleteMany({
       where: { publicId: { in: Object.values(navigationIds) } },
     });

--- a/tests/integration/gallery/gallery-service.test.ts
+++ b/tests/integration/gallery/gallery-service.test.ts
@@ -18,6 +18,10 @@ async function main() {
   const runAt = new Date("2026-08-31T04:35:00.000Z");
   const legacyPrompt = `A legacy-key Gallery prompt ${suffix}`;
   const racePrompt = `A selection and removal race ${suffix}`;
+  const officialSeedPrompts = {
+    [`official-seed-one-${suffix}`]: `Official Gallery seed one ${suffix}`,
+    [`official-seed-two-${suffix}`]: `Official Gallery seed two ${suffix}`,
+  };
   const {
     addGalleryExample,
     claimAnonymousGalleryVotes,
@@ -32,6 +36,7 @@ async function main() {
     submitGalleryAppeal,
     submitGalleryCandidate,
   } = await import("../../../lib/gallery/service");
+  const { seedGalleryOfficialPrompts } = await import("../../../scripts/seed-gallery-official-prompts");
 
   try {
     await db.user.createMany({
@@ -43,7 +48,13 @@ async function main() {
           publicNicknameNormalized: "cliff builder",
         },
         { id: visitorId, email: `gallery-visitor-${suffix}@example.test` },
-        { id: adminId, email: `gallery-admin-${suffix}@example.test`, isMineBenchAdmin: true },
+        {
+          id: adminId,
+          email: `gallery-admin-${suffix}@example.test`,
+          publicNickname: `MineBench ${suffix}`,
+          publicNicknameNormalized: `minebench ${suffix}`,
+          isMineBenchAdmin: true,
+        },
       ],
     });
     await db.customBuild.create({
@@ -237,6 +248,16 @@ async function main() {
     await db.galleryCandidate.deleteMany({
       where: { publicId: { in: Object.values(navigationIds) } },
     });
+
+    const firstSeed = await seedGalleryOfficialPrompts(adminId, officialSeedPrompts);
+    assert.deepEqual(firstSeed.map((result) => result.status), ["created", "created"]);
+    const repeatedSeed = await seedGalleryOfficialPrompts(adminId, officialSeedPrompts);
+    assert.deepEqual(repeatedSeed.map((result) => result.status), ["already_official", "already_official"]);
+    const seededIds = new Set(firstSeed.map((result) => result.candidateId));
+    const seededCandidates = (await listGalleryCandidates({ sort: "official", limit: 10 })).items
+      .filter((candidate) => seededIds.has(candidate.id));
+    assert.equal(seededCandidates.length, 2);
+    assert.equal(seededCandidates.every((candidate) => candidate.exampleCount === 0), true);
 
     const legacyCandidate = await db.galleryCandidate.create({
       data: {
@@ -490,8 +511,10 @@ async function main() {
 
     console.log("Gallery application-service checks passed");
   } finally {
-    await db.galleryCandidate.deleteMany({ where: { uploaderId } });
-    await db.prompt.deleteMany({ where: { text: { in: [prompt, legacyPrompt, racePrompt] } } });
+    await db.galleryCandidate.deleteMany({ where: { uploaderId: { in: [uploaderId, adminId] } } });
+    await db.prompt.deleteMany({
+      where: { text: { in: [prompt, legacyPrompt, racePrompt, ...Object.values(officialSeedPrompts)] } },
+    });
     await db.customBuild.deleteMany({ where: { ownerId: uploaderId } });
     await db.user.deleteMany({ where: { id: { in: [uploaderId, visitorId, adminId] } } });
     await db.$disconnect();

--- a/tests/ui/gallery-actions.test.ts
+++ b/tests/ui/gallery-actions.test.ts
@@ -47,7 +47,11 @@ assert.ok(
     detail.includes('event.key === "ArrowRight"') &&
     detail.includes("event.repeat || event.isComposing") &&
     detail.includes("motion-reduce:transform-none") &&
-    explore.includes('sort === "new" ? "?sort=new" : ""') &&
+    explore.includes('sort === "top" ? "" : `?sort=${sort}`') &&
+    explore.includes('["top", "new", "official"]') &&
+    detail.includes("gallerySortHref") &&
+    detail.includes("longPrompt") &&
+    detail.includes("text-2xl sm:text-3xl lg:text-4xl") &&
     galleryDetailPage.includes("navigationSort: sort"),
   "Gallery details should preserve their ordering and expose polished pointer and keyboard navigation",
 );

--- a/tests/ui/gallery-actions.test.ts
+++ b/tests/ui/gallery-actions.test.ts
@@ -48,7 +48,10 @@ assert.ok(
     detail.includes("event.repeat || event.isComposing") &&
     detail.includes("motion-reduce:transform-none") &&
     explore.includes('sort === "top" ? "" : `?sort=${sort}`') &&
-    explore.includes('["top", "new", "official"]') &&
+    explore.includes('["official", "top", "new"]') &&
+    explore.includes('aria-label="Gallery views"') &&
+    explore.includes("Official prompts are part of the benchmark.") &&
+    explore.includes('/faq#how-does-minebench-account-for-nondeterminism') &&
     detail.includes("gallerySortHref") &&
     detail.includes("longPrompt") &&
     detail.includes("text-2xl sm:text-3xl lg:text-4xl") &&

--- a/tests/ui/gallery-actions.test.ts
+++ b/tests/ui/gallery-actions.test.ts
@@ -134,6 +134,14 @@ assert.ok(
   "Gallery cards should keep a clear media frame and disclose distinct hidden models without extra client requests",
 );
 assert.ok(
+  detail.includes("Official prompt") &&
+    explore.includes("Official prompt") &&
+    detail.includes("example.runAt") &&
+    detail.includes("<time dateTime={example.runAt}") &&
+    galleryService.includes("customBuild.completedAt ?? example.createdAt"),
+  "official prompts should identify themselves and date each model run",
+);
+assert.ok(
   explore.includes("const previewsReady =") &&
     explore.includes("!candidate.alternate?.previewUrl || alternateLoaded") &&
     explore.includes("!previewsReady ?") &&

--- a/tests/unit/custom-builds/generate-job.test.ts
+++ b/tests/unit/custom-builds/generate-job.test.ts
@@ -333,6 +333,49 @@ async function main() {
   eventSeq = 0;
   txSeq = 0;
   currentCustomBuild = queuedCustomBuild;
+  const importedCompletedAt = new Date("2026-08-31T04:35:00.445Z");
+  await runCustomBuildGenerateJob({
+    id: "imported-job-row",
+    customBuildId,
+    type: "generate",
+    status: "running",
+    attempts: 1,
+    maxAttempts: 1,
+    payload: {},
+  } as never, {
+    importedBuild: {
+      build: {
+        version: "1.0",
+        blocks: [{ x: 8, y: 1, z: 3, type: "bricks" }],
+      },
+      warnings: [],
+      blockCount: 1,
+      generationTimeMs: 178_462,
+      completedAt: importedCompletedAt,
+      sourceArtifactSha256: "f".repeat(64),
+    },
+  });
+  const importedSuccess = updates.find((update) => update.data.status === "succeeded");
+  assert.ok(importedSuccess, "imports should finalize as successful saved generations");
+  assert.equal(importedSuccess.data.completedAt, importedCompletedAt);
+  assert.equal(importedSuccess.data.generationTimeMs, 178_462);
+  assert.deepEqual(importedSuccess.data.metrics, {
+    blockCount: 1,
+    generationTimeMs: 178_462,
+    warnings: [],
+    sourceArtifactSha256: "f".repeat(64),
+  });
+  assert.deepEqual(
+    artifactCreates.map((artifact) => artifact.kind).sort(),
+    ["build_json", "preview_mbv4", "preview_svg", "viewer_mbv4"],
+  );
+
+  updates.length = 0;
+  operations.length = 0;
+  artifactCreates.length = 0;
+  eventSeq = 0;
+  txSeq = 0;
+  currentCustomBuild = queuedCustomBuild;
   const previousWarn = console.warn;
   console.warn = () => {};
   try {

--- a/tests/unit/faq.test.ts
+++ b/tests/unit/faq.test.ts
@@ -28,6 +28,17 @@ assert.ok(
   "FAQ should explain manual prompt promotion and official retests",
 );
 
+const nondeterminism = FAQ_ITEMS.find(
+  (item) => item.id === "how-does-minebench-account-for-nondeterminism",
+);
+const nondeterminismAnswer = nondeterminism?.answer.join(" ") ?? "";
+assert.ok(
+  nondeterminismAnswer.includes("three times") &&
+    nondeterminismAnswer.includes("provider API costs") &&
+    nondeterminismAnswer.includes("official Gallery prompt"),
+  "FAQ should explain the ideal repeat protocol, cost constraint, and community reruns",
+);
+
 const readme = readFileSync("README.md", "utf8");
 for (const item of FAQ_ITEMS) {
   // Private evaluations stay discoverable without README promotion

--- a/tests/unit/faq.test.ts
+++ b/tests/unit/faq.test.ts
@@ -19,6 +19,15 @@ for (const item of FAQ_ITEMS) {
   assert.ok(item.answer.every((paragraph) => paragraph.trim().length > 0));
 }
 
+const galleryMethodology = FAQ_ITEMS.find(
+  (item) => item.id === "how-does-the-gallery-shape-the-benchmark",
+);
+assert.ok(
+  galleryMethodology?.answer.join(" ").includes("highest-voted prompts") &&
+    galleryMethodology.answer.join(" ").includes("run-to-run variation"),
+  "FAQ should explain manual prompt promotion and official retests",
+);
+
 const readme = readFileSync("README.md", "utf8");
 for (const item of FAQ_ITEMS) {
   // Private evaluations stay discoverable without README promotion

--- a/tests/unit/faq.test.ts
+++ b/tests/unit/faq.test.ts
@@ -35,7 +35,8 @@ const nondeterminismAnswer = nondeterminism?.answer.join(" ") ?? "";
 assert.ok(
   nondeterminismAnswer.includes("three times") &&
     nondeterminismAnswer.includes("provider API costs") &&
-    nondeterminismAnswer.includes("official Gallery prompt"),
+    nondeterminismAnswer.includes("official Gallery prompt") &&
+    nondeterminism?.links?.some((link) => link.href === "/gallery?sort=official"),
   "FAQ should explain the ideal repeat protocol, cost constraint, and community reruns",
 );
 

--- a/tests/unit/scripts/batch-benchmark-metrics.test.ts
+++ b/tests/unit/scripts/batch-benchmark-metrics.test.ts
@@ -87,6 +87,10 @@ assert.equal(
 );
 assert.equal(readLedger().jobs["openai_gpt_5_6_sol/castle"]?.state, "succeeded");
 assert.equal(
+  store.getSucceededSample(castle)?.completedAt.toISOString(),
+  "2026-07-22T18:17:26.000Z",
+);
+assert.equal(
   store.reconcile([castle], new Date(), { verifySucceededArtifacts: false }).refreshRequired,
   true,
   "a finalized sample must remain pending until generated metrics refresh",

--- a/tests/unit/scripts/gallery-import.test.ts
+++ b/tests/unit/scripts/gallery-import.test.ts
@@ -1,0 +1,72 @@
+import assert from "node:assert/strict";
+import {
+  galleryRetestPublicId,
+  parseGalleryImportArgs,
+  resolveGalleryImportSpec,
+} from "../../../scripts/import-gallery-retest";
+
+const parsed = parseGalleryImportArgs([
+  "--prompt",
+  "steampunk",
+  "--model",
+  "gemini-3-1-pro",
+]);
+assert.equal(parsed.help, false);
+if (parsed.help) throw new Error("Expected import arguments.");
+assert.deepEqual(parsed, {
+  help: false,
+  promptSlug: "steampunk",
+  model: "gemini-3-1-pro",
+  confirmed: false,
+});
+const confirmed = parseGalleryImportArgs([
+  "--prompt",
+  "steampunk",
+  "--model",
+  "gemini-3-1-pro",
+  "--yes",
+]);
+assert.equal(confirmed.help ? false : confirmed.confirmed, true);
+assert.equal(
+  resolveGalleryImportSpec(parsed, "/repo/uploads").filePath,
+  "/repo/uploads/steampunk/steampunk-gemini-3-1-pro.json",
+);
+
+assert.deepEqual(parseGalleryImportArgs(["--help"]), { help: true });
+assert.throws(
+  () => {
+    const invalid = parseGalleryImportArgs(["--prompt", "steampunk", "--model", "not-a-model"]);
+    if (invalid.help) throw new Error("Expected import arguments.");
+    resolveGalleryImportSpec(invalid);
+  },
+  /Unknown catalog model/,
+);
+assert.throws(
+  () => resolveGalleryImportSpec({ ...parsed, promptSlug: "custom-prompt" }),
+  /Unknown official prompt/,
+);
+assert.throws(
+  () => parseGalleryImportArgs(["--prompt", "steampunk", "--model"]),
+  /--model needs a value/,
+);
+
+const identity = {
+  publisherId: "00000000-0000-4000-8000-000000000001",
+  promptSlug: "steampunk",
+  modelKey: "gemini_3_1_pro",
+  sourceArtifactSha256: "a".repeat(64),
+  completedAt: "2026-08-31T04:35:00.445Z",
+};
+const publicId = galleryRetestPublicId(identity);
+assert.match(publicId, /^cb_[A-Za-z0-9_-]{24}$/);
+assert.equal(galleryRetestPublicId(identity), publicId);
+assert.notEqual(
+  galleryRetestPublicId({ ...identity, sourceArtifactSha256: "b".repeat(64) }),
+  publicId,
+);
+assert.notEqual(
+  galleryRetestPublicId({ ...identity, completedAt: "2026-09-01T04:35:00.445Z" }),
+  publicId,
+);
+
+console.log("Gallery retest import argument checks passed");

--- a/tests/unit/scripts/gallery-seed.test.ts
+++ b/tests/unit/scripts/gallery-seed.test.ts
@@ -1,0 +1,12 @@
+import assert from "node:assert/strict";
+import { parseGalleryOfficialSeedArgs } from "../../../scripts/seed-gallery-official-prompts";
+
+assert.deepEqual(parseGalleryOfficialSeedArgs([]), { help: false, confirmed: false });
+assert.deepEqual(parseGalleryOfficialSeedArgs(["--yes"]), { help: false, confirmed: true });
+assert.deepEqual(parseGalleryOfficialSeedArgs(["--help"]), { help: true });
+assert.deepEqual(parseGalleryOfficialSeedArgs(["-h"]), { help: true });
+assert.throws(() => parseGalleryOfficialSeedArgs(["--yes", "--yes"]), /Pass --yes once/);
+assert.throws(() => parseGalleryOfficialSeedArgs(["--all"]), /Unknown argument/);
+assert.throws(() => parseGalleryOfficialSeedArgs(["--help", "--yes"]), /Use --help by itself/);
+
+console.log("Gallery official seed argument checks passed");


### PR DESCRIPTION
## Summary

- import finalized official-prompt reruns into Gallery under MineBench without replacing the canonical benchmark build
- foreground an Official Gallery view with stable pagination and navigation, concise rerun methodology, and responsive detail typography for long benchmark prompts
- verify benchmark-ledger and artifact provenance, reuse saved-generation finalization, and keep reruns idempotent and dated
- add an additive, idempotent command that seeds every canonical benchmark prompt into the Official Gallery view
- explain prompt curation, nondeterminism, API-cost constraints, and community reruns in the FAQ

## Validation

- `pnpm exec tsc --noEmit`
- `pnpm lint`
- `pnpm test tests/unit tests/ui` (111 files)
- `node scripts/run-postgres-tests.mjs tests/integration/gallery/gallery-service.test.ts`
- `pnpm build`
- `pnpm gallery:seed-official --help`
- `npx impeccable --json components/gallery/GalleryDetail.tsx components/gallery/GalleryExplore.tsx`
- Alpha live seed repeated successfully: 15 official prompts, no duplicates, and the existing `steampunk × gemini-3-1-pro` rerun preserved

*(PR written by Codex)*
