### PR TITLE
feat(models): add GPT-6 Astra Pro benchmark support

### DIFF
--- a/components/leaderboard/ModelBenchmarkDetails.tsx
+++ b/components/leaderboard/ModelBenchmarkDetails.tsx
@@ -95,7 +95,7 @@ function formatJsonSize(bytes: number): string {
 }
 
 function formatCost(cost: BenchmarkCost): string {
-  return `$${cost.usd.toFixed(2)}`;
+  return `$${cost.usd.toFixed(2)}${cost.estimated ? "*" : ""}`;
 }
 
 // Unit follows whichever denominator was measured, since models benchmarked
@@ -103,10 +103,10 @@ function formatCost(cost: BenchmarkCost): string {
 function formatCostDetail(profile: ModelBenchmarkProfile): string | undefined {
   if (!profile.totalCost) return undefined;
   if (profile.totalCost.attemptCount) {
-    return `$${(profile.totalCost.usd / profile.totalCost.attemptCount).toFixed(2)} per attempt`;
+    return `${formatCost({ ...profile.totalCost, usd: profile.totalCost.usd / profile.totalCost.attemptCount })} per attempt`;
   }
   if (profile.buildCount) {
-    return `$${(profile.totalCost.usd / profile.buildCount).toFixed(2)} per build`;
+    return `${formatCost({ ...profile.totalCost, usd: profile.totalCost.usd / profile.buildCount })} per build`;
   }
   return undefined;
 }

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -112,10 +112,11 @@ Copy `.env.example` to `.env` and set what you need.
 - `ANTHROPIC_SONNET_4_6_EFFORT=low|medium|high|max` (runtime falls back automatically if provider rejects `max`)
 - `ANTHROPIC_STREAM_RESPONSES=1`
 - `OPENAI_STREAM_RESPONSES=1` (applies to live-delta callers; batch generation uses non-streamed Responses JSON)
-- `OPENAI_USE_BACKGROUND_MODE=1` (recommended for long-running Responses jobs; defaults on for `gpt-5*` when not streaming deltas)
+- `OPENAI_USE_BACKGROUND_MODE=1` (recommended for long-running Responses jobs; defaults on for `gpt-5*` and `gpt-6-astra` when not streaming deltas)
 - `OPENAI_BACKGROUND_POLL_MS=2000` (poll interval for background mode)
 - `ANTHROPIC_ENABLE_1M_CONTEXT_BETA=1`
 - `ANTHROPIC_THINKING_BUDGET` (legacy/manual thinking models)
+- GPT 6 Astra Pro uses `gpt-6-astra` through the Responses API with `reasoning.mode=pro`, `reasoning.effort=max`, high text verbosity, strict structured output, and provider-default sampling. Its context window is 1050000 tokens and its combined reasoning/output cap is 128000 tokens. Supported efforts are `max`, `xhigh`, `high`, `medium`, and `low`; `none` and `minimal` are unsupported. Its OpenRouter fallback uses `openai/gpt-6-astra-pro` with max effort and strict structured output. See the [model contract](https://developers.openai.com/api/docs/models/gpt-6-astra) and [migration guide](https://developers.openai.com/api/docs/guides/latest-model).
 - GPT 5.6 Sol uses the native OpenAI model ID `gpt-5.6-sol` through the Responses API with `reasoning.mode=pro`, defaults to `reasoning.effort=max`, and uses the model's 128000-token combined reasoning and output cap. Its OpenRouter fallback uses `openai/gpt-5.6-sol-pro` with max effort and strict structured output.
 - GPT 5.6 Luna uses the native OpenAI model ID `gpt-5.6-luna` through the Responses API with `reasoning.mode=pro`, defaults to `reasoning.effort=max`, and uses its 1050000-token context window and 128000-token combined reasoning and output cap. Its OpenRouter fallback uses `openai/gpt-5.6-luna-pro` with max effort and strict structured output.
 - Kimi K3 uses the native Moonshot model ID `kimi-k3`, always reasons with `reasoning_effort=max`, uses its 1048576-token completion ceiling, and omits its fixed sampling parameters. Its OpenRouter fallback uses `moonshotai/kimi-k3` with max effort and fails closed if that effort is rejected.

--- a/lib/ai/generateVoxelBuild.ts
+++ b/lib/ai/generateVoxelBuild.ts
@@ -195,7 +195,7 @@ function describeRequestedThinkingMode(opts: {
   }
 
   if (opts.provider === "openai") {
-    const usesProReasoning = opts.modelId.startsWith("gpt-5.6");
+    const usesProReasoning = opts.modelId.startsWith("gpt-5.6") || opts.modelId === "gpt-6-astra";
     const reasoningMode = usesProReasoning
       ? "reasoning_mode=pro,"
       : "";

--- a/lib/ai/modelBenchmarkMetrics.generated.json
+++ b/lib/ai/modelBenchmarkMetrics.generated.json
@@ -674,6 +674,28 @@
       "interruptedRunCount": 8,
       "providerCallTrackingJobCount": 15,
       "completedAttemptTrackingJobCount": 15
+    },
+    "openai_gpt_6_astra": {
+      "inferenceSampleCount": 15,
+      "expectedBuildCount": 15,
+      "finalizedBuildCount": 15,
+      "promptCohortId": "prompts-v1:bd8c28367f8a97f2",
+      "averageJsonSizeBytes": 134777521,
+      "configurationSampleCount": 15,
+      "configurationIsConsistent": true,
+      "outputCapSampleCount": 15,
+      "outputCapIsConsistent": true,
+      "averageInferenceMs": 1553517,
+      "finalizedAttemptCount": 15,
+      "outputCapTokens": 128000,
+      "providerCallCount": 15,
+      "completedAttemptCount": 15,
+      "rejectedResponseCount": 0,
+      "failedAttemptCount": 0,
+      "failedRunCount": 0,
+      "interruptedRunCount": 0,
+      "providerCallTrackingJobCount": 15,
+      "completedAttemptTrackingJobCount": 15
     }
   }
 }

--- a/lib/ai/modelBenchmarkProfiles.ts
+++ b/lib/ai/modelBenchmarkProfiles.ts
@@ -77,6 +77,11 @@ const OPENROUTER_XHIGH: ModelRunParameters = [
 ];
 
 const MODEL_RUN_PARAMETERS = {
+  openai_gpt_6_astra: [
+    { label: "Reasoning mode", value: "Pro" },
+    { label: "Reasoning effort", value: "Max" },
+    { label: "Text verbosity", value: "High" },
+  ],
   openai_gpt_5_6_luna: [
     { label: "Reasoning mode", value: "Pro" },
     { label: "Reasoning effort", value: "Max" },
@@ -243,6 +248,10 @@ const exactOutputCap = (tokens: number): BenchmarkOutputCap => ({
 export const HISTORICAL_BENCHMARK_OUTPUT_CAPS: Partial<
   Record<ModelKey, BenchmarkOutputCap>
 > = {
+  openai_gpt_6_astra: {
+    kind: "unavailable",
+    reason: "accepted-cap-unrecorded",
+  },
   openai_gpt_5_6_luna: {
     kind: "unavailable",
     reason: "accepted-cap-unrecorded",

--- a/lib/ai/modelBenchmarkProfiles.ts
+++ b/lib/ai/modelBenchmarkProfiles.ts
@@ -16,6 +16,7 @@ export type BenchmarkDuration = {
 
 export type BenchmarkCost = {
   usd: number;
+  estimated?: boolean;
   // Completed responses covered by this cost snapshot
   attemptCount?: number;
 };
@@ -327,6 +328,11 @@ export const HISTORICAL_BENCHMARK_OUTPUT_CAPS: Partial<
 const MODEL_BENCHMARK_METADATA: Partial<
   Record<ModelKey, Omit<ModelBenchmarkProfile, "outputCap" | "parameters">>
 > = {
+  openai_gpt_6_astra: {
+    sourceRelease: "4.3.0",
+    totalCost: { usd: 34.71, attemptCount: 15, estimated: true },
+    note: "* Estimated cost; the provider dashboard has not yet updated.",
+  },
   meta_muse_spark_1_3: {
     totalCost: { usd: 6.57, attemptCount: 28 },
   },

--- a/lib/ai/modelCatalog.ts
+++ b/lib/ai/modelCatalog.ts
@@ -29,6 +29,15 @@ type ModelCatalogEntryShape = {
 
 const CATALOG = [
   {
+    key: "openai_gpt_6_astra",
+    slug: "gpt-6-astra",
+    provider: "openai",
+    modelId: "gpt-6-astra",
+    displayName: "GPT 6 Astra Pro",
+    enabled: true,
+    openRouterModelId: "openai/gpt-6-astra-pro",
+  },
+  {
     key: "openai_gpt_5_6_luna",
     slug: "gpt-5-6-luna",
     provider: "openai",

--- a/lib/ai/modelRequestProfiles.ts
+++ b/lib/ai/modelRequestProfiles.ts
@@ -29,6 +29,7 @@ const OUTPUT_CEILINGS: readonly { tokens: number; ids: readonly string[] }[] = [
   },
   { tokens: 131_072, ids: ["qwen3.8-max"] },
   { tokens: 272_000, ids: ["gpt-5-pro"] },
+  { tokens: 128_000, ids: ["gpt-6-astra"] },
   // MiniMax M2.7 rejects the larger MineBench default on its OpenAI-compatible route
   {
     tokens: 131_072,
@@ -66,6 +67,7 @@ const OUTPUT_CEILING_PREFIXES: readonly { prefix: string; tokens: number }[] = [
 // Models that should use provider-default sampling instead of MineBench's
 // shared temperature, including models that reject sampling overrides
 const DEFAULT_SAMPLING_IDS: readonly string[] = [
+  "gpt-6-astra",
   "grok-4.6",
   "kimi-k3",
   "qwen3.8-max",

--- a/lib/ai/providers/openai.ts
+++ b/lib/ai/providers/openai.ts
@@ -421,7 +421,7 @@ function looksLikeVerbosityConfigError(body: string): boolean {
 }
 
 function defaultTextVerbosity(modelId: string): TextVerbosity | undefined {
-  return modelId.startsWith("gpt-5") ? "high" : undefined;
+  return modelId.startsWith("gpt-5") || modelId === "gpt-6-astra" ? "high" : undefined;
 }
 
 export async function openaiGenerateText(params: {
@@ -448,12 +448,13 @@ export async function openaiGenerateText(params: {
 
   const isGpt5Family = params.modelId.startsWith("gpt-5");
   const isGptOssFamily = params.modelId.startsWith("gpt-oss-");
-  const isGpt56 = params.modelId.startsWith("gpt-5.6");
+  const isGpt6Astra = params.modelId === "gpt-6-astra";
+  const usesProReasoning = params.modelId.startsWith("gpt-5.6") || isGpt6Astra;
   // Some models are Responses-only (or otherwise not supported in chat/completions).
   // For these, don't fall back to chat/completions because it hides the real failure cause.
   const isGpt55Pro = params.modelId.startsWith("gpt-5.5-pro");
   const isResponsesOnlyModel =
-    isGpt56 ||
+    usesProReasoning ||
     params.modelId === "gpt-5.2-pro" ||
     isGpt55Pro ||
     params.modelId.startsWith("gpt-5.4-pro") ||
@@ -461,7 +462,7 @@ export async function openaiGenerateText(params: {
     params.modelId === "gpt-5.2-codex" ||
     params.modelId === "gpt-5.3-codex";
   const defaultReasoningEffortAttempts: string[] =
-    isGpt5Family || isGptOssFamily
+    isGpt5Family || isGpt6Astra || isGptOssFamily
       ? openAiReasoningEffortAttempts(params.modelId) ?? []
       : [];
   const reasoningEffortAttempts =
@@ -474,7 +475,7 @@ export async function openaiGenerateText(params: {
   });
   // For GPT-5 family requests in MineBench we use reasoning mode, where sampling knobs
   // are not broadly compatible. Omit temperature and let API defaults apply.
-  const temperature = isGpt5Family ? undefined : (params.temperature ?? 0.2);
+  const temperature = isGpt5Family || isGpt6Astra ? undefined : (params.temperature ?? 0.2);
   const maxOutputTokens = params.maxOutputTokens ?? 32768;
   // Streaming is only useful when we have a live delta consumer.
   // For non-interactive callers (e.g. batch generation), use non-streaming
@@ -483,7 +484,7 @@ export async function openaiGenerateText(params: {
     !isGpt55Pro && Boolean(params.onDelta) && parseBooleanEnv("OPENAI_STREAM_RESPONSES", true);
   const useBackgroundMode =
     (isGpt55Pro || !params.onDelta) &&
-    parseBooleanEnv("OPENAI_USE_BACKGROUND_MODE", isGpt5Family);
+    parseBooleanEnv("OPENAI_USE_BACKGROUND_MODE", isGpt5Family || isGpt6Astra);
   const backgroundPollIntervalMs = parseIntEnv("OPENAI_BACKGROUND_POLL_MS", 15_000);
   const streamForRequest = useBackgroundMode ? false : streamResponses;
   const responsesApiMode = useBackgroundMode
@@ -510,17 +511,17 @@ export async function openaiGenerateText(params: {
       for (const [cfgIdx, cfg] of reasoningConfigAttempts.entries()) {
         const reasoning =
           cfg?.kind === "effort"
-            ? { effort: cfg.effort, ...(isGpt56 ? { mode: "pro" } : {}) }
+            ? { effort: cfg.effort, ...(usesProReasoning ? { mode: "pro" } : {}) }
             : cfg?.kind === "max_tokens"
               ? {
                   max_tokens: clampReasoningBudget(cfg.maxTokens, tok),
-                  ...(isGpt56 ? { mode: "pro" } : {}),
+                  ...(usesProReasoning ? { mode: "pro" } : {}),
                 }
-              : isGpt56
+              : usesProReasoning
                 ? { mode: "pro" }
                 : undefined;
         const currentReasoningLabel =
-          isGpt56 && !cfg ? "pro-default" : describeReasoningConfigAttempt(cfg, tok);
+          usesProReasoning && !cfg ? "pro-default" : describeReasoningConfigAttempt(cfg, tok);
         while (true) {
           const textVerbosity = useDefaultVerbosity ? defaultTextVerbosity(params.modelId) : undefined;
           const payload: Record<string, unknown> = {

--- a/lib/ai/reasoningProfiles.ts
+++ b/lib/ai/reasoningProfiles.ts
@@ -85,6 +85,10 @@ type EffortLadderRule = {
 
 const EFFORT_LADDER_RULES: readonly EffortLadderRule[] = [
   {
+    ids: ["gpt-6-astra", "openai/gpt-6-astra-pro"],
+    ladder: ["max", "xhigh", "high", "medium", "low"],
+  },
+  {
     prefixes: ["gpt-5.6", "openai/gpt-5.6"],
     ladder: ["max", "xhigh", "high", "medium", "low", "none"],
   },
@@ -230,6 +234,8 @@ export function zaiReasoningEffortAttempts(
 export function modelRequiresReasoning(modelId: string): boolean {
   const normalized = modelId.trim().toLowerCase();
   return (
+    normalized === "gpt-6-astra" ||
+    normalized === "openai/gpt-6-astra-pro" ||
     normalized === "grok-4.6" ||
     normalized === "x-ai/grok-4.6" ||
     normalized === "glm-5.3" ||

--- a/tests/unit/ai/model-benchmark-profiles.test.ts
+++ b/tests/unit/ai/model-benchmark-profiles.test.ts
@@ -16,6 +16,18 @@ import {
 import { promptCohortId } from "../../../lib/benchmark/promptCohortId";
 import { BENCHMARK_PROMPT_COHORT_ID } from "../../../lib/benchmark/prompts";
 
+const astra = getModelBenchmarkProfile("openai_gpt_6_astra");
+assert.ok(astra);
+assert.deepEqual(astra.parameters, [
+  { label: "Reasoning mode", value: "Pro" },
+  { label: "Reasoning effort", value: "Max" },
+  { label: "Text verbosity", value: "High" },
+]);
+assert.deepEqual(astra.outputCap, { kind: "unavailable", reason: "accepted-cap-unrecorded" });
+assert.equal(astra.totalCost, undefined);
+assert.equal(astra.averageInference, undefined);
+assert.equal(astra.buildCount, undefined);
+
 const gpt56Luna = getModelBenchmarkProfile("openai_gpt_5_6_luna");
 assert.ok(gpt56Luna, "GPT 5.6 Luna Pro should have benchmark run details");
 assert.deepEqual(gpt56Luna.parameters, [

--- a/tests/unit/ai/model-benchmark-profiles.test.ts
+++ b/tests/unit/ai/model-benchmark-profiles.test.ts
@@ -23,10 +23,13 @@ assert.deepEqual(astra.parameters, [
   { label: "Reasoning effort", value: "Max" },
   { label: "Text verbosity", value: "High" },
 ]);
-assert.deepEqual(astra.outputCap, { kind: "unavailable", reason: "accepted-cap-unrecorded" });
-assert.equal(astra.totalCost, undefined);
-assert.equal(astra.averageInference, undefined);
-assert.equal(astra.buildCount, undefined);
+assert.deepEqual(astra.outputCap, { kind: "exact", tokens: 128_000 });
+assert.deepEqual(astra.totalCost, { usd: 34.71, attemptCount: 15, estimated: true });
+assert.equal(astra.sourceRelease, "4.3.0");
+assert.deepEqual(astra.averageInference, { milliseconds: 1_553_517 });
+assert.equal(astra.averageJsonSizeBytes, 134_777_521);
+assert.equal(astra.totalAttempts, 15);
+assert.equal(astra.buildCount, 15);
 
 const gpt56Luna = getModelBenchmarkProfile("openai_gpt_5_6_luna");
 assert.ok(gpt56Luna, "GPT 5.6 Luna Pro should have benchmark run details");

--- a/tests/unit/ai/model-request-profiles.test.ts
+++ b/tests/unit/ai/model-request-profiles.test.ts
@@ -9,6 +9,7 @@ import { tokenBudgetCandidates } from "../../../lib/ai/tokenBudgets";
 
 // A ceiling belongs to the model, so both routes resolve the same number
 for (const [direct, routed] of [
+  ["gpt-6-astra", "openai/gpt-6-astra-pro"],
   ["kimi-k3", "moonshotai/kimi-k3"],
   ["grok-4.6", "x-ai/grok-4.6"],
   ["grok-4.5", "x-ai/grok-4.5"],
@@ -48,6 +49,7 @@ assert.equal(modelOutputCeiling("claude-opus-4-6"), undefined);
 // plus output, while OpenRouter counts visible output alone
 assert.equal(modelOutputCeiling("gpt-5.4"), 128_000);
 assert.equal(modelOutputCeiling("gpt-5.6-luna"), 128_000);
+assert.equal(modelOutputCeiling("gpt-6-astra"), 128_000);
 assert.equal(modelOutputCeiling("gpt-5-pro"), 272_000);
 assert.equal(modelOutputCeiling("openai/gpt-5.4"), undefined);
 
@@ -55,6 +57,7 @@ assert.equal(modelUsesDefaultSampling("kimi-k3"), true);
 assert.equal(modelUsesDefaultSampling("grok-4.6"), true);
 assert.equal(modelUsesDefaultSampling("x-ai/grok-4.6"), true);
 assert.equal(modelUsesDefaultSampling("gpt-5.6-sol"), true);
+assert.equal(modelUsesDefaultSampling("gpt-6-astra"), true);
 assert.equal(modelUsesDefaultSampling("gpt-5.6-luna"), true);
 assert.equal(modelUsesDefaultSampling("openai/gpt-5.6-luna-pro"), true);
 assert.equal(modelUsesDefaultSampling("claude-opus-5"), true);

--- a/tests/unit/leaderboard/model-benchmark-details-render.test.ts
+++ b/tests/unit/leaderboard/model-benchmark-details-render.test.ts
@@ -69,6 +69,7 @@ assert.ok(
 );
 
 const attemptCostSnapshots = [
+  ["openai_gpt_6_astra", "GPT 6 Astra Pro", "$34.71*", "$2.31* per attempt"],
   ["meta_muse_spark_1_3", "Muse Spark 1.3", "$6.57", "$0.23 per attempt"],
   ["openai_gpt_5_6_luna", "GPT 5.6 Luna Pro", "$1.15", "$0.05 per attempt"],
   ["anthropic_claude_fable_5_1", "Claude Fable 5.1", "$147.55", "$6.42 per attempt"],
@@ -95,6 +96,16 @@ for (const [modelKey, displayName, totalCost, averageCost] of attemptCostSnapsho
     `${displayName} should divide its cost snapshot by covered attempts`,
   );
 }
+
+const astraMarkup = renderToStaticMarkup(
+  React.createElement(ModelBenchmarkDetailsInline, {
+    id: "astra-details",
+    modelKey: "openai_gpt_6_astra",
+    displayName: "GPT 6 Astra Pro",
+    open: true,
+  }),
+);
+assert.ok(astraMarkup.includes("* Estimated cost; the provider dashboard has not yet updated."));
 
 const gemini30Markup = renderToStaticMarkup(
   React.createElement(ModelBenchmarkDetailsInline, {

--- a/tests/unit/providers/openai-family.test.ts
+++ b/tests/unit/providers/openai-family.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { generateVoxelBuild } from "../../../lib/ai/generateVoxelBuild";
 import {
   openAiReasoningEffortAttempts,
+  modelRequiresReasoning,
   openRouterReasoningEffortAttempts,
 } from "../../../lib/ai/reasoningProfiles";
 import {
@@ -15,10 +16,19 @@ import {
   type ExpectedCatalogEntry,
 } from "../../helpers/providerConfigHarness";
 
-// GPT 5.6 pro models share the full effort ladder and pro reasoning mode
+// OpenAI pro models use max effort and pro reasoning mode for benchmark runs
 const GPT_5_6_LADDER = ["max", "xhigh", "high", "medium", "low", "none"];
+const GPT_6_ASTRA_LADDER = ["max", "xhigh", "high", "medium", "low"];
 
 const PRO_EXPECTATIONS: ExpectedCatalogEntry[] = [
+  {
+    key: "openai_gpt_6_astra",
+    provider: "openai",
+    modelId: "gpt-6-astra",
+    displayName: "GPT 6 Astra Pro",
+    openRouterModelId: "openai/gpt-6-astra-pro",
+    slug: "gpt-6-astra",
+  },
   {
     key: "openai_gpt_5_6_luna",
     provider: "openai",
@@ -61,12 +71,10 @@ runProviderConfigTest(
     for (const expected of PRO_EXPECTATIONS) {
       const model = assertCatalogEntry(expected);
 
-      assert.deepEqual(openAiReasoningEffortAttempts(model.modelId), GPT_5_6_LADDER);
-      assert.deepEqual(openAiReasoningEffortAttempts(model.modelId, "max"), GPT_5_6_LADDER);
-      assert.deepEqual(
-        openRouterReasoningEffortAttempts(expected.openRouterModelId!),
-        GPT_5_6_LADDER,
-      );
+      const ladder = model.modelId === "gpt-6-astra" ? GPT_6_ASTRA_LADDER : GPT_5_6_LADDER;
+      assert.deepEqual(openAiReasoningEffortAttempts(model.modelId), ladder);
+      assert.deepEqual(openAiReasoningEffortAttempts(model.modelId, "max"), ladder);
+      assert.deepEqual(openRouterReasoningEffortAttempts(expected.openRouterModelId!), ladder);
 
       const direct = await runGeneration(capture, {
         modelKey: expected.key,
@@ -97,7 +105,7 @@ runProviderConfigTest(
         [
           `Routing via direct openai provider (${model.modelId})`,
           "max_output_tokens=128000",
-          "reasoning_effort_fallback=max->xhigh->high->medium->low->none->pro-default",
+          `reasoning_effort_fallback=${ladder.join("->")}->pro-default`,
           "reasoning_mode=pro",
           "temperature=default",
         ],
@@ -136,12 +144,28 @@ runProviderConfigTest(
         [
           `Routing via OpenRouter (${expected.openRouterModelId})`,
           "max_output_tokens=128000",
-          "effort_fallback=max->xhigh->high->medium->low->none->disabled",
+          `effort_fallback=${ladder.join("->")}${model.modelId === "gpt-6-astra" ? "" : "->disabled"}`,
           "temperature=default",
         ],
         `OpenRouter trace should report ${model.displayName}, its cap, and the max reasoning fallback`,
       );
     }
+
+    for (const effort of ["none", "minimal"]) {
+      assert.throws(() => openAiReasoningEffortAttempts("gpt-6-astra", effort), /does not support/);
+      assert.throws(() => openRouterReasoningEffortAttempts("openai/gpt-6-astra-pro", effort), /does not support/);
+    }
+    assert.equal(modelRequiresReasoning("openai/gpt-6-astra-pro"), true);
+    const rejectedStart = capture.requests.length;
+    capture.respondWith(() => jsonResponse({ error: { message: "Model access denied" } }, 403));
+    const rejectedAstra = await runGeneration(capture, {
+      modelKey: "openai_gpt_6_astra",
+      maxAttempts: 1,
+      providerKeys: { openai: "test-openai-key", openrouter: "test-openrouter-key" },
+    });
+    assert.equal(rejectedAstra.result.ok, false);
+    assert.ok(capture.requests.slice(rejectedStart).every((request) => request.url.endsWith("/responses")));
+    capture.respondWith(null);
 
     const overridden = await runGeneration(capture, {
       modelKey: "openai_gpt_5_6_sol",


### PR DESCRIPTION
## What does this PR do?

Adds GPT 6 Astra Pro as `gpt-6-astra`, using native OpenAI Responses with Pro mode at max reasoning effort and an `openai/gpt-6-astra-pro` OpenRouter fallback. Both routes use a 128,000-token output ceiling, structured output, and provider-default sampling; Astra reasoning remains enabled.

Records the completed 15-prompt benchmark:

| Average generation time | Total cost | Average JSON size | Maximum JSON size | Completed attempts |
| -- | -- | -- | -- | -- |
| 25m 53.5s | $34.71* | 128.53 MiB | 316.39 MiB (worldtree) | 15 |

* Estimated total cost; the provider dashboard currently reports $0 and has not yet updated. The model details mark the total and $2.31 per-attempt cost with an asterisk.

All 15 artifact checksums and canonical prompt hashes match their recorded samples. The cohort has consistent accepted settings and no rejected responses, failed runs, or interrupted runs.

## Validation

- Model-profile and details-render tests passed
- Targeted ESLint and TypeScript checks passed
- Provider request tests cover native/OpenRouter payloads, unsupported effort rejection, and direct-error routing
- GitHub CI passed: static analysis, regression tests, and production build
- [Alpha deployment](https://minebench-git-alpha-ammaar-alams-projects.vercel.app) succeeded at `a601f7b0`; `/sandbox` returned HTTP 200

Provider contracts: [OpenAI model](https://developers.openai.com/api/docs/models/gpt-6-astra), [OpenAI guidance](https://developers.openai.com/api/docs/guides/latest-model), [OpenRouter Pro](https://openrouter.ai/openai/gpt-6-astra-pro).

*(PR written by Codex)*
