### PR TITLE
feat(leaderboard): add interactive efficiency comparisons

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -559,11 +559,10 @@
 
   .mb-leaderboard-row {
     @apply cursor-pointer border-b border-border/65 outline-none;
-    transition-property: transform, background-color, box-shadow, border-color;
+    transition-property: background-color, box-shadow, border-color;
     transition-duration: 220ms;
     transition-timing-function: cubic-bezier(0.2, 0.8, 0.2, 1);
-    transform: translate3d(0, 0, 0);
-    will-change: transform;
+    animation: mb-col-fade-in 220ms ease-out both;
   }
 
   .mb-leaderboard-row:hover {
@@ -591,10 +590,6 @@
   }
 
   @media (prefers-reduced-motion: no-preference) {
-    .mb-leaderboard-row:hover {
-      transform: translateY(-2px);
-    }
-
     .mb-leaderboard-row:hover .mb-leaderboard-outcome-chip {
       transform: translateY(-1px) scale(1.02);
     }
@@ -1700,4 +1695,39 @@
 @media (prefers-reduced-motion: reduce) {
   .mb-efficiency-enter, .mb-efficiency-frontier, .mb-efficiency-detail { animation: none; }
   .mb-efficiency-point, .mb-efficiency-dot, .mb-efficiency-row { transition: none; }
+}
+
+.mb-leaderboard-switch {
+  display: inline-flex;
+  max-width: 100%;
+  gap: 2px;
+  padding: 3px;
+  border-radius: 6px;
+  background: hsl(var(--fg) / 0.045);
+}
+.mb-leaderboard-option {
+  min-height: 44px;
+  padding: 0 16px;
+  border-radius: 4px;
+  color: hsl(var(--muted));
+  font-size: 14px;
+  font-weight: 500;
+  white-space: nowrap;
+  transition: background-color 140ms ease-out, color 140ms ease-out;
+}
+.mb-leaderboard-option:hover { color: hsl(var(--fg)); }
+.mb-leaderboard-option[aria-pressed="true"] {
+  color: hsl(var(--fg));
+  background: hsl(var(--fg) / 0.1);
+}
+.mb-leaderboard-option:focus-visible,
+.mb-efficiency-sort:focus-visible {
+  outline: 2px solid hsl(var(--accent));
+  outline-offset: -2px;
+}
+.mb-efficiency-sort:hover { color: hsl(var(--fg)); }
+.mb-efficiency-tooltip { animation: efficiency-detail 120ms ease-out; }
+@media (prefers-reduced-motion: reduce) {
+  .mb-leaderboard-row, .mb-efficiency-tooltip { animation: none; }
+  .mb-leaderboard-option { transition: none; }
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -1685,3 +1685,19 @@
     background: hsl(var(--fg) / 0.09);
   }
 }
+
+.mb-efficiency-enter { animation: efficiency-enter 240ms cubic-bezier(0.22, 1, 0.36, 1) both; }
+.mb-efficiency-frontier { color: hsl(var(--accent)); animation: efficiency-enter 300ms cubic-bezier(0.22, 1, 0.36, 1) both; }
+.mb-efficiency-point { cursor: pointer; transition: opacity 160ms cubic-bezier(0.22, 1, 0.36, 1), transform 240ms cubic-bezier(0.22, 1, 0.36, 1); }
+.mb-efficiency-point:focus-visible { outline: 2px solid currentColor; outline-offset: 3px; }
+.mb-efficiency-dot { transform-origin: 0 0; transition: transform 160ms cubic-bezier(0.22, 1, 0.36, 1); }
+.mb-efficiency-point:hover .mb-efficiency-dot, .mb-efficiency-point:focus-visible .mb-efficiency-dot, .mb-efficiency-point[data-active="true"] .mb-efficiency-dot { transform: scale(1.2); }
+.mb-efficiency-detail { animation: efficiency-detail 140ms cubic-bezier(0.22, 1, 0.36, 1); }
+.mb-efficiency-row { transition: background-color 140ms cubic-bezier(0.22, 1, 0.36, 1); }
+.mb-efficiency-row:hover { background: hsl(var(--fg) / 0.035); }
+@keyframes efficiency-enter { from { opacity: 0; transform: translateY(4px); } to { opacity: 1; transform: translateY(0); } }
+@keyframes efficiency-detail { from { opacity: 0.6; } to { opacity: 1; } }
+@media (prefers-reduced-motion: reduce) {
+  .mb-efficiency-enter, .mb-efficiency-frontier, .mb-efficiency-detail { animation: none; }
+  .mb-efficiency-point, .mb-efficiency-dot, .mb-efficiency-row { transition: none; }
+}

