### PR TITLE
feat(generate): persist custom provider profiles

### DIFF
--- a/app/api/generate/route.ts
+++ b/app/api/generate/route.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { NextResponse } from "next/server";
 import { waitUntil } from "@vercel/functions";
+import { normalizeCustomProviderRequestConfig } from "@/lib/ai/customProviderConfig";
 import { generateVoxelBuild } from "@/lib/ai/generateVoxelBuild";
 import { getModelByKey, ModelKey } from "@/lib/ai/modelCatalog";
 import { assertSafeCustomApiUrl } from "@/lib/ai/providers/customApiGuard";
@@ -25,6 +26,15 @@ const providerKeysSchema = z
   })
   .optional();
 
+const customHeadersSchema = z
+  .record(z.string().trim().min(1).max(128), z.string().max(16_384))
+  .refine((value) => Object.keys(value).length <= 32, "Too many custom headers.")
+  .optional();
+const customBodySchema = z
+  .record(z.string().trim().min(1).max(128), z.unknown())
+  .refine((value) => JSON.stringify(value).length <= 65_536, "Custom body is too large.")
+  .optional();
+
 const modelRequestSchema = z.union([
   z.object({
     id: z.string().trim().min(1).max(200),
@@ -38,6 +48,8 @@ const modelRequestSchema = z.union([
     displayName: z.string().trim().min(1).max(120),
     modelId: z.string().trim().min(1).max(240),
     baseUrl: z.string().trim().url().max(4000),
+    headers: customHeadersSchema,
+    body: customBodySchema,
   }),
   z.object({
     id: z.string().trim().min(1).max(200),
@@ -114,7 +126,12 @@ export async function POST(req: Request) {
   for (const model of models) {
     if (model.kind !== "custom" || model.provider !== "custom") continue;
     try {
-      await assertSafeCustomApiUrl(model.baseUrl);
+      const config = normalizeCustomProviderRequestConfig({
+        baseUrl: model.baseUrl,
+        headers: model.headers,
+        body: model.body,
+      });
+      await assertSafeCustomApiUrl(config.baseUrl);
     } catch (error) {
       const message = error instanceof Error ? error.message : "Invalid custom API server URL";
       return NextResponse.json({ error: message }, { status: 400 });
@@ -226,6 +243,8 @@ export async function POST(req: Request) {
                         modelId: model.modelId,
                         displayName: model.displayName,
                         baseUrl: model.baseUrl,
+                        customHeaders: model.headers,
+                        customBody: model.body,
                       },
                 prompt: body.prompt,
                 gridSize: body.gridSize,

--- a/app/api/generations/[id]/retry/route.ts
+++ b/app/api/generations/[id]/retry/route.ts
@@ -8,6 +8,14 @@ export const runtime = "nodejs";
 const retryRequest = z.object({
   providerKey: z.string().trim().min(1).max(4000).optional(),
   customBaseUrl: z.string().trim().url().max(4000).optional(),
+  customHeaders: z
+    .record(z.string().trim().min(1).max(128), z.string().max(16_384))
+    .refine((value) => Object.keys(value).length <= 32, "Too many custom headers.")
+    .optional(),
+  customBody: z
+    .record(z.string().trim().min(1).max(128), z.unknown())
+    .refine((value) => JSON.stringify(value).length <= 65_536, "Custom body is too large.")
+    .optional(),
 });
 
 export async function POST(request: Request, context: { params: Promise<{ id: string }> }) {

--- a/app/api/generations/route.ts
+++ b/app/api/generations/route.ts
@@ -20,6 +20,15 @@ const providerKeys = z.object({
   custom: z.string().trim().min(1).max(4000).optional(),
 });
 
+const customHeaders = z
+  .record(z.string().trim().min(1).max(128), z.string().max(16_384))
+  .refine((value) => Object.keys(value).length <= 32, "Too many custom headers.")
+  .optional();
+const customBody = z
+  .record(z.string().trim().min(1).max(128), z.unknown())
+  .refine((value) => JSON.stringify(value).length <= 65_536, "Custom body is too large.")
+  .optional();
+
 const model = z.union([
   z.object({
     id: z.string().trim().min(1).max(200),
@@ -33,6 +42,8 @@ const model = z.union([
     displayName: z.string().trim().min(1).max(120),
     modelId: z.string().trim().min(1).max(240),
     baseUrl: z.string().trim().url().max(4000),
+    headers: customHeaders,
+    body: customBody,
   }),
   z.object({
     id: z.string().trim().min(1).max(200),

--- a/components/sandbox/SandboxLive.tsx
+++ b/components/sandbox/SandboxLive.tsx
@@ -5,6 +5,14 @@ import Link from "next/link";
 import { MODEL_CATALOG, ModelKey } from "@/lib/ai/modelCatalog";
 import type { GenerateEvent, GenerateModelRequest, ProviderApiKeys } from "@/lib/ai/types";
 import {
+  customProviderRequestConfigFromProfile,
+  loadCustomProviderProfile,
+  MAX_CUSTOM_REQUEST_ENTRIES,
+  saveCustomProviderProfile,
+  type CustomProviderProfile,
+  type CustomRequestEntry,
+} from "@/lib/ai/customProviderConfig";
+import {
   SandboxGifExportButton,
   type SandboxGifExportTarget,
 } from "@/components/sandbox/SandboxGifExportButton";
@@ -35,12 +43,6 @@ type SelectedModelValue =
   | typeof CUSTOM_MODEL_VALUE;
 type GenerationPreflightMode = "free" | "save" | "key";
 
-type CustomSandboxModel = {
-  displayName: string;
-  modelId: string;
-  baseUrl: string;
-};
-
 type SelectedLiveModel =
   | {
       id: string;
@@ -57,6 +59,7 @@ type SelectedLiveModel =
       providerLabel: string;
       modelId: string;
       baseUrl?: string;
+      profile?: CustomProviderProfile;
     };
 
 type ModelResult = {
@@ -113,11 +116,6 @@ const CUSTOM_MODEL_VALUE = "__custom_api__";
 const HOSTED_GEMINI_MODEL_KEY = "gemini_3_7_flash";
 const HOSTED_GEMINI_NOTICE_KEY = "mb_hosted_gemini_3_7_notice_v1";
 let anonymousHostedGeminiNoticeShown = false;
-const DEFAULT_CUSTOM_MODEL: CustomSandboxModel = {
-  displayName: "OpenAI-compatible model",
-  modelId: "",
-  baseUrl: "",
-};
 const ENABLED_MODELS = MODEL_CATALOG.filter((model) => model.enabled);
 const FALLBACK_MODEL_A: ModelKey = ENABLED_MODELS[0]?.key ?? "openai_gpt_5_4_mini";
 const DEFAULT_MODEL_A: ModelKey =
@@ -134,6 +132,94 @@ const DEFAULT_MODEL_B: ModelKey =
   )?.key ??
   ENABLED_MODELS.find((model) => model.key !== DEFAULT_MODEL_A)?.key ??
   DEFAULT_MODEL_A;
+
+function RequestEntriesEditor({
+  label,
+  addLabel,
+  entries,
+  onChange,
+  disabled,
+}: {
+  label: string;
+  addLabel: string;
+  entries: CustomRequestEntry[];
+  onChange: (entries: CustomRequestEntry[]) => void;
+  disabled: boolean;
+}) {
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex min-h-11 items-center justify-between gap-3">
+        <div className="text-xs font-medium text-muted">{label}</div>
+        <button
+          type="button"
+          className="inline-flex min-h-11 items-center gap-1.5 rounded-sm px-1 text-xs font-medium text-muted transition-colors hover:text-fg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 disabled:cursor-not-allowed disabled:opacity-50 motion-reduce:transition-none"
+          disabled={disabled || entries.length >= MAX_CUSTOM_REQUEST_ENTRIES}
+          onClick={() => onChange([...entries, { name: "", value: "" }])}
+        >
+          <svg aria-hidden="true" viewBox="0 0 16 16" className="h-3.5 w-3.5">
+            <path d="M8 3v10M3 8h10" fill="none" stroke="currentColor" strokeLinecap="round" strokeWidth="1.5" />
+          </svg>
+          {addLabel}
+        </button>
+      </div>
+
+      {entries.length > 0 ? (
+        <div className="flex flex-col gap-2">
+          <div className="hidden grid-cols-[minmax(0,0.85fr)_minmax(0,1.15fr)_2.75rem] gap-2 px-0.5 text-[11px] font-medium text-muted sm:grid">
+            <div>Name</div>
+            <div>Value</div>
+            <span aria-hidden="true" />
+          </div>
+          {entries.map((entry, index) => (
+            <div
+              key={index}
+              className="grid grid-cols-[minmax(0,1fr)_2.75rem] items-center gap-2 sm:grid-cols-[minmax(0,0.85fr)_minmax(0,1.15fr)_2.75rem]"
+            >
+              <input
+                aria-label={`${label} ${index + 1} name`}
+                className="mb-field col-start-1 row-start-1 h-10 min-w-0"
+                value={entry.name}
+                placeholder="Name"
+                maxLength={128}
+                disabled={disabled}
+                spellCheck={false}
+                autoCapitalize="none"
+                onChange={(event) => onChange(entries.map((item, itemIndex) =>
+                  itemIndex === index ? { ...item, name: event.target.value } : item
+                ))}
+              />
+              <input
+                aria-label={`${label} ${index + 1} value`}
+                className="mb-field col-start-1 row-start-2 h-10 min-w-0 sm:col-start-2 sm:row-start-1"
+                value={entry.value}
+                placeholder="Value"
+                maxLength={16_384}
+                disabled={disabled}
+                spellCheck={false}
+                autoCapitalize="none"
+                onChange={(event) => onChange(entries.map((item, itemIndex) =>
+                  itemIndex === index ? { ...item, value: event.target.value } : item
+                ))}
+              />
+              <button
+                type="button"
+                aria-label={`Remove ${label.toLowerCase()} ${index + 1}`}
+                title="Remove"
+                className="col-start-2 row-span-2 row-start-1 inline-flex h-11 w-11 items-center justify-center rounded-sm text-muted transition-colors hover:bg-fg/[0.05] hover:text-fg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 disabled:cursor-not-allowed disabled:opacity-50 motion-reduce:transition-none sm:col-start-3 sm:row-span-1"
+                disabled={disabled}
+                onClick={() => onChange(entries.filter((_, itemIndex) => itemIndex !== index))}
+              >
+                <svg aria-hidden="true" viewBox="0 0 16 16" className="h-4 w-4">
+                  <path d="M3.5 4.5h9M6 2.75h4M5 6.5v5.25m3-5.25v5.25m3-5.25v5.25M4.25 4.5l.5 9h6.5l.5-9" fill="none" stroke="currentColor" strokeLinecap="round" strokeLinejoin="round" strokeWidth="1.25" />
+                </svg>
+              </button>
+            </div>
+          ))}
+        </div>
+      ) : null}
+    </div>
+  );
+}
 
 function HostedGeminiAnnouncement({
   open,
@@ -568,8 +654,11 @@ export function SandboxLive({
   const [gridSize, setGridSize] = useState<GridSize>(256);
   const [palette, setPalette] = useState<Palette>("simple");
   const [providerKeys, setProviderKeys] = useState<ProviderApiKeys>(() => loadProviderKeysFromStorage());
-  const [customModel, setCustomModel] = useState<CustomSandboxModel>(DEFAULT_CUSTOM_MODEL);
+  const [customModel, setCustomModel] = useState<CustomProviderProfile>(() => loadCustomProviderProfile());
+  const [customProfileReady, setCustomProfileReady] = useState(false);
+  const [openRouterModelId, setOpenRouterModelId] = useState("");
   const [showKeys, setShowKeys] = useState(false);
+  const [customRequestOpen, setCustomRequestOpen] = useState(false);
   const [modelPair, setModelPair] = useState<{ a: SelectedModelValue; b: SelectedModelValue | null }>({
     a: DEFAULT_MODEL_A,
     b: DEFAULT_MODEL_B !== DEFAULT_MODEL_A ? DEFAULT_MODEL_B : null,
@@ -590,7 +679,16 @@ export function SandboxLive({
     useState<GenerationPreflightMode | null>(null);
   const [generationPreflightMessage, setGenerationPreflightMessage] = useState<string>();
   const [showHostedGeminiAnnouncement, setShowHostedGeminiAnnouncement] = useState(false);
-  const savedKeyCount = Object.values(providerKeys).filter((value) => Boolean(value?.trim())).length;
+  const savedKeyCount = Object.entries(providerKeys).filter(
+    ([provider, value]) => provider !== "custom" && Boolean(value?.trim()),
+  ).length;
+  const customRequestCount = [...customModel.headers, ...customModel.body].filter(
+    (entry) => Boolean(entry.name.trim() || entry.value.trim()),
+  ).length;
+  const customProviderOptionLabel =
+    customProfileReady && customModel.providerName.trim()
+      ? customModel.providerName.trim()
+      : "OpenAI-compatible model";
   const showHostedGeminiOffer = Boolean(
     hostedGeminiEnabled &&
     (!signedIn ||
@@ -615,6 +713,8 @@ export function SandboxLive({
   const viewerARef = useRef<VoxelViewerHandle | null>(null);
   const viewerBRef = useRef<VoxelViewerHandle | null>(null);
   const apiKeysSectionRef = useRef<HTMLElement | null>(null);
+  const customProviderSectionRef = useRef<HTMLDivElement | null>(null);
+  const customApiKeyRef = useRef<HTMLInputElement | null>(null);
 
   const modelGroups = useMemo(() => {
     const groups = new Map<string, (typeof ENABLED_MODELS)[number][]>();
@@ -634,7 +734,6 @@ export function SandboxLive({
     : compareEnabled && isAdHocModelValue(modelPair.b)
       ? modelPair.b
       : null;
-  const usesAdHocModel = adHocModelValue !== null;
   const usesOpenRouterModel = adHocModelValue === OPENROUTER_MODEL_VALUE;
   const usesOpenAiCompatibleModel = adHocModelValue === CUSTOM_MODEL_VALUE;
   const selectedModels = useMemo(() => {
@@ -648,11 +747,15 @@ export function SandboxLive({
           kind: "custom",
           provider: usesOpenRouter ? "openrouter" : "custom",
           displayName: usesOpenRouter
-            ? customModel.modelId.trim() || "OpenRouter model"
-            : customModel.displayName.trim() || "OpenAI-compatible model",
-          providerLabel: usesOpenRouter ? "OpenRouter" : "OpenAI-compatible",
-          modelId: customModel.modelId.trim(),
-          ...(usesOpenRouter ? {} : { baseUrl: customModel.baseUrl.trim() }),
+            ? openRouterModelId.trim() || "OpenRouter model"
+            : customModel.modelId.trim() || "OpenAI-compatible model",
+          providerLabel: usesOpenRouter
+            ? "OpenRouter"
+            : customModel.providerName.trim() || "Custom provider",
+          modelId: usesOpenRouter ? openRouterModelId.trim() : customModel.modelId.trim(),
+          ...(usesOpenRouter
+            ? {}
+            : { baseUrl: customModel.baseUrl.trim(), profile: customModel }),
         });
         return;
       }
@@ -671,7 +774,7 @@ export function SandboxLive({
       pushValue(modelPair.b);
     }
     return picked;
-  }, [compareEnabled, customModel, modelPair.a, modelPair.b]);
+  }, [compareEnabled, customModel, modelPair.a, modelPair.b, openRouterModelId]);
   const inputSignature = useMemo(
     () =>
       [
@@ -682,7 +785,7 @@ export function SandboxLive({
           .map((model) =>
             model.kind === "catalog"
               ? model.modelKey
-              : `${model.provider}:${model.displayName}:${model.modelId}:${model.baseUrl ?? ""}`,
+              : `${model.provider}:${model.displayName}:${model.modelId}:${JSON.stringify(model.profile ?? {})}`,
           )
           .join("|"),
       ].join("\0"),
@@ -699,6 +802,14 @@ export function SandboxLive({
   useEffect(() => {
     saveProviderKeysToStorage(providerKeys);
   }, [providerKeys]);
+
+  useEffect(() => {
+    setCustomProfileReady(true);
+  }, []);
+
+  useEffect(() => {
+    saveCustomProviderProfile(customModel);
+  }, [customModel]);
 
   useEffect(() => {
     if (!hostedGeminiEnabled || (signedIn && !hostedGeminiAvailable)) {
@@ -807,7 +918,7 @@ export function SandboxLive({
     });
   }
 
-  function updateCustomModel(patch: Partial<CustomSandboxModel>) {
+  function updateCustomModel(patch: Partial<CustomProviderProfile>) {
     setCustomModel((prev) => ({ ...prev, ...patch }));
   }
 
@@ -892,13 +1003,18 @@ export function SandboxLive({
       };
     }
     if (model.provider === "custom") {
+      const config = customProviderRequestConfigFromProfile(
+        model.profile ?? customModel,
+      );
       return {
         id: model.id,
         kind: "custom",
         provider: "custom",
         displayName: model.displayName,
         modelId: model.modelId,
-        baseUrl: model.baseUrl ?? "",
+        baseUrl: config.baseUrl,
+        headers: config.headers,
+        body: config.body,
       };
     }
     return {
@@ -911,6 +1027,10 @@ export function SandboxLive({
   }
 
   function hasProviderKey(model: SelectedLiveModel): boolean {
+    if (model.kind === "custom") {
+      const provider = model.provider === "custom" ? "custom" : "openrouter";
+      return Boolean(providerKeys[provider]?.trim());
+    }
     return Object.values(
       selectGenerationProviderKeys([customBuildRequestModel(model)], providerKeys),
     ).some((value) => Boolean(value?.trim()));
@@ -941,6 +1061,13 @@ export function SandboxLive({
 
   function openApiKeys() {
     setGenerationPreflight(null);
+    if (usesOpenAiCompatibleModel) {
+      window.requestAnimationFrame(() => {
+        customProviderSectionRef.current?.scrollIntoView({ block: "center" });
+        customApiKeyRef.current?.focus();
+      });
+      return;
+    }
     setApiKeysOpen(true);
     setProviderKeysOpen(true);
     window.requestAnimationFrame(() => {
@@ -1095,6 +1222,9 @@ export function SandboxLive({
     setRunning(true);
     setRequestError(null);
     try {
+      const customConfig = model.kind === "custom" && model.provider === "custom"
+        ? customProviderRequestConfigFromProfile(model.profile ?? customModel)
+        : null;
       const response = await fetch(
         `/api/generations/${encodeURIComponent(existing.customBuildId)}/retry`,
         {
@@ -1103,8 +1233,12 @@ export function SandboxLive({
           signal: abortController.signal,
           body: JSON.stringify({
             ...(providerKey ? { providerKey } : {}),
-            ...(model.kind === "custom" && model.provider === "custom"
-              ? { customBaseUrl: model.baseUrl }
+            ...(customConfig
+              ? {
+                  customBaseUrl: customConfig.baseUrl,
+                  customHeaders: customConfig.headers,
+                  customBody: customConfig.body,
+                }
               : {}),
           }),
         },
@@ -1146,6 +1280,7 @@ export function SandboxLive({
   async function runGenerateDurable(args: {
     abortController: AbortController;
     providerKeys: ProviderApiKeys;
+    models: GenerateModelRequest[];
     prompt: string;
     runId: number;
   }) {
@@ -1158,7 +1293,7 @@ export function SandboxLive({
         prompt: args.prompt,
         gridSize,
         palette,
-        models: selectedModels.map(customBuildRequestModel),
+        models: args.models,
         providerKeys: args.providerKeys,
       }),
     });
@@ -1256,7 +1391,13 @@ export function SandboxLive({
       setRequestError("Enter a chat completions URL for the OpenAI-compatible model.");
       return;
     }
-    const requestModels = selectedModels.map(customBuildRequestModel);
+    let requestModels: GenerateModelRequest[];
+    try {
+      requestModels = selectedModels.map(customBuildRequestModel);
+    } catch (error) {
+      setRequestError(error instanceof Error ? error.message : "Check the custom request settings.");
+      return;
+    }
     const missingProviderModels = selectedModels.filter((model) => {
       if (!signedIn && anonymousServerKeysEnabled) return false;
       if (
@@ -1330,6 +1471,7 @@ export function SandboxLive({
         await runGenerateDurable({
           abortController,
           providerKeys: sanitizedKeys,
+          models: requestModels,
           prompt: submittedPrompt,
           runId: durableRunId!,
         });
@@ -1834,7 +1976,7 @@ export function SandboxLive({
                     value={CUSTOM_MODEL_VALUE}
                     disabled={compareEnabled && isAdHocModelValue(modelPair.b)}
                   >
-                    OpenAI-compatible model
+                    {customProviderOptionLabel}
                   </option>
                 </optgroup>
               </select>
@@ -1872,7 +2014,7 @@ export function SandboxLive({
                   </optgroup>
                   <optgroup label="Custom">
                     <option value={CUSTOM_MODEL_VALUE} disabled={isAdHocModelValue(modelPair.a)}>
-                      OpenAI-compatible model
+                      {customProviderOptionLabel}
                     </option>
                   </optgroup>
                 </select>
@@ -1880,45 +2022,148 @@ export function SandboxLive({
             ) : null}
           </div>
 
-          {usesAdHocModel ? (
-            <div className="mt-3 rounded-md border border-border/70 bg-bg/35 p-3">
-              <div className="text-xs font-medium text-muted">
-                {usesOpenRouterModel ? "OpenRouter model" : "OpenAI-compatible model"}
+          {usesOpenRouterModel ? (
+            <label className="mt-4 flex flex-col gap-1 border-t border-border/70 pt-4">
+              <div className="text-xs font-medium text-muted">Model ID</div>
+              <input
+                className="mb-field h-10 w-full"
+                value={openRouterModelId}
+                onChange={(event) => setOpenRouterModelId(event.target.value)}
+                disabled={running}
+                placeholder="stealth/ox-alpha"
+                maxLength={240}
+                spellCheck={false}
+                autoCapitalize="none"
+              />
+            </label>
+          ) : null}
+
+          {usesOpenAiCompatibleModel ? (
+            <div
+              ref={customProviderSectionRef}
+              className="mt-4 flex scroll-mt-24 flex-col gap-4 border-t border-border/70 pt-4"
+            >
+              <div className="flex items-center justify-between gap-3">
+                <div className="text-xs font-medium text-muted">Provider profile</div>
+                <div className="text-[11px] text-muted">Saved in this browser</div>
               </div>
-              <div className="mt-3 grid grid-cols-1 gap-3">
-                {usesOpenAiCompatibleModel ? (
-                  <label className="flex flex-col gap-1">
-                    <div className="text-xs font-medium text-muted">Display name</div>
-                    <input
-                      className="mb-field h-10 w-full"
-                      value={customModel.displayName}
-                      onChange={(e) => updateCustomModel({ displayName: e.target.value })}
-                      disabled={running}
-                      placeholder="My model"
-                    />
-                  </label>
-                ) : null}
-                <label className="flex flex-col gap-1">
+
+              <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+                <label className="flex min-w-0 flex-col gap-1">
+                  <div className="text-xs font-medium text-muted">Provider name</div>
+                  <input
+                    className="mb-field h-10 w-full"
+                    value={customModel.providerName}
+                    onChange={(event) => updateCustomModel({ providerName: event.target.value })}
+                    disabled={running}
+                    maxLength={120}
+                  />
+                </label>
+                <label className="flex min-w-0 flex-col gap-1">
                   <div className="text-xs font-medium text-muted">Model ID</div>
                   <input
                     className="mb-field h-10 w-full"
                     value={customModel.modelId}
-                    onChange={(e) => updateCustomModel({ modelId: e.target.value })}
+                    onChange={(event) => updateCustomModel({ modelId: event.target.value })}
                     disabled={running}
-                    placeholder={usesOpenRouterModel ? "stealth/ox-alpha" : undefined}
+                    maxLength={240}
+                    spellCheck={false}
+                    autoCapitalize="none"
                   />
                 </label>
-                {usesOpenAiCompatibleModel ? (
-                  <label className="flex flex-col gap-1">
-                    <div className="text-xs font-medium text-muted">Chat completions URL</div>
-                    <input
-                      className="mb-field h-10 w-full"
-                      value={customModel.baseUrl}
-                      onChange={(e) => updateCustomModel({ baseUrl: e.target.value })}
-                      disabled={running}
-                      type="url"
-                    />
+              </div>
+
+              <label className="flex flex-col gap-1">
+                <div className="text-xs font-medium text-muted">Chat completions URL</div>
+                <input
+                  className="mb-field h-10 w-full"
+                  value={customModel.baseUrl}
+                  onChange={(event) => updateCustomModel({ baseUrl: event.target.value })}
+                  disabled={running}
+                  type="url"
+                  inputMode="url"
+                  maxLength={4_000}
+                  spellCheck={false}
+                  autoCapitalize="none"
+                />
+              </label>
+
+              <div className="flex flex-col gap-1">
+                <div className="flex min-h-11 items-center justify-between gap-3">
+                  <label htmlFor="sandbox-custom-api-key" className="text-xs font-medium text-muted">
+                    API key
                   </label>
+                  <button
+                    type="button"
+                    aria-pressed={showKeys}
+                    className="inline-flex min-h-11 items-center rounded-sm px-1 text-[11px] font-medium text-muted transition-colors hover:text-fg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 disabled:cursor-not-allowed disabled:opacity-50 motion-reduce:transition-none"
+                    onClick={() => setShowKeys((visible) => !visible)}
+                    disabled={running}
+                  >
+                    {showKeys ? "Hide" : "Show"}
+                  </button>
+                </div>
+                <input
+                  ref={customApiKeyRef}
+                  id="sandbox-custom-api-key"
+                  className="mb-field h-10 w-full"
+                  type={showKeys ? "text" : "password"}
+                  value={providerKeys.custom ?? ""}
+                  onChange={(event) =>
+                    setProviderKeys((current) => ({ ...current, custom: event.target.value }))
+                  }
+                  disabled={running}
+                  autoComplete="off"
+                  maxLength={4_000}
+                  spellCheck={false}
+                />
+              </div>
+
+              <div className="border-t border-border/70 pt-2">
+                <button
+                  type="button"
+                  aria-expanded={customRequestOpen}
+                  aria-controls="sandbox-custom-request"
+                  className="flex min-h-11 w-full items-center justify-between gap-3 rounded-sm px-1 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
+                  onClick={() => setCustomRequestOpen((open) => !open)}
+                >
+                  <span className="flex min-w-0 items-baseline gap-2">
+                    <span className="text-xs font-medium text-fg">Headers &amp; body</span>
+                    <span className="truncate text-[11px] text-muted">
+                      {customRequestCount ? `${customRequestCount} set` : "Optional"}
+                    </span>
+                  </span>
+                  <svg
+                    aria-hidden="true"
+                    className={`mb-disclosure-chevron h-3 w-3 shrink-0 text-muted ${customRequestOpen ? "is-open" : ""}`}
+                    viewBox="0 0 16 16"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="1.75"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  >
+                    <path d="M4 6.5L8 10.5L12 6.5" />
+                  </svg>
+                </button>
+
+                {customRequestOpen ? (
+                  <div id="sandbox-custom-request" className="mb-fade-in flex flex-col gap-5 pt-3">
+                    <RequestEntriesEditor
+                      label="Headers"
+                      addLabel="Add header"
+                      entries={customModel.headers}
+                      onChange={(headers) => updateCustomModel({ headers })}
+                      disabled={running}
+                    />
+                    <RequestEntriesEditor
+                      label="Body parameters"
+                      addLabel="Add parameter"
+                      entries={customModel.body}
+                      onChange={(body) => updateCustomModel({ body })}
+                      disabled={running}
+                    />
+                  </div>
                 ) : null}
               </div>
             </div>
@@ -2001,7 +2246,7 @@ export function SandboxLive({
                   type="button"
                   className="inline-flex min-h-11 items-center rounded-sm px-1 text-xs font-medium text-muted transition-colors hover:text-fg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 disabled:cursor-not-allowed disabled:opacity-50 motion-reduce:transition-none"
                   onClick={() => {
-                    setProviderKeys({});
+                    setProviderKeys((current) => ({ custom: current.custom }));
                     setRequestError(null);
                   }}
                   disabled={running}
@@ -2020,39 +2265,20 @@ export function SandboxLive({
               </button>
             </div>
 
-            <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
-              <label className="flex flex-col gap-1">
-                <div className="text-xs font-medium text-muted">OpenRouter</div>
-                <input
-                  className="mb-field h-10 w-full"
-                  type={showKeys ? "text" : "password"}
-                  value={providerKeys.openrouter ?? ""}
-                  onChange={(event) =>
-                    setProviderKeys((current) => ({ ...current, openrouter: event.target.value }))
-                  }
-                  autoComplete="off"
-                  spellCheck={false}
-                  placeholder="Paste key"
-                />
-              </label>
-
-              {usesOpenAiCompatibleModel ? (
-                <label className="flex flex-col gap-1">
-                  <div className="text-xs font-medium text-muted">OpenAI-compatible</div>
-                  <input
-                    className="mb-field h-10 w-full"
-                    type={showKeys ? "text" : "password"}
-                    value={providerKeys.custom ?? ""}
-                    onChange={(event) =>
-                      setProviderKeys((current) => ({ ...current, custom: event.target.value }))
-                    }
-                    autoComplete="off"
-                    spellCheck={false}
-                    placeholder="Paste key"
-                  />
-                </label>
-              ) : null}
-            </div>
+            <label className="flex max-w-xl flex-col gap-1">
+              <div className="text-xs font-medium text-muted">OpenRouter</div>
+              <input
+                className="mb-field h-10 w-full"
+                type={showKeys ? "text" : "password"}
+                value={providerKeys.openrouter ?? ""}
+                onChange={(event) =>
+                  setProviderKeys((current) => ({ ...current, openrouter: event.target.value }))
+                }
+                autoComplete="off"
+                spellCheck={false}
+                placeholder="Paste key"
+              />
+            </label>
 
             <div className="mt-5 border-t border-border/70 pt-2">
               <button

--- a/lib/ai/customProviderConfig.ts
+++ b/lib/ai/customProviderConfig.ts
@@ -1,0 +1,291 @@
+export type CustomRequestEntry = {
+  name: string;
+  value: string;
+};
+
+export type CustomRequestHeaders = Record<string, string>;
+export type CustomRequestBody = Record<string, unknown>;
+
+export type CustomProviderProfile = {
+  providerName: string;
+  modelId: string;
+  baseUrl: string;
+  headers: CustomRequestEntry[];
+  body: CustomRequestEntry[];
+};
+
+export type CustomProviderRequestConfig = {
+  baseUrl: string;
+  headers?: CustomRequestHeaders;
+  body?: CustomRequestBody;
+};
+
+const CUSTOM_PROVIDER_STORAGE_KEY = "mb_custom_provider_profile_v1";
+export const MAX_CUSTOM_REQUEST_ENTRIES = 32;
+const MAX_CUSTOM_REQUEST_VALUE_LENGTH = 16_384;
+const MAX_CUSTOM_REQUEST_BYTES = 65_536;
+const MAX_CUSTOM_OUTPUT_TOKENS = 1_000_000;
+const HEADER_NAME = /^[!#$%&'*+.^_`|~0-9A-Za-z-]+$/;
+const BLOCKED_HEADERS = new Set([
+  "connection",
+  "content-length",
+  "host",
+  "keep-alive",
+  "proxy-authenticate",
+  "proxy-authorization",
+  "te",
+  "trailer",
+  "transfer-encoding",
+  "upgrade",
+]);
+const BLOCKED_BODY_FIELDS = new Set([
+  "__proto__",
+  "constructor",
+  "messages",
+  "model",
+  "prototype",
+  "response_format",
+  "stream",
+]);
+
+export function emptyCustomProviderProfile(): CustomProviderProfile {
+  return {
+    providerName: "",
+    modelId: "",
+    baseUrl: "",
+    headers: [],
+    body: [],
+  };
+}
+
+function storedString(value: unknown, maxLength: number): string {
+  return typeof value === "string" ? value.slice(0, maxLength) : "";
+}
+
+function storedEntries(value: unknown): CustomRequestEntry[] {
+  if (!Array.isArray(value)) return [];
+  return value.slice(0, MAX_CUSTOM_REQUEST_ENTRIES).flatMap((entry) => {
+    if (!entry || typeof entry !== "object" || Array.isArray(entry)) return [];
+    const source = entry as Record<string, unknown>;
+    if (typeof source.name !== "string" || typeof source.value !== "string") return [];
+    return [{
+      name: source.name.slice(0, 128),
+      value: source.value.slice(0, MAX_CUSTOM_REQUEST_VALUE_LENGTH),
+    }];
+  });
+}
+
+export function parseCustomProviderProfile(value: unknown): CustomProviderProfile {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return emptyCustomProviderProfile();
+  }
+  const source = value as Record<string, unknown>;
+  return {
+    providerName: storedString(source.providerName, 120),
+    modelId: storedString(source.modelId, 240),
+    baseUrl: storedString(source.baseUrl, 4_000),
+    headers: storedEntries(source.headers),
+    body: storedEntries(source.body),
+  };
+}
+
+export function loadCustomProviderProfile(): CustomProviderProfile {
+  if (typeof window === "undefined") return emptyCustomProviderProfile();
+  try {
+    return parseCustomProviderProfile(
+      JSON.parse(window.localStorage.getItem(CUSTOM_PROVIDER_STORAGE_KEY) ?? "null"),
+    );
+  } catch {
+    return emptyCustomProviderProfile();
+  }
+}
+
+export function saveCustomProviderProfile(profile: CustomProviderProfile): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(
+      CUSTOM_PROVIDER_STORAGE_KEY,
+      JSON.stringify(parseCustomProviderProfile(profile)),
+    );
+  } catch {
+    // Local storage can be unavailable in restricted browser contexts
+  }
+}
+
+function assertEntryCount(entries: Array<[string, unknown]>, label: string): void {
+  if (entries.length > MAX_CUSTOM_REQUEST_ENTRIES) {
+    throw new Error(`Use no more than ${MAX_CUSTOM_REQUEST_ENTRIES} custom ${label}.`);
+  }
+}
+
+function normalizeHeaders(headers: CustomRequestHeaders | undefined): CustomRequestHeaders {
+  const entries = Object.entries(headers ?? {});
+  assertEntryCount(entries, "headers");
+  const seen = new Set<string>();
+  const normalized: Array<[string, string]> = [];
+  for (const [rawName, rawValue] of entries) {
+    const name = rawName.trim();
+    const lowerName = name.toLowerCase();
+    if (!name || name.length > 128 || !HEADER_NAME.test(name)) {
+      throw new Error("Use valid HTTP header names.");
+    }
+    if (BLOCKED_HEADERS.has(lowerName)) {
+      throw new Error(`${name} is managed by MineBench and cannot be customized.`);
+    }
+    if (seen.has(lowerName)) throw new Error("Header names must be unique.");
+    if (typeof rawValue !== "string" || rawValue.length > MAX_CUSTOM_REQUEST_VALUE_LENGTH) {
+      throw new Error(`Keep ${name} under ${MAX_CUSTOM_REQUEST_VALUE_LENGTH.toLocaleString()} characters.`);
+    }
+    if (/\r|\n/.test(rawValue)) throw new Error(`Remove line breaks from ${name}.`);
+    seen.add(lowerName);
+    normalized.push([name, rawValue.trim()]);
+  }
+  return Object.fromEntries(normalized);
+}
+
+function normalizeBody(body: CustomRequestBody | undefined): CustomRequestBody {
+  const entries = Object.entries(body ?? {});
+  assertEntryCount(entries, "body parameters");
+  const normalized: Array<[string, unknown]> = [];
+  for (const [rawName, value] of entries) {
+    const name = rawName.trim();
+    if (!name || name.length > 128) throw new Error("Add a name to each body parameter.");
+    if (BLOCKED_BODY_FIELDS.has(name.toLowerCase())) {
+      throw new Error(`${name} is managed by MineBench and cannot be customized.`);
+    }
+    normalized.push([name, value]);
+  }
+  const result = Object.fromEntries(normalized);
+  if (Object.hasOwn(result, "max_tokens") && Object.hasOwn(result, "max_completion_tokens")) {
+    throw new Error("Use either max_tokens or max_completion_tokens, not both.");
+  }
+  for (const name of ["max_tokens", "max_completion_tokens"] as const) {
+    if (!Object.hasOwn(result, name)) continue;
+    const value = result[name];
+    if (
+      typeof value !== "number" ||
+      !Number.isFinite(value) ||
+      value <= 0 ||
+      value > MAX_CUSTOM_OUTPUT_TOKENS
+    ) {
+      throw new Error(`${name} must be a number from 1 to ${MAX_CUSTOM_OUTPUT_TOKENS}.`);
+    }
+    result[name] = Math.floor(value);
+  }
+  let serialized: string;
+  try {
+    serialized = JSON.stringify(result);
+  } catch {
+    throw new Error("Custom body parameters must be valid JSON values.");
+  }
+  if (new TextEncoder().encode(serialized).byteLength > MAX_CUSTOM_REQUEST_BYTES) {
+    throw new Error("Keep custom body parameters under 64 KB.");
+  }
+  return result;
+}
+
+export function normalizeCustomProviderRequestConfig(
+  config: CustomProviderRequestConfig,
+): CustomProviderRequestConfig {
+  const baseUrl = config.baseUrl.trim();
+  const headers = normalizeHeaders(config.headers);
+  const body = normalizeBody(config.body);
+  return {
+    baseUrl,
+    ...(Object.keys(headers).length > 0 ? { headers } : {}),
+    ...(Object.keys(body).length > 0 ? { body } : {}),
+  };
+}
+
+function entriesToHeaders(entries: CustomRequestEntry[]): CustomRequestHeaders {
+  const pairs: Array<[string, string]> = [];
+  const seen = new Set<string>();
+  for (const entry of entries) {
+    const name = entry.name.trim();
+    const value = entry.value.trim();
+    if (!name && !value) continue;
+    if (!name) throw new Error("Add a name to each header.");
+    const lowerName = name.toLowerCase();
+    if (seen.has(lowerName)) throw new Error("Header names must be unique.");
+    seen.add(lowerName);
+    pairs.push([name, value]);
+  }
+  return Object.fromEntries(pairs);
+}
+
+function parseBodyValue(value: string): unknown {
+  const normalized = value.trim();
+  if (!normalized) return "";
+  try {
+    return JSON.parse(normalized) as unknown;
+  } catch {
+    return normalized;
+  }
+}
+
+function entriesToBody(entries: CustomRequestEntry[]): CustomRequestBody {
+  const pairs: Array<[string, unknown]> = [];
+  const seen = new Set<string>();
+  for (const entry of entries) {
+    const name = entry.name.trim();
+    const value = entry.value.trim();
+    if (!name && !value) continue;
+    if (!name) throw new Error("Add a name to each body parameter.");
+    if (seen.has(name)) throw new Error("Body parameter names must be unique.");
+    seen.add(name);
+    pairs.push([name, parseBodyValue(value)]);
+  }
+  return Object.fromEntries(pairs);
+}
+
+export function customProviderRequestConfigFromProfile(
+  profile: CustomProviderProfile,
+): CustomProviderRequestConfig {
+  return normalizeCustomProviderRequestConfig({
+    baseUrl: profile.baseUrl,
+    headers: entriesToHeaders(profile.headers),
+    body: entriesToBody(profile.body),
+  });
+}
+
+export function serializeCustomProviderRequestConfig(
+  config: CustomProviderRequestConfig,
+): string {
+  const normalized = normalizeCustomProviderRequestConfig(config);
+  if (!normalized.headers && !normalized.body) return normalized.baseUrl;
+  return JSON.stringify({ version: 1, ...normalized });
+}
+
+export function deserializeCustomProviderRequestConfig(
+  value: string,
+): CustomProviderRequestConfig {
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    if (
+      parsed &&
+      typeof parsed === "object" &&
+      !Array.isArray(parsed) &&
+      (parsed as { version?: unknown }).version === 1 &&
+      typeof (parsed as { baseUrl?: unknown }).baseUrl === "string"
+    ) {
+      const config = parsed as {
+        baseUrl: string;
+        headers?: CustomRequestHeaders;
+        body?: CustomRequestBody;
+      };
+      return normalizeCustomProviderRequestConfig(config);
+    }
+  } catch {
+    // Legacy endpoint secrets contain the URL directly
+  }
+  return normalizeCustomProviderRequestConfig({ baseUrl: value });
+}
+
+export function customProviderMaxOutputTokens(
+  body: CustomRequestBody | undefined,
+): number | undefined {
+  const value = body?.max_tokens ?? body?.max_completion_tokens;
+  return typeof value === "number" && Number.isFinite(value) && value > 0
+    ? Math.floor(value)
+    : undefined;
+}

--- a/lib/ai/generateVoxelBuild.ts
+++ b/lib/ai/generateVoxelBuild.ts
@@ -1,5 +1,10 @@
 import type { BlockDefinition } from "@/lib/blocks/palettes";
 import { getPalette } from "@/lib/blocks/palettes";
+import {
+  customProviderMaxOutputTokens,
+  type CustomRequestBody,
+  type CustomRequestHeaders,
+} from "@/lib/ai/customProviderConfig";
 import { extractBestVoxelBuildJson, extractFirstJsonObject } from "@/lib/ai/jsonExtract";
 import { modelOutputCeiling, modelUsesDefaultSampling } from "@/lib/ai/modelRequestProfiles";
 import { buildRepairPrompt, buildSystemPrompt, buildUserPrompt } from "@/lib/ai/prompts";
@@ -271,6 +276,8 @@ type ResolvedModel = {
   forceOpenRouter?: boolean;
   importOnly?: boolean;
   baseUrl?: string;
+  customHeaders?: CustomRequestHeaders;
+  customBody?: CustomRequestBody;
   requireStructuredOutput?: boolean;
 };
 
@@ -475,6 +482,8 @@ export type GenerateVoxelBuildParams = {
     forceOpenRouter?: boolean;
     importOnly?: boolean;
     baseUrl?: string;
+    customHeaders?: CustomRequestHeaders;
+    customBody?: CustomRequestBody;
     requireStructuredOutput?: boolean;
   };
   prompt: string;
@@ -540,6 +549,8 @@ async function callDirectProvider(args: {
   modelId: string;
   apiKey?: string;
   baseUrl?: string;
+  customHeaders?: CustomRequestHeaders;
+  customBody?: CustomRequestBody;
   requireStructuredOutput?: boolean;
   system: string;
   user: string;
@@ -657,6 +668,8 @@ async function callDirectProvider(args: {
       modelId: args.modelId,
       apiKey: args.apiKey,
       baseUrl: args.baseUrl,
+      customHeaders: args.customHeaders,
+      customBody: args.customBody,
       system: args.system,
       user: args.user,
       maxOutputTokens: args.maxOutputTokens,
@@ -899,6 +912,8 @@ async function providerGenerateText(args: {
         modelId: model.modelId,
         apiKey: directKey ?? undefined,
         baseUrl: model.baseUrl,
+        customHeaders: model.customHeaders,
+        customBody: model.customBody,
         requireStructuredOutput: model.requireStructuredOutput,
         system: args.system,
         user: args.user,
@@ -1099,7 +1114,7 @@ export async function generateVoxelBuild(
   const maxOutputTokens = defaultMaxOutputTokens(
     params.gridSize,
     model.modelId,
-    params.maxOutputTokens,
+    customProviderMaxOutputTokens(model.customBody) ?? params.maxOutputTokens,
   );
   const reasoningMaxTokens = defaultMaxReasoningTokens(model.modelId, maxOutputTokens);
   const schemaMaxBlocks = approxMaxBlocksForTokenBudget({

--- a/lib/ai/providers/openaiCompatible.ts
+++ b/lib/ai/providers/openaiCompatible.ts
@@ -1,4 +1,10 @@
 import { extractChatCompletionText, withMaxOutputTokens } from "@/lib/ai/providers/shared";
+import {
+  customProviderMaxOutputTokens,
+  normalizeCustomProviderRequestConfig,
+  type CustomRequestBody,
+  type CustomRequestHeaders,
+} from "@/lib/ai/customProviderConfig";
 import dns from "node:dns/promises";
 import http from "node:http";
 import https from "node:https";
@@ -119,6 +125,7 @@ async function postToResolvedApi(params: {
   body: string;
   signal: AbortSignal;
   stream: boolean;
+  customHeaders?: CustomRequestHeaders;
   onProviderRequest?: () => void;
 }): Promise<NodeHttpResponse> {
   return await new Promise<NodeHttpResponse>((resolve, reject) => {
@@ -135,19 +142,23 @@ async function postToResolvedApi(params: {
       : isHttps
         ? 443
         : 80;
+    const headers = new Headers({
+      Authorization: `Bearer ${params.apiKey}`,
+      "Content-Type": "application/json",
+      Accept: params.stream ? "text/event-stream" : "application/json",
+    });
+    for (const [name, value] of Object.entries(params.customHeaders ?? {})) {
+      headers.set(name, value);
+    }
+    headers.set("Host", params.target.url.host);
+    headers.set("Content-Length", Buffer.byteLength(params.body).toString());
     const options: RequestOptions = {
       method: "POST",
       hostname: params.target.address,
       family: params.target.family,
       port,
       path: `${params.target.url.pathname}${params.target.url.search}`,
-      headers: {
-        Authorization: `Bearer ${params.apiKey}`,
-        "Content-Type": "application/json",
-        Accept: params.stream ? "text/event-stream" : "application/json",
-        Host: params.target.url.host,
-        "Content-Length": Buffer.byteLength(params.body).toString(),
-      },
+      headers: Object.fromEntries(headers.entries()),
     };
 
     const cleanup = (abort: () => void) => {
@@ -225,6 +236,8 @@ export async function openAiCompatibleGenerateText(params: {
   modelId: string;
   apiKey?: string;
   baseUrl?: string;
+  customHeaders?: CustomRequestHeaders;
+  customBody?: CustomRequestBody;
   system: string;
   user: string;
   maxOutputTokens?: number;
@@ -245,7 +258,12 @@ export async function openAiCompatibleGenerateText(params: {
 
   const rawBaseUrl = params.baseUrl ?? process.env.CUSTOM_API_BASE_URL;
   if (!rawBaseUrl) throw new Error(`Missing ${serviceLabel} API server URL`);
-  const target = await resolveCustomApiTarget(rawBaseUrl);
+  const customConfig = normalizeCustomProviderRequestConfig({
+    baseUrl: rawBaseUrl,
+    headers: params.customHeaders,
+    body: params.customBody,
+  });
+  const target = await resolveCustomApiTarget(customConfig.baseUrl);
   const controller = new AbortController();
   const detachAbort = attachAbortSignal(controller, params.signal);
   const timeout: ReturnType<typeof setTimeout> | null = null;
@@ -253,27 +271,35 @@ export async function openAiCompatibleGenerateText(params: {
   let res: NodeHttpResponse | null = null;
   let lastBody = "";
   const maxTokens = params.maxOutputTokens ?? 65_536;
+  const customMaxTokens = customProviderMaxOutputTokens(customConfig.body);
   let selectedTokenBudget: number | null = null;
   let useStructuredOutput = Boolean(params.jsonSchema);
 
   try {
-    for (const tok of tokenBudgetCandidates(maxTokens)) {
+    const tokenBudgets = customMaxTokens
+      ? [customMaxTokens, customMaxTokens]
+      : tokenBudgetCandidates(maxTokens);
+    for (const tok of tokenBudgets) {
       res = await postToResolvedApi({
         target,
         apiKey,
         signal: controller.signal,
         stream: Boolean(params.onDelta),
+        customHeaders: customConfig.headers,
         onProviderRequest: params.onProviderRequest,
         body: JSON.stringify({
+          ...(params.temperature === undefined ? {} : { temperature: params.temperature }),
+          ...(customMaxTokens
+            ? {}
+            : { [params.maxTokensParameter ?? "max_tokens"]: tok }),
+          ...(params.reasoningEffort ? { reasoning_effort: params.reasoningEffort } : {}),
+          ...customConfig.body,
           model: params.modelId,
           messages: [
             { role: "system", content: params.system },
             { role: "user", content: params.user },
           ],
           stream: Boolean(params.onDelta),
-          ...(params.temperature === undefined ? {} : { temperature: params.temperature }),
-          [params.maxTokensParameter ?? "max_tokens"]: tok,
-          ...(params.reasoningEffort ? { reasoning_effort: params.reasoningEffort } : {}),
           ...(useStructuredOutput && params.jsonSchema
             ? {
                 response_format: {
@@ -289,10 +315,10 @@ export async function openAiCompatibleGenerateText(params: {
         }),
       });
       if (res.status >= 200 && res.status < 300) {
-        selectedTokenBudget = tok;
+        selectedTokenBudget = customMaxTokens ?? tok;
         break;
       }
-      selectedTokenBudget = tok;
+      selectedTokenBudget = customMaxTokens ?? tok;
       lastBody = await readResponseText(res.body).catch(() => "");
       if (res.status === 400 && useStructuredOutput && looksLikeStructuredOutputUnsupportedError(lastBody)) {
         if (params.requireStructuredOutput) break;
@@ -300,7 +326,10 @@ export async function openAiCompatibleGenerateText(params: {
         params.onTrace?.("Custom API structured output rejected; falling back to plain text output for this request.");
         continue;
       }
-      if (res.status === 400 && looksLikeTokenLimitError(lastBody)) continue;
+      if (res.status === 400 && looksLikeTokenLimitError(lastBody)) {
+        if (customMaxTokens) break;
+        continue;
+      }
       break;
     }
   } catch (err) {
@@ -330,10 +359,16 @@ export async function openAiCompatibleGenerateText(params: {
   params.onAcceptedRequestConfiguration?.({
     apiMode: "chat_completions",
     maxOutputTokens: budget,
-    thinkingMode: params.reasoningEffort
-      ? `reasoning=${params.reasoningEffort}`
-      : "default",
-    temperature: params.temperature ?? "default",
+    thinkingMode: typeof customConfig.body?.reasoning_effort === "string"
+      ? `reasoning=${customConfig.body.reasoning_effort}`
+      : Object.hasOwn(customConfig.body ?? {}, "thinking")
+        ? "custom"
+        : params.reasoningEffort
+          ? `reasoning=${params.reasoningEffort}`
+          : "default",
+    temperature: typeof customConfig.body?.temperature === "number"
+      ? customConfig.body.temperature
+      : params.temperature ?? "default",
     textVerbosity: "default",
     responseFormat: useStructuredOutput ? "json_schema" : "text",
   });

--- a/lib/ai/types.ts
+++ b/lib/ai/types.ts
@@ -1,4 +1,8 @@
 import type { ModelKey } from "@/lib/ai/modelCatalog";
+import type {
+  CustomRequestBody,
+  CustomRequestHeaders,
+} from "@/lib/ai/customProviderConfig";
 import type { VoxelBuild } from "@/lib/voxel/types";
 
 export type PaletteMode = "simple" | "advanced";
@@ -56,6 +60,8 @@ export type GenerateModelRequest =
       displayName: string;
       modelId: string;
       baseUrl: string;
+      headers?: CustomRequestHeaders;
+      body?: CustomRequestBody;
     }
   | {
       id: string;

--- a/lib/custom-builds/generateJob.ts
+++ b/lib/custom-builds/generateJob.ts
@@ -1,4 +1,8 @@
 import { Prisma, type CustomBuild, type CustomBuildJob } from "@prisma/client";
+import {
+  deserializeCustomProviderRequestConfig,
+  type CustomProviderRequestConfig,
+} from "@/lib/ai/customProviderConfig";
 import type { Provider } from "@/lib/ai/modelCatalog";
 import { generateVoxelBuild, type GenerateVoxelBuildParams } from "@/lib/ai/generateVoxelBuild";
 import { MAX_BLOCKS_BY_GRID, type GridSize } from "@/lib/ai/limits";
@@ -121,7 +125,7 @@ function customBuildProviderForGeneration(provider: string): Provider | "custom"
 
 export function customBuildModelForGeneration(
   customBuild: CustomBuild,
-  customBaseUrl?: string,
+  customConfig?: CustomProviderRequestConfig,
 ): GenerateVoxelBuildModel {
   return {
     key: customBuild.modelKind === "catalog" && customBuild.modelKey ? customBuild.modelKey : customBuild.publicId,
@@ -130,7 +134,9 @@ export function customBuildModelForGeneration(
     displayName: customBuild.modelDisplayName,
     openRouterModelId: customBuild.openRouterModelId ?? undefined,
     forceOpenRouter: customBuild.modelKind === "openrouter",
-    baseUrl: customBaseUrl,
+    baseUrl: customConfig?.baseUrl,
+    customHeaders: customConfig?.headers,
+    customBody: customConfig?.body,
   };
 }
 
@@ -274,16 +280,18 @@ async function generateBuild(
     keyAuthTag: secret.keyAuthTag ?? "",
     keyVersion: secret.keyVersion,
   }, customBuild.id);
-  const customBaseUrl =
+  const customConfig =
     secret.endpointCiphertext && secret.endpointIv && secret.endpointAuthTag
-      ? decryptSecretValue(
-          {
-            ciphertext: secret.endpointCiphertext,
-            iv: secret.endpointIv,
-            authTag: secret.endpointAuthTag,
-            keyVersion: secret.keyVersion,
-          },
-          customBuild.id,
+      ? deserializeCustomProviderRequestConfig(
+          decryptSecretValue(
+            {
+              ciphertext: secret.endpointCiphertext,
+              iv: secret.endpointIv,
+              authTag: secret.endpointAuthTag,
+              keyVersion: secret.keyVersion,
+            },
+            customBuild.id,
+          ),
         )
       : undefined;
   const gridSize = assertGridSize(customBuild.gridSize);
@@ -295,7 +303,7 @@ async function generateBuild(
   throwIfCustomBuildLeaseLost(opts.signal);
   const result = await generateVoxelBuild(
     {
-      model: customBuildModelForGeneration(customBuild, customBaseUrl),
+      model: customBuildModelForGeneration(customBuild, customConfig),
       prompt: customBuild.promptText,
       gridSize,
       palette,

--- a/lib/generations/model.ts
+++ b/lib/generations/model.ts
@@ -1,4 +1,9 @@
 import { getModelByKey } from "@/lib/ai/modelCatalog";
+import {
+  normalizeCustomProviderRequestConfig,
+  type CustomRequestBody,
+  type CustomRequestHeaders,
+} from "@/lib/ai/customProviderConfig";
 import { assertSafeCustomApiUrl } from "@/lib/ai/providers/customApiGuard";
 import type { GenerateModelRequest, ProviderApiKeys } from "@/lib/ai/types";
 
@@ -10,6 +15,8 @@ export type ResolvedSavedGenerationModel = {
   modelDisplayName: string;
   openRouterModelId?: string;
   customBaseUrl?: string;
+  customHeaders?: CustomRequestHeaders;
+  customBody?: CustomRequestBody;
   preferOpenRouter: boolean;
   credential: {
     provider: keyof ProviderApiKeys;
@@ -29,7 +36,12 @@ export async function resolveSavedGenerationModel(
   },
 ): Promise<ResolvedSavedGenerationModel> {
   if (request.kind === "custom" && request.provider === "custom") {
-    await deps.assertSafeCustomApiUrl(request.baseUrl);
+    const config = normalizeCustomProviderRequestConfig({
+      baseUrl: request.baseUrl,
+      headers: request.headers,
+      body: request.body,
+    });
+    await deps.assertSafeCustomApiUrl(config.baseUrl);
     const value = providerKeys.custom?.trim();
     if (!value) throw new Error("missing_provider_key");
     return {
@@ -37,7 +49,9 @@ export async function resolveSavedGenerationModel(
       modelProvider: "custom",
       modelId: request.modelId,
       modelDisplayName: request.displayName,
-      customBaseUrl: request.baseUrl,
+      customBaseUrl: config.baseUrl,
+      customHeaders: config.headers,
+      customBody: config.body,
       preferOpenRouter: false,
       credential: { provider: "custom", value },
     };

--- a/lib/generations/service.ts
+++ b/lib/generations/service.ts
@@ -1,5 +1,12 @@
 import { randomUUID } from "node:crypto";
 import { Prisma, type CustomBuildArtifactKind } from "@prisma/client";
+import {
+  normalizeCustomProviderRequestConfig,
+  serializeCustomProviderRequestConfig,
+  type CustomProviderRequestConfig,
+  type CustomRequestBody,
+  type CustomRequestHeaders,
+} from "@/lib/ai/customProviderConfig";
 import type { GenerateModelRequest, PaletteMode, ProviderApiKeys } from "@/lib/ai/types";
 import { isProviderApiKeyName } from "@/lib/ai/providerKeys";
 import { assertSafeCustomApiUrl } from "@/lib/ai/providers/customApiGuard";
@@ -237,7 +244,11 @@ export async function createSavedGenerations(input: CreateSavedGenerationsInput)
       binding: id,
     });
     const endpoint = model.customBaseUrl
-      ? encryptSecretValue(model.customBaseUrl, id)
+      ? encryptSecretValue(serializeCustomProviderRequestConfig({
+          baseUrl: model.customBaseUrl,
+          headers: model.customHeaders,
+          body: model.customBody,
+        }), id)
       : null;
     return { id, publicId, model, credential, endpoint, usesHostedGeneration };
   });
@@ -403,7 +414,12 @@ function retryCredentialProvider(build: {
 export async function retrySavedGeneration(
   ownerId: string,
   publicId: string,
-  input: { providerKey?: string; customBaseUrl?: string },
+  input: {
+    providerKey?: string;
+    customBaseUrl?: string;
+    customHeaders?: CustomRequestHeaders;
+    customBody?: CustomRequestBody;
+  },
 ) {
   const now = new Date();
   const build = await prisma.customBuild.findFirst({
@@ -434,20 +450,26 @@ export async function retrySavedGeneration(
   if (!provider || !providerKey) {
     throw new GenerationServiceError("missing_provider_key", "Reconnect this model in Generate.");
   }
-  let customBaseUrl: string | undefined;
+  let customConfig: CustomProviderRequestConfig | undefined;
   if (provider === "custom") {
-    customBaseUrl = input.customBaseUrl?.trim();
-    if (!customBaseUrl) {
+    if (!input.customBaseUrl?.trim()) {
       throw new GenerationServiceError("missing_provider_key", "Reconnect this model in Generate.");
     }
     try {
-      await assertSafeCustomApiUrl(customBaseUrl);
+      customConfig = normalizeCustomProviderRequestConfig({
+        baseUrl: input.customBaseUrl,
+        headers: input.customHeaders,
+        body: input.customBody,
+      });
+      await assertSafeCustomApiUrl(customConfig.baseUrl);
     } catch {
       throw new GenerationServiceError("invalid_model", "Check the custom model endpoint.");
     }
   }
   const credential = encryptProviderKey(providerKey, { provider, binding: build.id });
-  const endpoint = customBaseUrl ? encryptSecretValue(customBaseUrl, build.id) : null;
+  const endpoint = customConfig
+    ? encryptSecretValue(serializeCustomProviderRequestConfig(customConfig), build.id)
+    : null;
 
   await prisma.$transaction(async (tx) => {
     const queued = await tx.customBuild.updateMany({

--- a/tests/ui/sandbox-live-durable.test.ts
+++ b/tests/ui/sandbox-live-durable.test.ts
@@ -59,6 +59,7 @@ const completedBuildBody = functionBodyText("readCustomBuildViewer");
 const dismissHostedGeminiBody = functionBodyText("dismissHostedGeminiAnnouncement");
 const inputResetEffect = effectBodyTextContaining("lastGenerateInputRef.current === inputSignature");
 const hostedGeminiEffect = effectBodyTextContaining("HOSTED_GEMINI_NOTICE_KEY");
+const customProviderStorageEffect = effectBodyTextContaining("saveCustomProviderProfile");
 const assignIndex = durableBody.indexOf("customBuildAbortRef.current = args.abortController");
 assert.ok(assignIndex >= 0, "durable generation should store the active abort controller");
 assert.equal(
@@ -93,7 +94,8 @@ assert.ok(
 
 assert.ok(
   durableBody.includes('fetch("/api/generations"') &&
-    durableBody.includes("models: selectedModels.map(customBuildRequestModel)") &&
+    durableBody.includes("models: args.models") &&
+    runBody.includes("models: requestModels") &&
     durableBody.includes("created.generations.length !== selectedModels.length") &&
     durableBody.includes("await Promise.all(") &&
     durableBody.includes("selectedModels.map((model, index)"),
@@ -106,8 +108,10 @@ assert.ok(
   "saved generation requests should send only credentials selected by their model routes",
 );
 assert.ok(
-  requestModelBody.includes("id: model.id"),
-  "saved-generation requests should include the selected model identity required by the API",
+  requestModelBody.includes("id: model.id") &&
+    requestModelBody.includes("headers: config.headers") &&
+    requestModelBody.includes("body: config.body"),
+  "saved-generation requests should include custom model identity and request configuration",
 );
 assert.ok(
   stopBody.includes("if (signedIn)") &&
@@ -257,6 +261,19 @@ assert.ok(
     !retryBody.includes("Add the required API key") &&
     !sourceText.includes("hostedGenerationCount"),
   "the free Gemini offer should appear on every anonymous page load, persist in Generate, defer to user keys, and remain one-time for signed-in users",
+);
+assert.ok(
+  sourceText.includes("loadCustomProviderProfile") &&
+    customProviderStorageEffect.includes("saveCustomProviderProfile(customModel)") &&
+    sourceText.includes("Provider profile") &&
+    sourceText.includes("Saved in this browser") &&
+    sourceText.includes('label="Headers"') &&
+    sourceText.includes('label="Body parameters"') &&
+    sourceText.includes("customHeaders: customConfig.headers") &&
+    sourceText.includes("customBody: customConfig.body") &&
+    !sourceText.includes("value={customModel.displayName}") &&
+    !sourceText.includes('className="mt-3 rounded-md border border-border/70 bg-bg/35 p-3"'),
+  "custom providers should persist one flat profile and disclose request fields without a nested card",
 );
 
 console.log("sandbox saved-generation contract checks passed");

--- a/tests/unit/ai/custom-provider-config.test.ts
+++ b/tests/unit/ai/custom-provider-config.test.ts
@@ -1,0 +1,141 @@
+import assert from "node:assert/strict";
+import dns from "node:dns/promises";
+import http from "node:http";
+import type { IncomingMessage, RequestOptions } from "node:http";
+import https from "node:https";
+import {
+  customProviderMaxOutputTokens,
+  customProviderRequestConfigFromProfile,
+  deserializeCustomProviderRequestConfig,
+  normalizeCustomProviderRequestConfig,
+  parseCustomProviderProfile,
+  serializeCustomProviderRequestConfig,
+} from "../../../lib/ai/customProviderConfig";
+import { openAiCompatibleGenerateText } from "../../../lib/ai/providers/openaiCompatible";
+
+const profile = parseCustomProviderProfile({
+  providerName: "Example Cloud",
+  modelId: "example-reasoner",
+  baseUrl: "https://models.example.test/v1/chat/completions",
+  headers: [{ name: "User-Agent", value: "claude-cli/2.1.179 (external, cli)" }],
+  body: [
+    { name: "thinking", value: '{"type":"enabled"}' },
+    { name: "reasoning_effort", value: "max" },
+    { name: "max_tokens", value: "128000" },
+  ],
+});
+const config = customProviderRequestConfigFromProfile(profile);
+assert.deepEqual(config, {
+  baseUrl: "https://models.example.test/v1/chat/completions",
+  headers: { "User-Agent": "claude-cli/2.1.179 (external, cli)" },
+  body: {
+    thinking: { type: "enabled" },
+    reasoning_effort: "max",
+    max_tokens: 128_000,
+  },
+});
+assert.equal(customProviderMaxOutputTokens(config.body), 128_000);
+assert.deepEqual(
+  deserializeCustomProviderRequestConfig(serializeCustomProviderRequestConfig(config)),
+  config,
+);
+assert.deepEqual(
+  deserializeCustomProviderRequestConfig("https://legacy.example.test/v1/chat/completions"),
+  { baseUrl: "https://legacy.example.test/v1/chat/completions" },
+);
+
+assert.throws(
+  () => normalizeCustomProviderRequestConfig({
+    baseUrl: profile.baseUrl,
+    headers: { Host: "private.example.test" },
+  }),
+  /Host is managed by MineBench/,
+);
+assert.throws(
+  () => customProviderRequestConfigFromProfile({
+    ...profile,
+    body: [{ name: "messages", value: "[]" }],
+  }),
+  /messages is managed by MineBench/,
+);
+assert.throws(
+  () => customProviderRequestConfigFromProfile({
+    ...profile,
+    headers: [
+      { name: "User-Agent", value: "one" },
+      { name: "user-agent", value: "two" },
+    ],
+  }),
+  /Header names must be unique/,
+);
+
+const originalLookup = dns.lookup;
+const originalHttpsRequest = https.request;
+const requests: Array<{ headers: http.IncomingHttpHeaders; body: Record<string, unknown> }> = [];
+const server = http.createServer(async (request, response) => {
+  let rawBody = "";
+  for await (const chunk of request) rawBody += chunk.toString();
+  const body = JSON.parse(rawBody) as Record<string, unknown>;
+  requests.push({ headers: request.headers, body });
+  response.setHeader("Content-Type", "application/json");
+  if (Object.hasOwn(body, "response_format")) {
+    response.statusCode = 400;
+    response.end(JSON.stringify({ error: { message: "response_format unsupported" } }));
+    return;
+  }
+  response.end(JSON.stringify({ choices: [{ message: { content: "done" } }] }));
+});
+
+Object.defineProperty(dns, "lookup", {
+  configurable: true,
+  value: async () => [{ address: "93.184.216.34", family: 4 }],
+});
+Object.defineProperty(https, "request", {
+  configurable: true,
+  value: ((
+    options: RequestOptions,
+    callback: (response: IncomingMessage) => void,
+  ) => http.request({ ...options, hostname: "127.0.0.1", family: 4 }, callback)) as typeof https.request,
+});
+
+async function main() {
+  try {
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const address = server.address();
+    assert.ok(address && typeof address !== "string");
+    const result = await openAiCompatibleGenerateText({
+      modelId: profile.modelId,
+      apiKey: "test-key",
+      baseUrl: `https://models.example.test:${address.port}/v1/chat/completions`,
+      customHeaders: config.headers,
+      customBody: config.body,
+      system: "system",
+      user: "user",
+      jsonSchema: { type: "object" },
+    });
+
+    assert.equal(result.text, "done");
+    assert.equal(requests.length, 2);
+    assert.equal(requests[0].headers["user-agent"], "claude-cli/2.1.179 (external, cli)");
+    assert.equal(requests[0].headers.authorization, "Bearer test-key");
+    assert.deepEqual(requests[1].body.thinking, { type: "enabled" });
+    assert.equal(requests[1].body.reasoning_effort, "max");
+    assert.equal(requests[1].body.max_tokens, 128_000);
+    assert.equal(requests[1].body.model, profile.modelId);
+    assert.equal(Object.hasOwn(requests[1].body, "response_format"), false);
+  } finally {
+    Object.defineProperty(dns, "lookup", { configurable: true, value: originalLookup });
+    Object.defineProperty(https, "request", { configurable: true, value: originalHttpsRequest });
+    if (server.listening) {
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      });
+    }
+  }
+  console.log("custom provider config checks passed");
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/tests/unit/custom-builds/generate-job-routing.test.ts
+++ b/tests/unit/custom-builds/generate-job-routing.test.ts
@@ -36,7 +36,7 @@ assert.ok(
 );
 
 assert.ok(
-  generateBody.includes("model: customBuildModelForGeneration(customBuild, customBaseUrl)") &&
+  generateBody.includes("model: customBuildModelForGeneration(customBuild, customConfig)") &&
     !generateBody.includes("modelKey: customBuild.modelKey"),
   "custom generate jobs should not re-resolve queued catalog rows through the mutable model catalog",
 );
@@ -53,6 +53,22 @@ const openRouterModel = customBuildModelForGeneration({
 assert.equal(openRouterModel.provider, "custom");
 assert.equal(openRouterModel.forceOpenRouter, true);
 assert.equal(openRouterModel.openRouterModelId, "vendor/model");
+const customModel = customBuildModelForGeneration({
+  modelKind: "custom",
+  modelKey: null,
+  modelProvider: "custom",
+  modelId: "vendor-model",
+  modelDisplayName: "Vendor model",
+  openRouterModelId: null,
+  publicId: "cb_123456789012345678901234",
+} as never, {
+  baseUrl: "https://models.example.test/v1/chat/completions",
+  headers: { "User-Agent": "minebench-test" },
+  body: { reasoning_effort: "max" },
+});
+assert.equal(customModel.baseUrl, "https://models.example.test/v1/chat/completions");
+assert.deepEqual(customModel.customHeaders, { "User-Agent": "minebench-test" });
+assert.deepEqual(customModel.customBody, { reasoning_effort: "max" });
 assert.deepEqual(providerKeysForSecret("openrouter", "router-key"), { openrouter: "router-key" });
 assert.deepEqual(providerKeysForSecret("meta", "meta-key"), { meta: "meta-key" });
 assert.deepEqual(providerKeysForSecret("zai", "zai-key"), { zai: "zai-key" });

--- a/tests/unit/generations/model.test.ts
+++ b/tests/unit/generations/model.test.ts
@@ -25,6 +25,8 @@ const custom = await resolveSavedGenerationModel(
     displayName: "Local model",
     modelId: "local-1",
     baseUrl: "https://models.example.test/v1/chat/completions",
+    headers: { "User-Agent": "claude-cli/2.1.179" },
+    body: { thinking: { type: "enabled" }, max_tokens: 128_000 },
   },
   { custom: "custom-key", openrouter: "unused-key" },
   { assertSafeCustomApiUrl: async () => undefined },
@@ -32,6 +34,11 @@ const custom = await resolveSavedGenerationModel(
 assert.equal(custom.modelKind, "custom");
 assert.equal(custom.credential.provider, "custom");
 assert.equal(custom.customBaseUrl, "https://models.example.test/v1/chat/completions");
+assert.deepEqual(custom.customHeaders, { "User-Agent": "claude-cli/2.1.179" });
+assert.deepEqual(custom.customBody, {
+  thinking: { type: "enabled" },
+  max_tokens: 128_000,
+});
 
 const openRouter = await resolveSavedGenerationModel(
   {


### PR DESCRIPTION
## Summary

- persist the full OpenAI-compatible provider profile locally, including provider name, model ID, chat completions URL, and API key
- add custom request header and body parameter editors with a responsive, progressively disclosed layout
- pass validated request configuration through transient and durable generation paths using the existing encrypted endpoint secret

## Validation

- pnpm exec tsc --noEmit
- pnpm lint
- node scripts/with-local-env.mjs pnpm build
- focused custom-provider, durable routing, and UI contract tests
- desktop and mobile browser verification in light and dark themes
- Alpha deployment verified at 231a663e

*(PR written by Codex)*