### PR TITLE
feat(ai): add Claude Fable 5.1

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -50,6 +50,8 @@ GOOGLE_SITE_VERIFICATION=
 CONTACT_SMTP_PASSWORD=
 
 # Optional overrides (defaults are used if unset)
+# Claude Fable 5.1 adaptive thinking effort: low | medium | high | xhigh | max
+ANTHROPIC_FABLE_5_1_EFFORT=max
 # Claude Fable 5 adaptive thinking effort: low | medium | high | xhigh | max
 ANTHROPIC_FABLE_5_EFFORT=max
 # Claude Opus 5 adaptive thinking effort: low | medium | high | xhigh | max

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -102,6 +102,7 @@ Copy `.env.example` to `.env` and set what you need.
 ### Optional Provider and Runtime Tuning
 
 - `MINEBENCH_ALLOW_SERVER_KEYS=1` (production opt-in for server env keys in `/api/generate`)
+- `ANTHROPIC_FABLE_5_1_EFFORT=low|medium|high|xhigh|max`
 - `ANTHROPIC_FABLE_5_EFFORT=low|medium|high|xhigh|max`
 - `ANTHROPIC_OPUS_5_EFFORT=low|medium|high|xhigh|max`
 - `ANTHROPIC_SONNET_5_EFFORT=low|medium|high|xhigh|max`
@@ -118,6 +119,7 @@ Copy `.env.example` to `.env` and set what you need.
 - GPT 5.6 Sol uses the native OpenAI model ID `gpt-5.6-sol` through the Responses API with `reasoning.mode=pro`, defaults to `reasoning.effort=max`, and uses the model's 128000-token combined reasoning and output cap. Its OpenRouter fallback uses `openai/gpt-5.6-sol-pro` with max effort and strict structured output.
 - GPT 5.6 Luna uses the native OpenAI model ID `gpt-5.6-luna` through the Responses API with `reasoning.mode=pro`, defaults to `reasoning.effort=max`, and uses its 1050000-token context window and 128000-token combined reasoning and output cap. Its OpenRouter fallback uses `openai/gpt-5.6-luna-pro` with max effort and strict structured output.
 - Kimi K3 uses the native Moonshot model ID `kimi-k3`, always reasons with `reasoning_effort=max`, uses its 1048576-token completion ceiling, and omits its fixed sampling parameters. Its OpenRouter fallback uses `moonshotai/kimi-k3` with max effort and fails closed if that effort is rejected.
+- Claude Fable 5.1 uses the native Anthropic model ID `claude-fable-5-1`, supports always-on adaptive thinking with effort `low|medium|high|xhigh|max`, and MineBench defaults it to `max` with its 1M-token context window and 128000-token output cap. It omits sampling controls and uses native structured output without forced tool choice. Its OpenRouter fallback is `anthropic/claude-fable-5.1` with the same cap and effort ladder.
 - Claude Fable 5 uses the native Anthropic model ID `claude-fable-5`, supports always-on adaptive thinking with effort `low|medium|high|xhigh|max`, and MineBench defaults it to `max` with a 128000-token output cap.
 - Claude Opus 5 uses the native Anthropic model ID `claude-opus-5`, reaches its 1M-token context window without a beta header, supports adaptive thinking with effort `low|medium|high|xhigh|max`, and MineBench defaults it to `max` with a 128000-token output cap. Its OpenRouter fallback uses `anthropic/claude-opus-5` with the same cap and effort ladder.
 - Claude Sonnet 5 uses the native Anthropic model ID `claude-sonnet-5`, supports adaptive thinking with effort `low|medium|high|xhigh|max`, and MineBench defaults it to `max` with a 128000-token output cap.