--- a/components/leaderboard/Leaderboard.tsx
+++ b/components/leaderboard/Leaderboard.tsx
@@ -410,7 +410,7 @@ export function Leaderboard({
   }
 
   return (
-    <div className="flex h-full min-h-0 flex-col gap-4 sm:gap-5">
+    <div className="flex h-full min-h-0 min-w-0 flex-col gap-4 sm:gap-5">
       <div className="mb-panel shrink-0 px-5 py-5 ring-inset before:hidden">
         <div className="grid grid-cols-1 gap-4 sm:grid-cols-[auto_minmax(0,1fr)] sm:items-center xl:grid-cols-[minmax(0,1fr)_auto_auto] xl:gap-x-6 xl:gap-y-0">
           {topModel ? (
@@ -567,7 +567,7 @@ export function Leaderboard({
         </div>
       </div>
 
-      <div role="group" aria-label="Leaderboard view" className="flex shrink-0 gap-1 border-b border-border">
+      <div role="group" aria-label="Leaderboard view" className="mb-leaderboard-switch shrink-0 self-start">
         {(["rankings", "efficiency"] as const).map((item) => (
           <button
             key={item}
@@ -575,10 +575,9 @@ export function Leaderboard({
             aria-pressed={view === item}
             aria-controls="leaderboard-models"
             onClick={() => setView(item)}
-            className={`mb-btn mb-btn-ghost relative h-11 px-4 text-sm ${view === item ? "text-fg" : "text-muted"}`}
+            className="mb-leaderboard-option"
           >
             {item === "rankings" ? "Rankings" : "Efficiency"}
-            <span aria-hidden="true" className={`absolute inset-x-4 bottom-0 h-0.5 origin-left bg-accent transition-transform duration-200 ease-out motion-reduce:transition-none ${view === item ? "scale-x-100" : "scale-x-0"}`} />
           </button>
         ))}
       </div>
@@ -591,15 +590,14 @@ export function Leaderboard({
         />
       ) : null}
       {view === "efficiency" && data ? (
-        <div id="leaderboard-models" className="mb-leaderboard-scroll min-h-0 flex-1 overflow-y-auto overscroll-contain">
+        <div key="efficiency" id="leaderboard-models" className="mb-leaderboard-scroll min-h-0 min-w-0 flex-1 overflow-y-auto overscroll-contain">
           <LeaderboardEfficiency models={data.models} modelQuery={modelQuery} />
         </div>
-      ) : <div className="relative flex min-h-0 flex-1 flex-col overflow-hidden rounded-md border border-border">
-        <div className="pointer-events-none absolute inset-y-0 right-0 z-20 hidden w-8 bg-gradient-to-l from-bg/70 to-transparent sm:block md:hidden" />
+      ) : <div key="rankings" className="relative flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
 
         <div
           id="leaderboard-models"
-          className="mb-leaderboard-scroll min-h-0 flex-1 overflow-y-auto overflow-x-hidden overscroll-contain [-webkit-overflow-scrolling:touch]"
+          className="mb-leaderboard-scroll min-h-0 flex-1 overflow-auto overscroll-contain [-webkit-overflow-scrolling:touch]"
         >
           <div className="relative z-[2] space-y-2.5 p-2.5 sm:hidden">
 	            {visibleModels.map((m) => {
@@ -753,7 +751,7 @@ export function Leaderboard({
           <table
             aria-label="Model rankings"
             data-details={showDetailed ? "open" : "closed"}
-            className="mb-leaderboard-table relative z-[2] hidden w-full table-fixed border-separate border-spacing-0 text-left text-sm [font-variant-numeric:tabular-nums] sm:table"
+            className={`mb-leaderboard-table relative z-[2] hidden w-full table-fixed border-separate border-spacing-0 text-left text-sm [font-variant-numeric:tabular-nums] sm:table ${showDetailed ? "min-w-[1180px]" : "min-w-[880px]"}`}
           >
             <colgroup>
               <col className={showDetailed ? "w-[21%]" : "w-[28%]"} />
@@ -870,14 +868,14 @@ export function Leaderboard({
 	                    data-tier={tier}
 	                    onMouseEnter={() => prefetchModel(m.key)}
 	                    onClick={() => navigateToModel(m.key)}
-                    className={`mb-leaderboard-row group mb-card-enter ${
+                    className={`mb-leaderboard-row group ${
                       navigatingModelKey === m.key ? "opacity-75" : ""
                     }`}
                     style={{ animationDelay: `${Math.min(resultIndex, 10) * 34}ms` }}
                   >
 	                    <td className="mb-leaderboard-model-cell px-3 py-3 sm:px-3.5 sm:py-3.5">
 	                      <div className="flex items-start gap-3">
-		                        <div className="mt-0.5 flex w-9 flex-col items-center gap-0.5">
+		                        <div className="mt-0.5 flex w-9 shrink-0 flex-col items-center gap-0.5">
 		                          <span className="inline-flex h-6 min-w-6 items-center justify-center rounded-full bg-bg/62 px-1.5 text-[11px] font-mono text-muted ring-1 ring-border/80">
 		                            {m.rank}
 	                          </span>

--- a/components/leaderboard/Leaderboard.tsx
+++ b/components/leaderboard/Leaderboard.tsx
@@ -20,9 +20,11 @@ import {
   ModelBenchmarkDetailsTrigger,
 } from "@/components/leaderboard/ModelBenchmarkDetails";
 import { LeaderboardSkeleton } from "@/components/leaderboard/LeaderboardSkeleton";
+import { LeaderboardEfficiency } from "@/components/leaderboard/LeaderboardEfficiency";
 
 const LEADERBOARD_SLOW_THRESHOLD_MS = 5_000;
 const LEADERBOARD_TIMEOUT_MS = 10_000;
+const LEADERBOARD_REFRESH_MS = 60_000;
 
 function ChevronUp({ className }: { className?: string }) {
   return (
@@ -249,10 +251,14 @@ export function Leaderboard({
   const [reloadToken, setReloadToken] = useState(0);
   const [navigatingModelKey, setNavigatingModelKey] = useState<string | null>(null);
   const [showDetailed, setShowDetailed] = useState(false);
+  const [view, setView] = useState<"rankings" | "efficiency">("rankings");
   const [expandedMobileModelKey, setExpandedMobileModelKey] = useState<string | null>(null);
   const [modelQuery, setModelQuery] = useState("");
   const modelSearchInputRef = useRef<HTMLInputElement>(null);
   const initialDataCachedRef = useRef(false);
+  const dataRef = useRef(initialData);
+  const lastRefreshStartedRef = useRef(0);
+  const lastSuccessRef = useRef(Date.now());
   const router = useRouter();
   const activeModelCount = data?.models.length ?? 0;
   const topModel = data?.models[0] ?? null;
@@ -283,6 +289,7 @@ export function Leaderboard({
   useEffect(() => {
     const controller = new AbortController();
     let cancelled = false;
+    lastRefreshStartedRef.current = Date.now();
 
     // 1. hydrate from stale cache immediately so the first paint shows data —
     //    but only when the cache is still within our stated freshness window
@@ -290,7 +297,9 @@ export function Leaderboard({
     //    the primary table would mislead users; we'd rather show the loader
     //    and fall through to error handling if the fetch can't recover.
     const cached = readStale<LeaderboardResponse>(LEADERBOARD_CACHE_KEY, LEADERBOARD_STALE_MAX_AGE_MS);
-    if (!initialData && cached.value && cached.isFresh) {
+    if (!dataRef.current && cached.value && cached.isFresh) {
+      dataRef.current = cached.value;
+      lastSuccessRef.current = Date.now() - (cached.ageMs ?? 0);
       setData(cached.value);
       setDataAgeMs(cached.ageMs);
       setIsStale(true);
@@ -299,7 +308,7 @@ export function Leaderboard({
       writeStale(LEADERBOARD_CACHE_KEY, initialData);
       initialDataCachedRef.current = true;
     }
-    const hasFallbackData = initialData != null || Boolean(cached.value && cached.isFresh);
+    const hasFallbackData = dataRef.current != null;
 
     setError(null);
     setRefreshError(null);
@@ -321,6 +330,8 @@ export function Leaderboard({
       .then((r) => r.json())
       .then((d: LeaderboardResponse) => {
         if (cancelled) return;
+        dataRef.current = d;
+        lastSuccessRef.current = Date.now();
         setData(d);
         setDataAgeMs(0);
         setIsStale(false);
@@ -333,11 +344,10 @@ export function Leaderboard({
         const fetchErr = e instanceof FetchError
           ? e
           : new FetchError("network", "Failed to load leaderboard", null, true);
-        // keep cached data on refresh failure only if it was fresh enough to
-        // paint in the first place; otherwise fall through to the full error
-        // state so we don't leave hours-old rankings on screen with a soft
-        // "couldn't refresh" note pretending they're current.
+        // retain the latest successful response and mark its age on refresh failure
         if (hasFallbackData) {
+          setIsStale(true);
+          setDataAgeMs(Date.now() - lastSuccessRef.current);
           setRefreshError(fetchErr);
         } else {
           setError(fetchErr);
@@ -354,6 +364,22 @@ export function Leaderboard({
       controller.abort();
     };
   }, [initialData, reloadToken]);
+
+  useEffect(() => {
+    const refresh = () => {
+      if (document.visibilityState !== "visible" || Date.now() - lastRefreshStartedRef.current < LEADERBOARD_REFRESH_MS) return;
+      lastRefreshStartedRef.current = Date.now();
+      setReloadToken((value) => value + 1);
+    };
+    const interval = window.setInterval(refresh, LEADERBOARD_REFRESH_MS);
+    document.addEventListener("visibilitychange", refresh);
+    window.addEventListener("focus", refresh);
+    return () => {
+      window.clearInterval(interval);
+      document.removeEventListener("visibilitychange", refresh);
+      window.removeEventListener("focus", refresh);
+    };
+  }, []);
 
   const handleRetry = useCallback(() => {
     setRetrying(true);
@@ -456,7 +482,7 @@ export function Leaderboard({
                   <span className="absolute inset-0 rounded-full bg-success" />
                   <span className="absolute inset-0 animate-ping rounded-full bg-success/60 motion-reduce:animate-none" />
                 </span>
-                <span className="text-fg">Live</span>
+                <span className="text-fg">{isStale && refreshError ? "Saved" : "Live"}</span>
                 <span className="text-muted/40">·</span>
                 <span>{activeModelCount} models</span>
                 <span className="hidden text-muted/40 sm:inline">·</span>
@@ -479,7 +505,7 @@ export function Leaderboard({
             ) : null}
           </div>
           <div className="order-2 flex w-full min-w-0 items-center gap-3 sm:order-none sm:w-auto sm:justify-self-end">
-            <button
+            {view === "rankings" ? <button
               type="button"
               onClick={() => setShowDetailed((v) => !v)}
               aria-label={showDetailed ? "Hide details" : "Show details"}
@@ -491,7 +517,7 @@ export function Leaderboard({
               }`}
             >
               Details
-            </button>
+            </button> : null}
             <div
               role="search"
               aria-label="Leaderboard models"
@@ -541,6 +567,21 @@ export function Leaderboard({
         </div>
       </div>
 
+      <div role="group" aria-label="Leaderboard view" className="flex shrink-0 gap-1 border-b border-border">
+        {(["rankings", "efficiency"] as const).map((item) => (
+          <button
+            key={item}
+            type="button"
+            aria-pressed={view === item}
+            aria-controls="leaderboard-models"
+            onClick={() => setView(item)}
+            className={`mb-btn mb-btn-ghost relative h-11 px-4 text-sm ${view === item ? "text-fg" : "text-muted"}`}
+          >
+            {item === "rankings" ? "Rankings" : "Efficiency"}
+            <span aria-hidden="true" className={`absolute inset-x-4 bottom-0 h-0.5 origin-left bg-accent transition-transform duration-200 ease-out motion-reduce:transition-none ${view === item ? "scale-x-100" : "scale-x-0"}`} />
+          </button>
+        ))}
+      </div>
       {error ? (
         <ErrorState
           error={error}
@@ -549,7 +590,11 @@ export function Leaderboard({
           className="shrink-0"
         />
       ) : null}
-      <div className="relative flex min-h-0 flex-1 flex-col overflow-hidden rounded-md border border-border">
+      {view === "efficiency" && data ? (
+        <div id="leaderboard-models" className="mb-leaderboard-scroll min-h-0 flex-1 overflow-y-auto overscroll-contain">
+          <LeaderboardEfficiency models={data.models} modelQuery={modelQuery} />
+        </div>
+      ) : <div className="relative flex min-h-0 flex-1 flex-col overflow-hidden rounded-md border border-border">
         <div className="pointer-events-none absolute inset-y-0 right-0 z-20 hidden w-8 bg-gradient-to-l from-bg/70 to-transparent sm:block md:hidden" />
 
         <div
@@ -982,7 +1027,7 @@ export function Leaderboard({
             </tbody>
           </table>
         </div>
-      </div>
+      </div>}
     </div>
   );
 }

--- a/components/leaderboard/LeaderboardEfficiency.tsx
+++ b/components/leaderboard/LeaderboardEfficiency.tsx
@@ -9,18 +9,18 @@ import {
   getEfficiencyPoints,
   getEfficiencyResource,
   getParetoFrontier,
+  getResourcePerScore,
   type EfficiencyMetric,
 } from "@/lib/leaderboardEfficiency";
 import { matchesLeaderboardModelQuery } from "@/lib/leaderboardSearch";
 
 const METRICS = [
-  { key: "cost", label: "Cost", resource: "Cost per build", ratio: "Cost per score point" },
-  { key: "speed", label: "Speed", resource: "Time per build", ratio: "Time per score point" },
-  { key: "blocks", label: "Blocks", resource: "Blocks per build", ratio: "Blocks per score point" },
+  { key: "cost", label: "Cost", resource: "Cost per build" },
+  { key: "speed", label: "Speed", resource: "Time per build" },
+  { key: "blocks", label: "Blocks", resource: "Blocks per build" },
 ] as const;
 const HEIGHT = 340;
 const PAD = { left: 52, right: 28, top: 34, bottom: 54 };
-const control = "mb-btn mb-btn-ghost h-11 px-3 text-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent";
 const numeric = new Intl.NumberFormat("en-US", { maximumFractionDigits: 1 });
 
 export function LeaderboardEfficiency({ models, modelQuery }: {
@@ -34,7 +34,9 @@ export function LeaderboardEfficiency({ models, modelQuery }: {
   const [establishedOnly, setEstablishedOnly] = useState(false);
   const [logScale, setLogScale] = useState(true);
   const [selectedKey, setSelectedKey] = useState<string | null>(null);
-  const [sort, setSort] = useState<"rating" | "resource" | "ratio">("rating");
+  const [perScore, setPerScore] = useState(false);
+  const [hoveredKey, setHoveredKey] = useState<string | null>(null);
+  const [sort, setSort] = useState<{ key: EfficiencyMetric | "rating"; descending: boolean }>({ key: "cost", descending: false });
   const config = METRICS.find((item) => item.key === metric)!;
   const measured = useMemo(() => getEfficiencyPoints(models, metric), [models, metric]);
   const points = useMemo(() => getEfficiencyPoints(models, metric, establishedOnly), [models, metric, establishedOnly]);
@@ -47,10 +49,22 @@ export function LeaderboardEfficiency({ models, modelQuery }: {
   const [yMin, yMax] = getEfficiencyAxisDomain(points.map((point) => point.model.rankScore));
   const x = (value: number) => PAD.left + ((useLog ? Math.log10(value) : value) - xMin) / (xMax - xMin) * (width - PAD.left - PAD.right);
   const y = (value: number) => PAD.top + (yMax - value) / (yMax - yMin) * (HEIGHT - PAD.top - PAD.bottom);
-  const rows = points.filter((point) => matchesLeaderboardModelQuery(point.model, modelQuery)).sort((a, b) =>
-    (sort === "ratio" ? (a.perScore ?? Infinity) - (b.perScore ?? Infinity)
-      : sort === "resource" ? a.resource - b.resource : b.model.rankScore - a.model.rankScore) || a.model.key.localeCompare(b.model.key),
-  );
+  const valueFor = (model: LeaderboardResponse["models"][number], key: EfficiencyMetric) => {
+    const resource = getEfficiencyResource(model, key);
+    return perScore ? getResourcePerScore(resource, model.meanScore) : resource;
+  };
+  const rows = points.map((point) => point.model).filter((model) =>
+    matchesLeaderboardModelQuery(model, modelQuery),
+  ).sort((a, b) => {
+    const av = sort.key === "rating" ? a.rankScore : valueFor(a, sort.key);
+    const bv = sort.key === "rating" ? b.rankScore : valueFor(b, sort.key);
+    if (av == null || bv == null) return av == null ? bv == null ? a.rank - b.rank : 1 : -1;
+    return (sort.descending ? bv - av : av - bv) || a.rank - b.rank;
+  });
+  const sortBy = (key: typeof sort.key) => {
+    setSort((current) => ({ key, descending: current.key === key ? !current.descending : key === "rating" }));
+    if (key !== "rating") setMetric(key);
+  };
 
   useEffect(() => {
     const element = chartRef.current;
@@ -61,40 +75,32 @@ export function LeaderboardEfficiency({ models, modelQuery }: {
   }, []);
 
   return (
-    <section aria-labelledby={headingId} className="mb-efficiency-enter px-1 pb-5 sm:px-2">
-      <div className="flex flex-wrap items-end justify-between gap-4 pb-5 pt-1">
-        <div>
-          <h2 id={headingId} className="font-display text-2xl font-semibold tracking-tight text-fg">Quality meets efficiency</h2>
-          <p className="mt-1 text-sm text-muted">Explore the trade-offs.</p>
-        </div>
-        <div role="group" aria-label="Efficiency metric" className="flex gap-1 rounded-md border border-border p-1">
+    <section aria-labelledby={headingId} className="mb-efficiency-enter min-w-0 pb-5">
+      <h2 id={headingId} className="sr-only">Model efficiency</h2>
+      <div className="flex flex-wrap items-center justify-between gap-x-6 gap-y-2">
+        <div role="group" aria-label="Efficiency metric" className="mb-leaderboard-switch">
           {METRICS.map((item) => (
-            <button key={item.key} type="button" aria-pressed={metric === item.key} onClick={() => setMetric(item.key)}
-              className={`${control} ${metric === item.key ? "bg-accent/10 text-accent" : "text-muted"}`}>
+            <button key={item.key} type="button" aria-pressed={metric === item.key}
+              onClick={() => { setMetric(item.key); setSort({ key: item.key, descending: false }); }}
+              className="mb-leaderboard-option">
               {item.label}
             </button>
           ))}
         </div>
-      </div>
-      <div className="flex flex-wrap items-center justify-between gap-x-4 gap-y-1 border-y border-border py-1">
-        <div className="flex flex-wrap items-center gap-x-4 gap-y-2 text-xs text-muted">
-          <span className="inline-flex items-center gap-2"><span aria-hidden="true" className="h-0.5 w-5 bg-accent" />Pareto frontier</span>
-          <span>{points.length} models · {frontier.length} on frontier</span>
-        </div>
-        <div className="flex flex-wrap gap-4 text-sm text-muted">
-          <label className="inline-flex min-h-11 cursor-pointer items-center gap-2">
-            <input type="checkbox" checked={establishedOnly} onChange={(event) => setEstablishedOnly(event.target.checked)} className="h-4 w-4 accent-accent" />
+        <div className="flex flex-wrap gap-5 text-xs text-muted sm:text-sm">
+          <label className="inline-flex min-h-11 cursor-pointer items-center gap-2 whitespace-nowrap">
+            <input type="checkbox" checked={establishedOnly} onChange={(event) => setEstablishedOnly(event.target.checked)} className="h-3.5 w-3.5 accent-accent" />
             Established only
           </label>
-          <label className={`inline-flex min-h-11 items-center gap-2 ${canUseLog ? "cursor-pointer" : "opacity-50"}`}>
-            <input type="checkbox" checked={useLog} disabled={!canUseLog} onChange={(event) => setLogScale(event.target.checked)} className="h-4 w-4 accent-accent" />
+          <label className={`inline-flex min-h-11 items-center gap-2 whitespace-nowrap ${canUseLog ? "cursor-pointer" : "opacity-50"}`}>
+            <input type="checkbox" checked={useLog} disabled={!canUseLog} onChange={(event) => setLogScale(event.target.checked)} className="h-3.5 w-3.5 accent-accent" />
             Log scale
           </label>
         </div>
       </div>
-      <div className="grid gap-5 py-5 xl:grid-cols-[minmax(0,1fr)_17rem] xl:gap-8">
+      <div className="grid gap-6 pb-8 pt-5 lg:grid-cols-[minmax(0,1fr)_16rem] lg:gap-8">
         <div className="min-w-0">
-          <div ref={chartRef} className="relative min-w-0">
+          <div ref={chartRef} className="relative min-w-0" onMouseLeave={() => setHoveredKey(null)}>
             <svg width="100%" height={HEIGHT} viewBox={`0 0 ${width} ${HEIGHT}`} role="group" aria-label={`${config.resource} versus rating`}>
               <title>{`${config.resource} versus rating; higher and further left is better`}</title>
               {[0, 1, 2, 3].map((index) => {
@@ -130,7 +136,8 @@ export function LeaderboardEfficiency({ models, modelQuery }: {
                   aria-label={`${point.model.displayName}, ${Math.round(point.model.rankScore)} rating, ${formatEfficiencyResource(point.resource, metric)}${estimate ? " estimated" : ""}${onFrontier ? ", on frontier" : ""}${provisional ? ", provisional" : ""}`}
                   className={`mb-efficiency-point ${onFrontier ? "text-accent" : "text-muted"}`}
                   data-active={active} style={{ opacity: matches ? 1 : 0.16 }}
-                  onMouseEnter={() => setSelectedKey(point.model.key)} onFocus={() => setSelectedKey(point.model.key)}
+                  onMouseEnter={() => { setSelectedKey(point.model.key); setHoveredKey(point.model.key); }}
+                  onFocus={() => { setSelectedKey(point.model.key); setHoveredKey(point.model.key); }} onBlur={() => setHoveredKey(null)}
                   onClick={() => setSelectedKey(point.model.key)} onKeyDown={(event) => {
                     if (event.key === "Enter" || event.key === " ") { event.preventDefault(); setSelectedKey(point.model.key); }
                   }}>
@@ -141,64 +148,77 @@ export function LeaderboardEfficiency({ models, modelQuery }: {
                 </g>;
               })}
             </svg>
+            {selected && hoveredKey === selected.model.key ? <div role="tooltip" className="mb-efficiency-tooltip pointer-events-none absolute max-w-[220px] rounded-md bg-bg px-3 py-2 text-xs ring-1 ring-border"
+              style={{ left: Math.max(4, Math.min(width - 224, x(selected.resource) - 110)), top: Math.max(4, y(selected.model.rankScore) - 70) }}>
+              <div className="font-medium text-fg">{selected.model.displayName}</div>
+              <div className="mt-1 flex flex-wrap gap-x-3 text-muted tabular-nums"><span>{Math.round(selected.model.rankScore)} rating</span><span>{formatEfficiencyResource(selected.resource, metric)}{metric === "cost" && selected.model.benchmark?.costEstimated ? " est." : ""}</span></div>
+            </div> : null}
             {points.length === 0 ? <div className="absolute inset-0 flex items-center justify-center bg-bg px-6 text-center text-sm text-muted">
               {establishedOnly && measured.length ? "No established models have this measurement yet." : "This comparison needs recorded measurements and prompt votes."}
             </div> : null}
           </div>
-          <p className="mt-2 text-xs leading-relaxed text-muted">
-            Frontier models offer the best rating at their resource level. Hollow points are provisional.
-            {metric === "blocks" ? " Fewer blocks describe a smaller build, not better quality." : ""}
-          </p>
+          <div className="mt-3 flex flex-wrap items-center gap-x-5 gap-y-2 text-xs text-muted">
+            <span className="inline-flex items-center gap-2"><span aria-hidden="true" className="h-0.5 w-5 bg-accent" />Pareto frontier</span>
+            <span className="inline-flex items-center gap-2"><span aria-hidden="true" className="h-2 w-2 rounded-full border border-current" />Provisional</span>
+            <span>{points.length} models · {frontier.length} on frontier</span>
+          </div>
         </div>
-        <aside aria-label="Selected model" className="min-w-0 border-t border-border pt-4 xl:border-t-0 xl:pt-1">
+        <aside aria-label="Selected model" className="min-w-0 border-t border-border/60 pt-4 lg:border-t-0 lg:pt-6">
           {selected ? <div key={selected.model.key} className="mb-efficiency-detail">
-            <div className="flex flex-wrap items-center gap-2 text-xs text-muted">
-              <span className={frontierKeys.has(selected.model.key) ? "text-accent" : ""}>{frontierKeys.has(selected.model.key) ? "On the frontier" : "Outside the frontier"}</span>
-              <span>· {selected.model.stability}</span>
-            </div>
-            <h3 className="mt-2 break-words font-display text-xl font-semibold leading-tight text-fg">
+            <div className="text-xs text-muted">{frontierKeys.has(selected.model.key) ? "Frontier · " : ""}{selected.model.stability}</div>
+            <h3 className="mt-2 break-words text-lg font-semibold leading-snug text-fg">
               <Link href={`/leaderboard/${encodeURIComponent(selected.model.slug ?? selected.model.key)}`} className="decoration-accent/40 underline-offset-4 hover:underline focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent">{selected.model.displayName}</Link>
             </h3>
-            <dl className="mt-4 divide-y divide-border border-y border-border text-sm">
-              {[
-                ["Rating", `${Math.round(selected.model.rankScore)}${selected.model.ci95 != null ? ` ± ${numeric.format(selected.model.ci95)}` : ""}`],
-                ...METRICS.map((item) => {
-                  const value = getEfficiencyResource(selected.model, item.key);
-                  return [item.resource, value == null ? "Not recorded" : `${formatEfficiencyResource(value, item.key)}${item.key === "cost" && selected.model.benchmark?.costEstimated ? " est." : ""}`];
-                }),
-                ["Prompt score", selected.model.meanScore == null ? "Not scored" : `${numeric.format(selected.model.meanScore * 100)} / 100`],
-                [config.ratio, selected.perScore == null ? "Not scored" : `${formatEfficiencyResource(selected.perScore, metric)}${metric === "cost" && selected.model.benchmark?.costEstimated ? " est." : ""}`],
-              ].map(([label, value]) => <div key={label} className="flex justify-between gap-3 py-2.5"><dt className="text-muted">{label}</dt><dd className="text-right font-medium tabular-nums text-fg">{value}</dd></div>)}
+            <div className="mt-2 flex items-baseline gap-2 tabular-nums"><span className="text-xl font-semibold text-fg">{Math.round(selected.model.rankScore)}</span><span className="text-xs text-muted">{selected.model.ci95 != null ? `± ${numeric.format(selected.model.ci95)} · 95% CI` : "rating"}</span></div>
+            <dl className="mt-5 grid gap-3 text-sm">
+              {METRICS.map((item) => {
+                const value = getEfficiencyResource(selected.model, item.key);
+                return <div key={item.key} className="flex items-baseline justify-between gap-3"><dt className={metric === item.key ? "text-fg" : "text-muted"}>{item.resource}</dt>
+                  <dd className={`text-right tabular-nums ${metric === item.key ? "font-semibold text-accent" : "text-fg"}`}>{value == null ? "—" : formatEfficiencyResource(value, item.key)}{value != null && item.key === "cost" && selected.model.benchmark?.costEstimated ? <span className="ml-1 text-xs font-normal text-muted">est.</span> : null}</dd>
+                </div>;
+              })}
             </dl>
-            <p className="mt-3 text-xs leading-relaxed text-muted">{selected.model.sampledVotes.toLocaleString()} votes across {selected.model.sampledPrompts}/{selected.model.activePrompts} prompts. Rating intervals are 95% confidence intervals.</p>
+            <p className="mt-5 text-xs leading-relaxed text-muted">{selected.model.sampledVotes.toLocaleString()} votes · {selected.model.sampledPrompts}/{selected.model.activePrompts} prompts{selected.model.meanScore != null ? ` · ${numeric.format(selected.model.meanScore * 100)} prompt score` : ""}</p>
             {selected.model.benchmark?.note ? <p className="mt-2 text-xs leading-relaxed text-muted">{selected.model.benchmark.note.replace(/^\*\s*/, "")}</p> : null}
-          </div> : <p className="text-sm text-muted">More comparisons will appear as models are measured and rated.</p>}
+          </div> : <p className="text-sm text-muted">No measurements available.</p>}
         </aside>
       </div>
-      <div className="flex flex-wrap items-center justify-between gap-2 border-t border-border pb-2 pt-4">
-        <h3 className="font-display text-lg font-semibold text-fg">Compare the numbers</h3>
-        <label className="flex min-h-11 items-center gap-2 text-sm text-muted">Sort by
-          <select value={sort} onChange={(event) => setSort(event.target.value as typeof sort)} className="mb-field h-11 px-3 text-sm text-fg">
-            <option value="rating">Rating</option><option value="resource">{config.resource}</option><option value="ratio">Per score point</option>
-          </select>
-        </label>
+      <div className="mb-3 flex flex-wrap items-center justify-between gap-3">
+        <div role="group" aria-label="Comparison units" className="mb-leaderboard-switch">
+          <button type="button" aria-pressed={!perScore} className="mb-leaderboard-option" onClick={() => setPerScore(false)}>Per build</button>
+          <button type="button" aria-pressed={perScore} className="mb-leaderboard-option" onClick={() => setPerScore(true)}>Per score</button>
+        </div>
+        <span className="text-xs text-muted">{perScore ? "Resource use per prompt-score point" : "Average resource use per build"}</span>
       </div>
-      <div className="overflow-x-auto">
-        <table className="w-full min-w-[600px] border-collapse text-sm tabular-nums">
-          <caption className="sr-only">{config.resource} and resource use per observed prompt-score point</caption>
-          <thead className="border-y border-border text-left text-xs text-muted">
-            <tr><th className="py-3 pr-4 font-medium">Model</th><th className="px-3 py-3 text-right font-medium">Rating</th><th className="px-3 py-3 text-right font-medium">{config.resource}</th><th className="px-3 py-3 text-right font-medium">Per score point</th><th className="py-3 pl-3 text-right font-medium">Prompt coverage</th></tr>
+      <div className="overflow-x-auto md:overflow-visible">
+        <table className="w-full min-w-[680px] table-fixed border-collapse text-sm tabular-nums">
+          <caption className="sr-only">Cost, time, and blocks {perScore ? "per observed prompt-score point" : "per build"}</caption>
+          <colgroup><col className="w-[34%]" /><col className="w-[12%]" /><col className="w-[18%]" /><col className="w-[18%]" /><col className="w-[18%]" /></colgroup>
+          <thead className="border-b border-border bg-bg text-left text-xs text-muted md:sticky md:top-0 md:z-20">
+            <tr><th scope="col" className="sticky left-0 z-10 bg-bg py-3 pr-4 font-medium">Model</th>
+              {[{ key: "rating", label: "Rating" }, ...METRICS.map((item) => ({ key: item.key, label: item.key === "speed" ? "Time" : item.label }))].map((item) => {
+                const key = item.key as typeof sort.key;
+                return <th key={key} scope="col" aria-sort={sort.key === key ? sort.descending ? "descending" : "ascending" : "none"} className="text-right font-medium">
+                  <button type="button" onClick={() => sortBy(key)} className={`mb-efficiency-sort min-h-11 w-full whitespace-nowrap px-3 text-right ${sort.key === key ? "text-fg" : "text-muted"}`}>
+                    {item.label}{perScore && key !== "rating" ? " / score" : ""}<span aria-hidden="true" className={`ml-2 inline-block w-3 ${sort.key === key ? "text-accent" : "opacity-40"}`}>{sort.key === key ? sort.descending ? "↓" : "↑" : "↕"}</span>
+                  </button>
+                </th>;
+              })}
+            </tr>
           </thead>
           <tbody>
-            {rows.map((point) => <tr key={point.model.key} className={`mb-efficiency-row border-b border-border/60 ${selected?.model.key === point.model.key ? "bg-fg/[0.03]" : ""}`}>
-              <th scope="row" className="pr-4 text-left font-normal"><button type="button" onClick={() => setSelectedKey(point.model.key)} onFocus={() => setSelectedKey(point.model.key)} aria-pressed={selected?.model.key === point.model.key} className="min-h-11 py-3 text-left focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent">
-                <span className="font-medium text-fg">{point.model.displayName}</span>
-                <span className="mt-0.5 block text-xs text-muted">{frontierKeys.has(point.model.key) ? "Frontier · " : ""}{point.model.stability}</span>
+            {rows.map((model) => <tr key={model.key} className={`mb-efficiency-row border-b border-border/40 ${selected?.model.key === model.key ? "bg-fg/[0.03]" : ""}`}>
+              <th scope="row" className="sticky left-0 z-10 bg-bg pr-4 text-left font-normal"><button type="button" onClick={() => setSelectedKey(model.key)} onFocus={() => setSelectedKey(model.key)} aria-pressed={selected?.model.key === model.key} className="flex min-h-11 w-full items-start gap-3 py-3.5 text-left focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent">
+                <span className="w-6 shrink-0 text-right text-xs leading-5 text-muted2">{model.rank}</span>
+                <span className="min-w-0"><span className="block truncate font-medium text-fg">{model.displayName}</span><span className="mt-0.5 block text-xs text-muted">{frontierKeys.has(model.key) ? "Frontier · " : ""}{model.stability}</span></span>
               </button></th>
-              <td className="px-3 py-3 text-right text-fg">{Math.round(point.model.rankScore)}</td>
-              <td className="px-3 py-3 text-right text-fg">{formatEfficiencyResource(point.resource, metric)}{metric === "cost" && point.model.benchmark?.costEstimated ? <span className="ml-1 text-xs text-muted">est.</span> : null}</td>
-              <td className="px-3 py-3 text-right text-fg">{point.perScore == null ? "—" : formatEfficiencyResource(point.perScore, metric)}{point.perScore != null && metric === "cost" && point.model.benchmark?.costEstimated ? <span className="ml-1 text-xs text-muted">est.</span> : null}</td>
-              <td className="py-3 pl-3 text-right text-muted">{point.model.sampledPrompts}/{point.model.activePrompts}</td>
+              <td className="px-3 py-3.5 text-right text-fg">{Math.round(model.rankScore)}</td>
+              {METRICS.map((item) => {
+                const value = valueFor(model, item.key);
+                return <td key={item.key} className={`px-3 py-3.5 text-right ${sort.key === item.key ? "bg-fg/[0.025] font-medium text-fg" : "text-muted"}`}>
+                  {value == null ? "—" : formatEfficiencyResource(value, item.key)}{value != null && item.key === "cost" && model.benchmark?.costEstimated ? <span className="ml-1 text-xs font-normal text-muted">est.</span> : null}
+                </td>;
+              })}
             </tr>)}
             {rows.length === 0 ? <tr><td colSpan={5} className="py-8 text-center text-muted">{modelQuery.trim() ? "No matching models in this comparison." : "No measurements available for this selection."}</td></tr> : null}
           </tbody>
@@ -210,7 +230,7 @@ export function LeaderboardEfficiency({ models, modelQuery }: {
         {modelQuery.trim() ? <span>Search highlights matches; the frontier still includes the full comparison.</span> : null}
       </div>
       <details className="mt-3 text-sm text-muted">
-        <summary className="min-h-11 cursor-pointer py-3 font-medium text-fg focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent">How to read these metrics</summary>
+        <summary className="min-h-11 cursor-pointer py-3 font-medium text-fg focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent">Methodology</summary>
         <div className="max-w-[85ch] space-y-3 pb-3 leading-relaxed">
           <p>A model is on the Pareto frontier when no included model has an equal or higher rating with equal or lower resource use, with at least one strict improvement. The frontier follows point estimates; overlapping confidence intervals can mean the differences are uncertain.</p>
           <p>Per-score values divide average resource use by the observed prompt score on a 0–100 scale: wins count as 1, ties as 0.5, and losses as 0, averaged equally over prompts with at least two votes. Both-bad votes are excluded. These ratios depend on sampled opponents and prompts; they describe the evidence rather than replace the rating.</p>

--- a/components/leaderboard/LeaderboardEfficiency.tsx
+++ b/components/leaderboard/LeaderboardEfficiency.tsx
@@ -1,0 +1,222 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useId, useMemo, useRef, useState } from "react";
+import type { LeaderboardResponse } from "@/lib/arena/types";
+import {
+  formatEfficiencyResource,
+  getEfficiencyAxisDomain,
+  getEfficiencyPoints,
+  getEfficiencyResource,
+  getParetoFrontier,
+  type EfficiencyMetric,
+} from "@/lib/leaderboardEfficiency";
+import { matchesLeaderboardModelQuery } from "@/lib/leaderboardSearch";
+
+const METRICS = [
+  { key: "cost", label: "Cost", resource: "Cost per build", ratio: "Cost per score point" },
+  { key: "speed", label: "Speed", resource: "Time per build", ratio: "Time per score point" },
+  { key: "blocks", label: "Blocks", resource: "Blocks per build", ratio: "Blocks per score point" },
+] as const;
+const HEIGHT = 340;
+const PAD = { left: 52, right: 28, top: 34, bottom: 54 };
+const control = "mb-btn mb-btn-ghost h-11 px-3 text-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent";
+const numeric = new Intl.NumberFormat("en-US", { maximumFractionDigits: 1 });
+
+export function LeaderboardEfficiency({ models, modelQuery }: {
+  models: LeaderboardResponse["models"];
+  modelQuery: string;
+}) {
+  const headingId = useId();
+  const chartRef = useRef<HTMLDivElement>(null);
+  const [width, setWidth] = useState(720);
+  const [metric, setMetric] = useState<EfficiencyMetric>("cost");
+  const [establishedOnly, setEstablishedOnly] = useState(false);
+  const [logScale, setLogScale] = useState(true);
+  const [selectedKey, setSelectedKey] = useState<string | null>(null);
+  const [sort, setSort] = useState<"rating" | "resource" | "ratio">("rating");
+  const config = METRICS.find((item) => item.key === metric)!;
+  const measured = useMemo(() => getEfficiencyPoints(models, metric), [models, metric]);
+  const points = useMemo(() => getEfficiencyPoints(models, metric, establishedOnly), [models, metric, establishedOnly]);
+  const frontier = useMemo(() => getParetoFrontier(points), [points]);
+  const frontierKeys = new Set(frontier.map((point) => point.model.key));
+  const selected = points.find((point) => point.model.key === selectedKey) ?? frontier.at(-1) ?? null;
+  const canUseLog = points.length > 0 && points.every((point) => point.resource > 0);
+  const useLog = logScale && canUseLog;
+  const [xMin, xMax] = getEfficiencyAxisDomain(points.map((point) => point.resource), useLog);
+  const [yMin, yMax] = getEfficiencyAxisDomain(points.map((point) => point.model.rankScore));
+  const x = (value: number) => PAD.left + ((useLog ? Math.log10(value) : value) - xMin) / (xMax - xMin) * (width - PAD.left - PAD.right);
+  const y = (value: number) => PAD.top + (yMax - value) / (yMax - yMin) * (HEIGHT - PAD.top - PAD.bottom);
+  const rows = points.filter((point) => matchesLeaderboardModelQuery(point.model, modelQuery)).sort((a, b) =>
+    (sort === "ratio" ? (a.perScore ?? Infinity) - (b.perScore ?? Infinity)
+      : sort === "resource" ? a.resource - b.resource : b.model.rankScore - a.model.rankScore) || a.model.key.localeCompare(b.model.key),
+  );
+
+  useEffect(() => {
+    const element = chartRef.current;
+    if (!element) return;
+    const observer = new ResizeObserver(([entry]) => setWidth(Math.max(260, entry.contentRect.width)));
+    observer.observe(element);
+    return () => observer.disconnect();
+  }, []);
+
+  return (
+    <section aria-labelledby={headingId} className="mb-efficiency-enter px-1 pb-5 sm:px-2">
+      <div className="flex flex-wrap items-end justify-between gap-4 pb-5 pt-1">
+        <div>
+          <h2 id={headingId} className="font-display text-2xl font-semibold tracking-tight text-fg">Quality meets efficiency</h2>
+          <p className="mt-1 text-sm text-muted">Explore the trade-offs.</p>
+        </div>
+        <div role="group" aria-label="Efficiency metric" className="flex gap-1 rounded-md border border-border p-1">
+          {METRICS.map((item) => (
+            <button key={item.key} type="button" aria-pressed={metric === item.key} onClick={() => setMetric(item.key)}
+              className={`${control} ${metric === item.key ? "bg-accent/10 text-accent" : "text-muted"}`}>
+              {item.label}
+            </button>
+          ))}
+        </div>
+      </div>
+      <div className="flex flex-wrap items-center justify-between gap-x-4 gap-y-1 border-y border-border py-1">
+        <div className="flex flex-wrap items-center gap-x-4 gap-y-2 text-xs text-muted">
+          <span className="inline-flex items-center gap-2"><span aria-hidden="true" className="h-0.5 w-5 bg-accent" />Pareto frontier</span>
+          <span>{points.length} models · {frontier.length} on frontier</span>
+        </div>
+        <div className="flex flex-wrap gap-4 text-sm text-muted">
+          <label className="inline-flex min-h-11 cursor-pointer items-center gap-2">
+            <input type="checkbox" checked={establishedOnly} onChange={(event) => setEstablishedOnly(event.target.checked)} className="h-4 w-4 accent-accent" />
+            Established only
+          </label>
+          <label className={`inline-flex min-h-11 items-center gap-2 ${canUseLog ? "cursor-pointer" : "opacity-50"}`}>
+            <input type="checkbox" checked={useLog} disabled={!canUseLog} onChange={(event) => setLogScale(event.target.checked)} className="h-4 w-4 accent-accent" />
+            Log scale
+          </label>
+        </div>
+      </div>
+      <div className="grid gap-5 py-5 xl:grid-cols-[minmax(0,1fr)_17rem] xl:gap-8">
+        <div className="min-w-0">
+          <div ref={chartRef} className="relative min-w-0">
+            <svg width="100%" height={HEIGHT} viewBox={`0 0 ${width} ${HEIGHT}`} role="group" aria-label={`${config.resource} versus rating`}>
+              <title>{`${config.resource} versus rating; higher and further left is better`}</title>
+              {[0, 1, 2, 3].map((index) => {
+                const rating = yMin + (yMax - yMin) * index / 3;
+                return <g key={index} className="text-border">
+                  <line x1={PAD.left} x2={width - PAD.right} y1={y(rating)} y2={y(rating)} stroke="currentColor" strokeDasharray="3 5" />
+                  <text x={PAD.left - 10} y={y(rating) + 4} textAnchor="end" className="fill-muted text-[11px] tabular-nums">{Math.round(rating)}</text>
+                </g>;
+              })}
+              {[0, 1, 2].map((index) => {
+                const value = xMin + (xMax - xMin) * index / 2;
+                const resource = useLog ? 10 ** value : value;
+                return <text key={index} x={x(resource)} y={HEIGHT - PAD.bottom + 22} textAnchor="middle" className="fill-muted text-[11px] tabular-nums">
+                  {formatEfficiencyResource(resource, metric)}
+                </text>;
+              })}
+              <text x={PAD.left} y={15} className="fill-muted text-[12px]">Rating ↑</text>
+              <text x={width / 2} y={HEIGHT - 5} textAnchor="middle" className="fill-muted text-[12px]">← {config.resource}{useLog ? " · log scale" : ""}</text>
+              {frontier.length > 1 ? <path key={`${metric}-${useLog}-${establishedOnly}`} className="mb-efficiency-frontier" fill="none" stroke="currentColor" strokeWidth={2}
+                d={frontier.map((point, index) => `${index ? "L" : "M"}${x(point.resource)},${y(point.model.rankScore)}`).join(" ")} /> : null}
+              {selected ? <g aria-hidden="true" className="text-muted/30" stroke="currentColor" strokeDasharray="3 5">
+                <line x1={x(selected.resource)} x2={x(selected.resource)} y1={PAD.top} y2={HEIGHT - PAD.bottom} />
+                <line x1={PAD.left} x2={width - PAD.right} y1={y(selected.model.rankScore)} y2={y(selected.model.rankScore)} />
+              </g> : null}
+              {points.map((point) => {
+                const active = selected?.model.key === point.model.key;
+                const onFrontier = frontierKeys.has(point.model.key);
+                const matches = matchesLeaderboardModelQuery(point.model, modelQuery);
+                const provisional = point.model.stability === "Provisional";
+                const estimate = metric === "cost" && point.model.benchmark?.costEstimated;
+                return <g key={point.model.key} transform={`translate(${x(point.resource)},${y(point.model.rankScore)})`}
+                  role="button" tabIndex={0} aria-pressed={active}
+                  aria-label={`${point.model.displayName}, ${Math.round(point.model.rankScore)} rating, ${formatEfficiencyResource(point.resource, metric)}${estimate ? " estimated" : ""}${onFrontier ? ", on frontier" : ""}${provisional ? ", provisional" : ""}`}
+                  className={`mb-efficiency-point ${onFrontier ? "text-accent" : "text-muted"}`}
+                  data-active={active} style={{ opacity: matches ? 1 : 0.16 }}
+                  onMouseEnter={() => setSelectedKey(point.model.key)} onFocus={() => setSelectedKey(point.model.key)}
+                  onClick={() => setSelectedKey(point.model.key)} onKeyDown={(event) => {
+                    if (event.key === "Enter" || event.key === " ") { event.preventDefault(); setSelectedKey(point.model.key); }
+                  }}>
+                  <title>{point.model.displayName}</title>
+                  <circle r={14} fill="transparent" />
+                  <circle className="mb-efficiency-dot" r={onFrontier ? 5.5 : 4.5} fill={provisional ? "hsl(var(--bg))" : "currentColor"} stroke="currentColor" strokeWidth={1.5} />
+                  {active ? <circle r={10} fill="none" stroke="currentColor" strokeWidth={1} /> : null}
+                </g>;
+              })}
+            </svg>
+            {points.length === 0 ? <div className="absolute inset-0 flex items-center justify-center bg-bg px-6 text-center text-sm text-muted">
+              {establishedOnly && measured.length ? "No established models have this measurement yet." : "This comparison needs recorded measurements and prompt votes."}
+            </div> : null}
+          </div>
+          <p className="mt-2 text-xs leading-relaxed text-muted">
+            Frontier models offer the best rating at their resource level. Hollow points are provisional.
+            {metric === "blocks" ? " Fewer blocks describe a smaller build, not better quality." : ""}
+          </p>
+        </div>
+        <aside aria-label="Selected model" className="min-w-0 border-t border-border pt-4 xl:border-t-0 xl:pt-1">
+          {selected ? <div key={selected.model.key} className="mb-efficiency-detail">
+            <div className="flex flex-wrap items-center gap-2 text-xs text-muted">
+              <span className={frontierKeys.has(selected.model.key) ? "text-accent" : ""}>{frontierKeys.has(selected.model.key) ? "On the frontier" : "Outside the frontier"}</span>
+              <span>· {selected.model.stability}</span>
+            </div>
+            <h3 className="mt-2 break-words font-display text-xl font-semibold leading-tight text-fg">
+              <Link href={`/leaderboard/${encodeURIComponent(selected.model.slug ?? selected.model.key)}`} className="decoration-accent/40 underline-offset-4 hover:underline focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent">{selected.model.displayName}</Link>
+            </h3>
+            <dl className="mt-4 divide-y divide-border border-y border-border text-sm">
+              {[
+                ["Rating", `${Math.round(selected.model.rankScore)}${selected.model.ci95 != null ? ` ± ${numeric.format(selected.model.ci95)}` : ""}`],
+                ...METRICS.map((item) => {
+                  const value = getEfficiencyResource(selected.model, item.key);
+                  return [item.resource, value == null ? "Not recorded" : `${formatEfficiencyResource(value, item.key)}${item.key === "cost" && selected.model.benchmark?.costEstimated ? " est." : ""}`];
+                }),
+                ["Prompt score", selected.model.meanScore == null ? "Not scored" : `${numeric.format(selected.model.meanScore * 100)} / 100`],
+                [config.ratio, selected.perScore == null ? "Not scored" : `${formatEfficiencyResource(selected.perScore, metric)}${metric === "cost" && selected.model.benchmark?.costEstimated ? " est." : ""}`],
+              ].map(([label, value]) => <div key={label} className="flex justify-between gap-3 py-2.5"><dt className="text-muted">{label}</dt><dd className="text-right font-medium tabular-nums text-fg">{value}</dd></div>)}
+            </dl>
+            <p className="mt-3 text-xs leading-relaxed text-muted">{selected.model.sampledVotes.toLocaleString()} votes across {selected.model.sampledPrompts}/{selected.model.activePrompts} prompts. Rating intervals are 95% confidence intervals.</p>
+            {selected.model.benchmark?.note ? <p className="mt-2 text-xs leading-relaxed text-muted">{selected.model.benchmark.note.replace(/^\*\s*/, "")}</p> : null}
+          </div> : <p className="text-sm text-muted">More comparisons will appear as models are measured and rated.</p>}
+        </aside>
+      </div>
+      <div className="flex flex-wrap items-center justify-between gap-2 border-t border-border pb-2 pt-4">
+        <h3 className="font-display text-lg font-semibold text-fg">Compare the numbers</h3>
+        <label className="flex min-h-11 items-center gap-2 text-sm text-muted">Sort by
+          <select value={sort} onChange={(event) => setSort(event.target.value as typeof sort)} className="mb-field h-11 px-3 text-sm text-fg">
+            <option value="rating">Rating</option><option value="resource">{config.resource}</option><option value="ratio">Per score point</option>
+          </select>
+        </label>
+      </div>
+      <div className="overflow-x-auto">
+        <table className="w-full min-w-[600px] border-collapse text-sm tabular-nums">
+          <caption className="sr-only">{config.resource} and resource use per observed prompt-score point</caption>
+          <thead className="border-y border-border text-left text-xs text-muted">
+            <tr><th className="py-3 pr-4 font-medium">Model</th><th className="px-3 py-3 text-right font-medium">Rating</th><th className="px-3 py-3 text-right font-medium">{config.resource}</th><th className="px-3 py-3 text-right font-medium">Per score point</th><th className="py-3 pl-3 text-right font-medium">Prompt coverage</th></tr>
+          </thead>
+          <tbody>
+            {rows.map((point) => <tr key={point.model.key} className={`mb-efficiency-row border-b border-border/60 ${selected?.model.key === point.model.key ? "bg-fg/[0.03]" : ""}`}>
+              <th scope="row" className="pr-4 text-left font-normal"><button type="button" onClick={() => setSelectedKey(point.model.key)} onFocus={() => setSelectedKey(point.model.key)} aria-pressed={selected?.model.key === point.model.key} className="min-h-11 py-3 text-left focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent">
+                <span className="font-medium text-fg">{point.model.displayName}</span>
+                <span className="mt-0.5 block text-xs text-muted">{frontierKeys.has(point.model.key) ? "Frontier · " : ""}{point.model.stability}</span>
+              </button></th>
+              <td className="px-3 py-3 text-right text-fg">{Math.round(point.model.rankScore)}</td>
+              <td className="px-3 py-3 text-right text-fg">{formatEfficiencyResource(point.resource, metric)}{metric === "cost" && point.model.benchmark?.costEstimated ? <span className="ml-1 text-xs text-muted">est.</span> : null}</td>
+              <td className="px-3 py-3 text-right text-fg">{point.perScore == null ? "—" : formatEfficiencyResource(point.perScore, metric)}{point.perScore != null && metric === "cost" && point.model.benchmark?.costEstimated ? <span className="ml-1 text-xs text-muted">est.</span> : null}</td>
+              <td className="py-3 pl-3 text-right text-muted">{point.model.sampledPrompts}/{point.model.activePrompts}</td>
+            </tr>)}
+            {rows.length === 0 ? <tr><td colSpan={5} className="py-8 text-center text-muted">{modelQuery.trim() ? "No matching models in this comparison." : "No measurements available for this selection."}</td></tr> : null}
+          </tbody>
+        </table>
+      </div>
+      <div className="mt-4 flex flex-wrap gap-x-4 gap-y-2 text-xs text-muted">
+        {models.length > measured.length ? <span>{models.length - measured.length} models lack this measurement or sampled prompt votes.</span> : null}
+        {establishedOnly && measured.length > points.length ? <span>{measured.length - points.length} provisional models hidden.</span> : null}
+        {modelQuery.trim() ? <span>Search highlights matches; the frontier still includes the full comparison.</span> : null}
+      </div>
+      <details className="mt-3 text-sm text-muted">
+        <summary className="min-h-11 cursor-pointer py-3 font-medium text-fg focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent">How to read these metrics</summary>
+        <div className="max-w-[85ch] space-y-3 pb-3 leading-relaxed">
+          <p>A model is on the Pareto frontier when no included model has an equal or higher rating with equal or lower resource use, with at least one strict improvement. The frontier follows point estimates; overlapping confidence intervals can mean the differences are uncertain.</p>
+          <p>Per-score values divide average resource use by the observed prompt score on a 0–100 scale: wins count as 1, ties as 0.5, and losses as 0, averaged equally over prompts with at least two votes. Both-bad votes are excluded. These ratios depend on sampled opponents and prompts; they describe the evidence rather than replace the rating.</p>
+          <p>Cost is recorded cohort expenditure divided by finalized builds, including retries where recorded. Timing uses complete tracked cohorts or documented historical measurements. Block averages require complete public build coverage. Estimates are marked; missing measurements are omitted. New data follows the leaderboard’s regular refresh.</p>
+        </div>
+      </details>
+    </section>
+  );
+}

--- a/docs/adding-a-model.md
+++ b/docs/adding-a-model.md
@@ -136,8 +136,11 @@ generated metrics, and only then activates the model. Imported models stay
 staged (disabled) until verification passes, so a partial cohort never reaches
 public surfaces. Real publications use `DIRECT_URL` to hold a per-model database
 lock through activation; configure it as a direct or session-mode connection.
-Commit `lib/ai/modelBenchmarkMetrics.generated.json` after
-publication. Once a model has vote history, publication permits only
+Commit and deploy `lib/ai/modelBenchmarkMetrics.generated.json` after
+publication, along with any recorded cost updates in `modelBenchmarkProfiles.ts`.
+The leaderboard efficiency views use these profiles automatically; models enter
+each frontier once that measurement and sampled prompt votes are available.
+Once a model has vote history, publication permits only
 payload-identical cohort reconciliation; publish changed builds under a new
 model identity or explicitly reset the vote and derived rating history first.
 

--- a/docs/arena-ranking-system.md
+++ b/docs/arena-ranking-system.md
@@ -128,6 +128,41 @@ Here, `votesA` and `votesB` are decisive votes for each model on the prompt, and
 
 The consistency estimator is documented separately in [Consistency Metric](./consistency-metric-percentile-band.md).
 
+### Efficiency
+
+The cost, speed, and block frontiers compare the current rating against average
+resource use per build. A model is on a Pareto frontier when no other included
+model has an equal or higher rating and equal or lower resource use, with at
+least one strict improvement. Exact ties remain on the frontier. These are
+point-estimate comparisons, not claims of statistically significant superiority.
+
+- Cost divides recorded cohort expenditure by finalized builds, including retry
+  expenditure where recorded. Estimated costs are marked explicitly
+- Speed uses the existing benchmark inference-time profile, which requires
+  complete timing coverage or a documented historical measurement
+- Blocks average nonempty canonical public builds over Arena-eligible prompts
+  and require complete build coverage. Block count describes size, not quality
+
+Resource per score point divides each average by `100 * meanScore`. This observed
+prompt score averages win = 1, tie = 0.5, and loss = 0 across prompts with at least
+two eligible votes; `BOTH_BAD` is excluded. Missing or zero scores have no ratio.
+These descriptive ratios depend on sampled opponents and prompts; they do not
+replace the Bradley-Terry ranking. Dividing by the rating itself would depend on
+its arbitrary 1500-point origin.
+
+Models without sampled prompt evidence or a positive selected resource
+measurement are excluded. Provisional models remain identifiable, and the
+established-only filter recomputes the comparison population. Searching
+highlights matching models without changing frontier membership.
+
+Charts are derived from the same response as the rankings. Visible tabs refresh
+at most once per minute automatically, including when focus returns; failed
+refreshes retain the last successful data with a stale indicator. Server ranking
+and response caches still apply, so updates are eventual rather than instant.
+Publication activates eligible models after cohort verification. Generated
+benchmark metrics and profile cost updates must be committed and deployed through
+the existing model publication workflow; no separate chart export is needed.
+
 ## Operations
 
 `pnpm elo:recompute` performs a read-only replay. `pnpm elo:recompute --yes` writes current public Bradley-Terry ratings and counters while independently replaying private variant state. Private votes never enter the public fit.

--- a/lib/arena/leaderboard.ts
+++ b/lib/arena/leaderboard.ts
@@ -1,14 +1,22 @@
 import type { Prisma } from "@prisma/client";
 import { getCache } from "@vercel/functions";
+import {
+  getAverageBenchmarkCostPerBuildUsd,
+  getAverageBenchmarkInferenceTimeMs,
+  getModelBenchmarkProfile,
+} from "@/lib/ai/modelBenchmarkProfiles";
 import { resolveModelDisplayName, resolveModelSlug } from "@/lib/ai/modelCatalog";
 import { getArenaPairCoverageByKey } from "@/lib/arena/coverage";
-import { getArenaEligiblePromptIds } from "@/lib/arena/eligibility";
+import {
+  arenaCohortBuildWhere,
+  getArenaEligiblePromptIds,
+} from "@/lib/arena/eligibility";
 import { confidenceFromRd, stabilityTier } from "@/lib/arena/rating";
 import {
   getGlobalBradleyTerrySnapshot,
   getLeaderboardDispersionByModelId,
 } from "@/lib/arena/stats";
-import type { LeaderboardResponse } from "@/lib/arena/types";
+import type { LeaderboardModelBenchmark, LeaderboardResponse } from "@/lib/arena/types";
 import { summarizeArenaVotes } from "@/lib/arena/voteMath";
 import { prisma } from "@/lib/prisma";
 
@@ -18,12 +26,17 @@ const ADJ_PAIR_PROMPTS_FLOOR = 6;
 const MOVEMENT_LOOKBACK_MS = 24 * 60 * 60 * 1000;
 const MOVEMENT_CONFIDENCE_FLOOR = 50;
 const BRADLEY_TERRY_SNAPSHOT_EPOCH = new Date("2026-08-25T00:00:00.000Z");
-const LEADERBOARD_RUNTIME_CACHE_KEY = "response-v1";
+const LEADERBOARD_RUNTIME_CACHE_KEY = "response-v2";
 const LEADERBOARD_RUNTIME_CACHE_TTL_SECONDS = 30;
 
 type PairCoverage = {
   decisiveVotes: number;
   promptCount: number;
+};
+
+type LeaderboardBenchmarkBlockSummary = {
+  averageBlocks: number | null;
+  blockSampleCount: number;
 };
 
 const LEADERBOARD_MODEL_SELECT = {
@@ -62,6 +75,56 @@ function pairCompletion(coverage: PairCoverage | null): number {
   const votesCompletion = Math.min(1, coverage.decisiveVotes / ADJ_PAIR_VOTES_FLOOR);
   const promptsCompletion = Math.min(1, coverage.promptCount / ADJ_PAIR_PROMPTS_FLOOR);
   return Math.min(votesCompletion, promptsCompletion);
+}
+
+export function createLeaderboardBenchmark(
+  modelKey: string,
+  expectedBuildCount: number,
+  blockSummary?: LeaderboardBenchmarkBlockSummary,
+): LeaderboardModelBenchmark {
+  const profile = getModelBenchmarkProfile(modelKey);
+  const benchmark: LeaderboardModelBenchmark = {
+    averageCostUsd: getAverageBenchmarkCostPerBuildUsd(modelKey),
+    costEstimated: Boolean(profile?.totalCost?.estimated),
+    averageTimeMs: getAverageBenchmarkInferenceTimeMs(modelKey),
+    averageBlocks:
+      expectedBuildCount > 0 && blockSummary?.blockSampleCount === expectedBuildCount && (blockSummary.averageBlocks ?? 0) > 0
+        ? blockSummary.averageBlocks
+        : null,
+    blockSampleCount: blockSummary?.blockSampleCount ?? 0,
+    expectedBuildCount,
+  };
+  return profile?.note ? { ...benchmark, note: profile.note } : benchmark;
+}
+
+async function getLeaderboardBenchmarkBlocksByModelId(
+  eligiblePromptIds: readonly string[],
+): Promise<Map<string, LeaderboardBenchmarkBlockSummary>> {
+  if (eligiblePromptIds.length === 0) return new Map();
+
+  const where = {
+    ...arenaCohortBuildWhere(),
+    promptId: { in: [...eligiblePromptIds] },
+    blockCount: { gt: 0 },
+  } satisfies Prisma.BuildWhereInput;
+
+  const rows = await prisma.build.groupBy({
+    by: ["modelId"],
+    where,
+    _avg: { blockCount: true },
+    _count: { _all: true },
+  });
+
+  return new Map(
+    rows.map((row) => [
+      row.modelId,
+      {
+        averageBlocks:
+          typeof row._avg.blockCount === "number" ? row._avg.blockCount : null,
+        blockSampleCount: row._count._all,
+      },
+    ]),
+  );
 }
 
 function isLeaderboardResponse(value: unknown): value is LeaderboardResponse {
@@ -137,7 +200,7 @@ async function queryLeaderboardData(): Promise<LeaderboardResponse> {
   });
   const topBandIds = sortedModels.slice(0, CONTENDER_BAND_SIZE).map((model) => model.id);
 
-  const [baselineRows, pairCoverageByKey] = await Promise.all([
+  const [baselineRows, pairCoverageByKey, benchmarkBlocksByModelId] = await Promise.all([
     baselineAnchor
       ? prisma.modelRankSnapshot.findMany({
           where: { capturedAt: baselineAnchor.capturedAt },
@@ -147,6 +210,7 @@ async function queryLeaderboardData(): Promise<LeaderboardResponse> {
     topBandIds.length >= 2 && eligiblePromptIds.length > 0
       ? getArenaPairCoverageByKey(topBandIds, eligiblePromptIds)
       : Promise.resolve(new Map<string, PairCoverage>()),
+    getLeaderboardBenchmarkBlocksByModelId(eligiblePromptIds),
   ]);
   const baselineRanksByModelId = new Map(
     baselineRows.map((row) => [row.modelId, row.rank]),
@@ -240,6 +304,11 @@ async function queryLeaderboardData(): Promise<LeaderboardResponse> {
         consistency: dispersion.consistency,
         sampledPrompts: dispersion.sampledPrompts,
         sampledVotes: dispersion.sampledVotes,
+        benchmark: createLeaderboardBenchmark(
+          model.key,
+          eligiblePromptCount,
+          benchmarkBlocksByModelId.get(model.id),
+        ),
       };
     }),
   };

--- a/lib/arena/types.ts
+++ b/lib/arena/types.ts
@@ -118,6 +118,16 @@ export type PromptListResponse = {
   prompts: { id: string; text: string }[];
 };
 
+export type LeaderboardModelBenchmark = {
+  averageCostUsd: number | null;
+  costEstimated: boolean;
+  averageTimeMs: number | null;
+  averageBlocks: number | null;
+  blockSampleCount: number;
+  expectedBuildCount: number;
+  note?: string;
+};
+
 export type LeaderboardResponse = {
   models: {
     key: string;
@@ -152,5 +162,6 @@ export type LeaderboardResponse = {
     consistency: number | null;
     sampledPrompts: number;
     sampledVotes: number;
+    benchmark?: LeaderboardModelBenchmark;
   }[];
 };

--- a/lib/leaderboardEfficiency.ts
+++ b/lib/leaderboardEfficiency.ts
@@ -1,0 +1,77 @@
+import type { LeaderboardResponse } from "@/lib/arena/types";
+
+type LeaderboardModel = LeaderboardResponse["models"][number];
+export type EfficiencyMetric = "cost" | "speed" | "blocks";
+export type EfficiencyPoint = {
+  model: LeaderboardModel;
+  resource: number;
+  perScore: number | null;
+};
+
+export function getEfficiencyResource(model: LeaderboardModel, metric: EfficiencyMetric): number | null {
+  const benchmark = model.benchmark;
+  const value = metric === "cost"
+    ? benchmark?.averageCostUsd
+    : metric === "speed"
+      ? benchmark?.averageTimeMs == null ? null : benchmark.averageTimeMs / 1000
+      : benchmark?.averageBlocks;
+  return value != null && Number.isFinite(value) && value >= 0 && (metric === "cost" || value > 0)
+    ? value
+    : null;
+}
+
+export function getEfficiencyPoints(
+  models: LeaderboardModel[],
+  metric: EfficiencyMetric,
+  establishedOnly = false,
+): EfficiencyPoint[] {
+  return models.flatMap((model) => {
+    const resource = getEfficiencyResource(model, metric);
+    if (
+      resource == null || !Number.isFinite(model.rankScore) ||
+      model.sampledPrompts <= 0 || model.sampledVotes <= 0 ||
+      (establishedOnly && model.stability === "Provisional")
+    ) return [];
+    const score = model.meanScore;
+    return [{
+      model,
+      resource,
+      perScore: score != null && Number.isFinite(score) && score > 0 && score <= 1
+        ? resource / (score * 100)
+        : null,
+    }];
+  }).sort((a, b) => a.resource - b.resource || b.model.rankScore - a.model.rankScore || a.model.key.localeCompare(b.model.key));
+}
+
+export function getParetoFrontier(points: EfficiencyPoint[]): EfficiencyPoint[] {
+  const sorted = [...points].sort((a, b) => a.resource - b.resource || b.model.rankScore - a.model.rankScore);
+  let bestScore = -Infinity;
+  let bestResource = -Infinity;
+  return sorted.filter((point) => {
+    const score = point.model.rankScore;
+    if (score < bestScore || (score === bestScore && point.resource > bestResource)) return false;
+    bestScore = score;
+    bestResource = point.resource;
+    return true;
+  });
+}
+
+export function getEfficiencyAxisDomain(values: number[], logarithmic = false): [number, number] {
+  if (values.length === 0) return [0, 1];
+  const scaled = logarithmic ? values.map(Math.log10) : values;
+  const min = Math.min(...scaled);
+  const max = Math.max(...scaled);
+  const padding = (max - min) * 0.08 || Math.max(Math.abs(min) * 0.08, 0.1);
+  return [logarithmic ? min - padding : Math.min(min, Math.max(0, min - padding)), max + padding];
+}
+
+const numberFormat = new Intl.NumberFormat("en-US", { maximumSignificantDigits: 3 });
+const blockFormat = new Intl.NumberFormat("en-US", { notation: "compact", maximumSignificantDigits: 3 });
+
+export function formatEfficiencyResource(value: number, metric: EfficiencyMetric): string {
+  if (metric === "cost") return `$${numberFormat.format(value)}`;
+  if (metric === "blocks") return blockFormat.format(value);
+  if (value >= 3600) return `${numberFormat.format(value / 3600)}h`;
+  if (value >= 60) return `${numberFormat.format(value / 60)}m`;
+  return `${numberFormat.format(value)}s`;
+}

--- a/lib/leaderboardEfficiency.ts
+++ b/lib/leaderboardEfficiency.ts
@@ -32,15 +32,18 @@ export function getEfficiencyPoints(
       model.sampledPrompts <= 0 || model.sampledVotes <= 0 ||
       (establishedOnly && model.stability === "Provisional")
     ) return [];
-    const score = model.meanScore;
     return [{
       model,
       resource,
-      perScore: score != null && Number.isFinite(score) && score > 0 && score <= 1
-        ? resource / (score * 100)
-        : null,
+      perScore: getResourcePerScore(resource, model.meanScore),
     }];
   }).sort((a, b) => a.resource - b.resource || b.model.rankScore - a.model.rankScore || a.model.key.localeCompare(b.model.key));
+}
+
+export function getResourcePerScore(resource: number | null, score: number | null): number | null {
+  return resource != null && score != null && Number.isFinite(score) && score > 0 && score <= 1
+    ? resource / (score * 100)
+    : null;
 }
 
 export function getParetoFrontier(points: EfficiencyPoint[]): EfficiencyPoint[] {

--- a/lib/leaderboardOrder.ts
+++ b/lib/leaderboardOrder.ts
@@ -1,7 +1,7 @@
 /**
  * shared reader for the current leaderboard ordering.
  *
- * the leaderboard page writes its full response to the mb-leaderboard-v4
+ * the leaderboard page writes its full response to the mb-leaderboard-v5
  * sessionStorage entry (via staleCache). we piggyback on that cache so the
  * model-detail page can show prev/next arrows without doing its own fetch
  * whenever the user arrived from the leaderboard. if the cache is empty
@@ -12,7 +12,7 @@
 import type { LeaderboardResponse } from "@/lib/arena/types";
 import { readStale } from "@/lib/staleCache";
 
-export const LEADERBOARD_CACHE_KEY = "mb-leaderboard-v4";
+export const LEADERBOARD_CACHE_KEY = "mb-leaderboard-v5";
 export const LEADERBOARD_STALE_MAX_AGE_MS = 10 * 60 * 1000;
 
 export function readLeaderboardOrderFromCache(): string[] | null {

--- a/tests/unit/leaderboard/efficiency.test.ts
+++ b/tests/unit/leaderboard/efficiency.test.ts
@@ -1,0 +1,83 @@
+import assert from "node:assert/strict";
+import * as React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { LeaderboardEfficiency } from "../../../components/leaderboard/LeaderboardEfficiency";
+import type { LeaderboardResponse } from "../../../lib/arena/types";
+import {
+  formatEfficiencyResource,
+  getEfficiencyAxisDomain,
+  getEfficiencyPoints,
+  getEfficiencyResource,
+  getParetoFrontier,
+} from "../../../lib/leaderboardEfficiency";
+
+function model(key: string, cost: number, rating: number): LeaderboardResponse["models"][number] {
+  return {
+    key, displayName: key, provider: "test", stability: "Established",
+    rankScore: rating, eloRating: rating, ratingDeviation: 20, confidence: 80, rank: 1,
+    rankDelta24h: null, hasBaseline24h: false, movementVisible: false,
+    shownCount: 10, winCount: 5, lossCount: 3, drawCount: 2, bothBadCount: 0,
+    coveredPrompts: 15, activePrompts: 15, promptCoverage: 1, pairCoverageScore: null,
+    qualityFloorScore: 1, meanScore: 0.5, scoreVariance: 0, scoreSpread: 0,
+    consistency: 100, sampledPrompts: 15, sampledVotes: 100,
+    benchmark: {
+      averageCostUsd: cost, costEstimated: false, averageTimeMs: 100_000,
+      averageBlocks: 10_000, blockSampleCount: 15, expectedBuildCount: 15,
+    },
+  };
+}
+
+const models = [
+  model("expensive", 8, 1600), model("cheap", 1, 1400),
+  model("dominated", 4, 1400), model("balanced", 2, 1500),
+  model("same-cost-worse", 2, 1450), model("tied", 2, 1500),
+];
+const points = getEfficiencyPoints(models, "cost");
+assert.deepEqual(getParetoFrontier(points).map((point) => point.model.key), ["cheap", "balanced", "tied", "expensive"]);
+assert.deepEqual(models.map((entry) => entry.key), ["expensive", "cheap", "dominated", "balanced", "same-cost-worse", "tied"]);
+assert.deepEqual(
+  getParetoFrontier(getEfficiencyPoints(models.map((entry) => ({ ...entry, rankScore: entry.rankScore - 1500 })), "cost")).map((point) => point.model.key),
+  getParetoFrontier(points).map((point) => point.model.key),
+  "frontiers must not depend on the arbitrary rating origin",
+);
+assert.equal(points.find((point) => point.model.key === "balanced")?.perScore, 2 / 50);
+assert.equal(getEfficiencyPoints([model("timing", 2, 1500)], "speed")[0].perScore, 100 / 50);
+assert.equal(getEfficiencyPoints([model("blocks", 2, 1500)], "blocks")[0].perScore, 10_000 / 50);
+assert.equal(getEfficiencyPoints([{ ...models[0], meanScore: 0 }], "cost")[0].perScore, null);
+assert.equal(getEfficiencyPoints([{ ...models[0], meanScore: null }], "cost")[0].perScore, null);
+assert.equal(getEfficiencyPoints([model("free", 0, 1400)], "cost")[0].perScore, 0);
+assert.deepEqual(getParetoFrontier([]), []);
+assert.equal(getParetoFrontier(points.slice(0, 1)).length, 1);
+assert.deepEqual(getEfficiencyPoints([
+  { ...models[0], benchmark: undefined },
+  { ...models[0], sampledVotes: 0 },
+  { ...models[0], sampledPrompts: 0 },
+  { ...models[0], rankScore: NaN },
+  model("invalid-cost", -1, 1500), model("infinite-cost", Infinity, 1500),
+], "cost"), []);
+const provisional = { ...models[0], stability: "Provisional" as const };
+assert.equal(getEfficiencyPoints([provisional], "cost").length, 1);
+assert.equal(getEfficiencyPoints([provisional], "cost", true).length, 0);
+assert.equal(getEfficiencyResource({ ...models[0], benchmark: { ...models[0].benchmark!, averageTimeMs: 0 } }, "speed"), null);
+assert.equal(formatEfficiencyResource(0.004, "cost"), "$0.004");
+assert.equal(formatEfficiencyResource(120, "speed"), "2m");
+assert.equal(formatEfficiencyResource(10_000, "blocks"), "10K");
+const [logMin, logMax] = getEfficiencyAxisDomain([0.001, 0.01], true);
+assert.ok(logMin < -3 && logMax > -2, "sub-dollar log scales must retain negative exponents");
+const [linearMin, linearMax] = getEfficiencyAxisDomain([0.001, 0.01]);
+assert.ok(linearMin <= 0.001 && linearMax > 0.01 && linearMax - linearMin < 1);
+assert.deepEqual(getEfficiencyAxisDomain([]), [0, 1]);
+const [singleMin, singleMax] = getEfficiencyAxisDomain([0.5], true);
+assert.ok(singleMin < Math.log10(0.5) && singleMax > Math.log10(0.5));
+
+(globalThis as typeof globalThis & { React: typeof React }).React = React;
+const render = (entries = models, query = "") => renderToStaticMarkup(React.createElement(LeaderboardEfficiency, { models: entries, modelQuery: query }));
+const markup = render();
+assert.ok(markup.includes("Cost per score point") && markup.includes("How to read these metrics"));
+assert.ok(markup.includes("6 models · 4 on frontier"));
+const searched = render(models, "dominated");
+assert.ok(searched.includes("6 models · 4 on frontier"), "search must preserve the full frontier population");
+assert.ok(!/NaN|Infinity/.test(render([model("fractional", 0.001, 1400), model("small", 0.01, 1500)])));
+assert.ok(!/NaN|Infinity/.test(render([model("free", 0, 1400)])));
+assert.ok(render([]).includes("recorded measurements and prompt votes"));
+console.log("leaderboard efficiency checks passed");

--- a/tests/unit/leaderboard/efficiency.test.ts
+++ b/tests/unit/leaderboard/efficiency.test.ts
@@ -73,7 +73,7 @@ assert.ok(singleMin < Math.log10(0.5) && singleMax > Math.log10(0.5));
 (globalThis as typeof globalThis & { React: typeof React }).React = React;
 const render = (entries = models, query = "") => renderToStaticMarkup(React.createElement(LeaderboardEfficiency, { models: entries, modelQuery: query }));
 const markup = render();
-assert.ok(markup.includes("Cost per score point") && markup.includes("How to read these metrics"));
+assert.ok(markup.includes("Comparison units") && markup.includes("Methodology"));
 assert.ok(markup.includes("6 models · 4 on frontier"));
 const searched = render(models, "dominated");
 assert.ok(searched.includes("6 models · 4 on frontier"), "search must preserve the full frontier population");

--- a/tests/unit/leaderboard/leaderboard-efficiency-data.test.ts
+++ b/tests/unit/leaderboard/leaderboard-efficiency-data.test.ts
@@ -1,0 +1,38 @@
+import assert from "node:assert/strict";
+import { createLeaderboardBenchmark } from "../../../lib/arena/leaderboard";
+
+const tracked = createLeaderboardBenchmark("openai_gpt_5_6_sol", 15, {
+  averageBlocks: 1250,
+  blockSampleCount: 15,
+});
+
+assert.equal(tracked.averageCostUsd, 710.82 / 15);
+assert.equal(tracked.costEstimated, false);
+assert.equal(tracked.averageTimeMs, 1_516_200);
+assert.equal(tracked.averageBlocks, 1250);
+assert.equal(tracked.blockSampleCount, 15);
+assert.equal(tracked.expectedBuildCount, 15);
+
+const incomplete = createLeaderboardBenchmark("openai_gpt_5_6_sol", 15, {
+  averageBlocks: 1250,
+  blockSampleCount: 14,
+});
+
+assert.equal(incomplete.averageBlocks, null);
+assert.equal(incomplete.blockSampleCount, 14);
+
+const zeroBlocks = createLeaderboardBenchmark("unknown_model", 1, {
+  averageBlocks: 0,
+  blockSampleCount: 1,
+});
+
+assert.deepEqual(zeroBlocks, {
+  averageCostUsd: null,
+  costEstimated: false,
+  averageTimeMs: null,
+  averageBlocks: null,
+  blockSampleCount: 1,
+  expectedBuildCount: 1,
+});
+
+console.log("leaderboard efficiency data checks passed");


### PR DESCRIPTION
## What does this PR do?

Adds an Efficiency view alongside Rankings with interactive Pareto frontiers for cost, generation time, and block count. A sortable table compares all three resources per build or per observed prompt-score point, with hover and keyboard model inspection, provisional status, and estimated-cost labels.

Reuses benchmark profiles and complete public-cohort block counts in the shared leaderboard response. The page refreshes while visible and on return, retains its last successful response if a refresh fails, and picks up newly published measurements through the existing model publication flow. Per-score ratios use the observed 0–100 prompt score, so they do not depend on the arbitrary origin of the ranking scale.

Also fixes clipped ranking cells and retained scroll offsets when switching views, replaces redundant tab borders, and adds responsive comparisons, pinned desktop column headings, and reduced-motion support.

## Why?

Model quality alone does not show the cost, time, or build size involved. These comparisons make those trade-offs visible beside the existing rankings without changing how models are ranked.

## How to test

- Open `/leaderboard`, switch to Efficiency, and compare Cost, Speed, and Blocks. Inspect chart points, toggle the established-only filter and log scale, and search for a model.
- Switch between Per build and Per score, sort each column, then scroll and return to Rankings. Check model names, table headings, and scroll position at desktop and phone widths.
- Passed: `pnpm exec tsc --noEmit --pretty false`, targeted ESLint, and `pnpm staging:run pnpm build`.
- Passed: `pnpm staging:run pnpm exec tsx tests/run.ts tests/unit/leaderboard tests/unit/seo.test.ts tests/unit/leaderboard-search.test.ts` — six test files covering efficiency math, benchmark data, rendering, search, and SEO.
- Checked desktop layouts in light and dark themes, plus the phone layout. A clean browser reload had no rendering errors.
- [Alpha deployment](https://minebench-git-alpha-ammaar-alams-projects.vercel.app/leaderboard) succeeded at `41030eddbc0ac7df7e48ae7065e78ae88526d45a`.

## Checklist

- [x] Focused regression tests passed
- [x] TypeScript, targeted lint, and production build passed
- [x] Tested locally and deployed to Alpha
- [x] Updated ranking methodology and model publication documentation

*(PR written by Codex)*
