### PR TITLE
fix(admin): improve generation inspection and worker alerts

### DIFF
--- a/app/api/admin/generations/[id]/route.ts
+++ b/app/api/admin/generations/[id]/route.ts
@@ -1,0 +1,39 @@
+import { getAuthenticatedUserId } from "@/lib/auth/request";
+import { createCustomBuildArtifactSignedUrl, downloadCustomBuildArtifactBytes } from "@/lib/custom-builds/storage";
+import { apiJson, apiServiceError } from "@/lib/gallery/api";
+import { GenerationServiceError, getAdminGenerationArtifact } from "@/lib/generations/service";
+
+export const runtime = "nodejs";
+
+export async function GET(request: Request, context: { params: Promise<{ id: string }> }) {
+  const adminId = await getAuthenticatedUserId(request);
+  if (!adminId) return apiJson({ error: { code: "authentication_required", message: "Sign in to view this generation." } }, 401);
+  const { id } = await context.params;
+  const kind = new URL(request.url).searchParams.get("artifact");
+  const kinds = kind === "preview" ? (["preview_mbv4"] as const)
+    : kind === "thumbnail" ? (["preview_svg"] as const)
+      : kind === "viewer" ? (["viewer_mbf1", "viewer_mbv4"] as const)
+        : kind === "download" ? (["build_json"] as const)
+          : null;
+  if (!kinds) return apiJson({ error: { code: "not_found", message: "Artifact not found." } }, 404);
+  try {
+    const artifact = await getAdminGenerationArtifact(adminId, id, [...kinds]);
+    if (!artifact) throw new GenerationServiceError("not_found", "Artifact not found.");
+    const downloadFileName = kind === "download" ? `${id}.json` : undefined;
+    const signedUrl = await createCustomBuildArtifactSignedUrl({ ...artifact, downloadFileName });
+    if (signedUrl.startsWith("file:")) {
+      const bytes = await downloadCustomBuildArtifactBytes(artifact);
+      return new Response(bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength) as ArrayBuffer, {
+        headers: {
+          "Cache-Control": "private, no-store",
+          "Content-Type": artifact.contentType,
+          ...(artifact.encoding === "gzip" ? { "Content-Encoding": "gzip" } : {}),
+          ...(downloadFileName ? { "Content-Disposition": `attachment; filename="${downloadFileName}"` } : {}),
+        },
+      });
+    }
+    return new Response(null, { status: 307, headers: { Location: signedUrl, "Cache-Control": "private, no-store" } });
+  } catch (error) {
+    return apiServiceError(error);
+  }
+}

--- a/app/api/admin/generations/route.ts
+++ b/app/api/admin/generations/route.ts
@@ -1,0 +1,25 @@
+import { z } from "zod";
+import { getAuthenticatedUserId } from "@/lib/auth/request";
+import { apiJson, apiServiceError } from "@/lib/gallery/api";
+import { listAdminGenerations } from "@/lib/generations/service";
+
+export const runtime = "nodejs";
+
+const querySchema = z.object({
+  ownerId: z.string().uuid().optional(),
+  cursor: z.string().max(500).optional(),
+  query: z.string().max(800).optional(),
+  active: z.enum(["true", "false"]).optional(),
+});
+
+export async function GET(request: Request) {
+  const adminId = await getAuthenticatedUserId(request);
+  if (!adminId) return apiJson({ error: { code: "authentication_required", message: "Sign in to view generations." } }, 401);
+  const parsed = querySchema.safeParse(Object.fromEntries(new URL(request.url).searchParams));
+  if (!parsed.success) return apiJson({ error: { code: "invalid_request", message: "Check the generation filters." } }, 400);
+  try {
+    return apiJson(await listAdminGenerations(adminId, { ...parsed.data, active: parsed.data.active === "true" }));
+  } catch (error) {
+    return apiServiceError(error);
+  }
+}

--- a/components/gallery/GalleryAdminDashboard.tsx
+++ b/components/gallery/GalleryAdminDashboard.tsx
@@ -2,11 +2,12 @@
 
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { useEffect, useMemo, useRef, useState, useTransition } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState, useTransition } from "react";
 import {
   loadGalleryAdminPerson,
   mutateGalleryAdmin,
 } from "@/app/admin/gallery/actions";