--- a/lib/ai/claudeModels.ts
+++ b/lib/ai/claudeModels.ts
@@ -47,6 +47,12 @@ const MESSAGES_API_OUTPUT_MAX = 128_000;
 // Keyed by family and version
 // A release named without a minor, such as claude-opus-5, keys at minor 0
 const CLAUDE_RELEASES: Record<string, ClaudeRelease> = {
+  "fable-5.1": {
+    effortLadder: FULL_EFFORT_LADDER,
+    defaultSamplingOnly: true,
+    maxOutputTokens: MESSAGES_API_OUTPUT_MAX,
+    effortEnvVar: "ANTHROPIC_FABLE_5_1_EFFORT",
+  },
   "opus-5.0": {
     effortLadder: FULL_EFFORT_LADDER,
     defaultSamplingOnly: true,

--- a/lib/ai/modelBenchmarkMetrics.generated.json
+++ b/lib/ai/modelBenchmarkMetrics.generated.json
@@ -608,6 +608,28 @@
       "interruptedRunCount": 20,
       "providerCallTrackingJobCount": 15,
       "completedAttemptTrackingJobCount": 15
+    },
+    "anthropic_claude_fable_5_1": {
+      "inferenceSampleCount": 15,
+      "expectedBuildCount": 15,
+      "finalizedBuildCount": 15,
+      "promptCohortId": "prompts-v1:bd8c28367f8a97f2",
+      "averageJsonSizeBytes": 35728278,
+      "configurationSampleCount": 15,
+      "configurationIsConsistent": true,
+      "outputCapSampleCount": 15,
+      "outputCapIsConsistent": true,
+      "averageInferenceMs": 2411510,
+      "finalizedAttemptCount": 29,
+      "outputCapTokens": 128000,
+      "providerCallCount": 184,
+      "completedAttemptCount": 23,
+      "rejectedResponseCount": 8,
+      "failedAttemptCount": 166,
+      "failedRunCount": 25,
+      "interruptedRunCount": 3,
+      "providerCallTrackingJobCount": 15,
+      "completedAttemptTrackingJobCount": 15
     }
   }
 }

