### PR TITLE
feat(ai): add Gemini 3.8 Flash

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,7 +40,7 @@ ZAI_API_KEY=
 # OpenRouter (alternative/fallback for all providers)
 # If a direct provider key is missing or fails, OpenRouter will be used as fallback
 OPENROUTER_API_KEY=
-# Server-only key for the signed-in Gemini 3.7 Flash promotion
+# Server-only key for the signed-in Gemini 3.8 Flash promotion
 MINEBENCH_FREE_OPENROUTER_API_KEY=
 
 # Optional SEO verification token (Google Search Console)

--- a/app/api/generation-options/route.ts
+++ b/app/api/generation-options/route.ts
@@ -3,7 +3,7 @@ import { isProviderApiKeyName } from "@/lib/ai/providerKeys";
 
 export const runtime = "nodejs";
 
-const HOSTED_GEMINI_MODEL_KEY = "gemini_3_7_flash";
+const HOSTED_GEMINI_MODEL_KEY = "gemini_3_8_flash";
 
 export async function GET() {
   const hostedGeminiAvailable = Boolean(process.env.MINEBENCH_FREE_OPENROUTER_API_KEY?.trim());

--- a/components/arena/Arena.tsx
+++ b/components/arena/Arena.tsx
@@ -1211,7 +1211,7 @@ function ArenaAccountPrompt({
             id="arena-account-prompt-title"
             className="mt-2 font-display text-2xl font-semibold tracking-tight"
           >
-            Unlimited Gemini 3.7 Flash generations
+            Unlimited Gemini 3.8 Flash generations
           </h2>
           <p
             id="arena-account-prompt-description"

--- a/components/sandbox/SandboxLive.tsx
+++ b/components/sandbox/SandboxLive.tsx
@@ -113,13 +113,13 @@ const DIRECT_PROVIDER_KEYS = [
 ] as const satisfies ReadonlyArray<readonly [keyof ProviderApiKeys, string]>;
 const OPENROUTER_MODEL_VALUE = "__openrouter__";
 const CUSTOM_MODEL_VALUE = "__custom_api__";
-const HOSTED_GEMINI_MODEL_KEY = "gemini_3_7_flash";
-const HOSTED_GEMINI_NOTICE_KEY = "mb_hosted_gemini_3_7_notice_v1";
+const HOSTED_GEMINI_MODEL_KEY = "gemini_3_8_flash";
+const HOSTED_GEMINI_NOTICE_KEY = "mb_hosted_gemini_3_8_notice_v1";
 let anonymousHostedGeminiNoticeShown = false;
 const ENABLED_MODELS = MODEL_CATALOG.filter((model) => model.enabled);
 const FALLBACK_MODEL_A: ModelKey = ENABLED_MODELS[0]?.key ?? "openai_gpt_5_4_mini";
 const DEFAULT_MODEL_A: ModelKey =
-  ENABLED_MODELS.find((model) => model.key === "gemini_3_7_flash")?.key ?? FALLBACK_MODEL_A;
+  ENABLED_MODELS.find((model) => model.key === "gemini_3_8_flash")?.key ?? FALLBACK_MODEL_A;
 const DEFAULT_MODEL_B: ModelKey =
   ENABLED_MODELS.find(
     (model) => model.key === "openai_gpt_5_4_nano" && model.key !== DEFAULT_MODEL_A
@@ -254,7 +254,7 @@ function HostedGeminiAnnouncement({
         <div>
           <p className="mb-eyebrow">Generate</p>
           <h2 id="hosted-gemini-title" className="mt-2 text-2xl font-semibold tracking-tight">
-            Gemini 3.7 Flash is free
+            Gemini 3.8 Flash is free
           </h2>
           <p className="mt-2 text-sm leading-6 text-muted">
             {signedIn
@@ -1869,7 +1869,7 @@ export function SandboxLive({
           <div className="-mx-4 flex flex-col gap-3 border-y border-accent/20 bg-accent/[0.06] px-4 py-3 sm:-mx-5 sm:flex-row sm:items-center sm:justify-between sm:px-5">
             <div className="min-w-0">
               <div className="mb-eyebrow text-accent">Free right now</div>
-              <div className="mt-1 text-sm font-semibold text-fg">Gemini 3.7 Flash</div>
+              <div className="mt-1 text-sm font-semibold text-fg">Gemini 3.8 Flash</div>
               <div className="mt-0.5 text-xs text-muted">
                 {signedIn ? "No API key needed." : "Sign in. No API key needed."}
               </div>

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -97,7 +97,7 @@ Copy `.env.example` to `.env` and set what you need.
 - `META_MODEL_API_KEY`
 - `ZAI_API_KEY`
 - `OPENROUTER_API_KEY`
-- `MINEBENCH_FREE_OPENROUTER_API_KEY` (server-only key for the signed-in Gemini 3.7 Flash promotion)
+- `MINEBENCH_FREE_OPENROUTER_API_KEY` (server-only key for the signed-in Gemini 3.8 Flash promotion)
 
 ### Optional Provider and Runtime Tuning
 
@@ -124,6 +124,7 @@ Copy `.env.example` to `.env` and set what you need.
 - Claude Opus 5 uses the native Anthropic model ID `claude-opus-5`, reaches its 1M-token context window without a beta header, supports adaptive thinking with effort `low|medium|high|xhigh|max`, and MineBench defaults it to `max` with a 128000-token output cap. Its OpenRouter fallback uses `anthropic/claude-opus-5` with the same cap and effort ladder.
 - Claude Sonnet 5 uses the native Anthropic model ID `claude-sonnet-5`, supports adaptive thinking with effort `low|medium|high|xhigh|max`, and MineBench defaults it to `max` with a 128000-token output cap.
 - Claude 4.8 Opus uses the native Anthropic model ID `claude-opus-4-8`, supports adaptive effort `low|medium|high|xhigh|max`, and MineBench defaults it to `max` with a 128000-token output cap.
+- Gemini 3.8 Flash uses the native Google AI model ID `gemini-3.8-flash`, supports `thinking_level=high|medium|low`, and MineBench defaults it to `high` with a 65536-token output cap. OpenRouter fallback uses `google/gemini-3.8-flash` with the same cap and mandatory reasoning.
 - Gemini 3.7 Flash uses the native Google AI model ID `gemini-3.7-flash`, supports `thinking_level=high|medium|low`, and MineBench defaults it to `high` with a 65536-token output cap. OpenRouter fallback uses `google/gemini-3.7-flash` with the same cap and mandatory reasoning.
 - Gemini 3.6 Flash uses the native Google AI model ID `gemini-3.6-flash`, supports `thinking_level=high|medium|low|minimal`, and MineBench defaults it to `high` with a 65536-token output cap. OpenRouter fallback uses `google/gemini-3.6-flash` with the same cap and highest reasoning effort.
 - Gemini 3.5 Flash-Lite uses the native Google AI model ID `gemini-3.5-flash-lite`, supports `thinking_level=high|medium|low|minimal`, and MineBench defaults it to `high` with a 65536-token output cap. OpenRouter fallback uses `google/gemini-3.5-flash-lite` with the same cap and highest reasoning effort.

--- a/lib/ai/modelBenchmarkMetrics.generated.json
+++ b/lib/ai/modelBenchmarkMetrics.generated.json
@@ -630,6 +630,28 @@
       "interruptedRunCount": 3,
       "providerCallTrackingJobCount": 15,
       "completedAttemptTrackingJobCount": 15
+    },
+    "gemini_3_8_flash": {
+      "inferenceSampleCount": 15,
+      "expectedBuildCount": 15,
+      "finalizedBuildCount": 15,
+      "promptCohortId": "prompts-v1:bd8c28367f8a97f2",
+      "averageJsonSizeBytes": 31907429,
+      "configurationSampleCount": 15,
+      "configurationIsConsistent": true,
+      "outputCapSampleCount": 15,
+      "outputCapIsConsistent": true,
+      "averageInferenceMs": 110860,
+      "finalizedAttemptCount": 20,
+      "outputCapTokens": 65536,
+      "providerCallCount": 20,
+      "completedAttemptCount": 20,
+      "rejectedResponseCount": 5,
+      "failedAttemptCount": 5,
+      "failedRunCount": 0,
+      "interruptedRunCount": 0,
+      "providerCallTrackingJobCount": 15,
+      "completedAttemptTrackingJobCount": 15
     }
   }
 }

--- a/lib/ai/modelBenchmarkProfiles.ts
+++ b/lib/ai/modelBenchmarkProfiles.ts
@@ -318,32 +318,32 @@ const MODEL_BENCHMARK_METADATA: Partial<
   Record<ModelKey, Omit<ModelBenchmarkProfile, "outputCap" | "parameters">>
 > = {
   anthropic_claude_fable_5_1: {
-    totalCost: { usd: 147.55 },
+    totalCost: { usd: 147.55, attemptCount: 23 },
   },
   zai_glm_5_3_flash: {
-    totalCost: { usd: 0.74 },
+    totalCost: { usd: 0.74, attemptCount: 37 },
   },
   zai_glm_5_3: {
     totalCost: { usd: 6.42, attemptCount: 24 },
   },
   gemini_3_8_flash: {
-    totalCost: { usd: 1.18 },
+    totalCost: { usd: 1.18, attemptCount: 20 },
   },
   gemini_3_7_flash: {
-    totalCost: { usd: 1.46 },
+    totalCost: { usd: 1.46, attemptCount: 19 },
   },
   xai_grok_4_6: {
     sourceRelease: "3.13.0",
-    totalCost: { usd: 11.22 },
+    totalCost: { usd: 11.22, attemptCount: 20 },
   },
   openai_gpt_5_6_luna: {
     sourceRelease: "3.12.0",
-    totalCost: { usd: 1.15 },
+    totalCost: { usd: 1.15, attemptCount: 24 },
   },
   qwen_qwen3_8_max: {
     sourceRelease: "3.12.0",
     averageInference: { milliseconds: 1_463_039 },
-    totalCost: { usd: 11.53 },
+    totalCost: { usd: 11.53, attemptCount: 40 },
   },
   openai_gpt_5_6_sol: {
     sourceRelease: "3.9.0",

--- a/lib/ai/modelBenchmarkProfiles.ts
+++ b/lib/ai/modelBenchmarkProfiles.ts
@@ -326,6 +326,9 @@ const MODEL_BENCHMARK_METADATA: Partial<
   zai_glm_5_3: {
     totalCost: { usd: 6.42, attemptCount: 24 },
   },
+  gemini_3_8_flash: {
+    totalCost: { usd: 1.18 },
+  },
   gemini_3_7_flash: {
     totalCost: { usd: 1.46 },
   },

--- a/lib/ai/modelBenchmarkProfiles.ts
+++ b/lib/ai/modelBenchmarkProfiles.ts
@@ -148,6 +148,10 @@ const MODEL_RUN_PARAMETERS = {
     { label: "Thinking", value: "Adaptive" },
     { label: "Reasoning effort", value: "Max" },
   ],
+  gemini_3_8_flash: [
+    { label: "Thinking level", value: "High" },
+    { label: "Sampling", value: "Provider default" },
+  ],
   gemini_3_7_flash: [
     { label: "Thinking level", value: "High" },
     { label: "Sampling", value: "Provider default" },
@@ -272,6 +276,7 @@ export const HISTORICAL_BENCHMARK_OUTPUT_CAPS: Partial<
   anthropic_claude_4_6_opus: exactOutputCap(131_072),
   anthropic_claude_4_7_opus: exactOutputCap(128_000),
   anthropic_claude_4_8_opus: exactOutputCap(128_000),
+  gemini_3_8_flash: exactOutputCap(65_536),
   gemini_3_7_flash: exactOutputCap(65_536),
   gemini_3_6_flash: exactOutputCap(65_536),
   gemini_3_5_flash_lite: exactOutputCap(65_536),

--- a/lib/ai/modelCatalog.ts
+++ b/lib/ai/modelCatalog.ts
@@ -281,6 +281,15 @@ const CATALOG = [
     openRouterModelId: "anthropic/claude-opus-4.8",
   },
   {
+    key: "gemini_3_8_flash",
+    slug: "gemini-3-8-flash",
+    provider: "gemini",
+    modelId: "gemini-3.8-flash",
+    displayName: "Gemini 3.8 Flash",
+    enabled: true,
+    openRouterModelId: "google/gemini-3.8-flash",
+  },
+  {
     key: "gemini_3_7_flash",
     slug: "gemini-3-7-flash",
     provider: "gemini",

--- a/lib/ai/modelRequestProfiles.ts
+++ b/lib/ai/modelRequestProfiles.ts
@@ -37,6 +37,7 @@ const OUTPUT_CEILINGS: readonly { tokens: number; ids: readonly string[] }[] = [
   {
     tokens: 65_536,
     ids: [
+      "gemini-3.8-flash",
       "gemini-3.7-flash",
       "gemini-3.6-flash",
       "gemini-3.5-flash-lite",
@@ -68,6 +69,7 @@ const DEFAULT_SAMPLING_IDS: readonly string[] = [
   "grok-4.6",
   "kimi-k3",
   "qwen3.8-max",
+  "gemini-3.8-flash",
   "gemini-3.7-flash",
   "gemini-3.6-flash",
   "gemini-3.5-flash-lite",

--- a/lib/ai/reasoningProfiles.ts
+++ b/lib/ai/reasoningProfiles.ts
@@ -28,7 +28,7 @@ function isGemini3FlashFamily(modelId: string): boolean {
 }
 
 function gemini3FlashThinkingLevels(modelId: string): readonly GeminiThinkingLevel[] {
-  return modelId.endsWith("gemini-3.7-flash")
+  return modelId.endsWith("gemini-3.8-flash") || modelId.endsWith("gemini-3.7-flash")
     ? ["high", "medium", "low"]
     : ["high", "medium", "low", "minimal"];
 }
@@ -232,6 +232,7 @@ export function modelRequiresReasoning(modelId: string): boolean {
     normalized === "z-ai/glm-5.3" ||
     normalized === "glm-5.3-flash" ||
     normalized === "z-ai/glm-5.3-flash" ||
+    normalized === "google/gemini-3.8-flash" ||
     normalized === "google/gemini-3.7-flash" ||
     normalized === "muse-spark-1.2" ||
     normalized === "meta/muse-spark-1.2"

--- a/lib/generations/service.ts
+++ b/lib/generations/service.ts
@@ -23,6 +23,10 @@ const STORAGE_FAILSAFE_BYTES = 1024 * 1024 * 1024;
 const SECRET_TTL_MS = 24 * 60 * 60 * 1000;
 const GENERATE_JOB_MAX_ATTEMPTS = 2;
 const HOSTED_GEMINI_MODEL_KEY = "gemini_3_8_flash";
+const HOSTED_GEMINI_RETRY_MODEL_KEYS = new Set([
+  "gemini_3_7_flash",
+  HOSTED_GEMINI_MODEL_KEY,
+]);
 
 export class GenerationServiceError extends Error {
   constructor(
@@ -442,7 +446,7 @@ export async function retrySavedGeneration(
   const provider = retryCredentialProvider(build);
   const providerKey = input.providerKey?.trim() || (
     build.usesHostedGeneration &&
-    build.modelKey === HOSTED_GEMINI_MODEL_KEY &&
+    HOSTED_GEMINI_RETRY_MODEL_KEYS.has(build.modelKey ?? "") &&
     provider === "openrouter"
       ? process.env.MINEBENCH_FREE_OPENROUTER_API_KEY?.trim()
       : undefined

--- a/lib/generations/service.ts
+++ b/lib/generations/service.ts
@@ -22,7 +22,7 @@ import { prisma } from "@/lib/prisma";
 const STORAGE_FAILSAFE_BYTES = 1024 * 1024 * 1024;
 const SECRET_TTL_MS = 24 * 60 * 60 * 1000;
 const GENERATE_JOB_MAX_ATTEMPTS = 2;
-const HOSTED_GEMINI_MODEL_KEY = "gemini_3_7_flash";
+const HOSTED_GEMINI_MODEL_KEY = "gemini_3_8_flash";
 
 export class GenerationServiceError extends Error {
   constructor(
@@ -273,7 +273,7 @@ export async function createSavedGenerations(input: CreateSavedGenerationsInput)
       throw new GenerationServiceError(
         hostedGenerationCount > 0 ? "hosted_generation_limit_reached" : "invalid_request",
         hostedGenerationCount > 0
-          ? "Free Gemini 3.7 Flash limit reached. Add a Gemini or OpenRouter key to continue."
+          ? "Free Gemini 3.8 Flash limit reached. Add a Gemini or OpenRouter key to continue."
           : "Account not found.",
       );
     }

--- a/tests/integration/gallery/application-service.test.ts
+++ b/tests/integration/gallery/application-service.test.ts
@@ -199,6 +199,7 @@ async function main() {
     await db.customBuild.update({
       where: { id: hostedRow.id },
       data: {
+        modelKey: "gemini_3_7_flash",
         status: "failed",
         currentStage: "failed",
         completedAt: new Date(),
@@ -212,7 +213,11 @@ async function main() {
       data: { status: "failed", completedAt: new Date() },
     });
     await db.customBuildSecret.deleteMany({ where: { customBuildId: hostedRow.id } });
-    assert.equal((await retrySavedGeneration(ownerId, hosted[0]!.id, {})).status, "queued");
+    assert.equal(
+      (await retrySavedGeneration(ownerId, hosted[0]!.id, {})).status,
+      "queued",
+      "previously hosted Gemini models should remain retryable",
+    );
     const hostedRetrySecret = await db.customBuildSecret.findUniqueOrThrow({
       where: { customBuildId: hostedRow.id },
     });

--- a/tests/integration/gallery/application-service.test.ts
+++ b/tests/integration/gallery/application-service.test.ts
@@ -83,7 +83,7 @@ async function main() {
       prompt: "A hosted observatory",
       gridSize: 64,
       palette: "simple",
-      models: [{ id: "hosted", kind: "catalog", modelKey: "gemini_3_7_flash" }],
+      models: [{ id: "hosted", kind: "catalog", modelKey: "gemini_3_8_flash" }],
       providerKeys: {},
     });
     const hostedRow = await db.customBuild.findUniqueOrThrow({
@@ -92,7 +92,7 @@ async function main() {
     });
     assert.equal(hostedRow.usesHostedGeneration, true);
     assert.equal(hostedRow.preferOpenRouter, true);
-    assert.equal(hostedRow.openRouterModelId, "google/gemini-3.7-flash");
+    assert.equal(hostedRow.openRouterModelId, "google/gemini-3.8-flash");
     assert.equal(hostedRow.secret?.provider, "openrouter");
     assert.notEqual(hostedRow.secret?.keyCiphertext, "hosted-openrouter-secret");
     assert.deepEqual(
@@ -108,7 +108,7 @@ async function main() {
       prompt: "A user-funded observatory",
       gridSize: 64,
       palette: "simple",
-      models: [{ id: "user-funded", kind: "catalog", modelKey: "gemini_3_7_flash" }],
+      models: [{ id: "user-funded", kind: "catalog", modelKey: "gemini_3_8_flash" }],
       providerKeys: { openrouter: "user-openrouter-secret" },
     });
     assert.equal(
@@ -129,7 +129,7 @@ async function main() {
         prompt: "An ineligible hosted model",
         gridSize: 64,
         palette: "simple",
-        models: [{ id: "ineligible", kind: "catalog", modelKey: "openai_gpt_5_4_mini" }],
+        models: [{ id: "ineligible", kind: "catalog", modelKey: "gemini_3_7_flash" }],
         providerKeys: {},
       }),
       (error: unknown) => error instanceof GenerationServiceError && error.code === "missing_provider_key",
@@ -145,7 +145,7 @@ async function main() {
         prompt: "First concurrent hosted build",
         gridSize: 64,
         palette: "simple",
-        models: [{ id: "concurrent-one", kind: "catalog", modelKey: "gemini_3_7_flash" }],
+        models: [{ id: "concurrent-one", kind: "catalog", modelKey: "gemini_3_8_flash" }],
         providerKeys: {},
       }),
       createSavedGenerations({
@@ -153,7 +153,7 @@ async function main() {
         prompt: "Second concurrent hosted build",
         gridSize: 64,
         palette: "simple",
-        models: [{ id: "concurrent-two", kind: "catalog", modelKey: "gemini_3_7_flash" }],
+        models: [{ id: "concurrent-two", kind: "catalog", modelKey: "gemini_3_8_flash" }],
         providerKeys: {},
       }),
     ]);
@@ -181,7 +181,7 @@ async function main() {
       prompt: "A build after the hosted limit",
       gridSize: 64,
       palette: "simple",
-      models: [{ id: "byok-at-limit", kind: "catalog", modelKey: "gemini_3_7_flash" }],
+      models: [{ id: "byok-at-limit", kind: "catalog", modelKey: "gemini_3_8_flash" }],
       providerKeys: { gemini: "user-gemini-secret" },
     });
     assert.equal(

--- a/tests/ui/arena-anonymous-conversion.test.ts
+++ b/tests/ui/arena-anonymous-conversion.test.ts
@@ -91,7 +91,7 @@ assert.ok(
     promptBody.includes("onCancel") &&
     promptBody.includes("event.target !== dialog") &&
     sourceText.includes("For a limited time") &&
-    sourceText.includes("Unlimited Gemini 3.7 Flash generations") &&
+    sourceText.includes("Unlimited Gemini 3.8 Flash generations") &&
     sourceText.includes("Sign in to generate free, save your builds, and keep your votes.") &&
     sourceText.includes("No API key needed.") &&
     sourceText.includes("/sign-in?next=/sandbox%3Fmode%3Dlive") &&

--- a/tests/ui/sandbox-live-durable.test.ts
+++ b/tests/ui/sandbox-live-durable.test.ts
@@ -232,15 +232,15 @@ assert.ok(
   "API keys should use a flat full-width disclosure with literal labels and shared motion",
 );
 assert.ok(
-  sourceText.includes('model.key === "gemini_3_7_flash"') &&
+  sourceText.includes('model.key === "gemini_3_8_flash"') &&
     !sourceText.includes('model.key === "openai_gpt_5_6_luna"') &&
     sourceText.includes('useState(() => initialPrompt ?? "")') &&
     !sourceText.includes("a pirate ship with sails"),
-  "Generate should start blank with Gemini 3.7 Flash selected",
+  "Generate should start blank with Gemini 3.8 Flash selected",
 );
 assert.ok(
   sourceText.includes("HOSTED_GEMINI_NOTICE_KEY") &&
-    sourceText.includes("Gemini 3.7 Flash is free") &&
+    sourceText.includes("Gemini 3.8 Flash is free") &&
     sourceText.includes("Free right now") &&
     sourceText.includes("No API key needed.") &&
     sourceText.includes("Start free") &&

--- a/tests/unit/ai/model-benchmark-profiles.test.ts
+++ b/tests/unit/ai/model-benchmark-profiles.test.ts
@@ -27,7 +27,7 @@ assert.deepEqual(gpt56Luna.outputCap, { kind: "exact", tokens: 128_000 });
 assert.equal(gpt56Luna.sourceRelease, "3.12.0");
 assert.deepEqual(gpt56Luna.averageInference, { milliseconds: 804_533 });
 assert.equal(gpt56Luna.averageJsonSizeBytes, 59_966_032);
-assert.deepEqual(gpt56Luna.totalCost, { usd: 1.15 });
+assert.deepEqual(gpt56Luna.totalCost, { usd: 1.15, attemptCount: 24 });
 assert.equal(gpt56Luna.totalAttempts, 24);
 assert.equal(gpt56Luna.buildCount, 15);
 
@@ -41,7 +41,7 @@ assert.deepEqual(grok46.outputCap, { kind: "exact", tokens: 496_000 });
 assert.equal(grok46.sourceRelease, "3.13.0");
 assert.deepEqual(grok46.averageInference, { milliseconds: 623_697 });
 assert.equal(grok46.averageJsonSizeBytes, 103_678_079);
-assert.deepEqual(grok46.totalCost, { usd: 11.22 });
+assert.deepEqual(grok46.totalCost, { usd: 11.22, attemptCount: 20 });
 assert.equal(grok46.totalAttempts, 20);
 assert.equal(grok46.buildCount, 15);
 
@@ -172,7 +172,7 @@ assert.deepEqual(gemini36Flash?.totalCost, { usd: 3.22 });
 assert.equal(gemini36Flash?.buildCount, 15);
 
 const gemini38Flash = getModelBenchmarkProfile("gemini_3_8_flash");
-assert.deepEqual(gemini38Flash?.totalCost, { usd: 1.18 });
+assert.deepEqual(gemini38Flash?.totalCost, { usd: 1.18, attemptCount: 20 });
 
 const gemini37Flash = getModelBenchmarkProfile("gemini_3_7_flash");
 assert.ok(gemini37Flash, "Gemini 3.7 Flash should have verified benchmark details");
@@ -183,7 +183,7 @@ assert.deepEqual(gemini37Flash.parameters, [
 assert.deepEqual(gemini37Flash.outputCap, { kind: "exact", tokens: 65_536 });
 assert.deepEqual(gemini37Flash.averageInference, { milliseconds: 65_219 });
 assert.equal(gemini37Flash.averageJsonSizeBytes, 51_459_756);
-assert.deepEqual(gemini37Flash.totalCost, { usd: 1.46 });
+assert.deepEqual(gemini37Flash.totalCost, { usd: 1.46, attemptCount: 19 });
 assert.equal(gemini37Flash.totalAttempts, 19);
 assert.equal(gemini37Flash.buildCount, 15);
 
@@ -197,7 +197,7 @@ const gemini30Flash = getModelBenchmarkProfile("gemini_3_0_flash");
 assert.deepEqual(gemini30Flash?.outputCap, { kind: "exact", tokens: 65_536 });
 
 const fable51 = getModelBenchmarkProfile("anthropic_claude_fable_5_1");
-assert.deepEqual(fable51?.totalCost, { usd: 147.55 });
+assert.deepEqual(fable51?.totalCost, { usd: 147.55, attemptCount: 23 });
 
 const fable5 = getModelBenchmarkProfile("anthropic_claude_fable_5");
 assert.deepEqual(fable5?.averageInference, { milliseconds: 1_084_400 });
@@ -333,7 +333,7 @@ assert.deepEqual(qwen38?.parameters, [
 assert.equal(qwen38?.sourceRelease, "3.12.0");
 assert.deepEqual(qwen38?.averageInference, { milliseconds: 1_463_039 });
 assert.equal(qwen38?.averageJsonSizeBytes, 15_361_898);
-assert.deepEqual(qwen38?.totalCost, { usd: 11.53 });
+assert.deepEqual(qwen38?.totalCost, { usd: 11.53, attemptCount: 40 });
 assert.equal(qwen38?.totalAttempts, 40);
 assert.deepEqual(
   qwen38?.outputCap,

--- a/tests/unit/ai/model-benchmark-profiles.test.ts
+++ b/tests/unit/ai/model-benchmark-profiles.test.ts
@@ -171,6 +171,9 @@ assert.deepEqual(gemini36Flash?.averageInference, { milliseconds: 101_900 });
 assert.deepEqual(gemini36Flash?.totalCost, { usd: 3.22 });
 assert.equal(gemini36Flash?.buildCount, 15);
 
+const gemini38Flash = getModelBenchmarkProfile("gemini_3_8_flash");
+assert.deepEqual(gemini38Flash?.totalCost, { usd: 1.18 });
+
 const gemini37Flash = getModelBenchmarkProfile("gemini_3_7_flash");
 assert.ok(gemini37Flash, "Gemini 3.7 Flash should have verified benchmark details");
 assert.deepEqual(gemini37Flash.parameters, [

--- a/tests/unit/api/ios-contracts.test.ts
+++ b/tests/unit/api/ios-contracts.test.ts
@@ -43,15 +43,19 @@ async function main() {
   assert.equal(new Set(options.models.map((model) => model.key)).size, options.models.length);
   assert.equal(options.models.some((model) => model.key === "openai_gpt_4_5_web_harness"), false);
   assert.deepEqual(
-    options.models.find((model) => model.key === "gemini_3_7_flash"),
+    options.models.find((model) => model.key === "gemini_3_8_flash"),
     {
-      key: "gemini_3_7_flash",
+      key: "gemini_3_8_flash",
       provider: "gemini",
-      displayName: "Gemini 3.7 Flash",
+      displayName: "Gemini 3.8 Flash",
       directKey: "gemini",
       openRouter: true,
       hostedEligible: true,
     },
+  );
+  assert.equal(
+    options.models.find((model) => model.key === "gemini_3_7_flash")?.hostedEligible,
+    false,
   );
   assert.equal(
     options.models.find((model) => model.key === "qwen_qwen3_8_max")?.directKey,

--- a/tests/unit/generations/transitions.test.ts
+++ b/tests/unit/generations/transitions.test.ts
@@ -22,5 +22,11 @@ assert.ok(
     generateJob.includes("if (requeued.count !== 1) throw new CustomBuildLeaseLostError()"),
   "failure and retry writes should yield to cancellation or removal",
 );
+assert.ok(
+  generationService.includes("HOSTED_GEMINI_RETRY_MODEL_KEYS") &&
+    generationService.includes('"gemini_3_7_flash"') &&
+    generationService.includes('HOSTED_GEMINI_RETRY_MODEL_KEYS.has(build.modelKey ?? "")'),
+  "historical hosted Gemini retries should still restore the hosted key",
+);
 
 console.log("saved-generation transition checks passed");

--- a/tests/unit/leaderboard/model-benchmark-details-render.test.ts
+++ b/tests/unit/leaderboard/model-benchmark-details-render.test.ts
@@ -68,31 +68,32 @@ assert.ok(
   "a fully tracked Gemini model should render every normalized statistic row",
 );
 
-const lunaMarkup = renderToStaticMarkup(
-  React.createElement(ModelBenchmarkDetailsInline, {
-    id: "gpt-5-6-luna-details",
-    modelKey: "openai_gpt_5_6_luna",
-    displayName: "GPT 5.6 Luna Pro",
-    open: true,
-  }),
-);
-assert.ok(
-  lunaMarkup.includes("$1.15") && lunaMarkup.includes("$0.08 per build"),
-  "GPT 5.6 Luna Pro should render its canonical benchmark total and finalized-build rate",
-);
+const attemptCostSnapshots = [
+  ["openai_gpt_5_6_luna", "GPT 5.6 Luna Pro", "$1.15", "$0.05 per attempt"],
+  ["anthropic_claude_fable_5_1", "Claude Fable 5.1", "$147.55", "$6.42 per attempt"],
+  ["gemini_3_8_flash", "Gemini 3.8 Flash", "$1.18", "$0.06 per attempt"],
+  ["gemini_3_7_flash", "Gemini 3.7 Flash", "$1.46", "$0.08 per attempt"],
+  ["xai_grok_4_6", "Grok 4.6", "$11.22", "$0.56 per attempt"],
+  ["zai_glm_5_3_flash", "Z.AI GLM 5.3 Flash", "$0.74", "$0.02 per attempt"],
+  ["qwen_qwen3_8_max", "Qwen 3.8 Max", "$11.53", "$0.29 per attempt"],
+] as const;
 
-const qwenMarkup = renderToStaticMarkup(
-  React.createElement(ModelBenchmarkDetailsInline, {
-    id: "qwen-details",
-    modelKey: "qwen_qwen3_8_max",
-    displayName: "Qwen 3.8 Max",
-    open: true,
-  }),
-);
-assert.ok(
-  qwenMarkup.includes("$11.53") && qwenMarkup.includes("$0.77 per build"),
-  "Qwen 3.8 Max should render its canonical benchmark total and finalized-build rate",
-);
+for (const [modelKey, displayName, totalCost, averageCost] of attemptCostSnapshots) {
+  const markup = renderToStaticMarkup(
+    React.createElement(ModelBenchmarkDetailsInline, {
+      id: `${modelKey}-details`,
+      modelKey,
+      displayName,
+      open: true,
+    }),
+  );
+  assert.ok(
+    markup.includes(totalCost) &&
+      markup.includes(averageCost) &&
+      !markup.includes("per build"),
+    `${displayName} should divide its cost snapshot by covered attempts`,
+  );
+}
 
 const gemini30Markup = renderToStaticMarkup(
   React.createElement(ModelBenchmarkDetailsInline, {

--- a/tests/unit/providers/gemini-family.test.ts
+++ b/tests/unit/providers/gemini-family.test.ts
@@ -31,6 +31,21 @@ type GeminiExpectation = {
 const EXPECTATIONS: GeminiExpectation[] = [
   {
     catalog: {
+      key: "gemini_3_8_flash",
+      provider: "gemini",
+      modelId: "gemini-3.8-flash",
+      displayName: "Gemini 3.8 Flash",
+      openRouterModelId: "google/gemini-3.8-flash",
+      slug: "gemini-3-8-flash",
+    },
+    effortAttempts: ["high", "medium", "low"],
+    unsupportedEffort: { value: "minimal", message: /Supported values: high, medium, low/ },
+    minimalSupported: false,
+    requiresReasoning: true,
+    effortFallbackTrace: "effort_fallback=high->medium->low",
+  },
+  {
+    catalog: {
       key: "gemini_3_7_flash",
       provider: "gemini",
       modelId: "gemini-3.7-flash",

--- a/tests/unit/providers/zai-family.test.ts
+++ b/tests/unit/providers/zai-family.test.ts
@@ -179,7 +179,10 @@ runProviderConfigTest("zai family", {
     { label: "Reasoning effort", value: "Max" },
     { label: "Sampling", value: "Temperature 1 · Top P 0.95" },
   ]);
-  assert.deepEqual(getModelBenchmarkProfile(flash.key)?.totalCost, { usd: 0.74 });
+  assert.deepEqual(getModelBenchmarkProfile(flash.key)?.totalCost, {
+    usd: 0.74,
+    attemptCount: 37,
+  });
   assert.deepEqual(getModelBenchmarkProfile(flash.key)?.averageInference, {
     milliseconds: 2_239_861,
   });


### PR DESCRIPTION
## Summary

- add Gemini 3.8 Flash through the native Google and OpenRouter benchmark paths
- use the 65,536-token output cap with high-to-low thinking fallback and provider-default sampling
- move signed-in hosted generation and its UI/API contracts from Gemini 3.7 Flash to Gemini 3.8 Flash
- preserve retries for saved Gemini 3.7 hosted generations
- pin cost snapshots to their covered attempts so reruns do not distort average cost

## Benchmark

- 15/15 finalized builds
- 1m 50.9s average inference time
- 30.43 MiB average JSON size
- 20 provider calls and completed attempts, including 5 rejected responses
- $1.18 total cost

## Testing

- `pnpm test tests/unit/providers/gemini-family.test.ts tests/unit/ai/model-request-profiles.test.ts tests/unit/ai/model-benchmark-profiles.test.ts tests/unit/api/ios-contracts.test.ts tests/ui/sandbox-live-durable.test.ts tests/ui/arena-anonymous-conversion.test.ts`
- `pnpm test tests/unit/providers`
- `pnpm test tests/unit/ai/model-benchmark-profiles.test.ts tests/unit/leaderboard/model-benchmark-details-render.test.ts tests/unit/providers/zai-family.test.ts`
- `node scripts/run-postgres-tests.mjs tests/integration/gallery/application-service.test.ts`
- `pnpm exec tsc --noEmit`
- `pnpm lint`
- `pnpm build`

*(PR written by Codex)*