+import { GalleryAdminGenerations } from "@/components/gallery/GalleryAdminGenerations";
 import type {
   getGalleryAdminDashboard,
   getGalleryAdminPerson,
@@ -150,20 +151,20 @@ function PersonInspector({
   person,
   loading,
   pending,
-  onBack,
   onReload,
+  onViewGenerations,
   onMutate,
   onSuspend,
 }: {
   person: Person | null;
   loading: boolean;
   pending: boolean;
-  onBack: () => void;
   onReload: () => void;
+  onViewGenerations: () => void;
   onMutate: (mutation: Mutation) => Promise<boolean>;
   onSuspend: (target: { userId: string; email: string }) => void;
 }) {
-  if (loading) return <p className="py-8 text-sm text-muted">Loading person…</p>;
+  if (loading && !person) return <p className="py-8 text-sm text-muted">Loading person…</p>;
   if (!person) {
     return (
       <div className="space-y-4 py-8">
@@ -177,21 +178,6 @@ function PersonInspector({
   return (
     <div className="min-h-0 min-w-0 space-y-5">
       <div className="min-w-0 space-y-3">
-        <div className="flex items-center justify-between gap-3">
-          <button
-            type="button"
-            className="group -ml-2 inline-flex min-h-9 items-center gap-1.5 rounded-md px-2 text-xs font-medium text-muted transition-colors hover:bg-card/40 hover:text-fg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
-            aria-label="Back to people"
-            onClick={onBack}
-          >
-            <span aria-hidden="true" className="transition-transform duration-200 group-hover:-translate-x-0.5 motion-reduce:transform-none motion-reduce:transition-none">←</span>
-            <span>All people</span>
-          </button>
-          <span className={`inline-flex items-center gap-1.5 text-xs font-medium ${person.online ? "text-success" : "text-muted"}`}>
-            <span aria-hidden="true" className={`h-1.5 w-1.5 rounded-full ${person.online ? "bg-success" : "bg-muted/40"}`} />
-            {person.online ? "Online" : "Offline"}
-          </span>
-        </div>
         <div className="min-w-0 space-y-0.5">
           <h3 className="truncate text-lg font-semibold text-fg" title={person.label}>{person.label}</h3>
           {person.email ? <p className="truncate font-mono text-xs text-muted" title={person.email}>{person.email}</p> : null}
@@ -253,6 +239,7 @@ function PersonInspector({
       ) : null}
 
       <div className="flex flex-wrap gap-2">
+        {userId ? <button type="button" className="mb-btn mb-btn-ghost h-9 text-xs" onClick={onViewGenerations}>Generations</button> : null}
         {person.userId && person.email ? (
           person.suspended ? (
             <button
@@ -284,7 +271,7 @@ function PersonInspector({
             <h4 className="text-xs font-semibold uppercase tracking-wider text-muted">Prompts</h4>
             <span className="text-[11px] tabular-nums text-muted">{person.contributions.length}</span>
           </div>
-          <div className={person.contributions.length > 0 ? "max-h-40 min-w-0 divide-y divide-border/60 overflow-y-auto rounded-md border border-border/60 bg-card/10 px-3" : ""}>
+          <div className={person.contributions.length > 0 ? "min-w-0 divide-y divide-border/60 rounded-md border border-border/60 bg-card/10 px-3" : ""}>
             {person.contributions.map((candidate) => {
               const content = (
                 <div className="flex min-w-0 flex-1 items-center justify-between gap-3">
@@ -309,10 +296,10 @@ function PersonInspector({
           <h4 className="text-xs font-semibold uppercase tracking-wider text-muted">Vote history</h4>
           <span className="text-[11px] tabular-nums text-muted">{person.votes.length}</span>
         </div>
-        <div className={person.votes.length > 0 ? "max-h-80 min-w-0 space-y-2 overflow-y-auto pr-1" : ""}>
+        <div className={person.votes.length > 0 ? "min-w-0 space-y-2" : ""}>
           {person.votes.map((vote) => (
-            <article key={vote.id} className="min-w-0 rounded-lg border border-border/70 bg-card/20 p-3 transition-colors hover:border-border hover:bg-card/40">
-              <div className="flex items-center justify-between gap-2">
+            <article key={vote.id} className="min-w-0 rounded-md border border-border/70 bg-card/20 p-3 transition-colors hover:border-border hover:bg-card/40">
+              <div className="flex flex-wrap items-center justify-between gap-2">
                 <span className={`inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-[10px] font-medium ${
                   vote.source === "Arena"
                     ? "border border-border/80 bg-bg/70 text-muted"
@@ -395,6 +382,8 @@ function PersonInspector({
 
 export function GalleryAdminDashboard({ dashboard }: { dashboard: Dashboard }) {
   const router = useRouter();
+  const [view, setView] = useState<"generations" | "prompts">("generations");
+  const [generationOwner, setGenerationOwner] = useState<{ id: string; label: string } | null>(null);
   const [promptFilter, setPromptFilter] = useState<PromptFilter>("latest");
   const [peopleFilter, setPeopleFilter] = useState<PeopleFilter>("online");
   const [promptQuery, setPromptQuery] = useState("");
@@ -405,11 +394,12 @@ export function GalleryAdminDashboard({ dashboard }: { dashboard: Dashboard }) {
   const [pendingKey, setPendingKey] = useState<string | null>(null);
   const [notice, setNotice] = useState<string | null>(null);
   const [suspendTarget, setSuspendTarget] = useState<{ userId: string; email: string } | null>(null);
-  const [, startTransition] = useTransition();
+  const [refreshing, startTransition] = useTransition();
+  const personRequest = useRef(0);
 
   useEffect(() => {
     const interval = window.setInterval(() => {
-      if (document.visibilityState === "visible") router.refresh();
+      if (document.visibilityState === "visible") startTransition(() => router.refresh());
     }, 60_000);
     return () => window.clearInterval(interval);
   }, [router]);
@@ -433,35 +423,44 @@ export function GalleryAdminDashboard({ dashboard }: { dashboard: Dashboard }) {
     });
   }, [dashboard.people, peopleFilter, peopleQuery]);
 
-  async function loadPerson(personId: string) {
-    setSelectedPersonId(personId);
+  const loadPerson = useCallback(async (personId: string) => {
+    const request = ++personRequest.current;
     setPersonLoading(true);
-    setPerson(null);
-    const result = await loadGalleryAdminPerson(personId);
-    setPersonLoading(false);
-    if (result.ok) setPerson(result.person);
-    else setNotice(result.error);
-  }
+    setNotice(null);
+    try {
+      const result = await loadGalleryAdminPerson(personId);
+      if (request !== personRequest.current) return;
+      if (result.ok) setPerson(result.person);
+      else setNotice(result.error);
+    } catch {
+      if (request === personRequest.current) setNotice("Could not load this person. Try again.");
+    } finally {
+      if (request === personRequest.current) setPersonLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (selectedPersonId) void loadPerson(selectedPersonId);
+    return () => { personRequest.current += 1; };
+  }, [dashboard.refreshedAt, selectedPersonId, loadPerson]);
 
   async function mutate(mutation: Mutation, key: string = mutation.type): Promise<boolean> {
     setPendingKey(key);
     setNotice(null);
-    const result = await mutateGalleryAdmin(mutation);
-    setPendingKey(null);
-    if (!result.ok) {
-      setNotice(result.error);
+    try {
+      const result = await mutateGalleryAdmin(mutation);
+      if (!result.ok) {
+        setNotice(result.error);
+        return false;
+      }
+      startTransition(() => router.refresh());
+      return true;
+    } catch {
+      setNotice("Could not save this change. Try again.");
       return false;
+    } finally {
+      setPendingKey(null);
     }
-    setNotice(null);
-    if (selectedPersonId && (
-      mutation.type === "account_suspended" ||
-      mutation.type === "votes_blocked" ||
-      mutation.type === "hosted_generation_limit"
-    )) {
-      await loadPerson(selectedPersonId);
-    }
-    startTransition(() => router.refresh());
-    return true;
   }
 
   function openSuspend(target: { userId: string; email: string }) {
@@ -472,7 +471,27 @@ export function GalleryAdminDashboard({ dashboard }: { dashboard: Dashboard }) {
   return (
     <>
       {notice ? <p role="alert" className="text-sm text-danger">{notice}</p> : null}
-      <div className="grid items-start gap-8 lg:h-[calc(100dvh-8rem)] lg:grid-cols-[minmax(0,1.5fr)_minmax(0,1fr)] xl:grid-cols-[minmax(0,1.7fr)_minmax(0,1fr)]">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div className="flex min-w-0 flex-wrap items-center gap-x-5" aria-label="Admin views">
+          <FilterButton active={view === "generations"} onClick={() => { setView("generations"); setGenerationOwner(null); }}>Generations</FilterButton>
+          <FilterButton active={view === "prompts"} onClick={() => setView("prompts")}>Prompts</FilterButton>
+          {view === "generations" && generationOwner ? <button type="button" className="max-w-48 truncate text-xs text-muted hover:text-fg" title="Show all generations" onClick={() => setGenerationOwner(null)}>{generationOwner.label} · Clear</button> : null}
+        </div>
+        <div className="flex items-center gap-4">
+          <span className="inline-flex items-center gap-1.5 text-sm font-medium text-success" title="Active in the last 10 minutes">
+            <span aria-hidden="true" className="h-1.5 w-1.5 rounded-full bg-success" />
+            {dashboard.onlinePeopleCount.toLocaleString()} online
+          </span>
+          <time className="hidden text-xs text-muted sm:block" dateTime={dashboard.refreshedAt}>
+            Updated {dateTime.format(new Date(dashboard.refreshedAt))}
+          </time>
+          <button type="button" className="mb-btn mb-btn-ghost h-9 text-xs" disabled={refreshing || personLoading || Boolean(pendingKey)} onClick={() => startTransition(() => router.refresh())}>
+            {refreshing ? "Refreshing…" : "Refresh"}
+          </button>
+        </div>
+      </div>
+      <div className="grid items-start gap-8 lg:h-[max(36rem,calc(100dvh-22rem))] lg:grid-cols-[minmax(0,1.5fr)_minmax(0,1fr)] xl:grid-cols-[minmax(0,1.7fr)_minmax(0,1fr)]">
+        {view === "generations" ? <GalleryAdminGenerations ownerId={generationOwner?.id} refreshedAt={dashboard.refreshedAt} /> : (
         <section className="min-w-0 lg:flex lg:h-full lg:min-h-0 lg:flex-col" aria-labelledby="admin-prompts-title">
           <div className="flex flex-wrap items-end justify-between gap-5 border-b border-border pb-4">
             <div>
@@ -491,7 +510,7 @@ export function GalleryAdminDashboard({ dashboard }: { dashboard: Dashboard }) {
               </FilterButton>
             ))}
           </div>
-          <div className="divide-y divide-border border-b border-border lg:min-h-0 lg:flex-1 lg:overflow-y-auto lg:overscroll-contain lg:pr-1">
+          <div className="divide-y divide-border border-b border-border lg:min-h-0 lg:flex-1 lg:overflow-y-auto lg:overscroll-contain lg:px-1 lg:pb-1">
             {prompts.map((prompt) => {
               const key = `prompt:${prompt.publicId}`;
               return (
@@ -530,21 +549,38 @@ export function GalleryAdminDashboard({ dashboard }: { dashboard: Dashboard }) {
             {prompts.length === 0 ? <p className="py-10 text-sm text-muted">No matching prompts</p> : null}
           </div>
         </section>
+        )}
 
         <aside className="grid min-h-0 min-w-0 w-full gap-8 lg:sticky lg:top-24 lg:h-full lg:grid-rows-[minmax(18rem,3fr)_minmax(14rem,2fr)] lg:border-l lg:border-border lg:pl-8">
           <section className="flex min-h-0 min-w-0 w-full flex-col" aria-labelledby="admin-people-title">
             {selectedPersonId ? (
-              <div className="min-h-0 min-w-0 overflow-y-auto pr-1">
+              <>
+              <div className="flex shrink-0 items-center justify-between gap-3 border-b border-border pb-3">
+                <button type="button" className="inline-flex min-h-9 items-center gap-1.5 rounded-md px-1 text-xs font-medium text-muted hover:text-fg focus-visible:outline-none focus-visible:text-accent" aria-label="Back to people" onClick={() => { personRequest.current += 1; setSelectedPersonId(null); setPerson(null); setPersonLoading(false); setNotice(null); }}>
+                  <span aria-hidden="true">←</span> All people
+                </button>
+                <h2 id="admin-people-title" className="sr-only">Person details</h2>
+                {personLoading ? <span role="status" className="text-xs text-muted">Updating…</span> : person ? (
+                  <span className={`inline-flex items-center gap-1.5 text-xs font-medium ${person.online ? "text-success" : "text-muted"}`}>
+                    <span aria-hidden="true" className={`h-1.5 w-1.5 rounded-full ${person.online ? "bg-success" : "bg-muted/40"}`} />
+                    {person.online ? "Online" : "Offline"}
+                  </span>
+                ) : null}
+              </div>
+              <div className="min-h-0 min-w-0 flex-1 overflow-y-auto overscroll-contain px-1 py-4">
                 <PersonInspector
                   person={person}
                   loading={personLoading}
                   pending={Boolean(pendingKey)}
-                  onBack={() => { setSelectedPersonId(null); setPerson(null); }}
                   onReload={() => void loadPerson(selectedPersonId)}
+                  onViewGenerations={() => {
+                    if (person?.userId) { setGenerationOwner({ id: person.userId, label: person.label }); setView("generations"); }
+                  }}
                   onMutate={mutate}
                   onSuspend={openSuspend}
                 />
               </div>
+              </>
             ) : (
               <>
                 <div className="flex flex-wrap items-end justify-between gap-3 border-b border-border pb-3">
@@ -563,7 +599,7 @@ export function GalleryAdminDashboard({ dashboard }: { dashboard: Dashboard }) {
                 </div>
                 <div className="max-h-[32rem] min-h-0 flex-1 divide-y divide-border overflow-y-auto border-b border-border pr-1 lg:max-h-none">
                   {people.map((entry) => (
-                    <button key={entry.id} type="button" className="flex min-h-14 w-full items-center justify-between gap-3 py-3 text-left transition-colors hover:text-accent focus-visible:outline-none focus-visible:text-accent" onClick={() => void loadPerson(entry.id)}>
+                    <button key={entry.id} type="button" className="flex min-h-14 w-full items-center justify-between gap-3 py-3 text-left transition-colors hover:text-accent focus-visible:outline-none focus-visible:text-accent" onClick={() => { setPerson(null); setPersonLoading(true); setSelectedPersonId(entry.id); }}>
                       <span className="min-w-0">
                         <span className="block truncate text-sm font-medium">{entry.label}</span>
                         <span className="block truncate text-xs text-muted">

--- a/components/gallery/GalleryAdminGenerations.tsx
+++ b/components/gallery/GalleryAdminGenerations.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { SavedBuildDialog } from "@/components/gallery/GalleryYours";
+import { formatBuildDuration } from "@/lib/buildMetrics";
+import type { listAdminGenerations } from "@/lib/generations/service";
+
+type Page = Awaited<ReturnType<typeof listAdminGenerations>>;
+const dateTime = new Intl.DateTimeFormat("en-US", { dateStyle: "medium", timeStyle: "short" });
+
+export function GalleryAdminGenerations({ ownerId, refreshedAt }: { ownerId?: string; refreshedAt?: string }) {
+  const [page, setPage] = useState<Page>({ items: [], nextCursor: null });
+  const [query, setQuery] = useState("");
+  const [active, setActive] = useState(false);
+  const [loading, setLoading] = useState(true);
+  const [pageCount, setPageCount] = useState(1);
+  const [error, setError] = useState<string | null>(null);
+  const [selected, setSelected] = useState<Page["items"][number] | null>(null);
+  const [reload, setReload] = useState(0);
+  const params = new URLSearchParams({ query, active: String(active), ...(ownerId ? { ownerId } : {}) }).toString();
+
+  useEffect(() => {
+    setPageCount(1);
+    setPage({ items: [], nextCursor: null });
+    setLoading(true);
+    setError(null);
+  }, [params]);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    const timer = window.setTimeout(() => {
+      setLoading(true);
+      setError(null);
+      void (async () => {
+        const items: Page["items"] = [];
+        let nextCursor: string | null = null;
+        for (let index = 0; index < pageCount; index += 1) {
+          const cursor = nextCursor ? `&cursor=${encodeURIComponent(nextCursor)}` : "";
+          const response = await fetch(`/api/admin/generations?${params}${cursor}`, { cache: "no-store", signal: controller.signal });
+          if (!response.ok) throw new Error("Generations unavailable.");
+          const next = await response.json() as Page;
+          items.push(...next.items);
+          nextCursor = next.nextCursor;
+          if (!nextCursor) break;
+        }
+        if (!controller.signal.aborted) setPage({ items, nextCursor });
+      })()
+        .catch(() => { if (!controller.signal.aborted) setError("Generations unavailable."); })
+        .finally(() => { if (!controller.signal.aborted) setLoading(false); });
+    }, 200);
+    return () => { window.clearTimeout(timer); controller.abort(); };
+  }, [params, refreshedAt, reload, pageCount]);
+
+  useEffect(() => {
+    const interval = window.setInterval(() => {
+      if (document.visibilityState === "visible") setReload((value) => value + 1);
+    }, 30_000);
+    return () => window.clearInterval(interval);
+  }, []);
+
+
+  return (
+    <section className="flex min-h-0 min-w-0 flex-1 flex-col lg:h-full" aria-label="Generations" aria-busy={loading}>
+      <div className="flex flex-wrap items-center justify-between gap-3 border-b border-border pb-3">
+        <div className="flex items-center gap-3">
+          {([false, true] as const).map((value) => (
+            <button key={String(value)} type="button" aria-pressed={active === value} onClick={() => setActive(value)} className={`min-h-10 text-sm ${active === value ? "font-semibold text-fg" : "text-muted hover:text-fg"}`}>
+              {value ? "Active" : "All"}
+            </button>
+          ))}
+        </div>
+        <label className="w-full sm:w-64">
+          <span className="sr-only">Search generations</span>
+          <input className="mb-field h-9" type="search" placeholder="Search generations" maxLength={800} value={query} onChange={(event) => setQuery(event.target.value)} />
+        </label>
+      </div>
+      {error ? <div role="status" className="flex items-center gap-3 py-3 text-sm text-danger">{error}<button type="button" className="mb-btn h-9" onClick={() => setReload((value) => value + 1)}>Retry</button></div> : null}
+      <div className="min-h-0 flex-1 divide-y divide-border overflow-y-auto px-1" aria-label="Generation results">
+        {page.items.map((generation) => (
+          <article key={generation.id} className="space-y-2 py-4">
+            <div className="flex flex-wrap items-start justify-between gap-3">
+              <p className="min-w-0 flex-1 whitespace-pre-wrap break-words text-sm font-medium text-fg [overflow-wrap:anywhere]">{generation.prompt}</p>
+              {generation.viewerUrl ? <button type="button" className="mb-btn h-9 shrink-0 text-xs" onClick={() => setSelected(generation)}>View build</button> : null}
+            </div>
+            <p className="break-all text-xs text-muted">{generation.owner?.email ?? "Guest"}{generation.owner?.publicNickname ? ` · ${generation.owner.publicNickname}` : ""}</p>
+            <div className="flex flex-wrap gap-x-3 gap-y-1 text-xs text-muted">
+              <span className="font-medium text-fg">{generation.model.label}</span>
+              <span className={generation.status === "failed" ? "text-danger" : generation.status === "running" || generation.status === "queued" ? "text-accent" : ""}>
+                {generation.status === "succeeded" ? "Ready" : generation.status === "running" ? "Generating" : generation.status === "queued" ? "Queued" : generation.status === "failed" ? "Failed" : "Canceled"}
+              </span>
+              <span>{generation.published ? "Published" : "Unpublished"}</span>
+              {generation.generationTimeMs != null ? <span>{formatBuildDuration(generation.generationTimeMs)}</span> : null}
+              <time dateTime={generation.createdAt}>{dateTime.format(new Date(generation.createdAt))}</time>
+            </div>
+            {generation.error ? <p className="break-words text-xs text-danger">{generation.error.message}</p> : null}
+          </article>
+        ))}
+        {page.items.length === 0 ? <p className="py-8 text-sm text-muted">{loading ? "Loading generations…" : "No matching generations"}</p> : null}
+        {page.nextCursor ? <div className="py-3"><button type="button" className="mb-btn h-10" disabled={loading} onClick={() => setPageCount((value) => value + 1)}>{loading ? "Loading…" : "Load more"}</button></div> : null}
+      </div>
+      {selected ? <SavedBuildDialog generation={selected} onClose={() => setSelected(null)} onExplorerExit={() => setSelected(null)} /> : null}
+    </section>
+  );
+}

--- a/components/gallery/GalleryYours.tsx
+++ b/components/gallery/GalleryYours.tsx
@@ -216,7 +216,7 @@ function GenerationActions({
   );
 }
 
-function SavedBuildDialog({
+export function SavedBuildDialog({
   generation,
   onClose,
   onExplorerExit,

--- a/docs/cloudwatch-monitoring.md
+++ b/docs/cloudwatch-monitoring.md
@@ -40,7 +40,7 @@ All telemetry is emitted under the `MineBench/Production` namespace.
 | `disk_used_percent` | Percent | Host disk space utilization percentage. |
 | `cpu_usage_idle` | Percent | Host idle CPU percentage. |
 
-Worker heartbeats and queue health are emitted immediately at startup and every 30 seconds. They continue while active work drains after shutdown begins, so deploys remain visible. The queue alarm treats missing telemetry as unhealthy; `WorkerAcceptingJobs` is currently dashboard-only.
+Worker heartbeats and queue health are emitted immediately at startup and every 30 seconds. They continue while active work drains after shutdown begins, so deploys remain visible. The queue and worker-availability alarms treat missing telemetry as unhealthy.
 
 Success, duration, and error events publish both an `Environment` aggregate for alarms and detailed model dimensions for dashboards. CloudWatch does not aggregate custom metrics across dimension sets automatically, so alarms must use the aggregate series.
 
@@ -62,15 +62,30 @@ Verified in `us-east-1` on 2026-09-05. Enabled alarms notify the `minebench-prod
 | `MineBench-GenerationErrors` | At least one failed generation attempt in 5 minutes | Sensitive: includes user credentials, exhausted credits, invalid model output, and provider errors as well as infrastructure failures. Keep error details visible; consider paging only on actionable infrastructure failures or sustained failures after defining the desired policy. |
 | `MineBench-HighCPU` | Average CPU busy >= 85% for two consecutive 5-minute periods | Reasonable sustained host-pressure warning; missing data becomes insufficient data. |
 | `MineBench-HighMemory` | Average RAM used >= 85% for two consecutive 1-minute periods | Reasonable for the small worker host; missing data becomes insufficient data. |
+| `MineBench-WorkerUnavailable` | Maximum `WorkerAcceptingJobs` < 1 for three consecutive 1-minute periods | Detects a stopped or persistently draining worker, including missing telemetry. A worker doing long inference continues reporting 1. |
+| `MineBench-HighDisk` | Average root filesystem usage >= 85% for two consecutive 5-minute periods | Warns before artifact/log growth fills the worker disk; missing data becomes insufficient data. |
 | `MineBench-StuckQueuedGenerations` | Maximum oldest runnable queue age >= 180 seconds for two consecutive 1-minute periods | Detects waiting work, not running inference. Missing data breaches. A healthy worker at capacity can also trigger this, so inspect active jobs and accepting-jobs status before treating it as stuck. |
 
 Low traffic makes the duration alarm especially noisy: a single completed build can determine the period's p95, then an idle period returns it to OK because missing data is non-breaching. CloudWatch supports [ignoring low-sample percentiles](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/percentiles-with-low-samples.html), but that would not make generation duration a useful responsiveness alarm.
 
 The seven days reviewed contained 84 HighLatency ALARM transitions, 27 GenerationErrors transitions, and one StuckQueuedGenerations transition. There were 206 recorded successes and 71 error events; these are telemetry events, not a unique-job failure rate, because retries can emit errors before success.
 
+### Applying worker and disk alarms
+
+The checked-in definitions target the existing production metrics and SNS topic. Apply them from the repository root; `put-metric-alarm` creates or updates the named alarm:
+
+```bash
+aws cloudwatch put-metric-alarm --profile minebench --region us-east-1 --cli-input-json file://docs/cloudwatch/worker-unavailable.json
+aws cloudwatch put-metric-alarm --profile minebench --region us-east-1 --cli-input-json file://docs/cloudwatch/high-disk.json
+```
+
+Worker availability uses the maximum sample in each minute so a healthy heartbeat clears that minute. Three breaching periods allow the normal 45-second restart window. Missing-heartbeat detection can take longer than three minutes because CloudWatch can evaluate earlier real samples before filling missing periods as breaching; see [AWS missing-data evaluation](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/alarms-and-missing-data.html).
+
+The disk dimensions match the current root filesystem (`/`, `nvme0n1p1`, `xfs`). Recheck them after replacing the host. Both alarms send notifications only; they do not restart the worker or delete files. Pushing these definitions to Alpha does not apply AWS configuration automatically.
+
 ### Coverage limits
 
-- `WorkerAcceptingJobs`, disk usage, and swap usage have metrics but no dedicated alarms. Queue telemetry can detect a dead reporter; a live draining worker with an empty queue will not trip the queue alarm.
+- Swap usage has a metric but no dedicated alarm. Worker availability detects a persistently draining worker even when its queue is empty; it does not measure provider progress or worker capacity.
 - Active jobs and queue health include private checkpoint work. Success/duration/error events currently cover saved Sandbox generation jobs and `/api/generate` streams, not private checkpoint generations, imports, or all benchmark batch jobs.
 - `ActiveGenerations` measures worker jobs, not simultaneous Vercel streams.
 - Host metrics belong to the worker host; they do not describe Vercel web functions or database health.

--- a/docs/cloudwatch-monitoring.md
+++ b/docs/cloudwatch-monitoring.md
@@ -1,6 +1,6 @@
 # CloudWatch Metrics & Architecture
 
-MineBench publishes asynchronous telemetry to Amazon CloudWatch to monitor generation workloads, throughput, latency distributions, worker health, and queue latency.
+MineBench publishes asynchronous telemetry to Amazon CloudWatch to monitor generation workloads, throughput, generation time, worker health, and queue wait time.
 
 ```mermaid
 flowchart LR
@@ -30,7 +30,7 @@ All telemetry is emitted under the `MineBench/Production` namespace.
 | Metric | Unit | Description |
 | :--- | :--- | :--- |
 | `GenerationsCount` | Count | Aggregate successful generation volume (Sum). |
-| `GenerationDuration` | Milliseconds | Generation latency distribution (p50, p90, p95, p99, Min, Max). |
+| `GenerationDuration` | Milliseconds | Successful build generation time, split by model; not web request latency. |
 | `ActiveGenerations` | Count | In-flight generation concurrency gauge. |
 | `WorkerAcceptingJobs` | Count | `1` while the worker accepts jobs and `0` while it drains. |
 | `QueuedJobsCount` | Count | Count of saved-generation and private-checkpoint jobs waiting in the queue. |
@@ -40,9 +40,41 @@ All telemetry is emitted under the `MineBench/Production` namespace.
 | `disk_used_percent` | Percent | Host disk space utilization percentage. |
 | `cpu_usage_idle` | Percent | Host idle CPU percentage. |
 
-Worker heartbeats and queue health are emitted immediately at startup and every 30 seconds. They continue while active work drains after shutdown begins, so deploys remain visible. Missing `WorkerAcceptingJobs` data is an alarm condition rather than a healthy state.
+Worker heartbeats and queue health are emitted immediately at startup and every 30 seconds. They continue while active work drains after shutdown begins, so deploys remain visible. The queue alarm treats missing telemetry as unhealthy; `WorkerAcceptingJobs` is currently dashboard-only.
 
 Success, duration, and error events publish both an `Environment` aggregate for alarms and detailed model dimensions for dashboards. CloudWatch does not aggregate custom metrics across dimension sets automatically, so alarms must use the aggregate series.
+
+## Generation time versus responsiveness
+
+`GenerationDuration` comes from `generateVoxelBuild().generationTimeMs`. It covers provider requests, repair attempts, and build execution/validation, subtracting caller callbacks and time waiting for the worker's build-processing gate. It excludes the initial durable queue wait and subsequent artifact storage. It is mostly inference time, but is not a pure provider-only timer.
+
+A successful build taking 20 minutes is expected for some models. Keep its duration visible by model instead of paging on one global threshold. The metric is emitted on success, so it cannot detect a generation that never finishes.
+
+Website responsiveness is measured separately through Vercel Speed Insights and the `minebench.arena.*` / `minebench.voxel.*` delivery and rendering metrics. None of the CloudWatch alarms below measures page load or API response latency.
+
+## Production alarms
+
+Verified in `us-east-1` on 2026-09-05. Enabled alarms notify the `minebench-production-alerts` SNS topic, which has one confirmed email subscription. They have no recovery or insufficient-data notification actions.
+
+| Alarm | Trigger | Assessment |
+| :--- | :--- | :--- |
+| `MineBench-HighLatency` | p95 `GenerationDuration` > 60 seconds in one 5-minute period | **Notifications disabled.** Successful long inference is expected. The dashboard labels this metric “Generation time.” |
+| `MineBench-GenerationErrors` | At least one failed generation attempt in 5 minutes | Sensitive: includes user credentials, exhausted credits, invalid model output, and provider errors as well as infrastructure failures. Keep error details visible; consider paging only on actionable infrastructure failures or sustained failures after defining the desired policy. |
+| `MineBench-HighCPU` | Average CPU busy >= 85% for two consecutive 5-minute periods | Reasonable sustained host-pressure warning; missing data becomes insufficient data. |
+| `MineBench-HighMemory` | Average RAM used >= 85% for two consecutive 1-minute periods | Reasonable for the small worker host; missing data becomes insufficient data. |
+| `MineBench-StuckQueuedGenerations` | Maximum oldest runnable queue age >= 180 seconds for two consecutive 1-minute periods | Detects waiting work, not running inference. Missing data breaches. A healthy worker at capacity can also trigger this, so inspect active jobs and accepting-jobs status before treating it as stuck. |
+
+Low traffic makes the duration alarm especially noisy: a single completed build can determine the period's p95, then an idle period returns it to OK because missing data is non-breaching. CloudWatch supports [ignoring low-sample percentiles](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/percentiles-with-low-samples.html), but that would not make generation duration a useful responsiveness alarm.
+
+The seven days reviewed contained 84 HighLatency ALARM transitions, 27 GenerationErrors transitions, and one StuckQueuedGenerations transition. There were 206 recorded successes and 71 error events; these are telemetry events, not a unique-job failure rate, because retries can emit errors before success.
+
+### Coverage limits
+
+- `WorkerAcceptingJobs`, disk usage, and swap usage have metrics but no dedicated alarms. Queue telemetry can detect a dead reporter; a live draining worker with an empty queue will not trip the queue alarm.
+- Active jobs and queue health include private checkpoint work. Success/duration/error events currently cover saved Sandbox generation jobs and `/api/generate` streams, not private checkpoint generations, imports, or all benchmark batch jobs.
+- `ActiveGenerations` measures worker jobs, not simultaneous Vercel streams.
+- Host metrics belong to the worker host; they do not describe Vercel web functions or database health.
+- Worker logs use `/minebench/production/worker` with 14-day retention.
 
 ## Vercel publishing
 

--- a/docs/cloudwatch/high-disk.json
+++ b/docs/cloudwatch/high-disk.json
@@ -1,0 +1,22 @@
+{
+  "AlarmName": "MineBench-HighDisk",
+  "AlarmDescription": "Average root filesystem usage is at least 85 percent for two consecutive five-minute periods.",
+  "ActionsEnabled": true,
+  "AlarmActions": ["arn:aws:sns:us-east-1:571600857924:minebench-production-alerts"],
+  "OKActions": [],
+  "InsufficientDataActions": [],
+  "Namespace": "MineBench/Production",
+  "MetricName": "disk_used_percent",
+  "Dimensions": [
+    { "Name": "path", "Value": "/" },
+    { "Name": "device", "Value": "nvme0n1p1" },
+    { "Name": "fstype", "Value": "xfs" }
+  ],
+  "Statistic": "Average",
+  "Period": 300,
+  "EvaluationPeriods": 2,
+  "DatapointsToAlarm": 2,
+  "Threshold": 85,
+  "ComparisonOperator": "GreaterThanOrEqualToThreshold",
+  "TreatMissingData": "missing"
+}

--- a/docs/cloudwatch/worker-unavailable.json
+++ b/docs/cloudwatch/worker-unavailable.json
@@ -1,0 +1,21 @@
+{
+  "AlarmName": "MineBench-WorkerUnavailable",
+  "AlarmDescription": "No accepting worker for three consecutive one-minute periods, or missing worker heartbeat telemetry. Normal short restarts and long active generations do not breach.",
+  "ActionsEnabled": true,
+  "AlarmActions": ["arn:aws:sns:us-east-1:571600857924:minebench-production-alerts"],
+  "OKActions": [],
+  "InsufficientDataActions": [],
+  "Namespace": "MineBench/Production",
+  "MetricName": "WorkerAcceptingJobs",
+  "Dimensions": [
+    { "Name": "Environment", "Value": "production" },
+    { "Name": "JobType", "Value": "worker" }
+  ],
+  "Statistic": "Maximum",
+  "Period": 60,
+  "EvaluationPeriods": 3,
+  "DatapointsToAlarm": 3,
+  "Threshold": 1,
+  "ComparisonOperator": "LessThanThreshold",
+  "TreatMissingData": "breaching"
+}

--- a/lib/gallery/service.ts
+++ b/lib/gallery/service.ts
@@ -68,7 +68,7 @@ function generateGalleryPublicId(): string {
   return `gal_${randomBytes(12).toString("base64url")}`;
 }
 
-const publicCandidateWhere = {
+export const publicCandidateWhere = {
   removedAt: null,
   adminHiddenAt: null,
   OR: [
@@ -77,7 +77,7 @@ const publicCandidateWhere = {
   ],
 } satisfies Prisma.GalleryCandidateWhereInput;
 
-const publicExampleWhere = {
+export const publicExampleWhere = {
   removedAt: null,
   adminHiddenAt: null,
   contributor: { gallerySuspendedAt: null },

--- a/lib/gallery/service.ts
+++ b/lib/gallery/service.ts
@@ -843,9 +843,9 @@ export async function claimAnonymousGalleryVotes(userId: string, sessionId: stri
   });
 }
 
-async function requireMineBenchAdmin(userId: string) {
+export async function requireMineBenchAdmin(userId: string) {
   const admin = await prisma.user.findFirst({
-    where: { id: userId, isMineBenchAdmin: true },
+    where: { id: userId, isMineBenchAdmin: true, deletedAt: null },
     select: { id: true },
   });
   if (!admin) throw new GalleryServiceError("forbidden", "MineBench admin access required.");
@@ -1447,7 +1447,8 @@ export async function getGalleryAdminDashboard(
   await requireMineBenchAdmin(adminId);
   const now = options.now ?? new Date();
   const retainedSince = new Date(now.getTime() - PUBLIC_SESSION_RETENTION_MS);
-  const [moderation, prompts, accounts, sessions, voteBlocks] = await Promise.all([
+  const onlineSince = now.getTime() - PUBLIC_SESSION_ONLINE_MS;
+  const [moderation, prompts, accounts, sessions, voteBlocks, onlineGroups] = await Promise.all([
     prisma.galleryModerationRecord.findMany({
       where: { NOT: { action: "email_delivery_failed" } },
       orderBy: { createdAt: "desc" },
@@ -1534,12 +1535,16 @@ export async function getGalleryAdminDashboard(
       where: { reversedAt: null },
       select: { userId: true, sessionHash: true, ipHmac: true },
     }),
+    prisma.publicSessionActivity.groupBy({
+      by: ["userId"],
+      where: { lastSeenAt: { gte: new Date(onlineSince) } },
+      _count: { _all: true },
+    }),
   ]);
 
   const blockedUsers = new Set(voteBlocks.flatMap((block) => block.userId ? [block.userId] : []));
   const blockedSessions = new Set(voteBlocks.flatMap((block) => block.sessionHash ? [block.sessionHash] : []));
   const blockedIps = new Set(voteBlocks.flatMap((block) => block.ipHmac ? [block.ipHmac] : []));
-  const onlineSince = now.getTime() - PUBLIC_SESSION_ONLINE_MS;
   const people = new Map<string, {
     id: string;
     label: string;
@@ -1612,6 +1617,8 @@ export async function getGalleryAdminDashboard(
   }
 
   return {
+    refreshedAt: now.toISOString(),
+    onlinePeopleCount: onlineGroups.reduce((total, group) => total + (group.userId ? 1 : group._count._all), 0),
     prompts: prompts.map((prompt) => ({
       publicId: prompt.publicId,
       prompt: prompt.promptText,

--- a/lib/generations/service.ts
+++ b/lib/generations/service.ts
@@ -19,7 +19,7 @@ import { redactSensitiveText } from "@/lib/custom-builds/sanitize";
 import { deleteCustomBuildArtifact } from "@/lib/custom-builds/storage";
 import { resolveSavedGenerationModel } from "@/lib/generations/model";
 import { prisma } from "@/lib/prisma";
-import { requireMineBenchAdmin } from "@/lib/gallery/service";
+import { publicCandidateWhere, publicExampleWhere, requireMineBenchAdmin } from "@/lib/gallery/service";
 
 const STORAGE_FAILSAFE_BYTES = 1024 * 1024 * 1024;
 const SECRET_TTL_MS = 24 * 60 * 60 * 1000;
@@ -429,7 +429,7 @@ export async function listAdminGenerations(
     select: {
       ...generationSelect,
       owner: { select: { id: true, email: true, publicNickname: true } },
-      galleryExamples: { where: { removedAt: null }, select: { id: true } },
+      galleryExamples: { where: { ...publicExampleWhere, candidate: publicCandidateWhere }, select: { id: true } },
     },
     orderBy: [{ createdAt: "desc" }, { id: "desc" }],
     take: limit + 1,

--- a/lib/generations/service.ts
+++ b/lib/generations/service.ts
@@ -19,6 +19,7 @@ import { redactSensitiveText } from "@/lib/custom-builds/sanitize";
 import { deleteCustomBuildArtifact } from "@/lib/custom-builds/storage";
 import { resolveSavedGenerationModel } from "@/lib/generations/model";
 import { prisma } from "@/lib/prisma";
+import { requireMineBenchAdmin } from "@/lib/gallery/service";
 
 const STORAGE_FAILSAFE_BYTES = 1024 * 1024 * 1024;
 const SECRET_TTL_MS = 24 * 60 * 60 * 1000;
@@ -398,6 +399,75 @@ export async function listSavedGenerations(
     items: page.map(serializeGeneration),
     nextCursor: hasMore && last ? encodeCursor({ createdAt: last.createdAt, id: last.id }) : null,
   };
+}
+
+export async function listAdminGenerations(
+  adminId: string,
+  options: { ownerId?: string; cursor?: string | null; query?: string; active?: boolean; limit?: number } = {},
+) {
+  await requireMineBenchAdmin(adminId);
+  const limit = Math.max(1, Math.min(options.limit ?? 20, 50));
+  const cursor = decodeCursor(options.cursor);
+  const query = options.query?.trim();
+  const rows = await prisma.customBuild.findMany({
+    where: {
+      removedAt: null,
+      ...(options.ownerId ? { ownerId: options.ownerId } : {}),
+      ...(options.active ? { status: { in: ["queued", "running"] } } : {}),
+      AND: [
+        ...(query ? [{ OR: [
+          { promptText: { contains: query, mode: "insensitive" as const } },
+          { modelDisplayName: { contains: query, mode: "insensitive" as const } },
+          { owner: { email: { contains: query, mode: "insensitive" as const } } },
+        ] }] : []),
+        ...(cursor ? [{ OR: [
+          { createdAt: { lt: cursor.createdAt } },
+          { createdAt: cursor.createdAt, id: { lt: cursor.id } },
+        ] }] : []),
+      ],
+    },
+    select: {
+      ...generationSelect,
+      owner: { select: { id: true, email: true, publicNickname: true } },
+      galleryExamples: { where: { removedAt: null }, select: { id: true } },
+    },
+    orderBy: [{ createdAt: "desc" }, { id: "desc" }],
+    take: limit + 1,
+  });
+  const page = rows.slice(0, limit);
+  const last = page.at(-1);
+  return {
+    items: page.map((row) => {
+      const generation = serializeGeneration(row);
+      const artifactUrl = (kind: string) => `/api/admin/generations/${row.publicId}?artifact=${kind}`;
+      return {
+        ...generation,
+        previewUrl: generation.previewUrl ? artifactUrl("preview") : null,
+        thumbnailUrl: generation.thumbnailUrl ? artifactUrl("thumbnail") : null,
+        viewerUrl: generation.viewerUrl ? artifactUrl("viewer") : null,
+        downloadUrl: generation.downloadUrl ? artifactUrl("download") : null,
+        owner: row.owner,
+        published: row.galleryExamples.length > 0,
+      };
+    }),
+    nextCursor: rows.length > limit && last ? encodeCursor({ createdAt: last.createdAt, id: last.id }) : null,
+  };
+}
+
+export async function getAdminGenerationArtifact(
+  adminId: string,
+  publicId: string,
+  kinds: CustomBuildArtifactKind[],
+) {
+  await requireMineBenchAdmin(adminId);
+  return prisma.customBuildArtifact.findFirst({
+    where: {
+      kind: { in: kinds },
+      customBuild: { publicId, removedAt: null, status: "succeeded" },
+    },
+    select: { kind: true, bucket: true, path: true, contentType: true, encoding: true },
+    orderBy: { createdAt: "desc" },
+  });
 }
 
 export async function getSavedGeneration(ownerId: string, publicId: string) {

--- a/tests/integration/gallery/admin-dashboard.test.ts
+++ b/tests/integration/gallery/admin-dashboard.test.ts
@@ -17,6 +17,8 @@ async function main() {
   const memberIpHmac = `member-ip-${suffix}`;
   const guestSession = `admin-guest-${suffix}`;
   const staleSession = `admin-stale-${suffix}`;
+  const extraSessions = Array.from({ length: 252 }, (_, index) => `admin-online-${suffix}-${index}`);
+  extraSessions.push(`${memberSession}-other`);
   const promptText = `Gallery admin fixture ${suffix}`;
   const modelAKey = `admin-a-${suffix}`;
   const modelBKey = `admin-b-${suffix}`;
@@ -31,6 +33,9 @@ async function main() {
     setGalleryPublishingSuspension,
     setHostedGenerationLimit,
   } = await import("../../../lib/gallery/service");
+  const { listAdminGenerations, getAdminGenerationArtifact, getOwnedGenerationArtifact, getSavedGeneration } = await import("../../../lib/generations/service");
+  const { GET: listGenerationRoute } = await import("../../../app/api/admin/generations/route");
+  const { GET: generationArtifactRoute } = await import("../../../app/api/admin/generations/[id]/route");
   const { touchPublicSessionActivity } = await import("../../../lib/publicPresence");
   const { hashVoteSession } = await import("../../../lib/voteBlock");
   const { POST: recordPresence } = await import("../../../app/api/presence/route");
@@ -200,6 +205,58 @@ async function main() {
     assert.equal(detail.hostedGenerationCount, 7);
     assert.equal(detail.hostedGenerationLimit, 125);
 
+    const publicId = `cst_admin_one_${suffix}`;
+    const removedPublicId = `cst_admin_two_${suffix}`;
+    const generations = await listAdminGenerations(adminId, { ownerId: memberId, active: true });
+    assert.equal(generations.items.length, 1, "active unpublished generations are visible to admins");
+    assert.equal(generations.items[0]?.prompt, promptText);
+    assert.equal(generations.items[0]?.owner?.id, memberId);
+    assert.equal(generations.items[0]?.published, false);
+    assert.equal(generations.items[0]?.viewerUrl, null);
+    assert.equal((await listAdminGenerations(adminId, { ownerId: adminId })).items.length, 0);
+    assert.equal((await listAdminGenerations(adminId, { query: `member-${suffix}@example.test` })).items.length, 1);
+    assert.equal((await listAdminGenerations(adminId, { query: `missing-${suffix}` })).items.length, 0);
+    await assert.rejects(() => listAdminGenerations(memberId), (error: unknown) => error instanceof GalleryServiceError && error.code === "forbidden");
+    await assert.rejects(() => getAdminGenerationArtifact(memberId, publicId, ["viewer_mbv4"]), (error: unknown) => error instanceof GalleryServiceError && error.code === "forbidden");
+    assert.equal((await listGenerationRoute(new Request("http://localhost/api/admin/generations"))).status, 401);
+    assert.equal((await generationArtifactRoute(new Request(`http://localhost/api/admin/generations/${publicId}?artifact=viewer`), { params: Promise.resolve({ id: publicId }) })).status, 401);
+
+    await db.customBuild.update({ where: { publicId: removedPublicId }, data: { removedAt: null } });
+    const firstPage = await listAdminGenerations(adminId, { ownerId: memberId, limit: 1 });
+    assert.ok(firstPage.nextCursor);
+    const secondPage = await listAdminGenerations(adminId, { ownerId: memberId, limit: 1, cursor: firstPage.nextCursor });
+    assert.equal(secondPage.items.length, 1);
+    assert.notEqual(firstPage.items[0]?.id, secondPage.items[0]?.id);
+    assert.equal(secondPage.nextCursor, null);
+    await db.customBuild.update({ where: { publicId: removedPublicId }, data: { removedAt: now } });
+    const completed = await db.customBuild.update({ where: { publicId }, data: { status: "succeeded", generationTimeMs: 1_200_000 } });
+    await db.customBuildArtifact.create({ data: {
+      customBuildId: completed.id,
+      kind: "viewer_mbv4",
+      format: "mbv4",
+      bucket: "private-builds",
+      path: `admin/${suffix}/viewer.mbv4`,
+      contentType: "application/octet-stream",
+      fileName: "viewer.mbv4",
+      sha256: "c".repeat(64),
+      byteSize: 10,
+      storedByteSize: 10,
+    } });
+    const ready = (await listAdminGenerations(adminId, { ownerId: memberId })).items[0]!;
+    assert.equal(ready.viewerUrl, `/api/admin/generations/${publicId}?artifact=viewer`);
+    assert.equal(ready.generationTimeMs, 1_200_000);
+    assert.equal((await listAdminGenerations(adminId, { ownerId: memberId, active: true })).items.length, 0);
+    assert.ok(await getAdminGenerationArtifact(adminId, publicId, ["viewer_mbv4"]));
+    assert.equal(await getOwnedGenerationArtifact(adminId, publicId, ["viewer_mbv4"]), null, "ordinary owner routes remain owner-only even for admins");
+    assert.equal(await getSavedGeneration(adminId, publicId), null);
+    assert.ok(await getOwnedGenerationArtifact(memberId, publicId, ["viewer_mbv4"]));
+    await db.customBuild.update({ where: { publicId }, data: { removedAt: now } });
+    assert.equal(await getAdminGenerationArtifact(adminId, publicId, ["viewer_mbv4"]), null, "removed artifacts remain unavailable to admins");
+    await db.customBuild.update({ where: { publicId }, data: { removedAt: null } });
+    await db.user.update({ where: { id: adminId }, data: { deletedAt: now } });
+    await assert.rejects(() => listAdminGenerations(adminId), (error: unknown) => error instanceof GalleryServiceError && error.code === "forbidden");
+    await db.user.update({ where: { id: adminId }, data: { deletedAt: null } });
+
     await setHostedGenerationLimit(adminId, memberId, 0);
     assert.deepEqual(
       await db.user.findUniqueOrThrow({
@@ -250,11 +307,23 @@ async function main() {
       },
     }), 0);
 
+    await db.publicSessionActivity.createMany({
+      data: extraSessions.map((sessionId, index) => ({
+        sessionId,
+        userId: sessionId === `${memberSession}-other` ? memberId : null,
+        lastSeenAt: new Date(now.getTime() - (index === 251 ? 10 * 60_000 : 0)),
+      })),
+    });
+    dashboard = await getGalleryAdminDashboard(adminId, { now });
+    assert.equal(dashboard.onlinePeopleCount, 255, "online count includes boundary sessions beyond the list cap and counts signed-in people once");
+    assert.ok(dashboard.onlinePeopleCount > dashboard.people.filter((person) => person.online).length);
+    assert.equal(dashboard.refreshedAt, now.toISOString());
+
     console.log("Gallery admin dashboard checks passed");
   } finally {
     await db.galleryVoteBlock.deleteMany({ where: { OR: [{ userId: memberId }, { createdById: adminId }] } });
     await db.publicSessionActivity.deleteMany({
-      where: { sessionId: { in: [memberSession, guestSession, staleSession, ...(routeSession ? [routeSession] : [])] } },
+      where: { sessionId: { in: [memberSession, guestSession, staleSession, ...extraSessions, ...(routeSession ? [routeSession] : [])] } },
     });
     await db.galleryModerationRecord.deleteMany({ where: { OR: [{ actorUserId: adminId }, { subjectUserId: memberId }] } });
     await db.galleryCandidate.deleteMany({ where: { uploaderId: memberId } });

--- a/tests/integration/gallery/admin-dashboard.test.ts
+++ b/tests/integration/gallery/admin-dashboard.test.ts
@@ -245,6 +245,20 @@ async function main() {
     const ready = (await listAdminGenerations(adminId, { ownerId: memberId })).items[0]!;
     assert.equal(ready.viewerUrl, `/api/admin/generations/${publicId}?artifact=viewer`);
     assert.equal(ready.generationTimeMs, 1_200_000);
+    const example = await db.galleryExample.create({ data: {
+      candidateId: candidate.id, customBuildId: completed.id, contributorId: memberId,
+    } });
+    assert.equal((await listAdminGenerations(adminId, { ownerId: memberId })).items[0]?.published, true);
+    await setGalleryCandidateHidden(adminId, candidate.publicId, true);
+    assert.equal((await listAdminGenerations(adminId, { ownerId: memberId })).items[0]?.published, false, "hidden prompts are not in the public Gallery");
+    await setGalleryCandidateHidden(adminId, candidate.publicId, false);
+    assert.equal((await listAdminGenerations(adminId, { ownerId: memberId })).items[0]?.published, true, "restoring the prompt restores its publication status");
+    await db.galleryExample.update({ where: { id: example.id }, data: { adminHiddenAt: now } });
+    assert.equal((await listAdminGenerations(adminId, { ownerId: memberId })).items[0]?.published, false, "hidden examples are not in the public Gallery");
+    await db.galleryExample.update({ where: { id: example.id }, data: { adminHiddenAt: null } });
+    await db.user.update({ where: { id: memberId }, data: { gallerySuspendedAt: now } });
+    assert.equal((await listAdminGenerations(adminId, { ownerId: memberId })).items[0]?.published, false, "suspended contributions are not in the public Gallery");
+    await db.user.update({ where: { id: memberId }, data: { gallerySuspendedAt: null } });
     assert.equal((await listAdminGenerations(adminId, { ownerId: memberId, active: true })).items.length, 0);
     assert.ok(await getAdminGenerationArtifact(adminId, publicId, ["viewer_mbv4"]));
     assert.equal(await getOwnedGenerationArtifact(adminId, publicId, ["viewer_mbv4"]), null, "ordinary owner routes remain owner-only even for admins");


### PR DESCRIPTION
Gallery admin now shows active and saved generations, including unpublished prompts and builds, with search and per-person filtering. The dashboard also displays a deduplicated online count and preserves person details during refresh, with padded controls and a single inspector scrollbar.

Add reproducible CloudWatch definitions for worker availability and root disk pressure. Worker availability uses three consecutive one-minute periods without an accepting heartbeat, including missing telemetry; disk usage alerts at 85% across two five-minute periods. Generation duration remains visible by model with HighLatency notifications disabled.

Validation:
- TypeScript, ESLint, production build, and targeted PostgreSQL authorization, pagination, and online-count checks passed
- Browser checks covered refresh/back/error states, responsive layout, active-generation filtering, and unpublished build rendering
- CloudWatch metric tests and AWS CLI input validation passed; live alarm configurations match the checked-in definitions
- Changes pushed to Alpha; the two production alarms were applied through AWS independently of application deployment

*(PR written by Codex)*