--- a/lib/ai/modelBenchmarkProfiles.ts
+++ b/lib/ai/modelBenchmarkProfiles.ts
@@ -312,6 +312,9 @@ export const HISTORICAL_BENCHMARK_OUTPUT_CAPS: Partial<
 const MODEL_BENCHMARK_METADATA: Partial<
   Record<ModelKey, Omit<ModelBenchmarkProfile, "outputCap" | "parameters">>
 > = {
+  anthropic_claude_fable_5_1: {
+    totalCost: { usd: 147.55 },
+  },
   zai_glm_5_3_flash: {
     totalCost: { usd: 0.74 },
   },

--- a/lib/ai/modelBenchmarkProfiles.ts
+++ b/lib/ai/modelBenchmarkProfiles.ts
@@ -116,6 +116,11 @@ const MODEL_RUN_PARAMETERS = {
     { label: "Reasoning effort", value: "Max" },
     { label: "Sampling", value: "Provider default" },
   ],
+  anthropic_claude_fable_5_1: [
+    { label: "Thinking", value: "Adaptive" },
+    { label: "Reasoning effort", value: "Max" },
+    { label: "Sampling", value: "Provider default" },
+  ],
   anthropic_claude_opus_5: [
     { label: "Thinking", value: "Adaptive" },
     { label: "Reasoning effort", value: "Max" },

--- a/lib/ai/modelCatalog.ts
+++ b/lib/ai/modelCatalog.ts
@@ -191,6 +191,15 @@ const CATALOG = [
     openRouterModelId: "openai/gpt-oss-120b",
   },
   {
+    key: "anthropic_claude_fable_5_1",
+    slug: "claude-fable-5-1",
+    provider: "anthropic",
+    modelId: "claude-fable-5-1",
+    displayName: "Claude Fable 5.1",
+    enabled: true,
+    openRouterModelId: "anthropic/claude-fable-5.1",
+  },
+  {
     key: "anthropic_claude_fable_5",
     slug: "claude-fable-5",
     provider: "anthropic",

--- a/tests/unit/ai/model-benchmark-profiles.test.ts
+++ b/tests/unit/ai/model-benchmark-profiles.test.ts
@@ -193,6 +193,9 @@ assert.equal(gemini35FlashLite?.buildCount, 15);
 const gemini30Flash = getModelBenchmarkProfile("gemini_3_0_flash");
 assert.deepEqual(gemini30Flash?.outputCap, { kind: "exact", tokens: 65_536 });
 
+const fable51 = getModelBenchmarkProfile("anthropic_claude_fable_5_1");
+assert.deepEqual(fable51?.totalCost, { usd: 147.55 });
+
 const fable5 = getModelBenchmarkProfile("anthropic_claude_fable_5");
 assert.deepEqual(fable5?.averageInference, { milliseconds: 1_084_400 });
 assert.deepEqual(fable5?.totalCost, { usd: 54.93 });

--- a/tests/unit/providers/anthropic-family.test.ts
+++ b/tests/unit/providers/anthropic-family.test.ts
@@ -21,6 +21,14 @@ const FULL_LADDER = ["max", "xhigh", "high", "medium", "low"];
 
 const EXPECTATIONS: ExpectedCatalogEntry[] = [
   {
+    key: "anthropic_claude_fable_5_1",
+    provider: "anthropic",
+    modelId: "claude-fable-5-1",
+    displayName: "Claude Fable 5.1",
+    openRouterModelId: "anthropic/claude-fable-5.1",
+    slug: "claude-fable-5-1",
+  },
+  {
     key: "anthropic_claude_fable_5",
     provider: "anthropic",
     modelId: "claude-fable-5",
@@ -93,6 +101,7 @@ runProviderConfigTest(
   "anthropic family",
   {
     ANTHROPIC_STREAM_RESPONSES: "0",
+    ANTHROPIC_FABLE_5_1_EFFORT: "max",
     ANTHROPIC_OPUS_5_EFFORT: "max",
     ANTHROPIC_SONNET_5_EFFORT: "max",
   },
@@ -162,6 +171,9 @@ runProviderConfigTest(
         (directRequest.body.output_config as { effort?: unknown })?.effort,
         "max",
       );
+      if (expected.key === "anthropic_claude_fable_5_1") {
+        assert.equal(Object.hasOwn(directRequest.body, "tool_choice"), false);
+      }
       assertTraceLine(
         direct.traces,
         [
@@ -186,6 +198,9 @@ runProviderConfigTest(
       assert.equal(Object.hasOwn(openRouterRequest, "temperature"), false);
       assert.equal(Object.hasOwn(openRouterRequest, "top_p"), false);
       assert.equal(Object.hasOwn(openRouterRequest, "top_k"), false);
+      if (expected.key === "anthropic_claude_fable_5_1") {
+        assert.equal(Object.hasOwn(openRouterRequest, "tool_choice"), false);
+      }
       assert.deepEqual(openRouterRequest.reasoning, { effort: "max" });
       assert.deepEqual(openRouterRequest.provider, { require_parameters: true });
       const responseFormat = openRouterRequest.response_format as {


### PR DESCRIPTION
## Summary

- add Claude Fable 5.1 through the existing Anthropic catalog and capability path
- configure the native `claude-fable-5-1` and OpenRouter `anthropic/claude-fable-5.1` routes
- request the 128000-token output ceiling with always-on adaptive thinking at `max` effort
- omit unsupported sampling parameters and forced tool choice while preserving strict structured output
- extend the Anthropic family fixture across direct and OpenRouter requests
- record the completed 15-prompt benchmark cohort

## Provider contract

- 1M-token context window without a beta header
- `max -> xhigh -> high -> medium -> low` effort fallback
- `ANTHROPIC_FABLE_5_1_EFFORT` runtime override
- provider-default sampling
- generated benchmark metadata records the accepted configuration and consistent 128000-token cap
- total benchmark cost: $147.55

## Validation

- `pnpm exec tsx tests/run.ts tests/unit/providers/anthropic-family.test.ts tests/unit/ai/claude-capabilities.test.ts tests/unit/ai/model-catalog.test.ts tests/unit/ai/model-benchmark-profiles.test.ts`
- `pnpm exec tsx tests/run.ts tests/unit/providers` — 13 files passed
- `pnpm exec tsx tests/run.ts tests/unit/ai/model-benchmark-profiles.test.ts tests/unit/scripts/batch-benchmark-metrics.test.ts`
- `pnpm exec tsc --noEmit`
- `pnpm lint`
- `pnpm build`
- `pnpm batch:status --model claude-fable-5-1` — 15/15 finalized builds
- `graphify update .`

The repository-wide test run completed every other file but requires a reachable database for `tests/unit/seo.test.ts`.

## Sources

- [Claude Fable 5.1 overview](https://platform.claude.com/docs/en/models/fable-5-1/overview)
- [Anthropic effort levels](https://platform.claude.com/docs/en/build-with-claude/effort)
- [Anthropic thinking compatibility](https://platform.claude.com/docs/en/build-with-claude/thinking)
- [OpenRouter model catalog](https://openrouter.ai/api/v1/models)

*(PR written by Codex)*
