### PR TITLE
feat(admin): review arena votes and publish gallery builds anonymously

### DIFF
--- a/app/admin/gallery/actions.ts
+++ b/app/admin/gallery/actions.ts
@@ -2,7 +2,10 @@
 
 import { revalidatePath } from "next/cache";
 import { z } from "zod";
+import { publishAdminGeneration } from "@/lib/generations/service";
 import { getCurrentAccount } from "@/lib/auth/account";
+import { getArenaVotePage, getArenaVoteReview, setArenaVoteSessionBlocked } from "@/lib/arena/voteReview";
+import { removePublicArenaVotes } from "@/lib/arena/voteModeration";
 import {
   GalleryServiceError,
   getGalleryAdminPerson,
@@ -15,6 +18,7 @@ import {
 } from "@/lib/gallery/service";
 
 const mutationSchema = z.discriminatedUnion("type", [
+  z.object({ type: z.literal("generation_published"), publicId: z.string().min(1).max(100) }),
   z.object({ type: z.literal("candidate_hidden"), publicId: z.string().min(1).max(100), hidden: z.boolean() }),
   z.object({ type: z.literal("example_hidden"), exampleId: z.string().min(1).max(100) }),
   z.object({
@@ -59,6 +63,9 @@ export async function mutateGalleryAdmin(input: unknown) {
   try {
     const actorId = await adminId();
     switch (parsed.data.type) {
+      case "generation_published":
+        await publishAdminGeneration(actorId, parsed.data.publicId);
+        break;
       case "candidate_hidden":
         await setGalleryCandidateHidden(actorId, parsed.data.publicId, parsed.data.hidden);
         break;
@@ -91,6 +98,52 @@ export async function mutateGalleryAdmin(input: unknown) {
 export async function loadGalleryAdminPerson(personId: string) {
   try {
     return { ok: true as const, person: await getGalleryAdminPerson(await adminId(), personId) };
+  } catch (error) {
+    return { ok: false as const, error: actionError(error) };
+  }
+}
+
+const sessionSchema = z.string().min(1).max(191);
+const voteCursorSchema = z.object({ id: z.string().min(1).max(191), createdAt: z.string().datetime() }).optional();
+
+export async function loadArenaVoteReview() {
+  try {
+    return { ok: true as const, data: await getArenaVoteReview(await adminId()) };
+  } catch (error) {
+    return { ok: false as const, error: actionError(error) };
+  }
+}
+
+export async function loadArenaVotePage(sessionId: string, cursor?: { id: string; createdAt: string }) {
+  const parsed = z.object({ sessionId: sessionSchema, cursor: voteCursorSchema }).safeParse({ sessionId, cursor });
+  if (!parsed.success) return { ok: false as const, error: "Invalid vote selection." };
+  try {
+    return { ok: true as const, data: await getArenaVotePage(await adminId(), parsed.data.sessionId, parsed.data.cursor) };
+  } catch (error) {
+    return { ok: false as const, error: actionError(error) };
+  }
+}
+
+export async function removeArenaReviewVotes(sessionId: string, voteIds: string[]) {
+  const parsed = z.object({ sessionId: sessionSchema, voteIds: z.array(z.string().min(1).max(191)).min(1).max(1000) }).safeParse({ sessionId, voteIds });
+  if (!parsed.success) return { ok: false as const, error: "Select up to 1,000 votes." };
+  try {
+    const result = await removePublicArenaVotes(await adminId(), parsed.data.sessionId, parsed.data.voteIds);
+    refreshGalleryAdmin();
+    revalidatePath("/leaderboard");
+    return { ok: true as const, ...result };
+  } catch (error) {
+    return { ok: false as const, error: actionError(error) };
+  }
+}
+
+export async function blockArenaReviewSession(sessionId: string, blocked: boolean) {
+  const parsed = z.object({ sessionId: sessionSchema, blocked: z.boolean() }).safeParse({ sessionId, blocked });
+  if (!parsed.success) return { ok: false as const, error: "Invalid vote restriction." };
+  try {
+    await setArenaVoteSessionBlocked(await adminId(), parsed.data.sessionId, parsed.data.blocked);
+    refreshGalleryAdmin();
+    return { ok: true as const };
   } catch (error) {
     return { ok: false as const, error: actionError(error) };
   }

--- a/app/admin/gallery/page.tsx
+++ b/app/admin/gallery/page.tsx
@@ -19,7 +19,7 @@ export default async function GalleryAdminPage() {
   const dashboard = await getGalleryAdminDashboard(account.id);
 
   return (
-    <div className="mx-auto w-full max-w-[92rem] space-y-8 py-6 sm:py-10">
+    <div className="mx-auto w-full max-w-[92rem] space-y-8 py-6 sm:py-10 lg:flex lg:h-full lg:min-h-0 lg:flex-col lg:gap-5 lg:space-y-0 lg:py-2">
       <header className="flex flex-wrap items-end justify-between gap-4 border-b border-border pb-6">
         <div>
           <p className="mb-eyebrow">MineBench</p>

--- a/app/api/gallery/candidates/[publicId]/examples/route.ts
+++ b/app/api/gallery/candidates/[publicId]/examples/route.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import { getAuthenticatedUserId } from "@/lib/auth/request";
 import { apiJson, apiServiceError } from "@/lib/gallery/api";
-import { addGalleryExample } from "@/lib/gallery/service";
+import { addGalleryExample, removeGalleryExample } from "@/lib/gallery/service";
 
 export const runtime = "nodejs";
 
@@ -18,6 +18,18 @@ export async function POST(request: Request, context: { params: Promise<{ public
   try {
     const result = await addGalleryExample(userId, (await context.params).publicId, parsed.data);
     return apiJson(result, result.created ? 201 : 200);
+  } catch (error) {
+    return apiServiceError(error);
+  }
+}
+
+export async function DELETE(request: Request, context: { params: Promise<{ publicId: string }> }) {
+  const userId = await getAuthenticatedUserId(request);
+  if (!userId) return apiJson({ error: { code: "authentication_required", message: "Sign in to remove a build." } }, 401);
+  const parsed = z.object({ exampleId: z.string().min(1).max(191) }).safeParse(await request.json().catch(() => null));
+  if (!parsed.success) return apiJson({ error: { code: "invalid_request", message: "Check the Gallery build." } }, 400);
+  try {
+    return apiJson(await removeGalleryExample(userId, (await context.params).publicId, parsed.data.exampleId));
   } catch (error) {
     return apiServiceError(error);
   }

--- a/components/arena/ArenaVoteReview.tsx
+++ b/components/arena/ArenaVoteReview.tsx
@@ -411,43 +411,29 @@ export function ArenaVoteReview({ refreshedAt }: { refreshedAt: string }) {
   return (
     <section className="flex min-h-0 flex-col gap-4 lg:flex-1" aria-labelledby="arena-vote-review-title">
       {notice ? <p role="alert" className="text-sm text-danger">{notice}</p> : null}
-      <div className="flex flex-wrap items-end justify-between gap-4 border-b border-border pb-4">
-        <div className="min-w-0">
-          <h2 id="arena-vote-review-title" className="text-xl font-semibold text-fg">Votes</h2>
-          <p className="mt-1 text-sm text-muted">
-            {data ? `${formatDate(data.since)} - ${formatDate(data.until)}` : `Updated ${formatDate(refreshedAt)}`}
-          </p>
+      <div className="flex flex-wrap items-center justify-between gap-x-6 gap-y-2 border-b border-border pb-2">
+        <h2 id="arena-vote-review-title" className="sr-only">Votes</h2>
+        <div className="flex flex-wrap items-center gap-5" aria-label="Vote session filters">
+          {([
+            ["suspicious", "Suspicious", counts.suspicious],
+            ["all", "All", counts.all],
+            ["restricted", "Restricted", counts.restricted],
+          ] as const).map(([key, label, count]) => (
+            <FilterButton key={key} active={filter === key} onClick={() => setFilter(key)}>
+              {label} <span className="ml-1 text-xs text-muted">{count.toLocaleString()}</span>
+            </FilterButton>
+          ))}
         </div>
-        <div className="flex w-full flex-wrap items-center gap-3 sm:w-auto">
-          <label className="min-w-0 flex-1 sm:w-72 sm:flex-none">
+        <div className="flex items-center gap-4">
+          <span className="text-xs text-muted" title={data ? `${formatDate(data.since)} – ${formatDate(data.until)}` : undefined}>Last 24 hours</span>
+          <label className="w-48 sm:w-60">
             <span className="sr-only">Search vote sessions</span>
-            <input
-              className="mb-field h-10"
-              type="search"
-              placeholder="Search sessions"
-              value={query}
-              onChange={(event) => setQuery(event.target.value)}
-            />
+            <input className="mb-field h-10" type="search" placeholder="Search sessions" value={query} onChange={(event) => setQuery(event.target.value)} />
           </label>
-          <button type="button" className="mb-btn mb-btn-ghost h-10" disabled={busy} onClick={() => void loadList()}>
-            {listLoading ? "Refreshing..." : "Refresh"}
-          </button>
         </div>
       </div>
 
-      <div className="flex flex-wrap gap-5 border-b border-border py-1" aria-label="Vote session filters">
-        {([
-          ["suspicious", "Suspicious", counts.suspicious],
-          ["all", "All", counts.all],
-          ["restricted", "Restricted", counts.restricted],
-        ] as const).map(([key, label, count]) => (
-          <FilterButton key={key} active={filter === key} onClick={() => setFilter(key)}>
-            {label} <span className="text-xs text-muted">{count.toLocaleString()}</span>
-          </FilterButton>
-        ))}
-      </div>
-
-      <div className="grid gap-8 lg:min-h-0 lg:flex-1 lg:grid-cols-[minmax(16rem,0.85fr)_minmax(0,1.4fr)] lg:overflow-hidden">
+      <div className="grid gap-8 lg:min-h-0 lg:flex-1 lg:grid-cols-[minmax(15rem,0.7fr)_minmax(0,1.6fr)] lg:overflow-hidden">
         <section className="min-w-0 lg:flex lg:min-h-0 lg:flex-col" aria-label="Vote sessions">
           <div className="divide-y divide-border border-b border-border lg:min-h-0 lg:flex-1 lg:overflow-y-auto lg:overscroll-contain lg:pr-2">
             {listLoading && !data ? <p className="py-8 text-sm text-muted">Loading votes...</p> : null}
@@ -471,22 +457,19 @@ export function ArenaVoteReview({ refreshedAt }: { refreshedAt: string }) {
           </div>
         </section>
 
-        <section className="min-w-0 lg:flex lg:min-h-0 lg:flex-col" aria-labelledby="arena-vote-detail-title">
-          <div className="flex flex-wrap items-start justify-between gap-4 border-b border-border pb-4">
+        <section className="min-w-0 lg:min-h-0 lg:overflow-y-auto lg:overscroll-contain lg:pr-2" aria-labelledby="arena-vote-detail-title">
+          <div className="flex flex-wrap items-center justify-between gap-3 border-b border-border bg-bg pb-3 lg:sticky lg:top-0 lg:z-10">
             <div className="min-w-0 space-y-1">
               <h3 id="arena-vote-detail-title" className="truncate text-lg font-semibold text-fg" title={selectedSession?.label ?? undefined}>
                 {selectedSession?.label ?? "Session"}
               </h3>
-              <p className="max-w-2xl text-sm text-muted">
-                Restricts the account when known, plus recorded browser sessions and IP addresses. Shared IPs can affect other visitors.
-              </p>
             </div>
             <div className="flex flex-wrap gap-2">
               <button type="button" className="mb-btn h-10" disabled={busy || pageVoteIds.length === 0} onClick={togglePage}>
                 {pageSelected ? "Clear page" : "Select page"}
               </button>
               <button type="button" className="mb-btn mb-btn-danger h-10" disabled={busy || selectedVoteIds.size === 0} onClick={() => void removeSelectedVotes()}>
-                {pendingAction === "remove" ? "Removing..." : `Remove ${selectedVoteIds.size.toLocaleString()}`}
+                {pendingAction === "remove" ? "Removing..." : selectedVoteIds.size ? `Remove ${selectedVoteIds.size.toLocaleString()}` : "Remove"}
               </button>
               {selectedSession ? (
                 <button
@@ -501,66 +484,15 @@ export function ArenaVoteReview({ refreshedAt }: { refreshedAt: string }) {
             </div>
           </div>
 
-          <div className="grid gap-3 border-b border-border py-4 text-xs sm:grid-cols-2 xl:grid-cols-4">
-            <div className="min-w-0 rounded-md border border-border/60 bg-card/20 p-2.5">
-              <p className="text-muted">Choices</p>
-              <p className="mt-1 font-medium text-fg">
-                A {selectedSession?.choiceA.toLocaleString() ?? 0} · B {selectedSession?.choiceB.toLocaleString() ?? 0}
-              </p>
-              <p className="mt-1 text-muted">
-                Tie {selectedSession?.ties.toLocaleString() ?? 0} · Both bad {selectedSession?.bothBad.toLocaleString() ?? 0}
-              </p>
-            </div>
-            <div className="min-w-0 rounded-md border border-border/60 bg-card/20 p-2.5">
-              <p className="text-muted">Ranking signals</p>
-              <p className="mt-1 font-medium text-fg">
-                {metric(selectedSession?.upsets ?? 0, "upsets")} · {metric(selectedSession?.largeUpsets ?? 0, "large")}
-              </p>
-              <p className="mt-1 text-muted">{metric(selectedSession?.rankedVotes ?? 0, "ranked votes")}</p>
-            </div>
-            <div className="min-w-0 rounded-md border border-border/60 bg-card/20 p-2.5">
-              <p className="text-muted">Pace</p>
-              <p className="mt-1 font-medium text-fg">
-                {metric(selectedSession?.repeatVotes ?? 0, "repeat")} · {metric(selectedSession?.fastVotes ?? 0, "fast")}
-              </p>
-              <p className="mt-1 text-muted">Median {formatGap(selectedSession?.medianGapSeconds ?? null)}</p>
-            </div>
-            <div className="min-w-0 rounded-md border border-border/60 bg-card/20 p-2.5">
-              <p className="text-muted">Network</p>
-              <p className="mt-1 truncate font-medium text-fg" title={selectedSession?.location ?? "Location unavailable"}>
-                {selectedSession?.location ?? "Location unavailable"}
-              </p>
-              <p className="mt-1 truncate text-muted" title={selectedSession?.networkLabel ?? "No network hash"}>
-                {selectedSession?.networkLabel ?? "No network hash"} · {metric(selectedSession?.matchingSessions ?? 0, "matched")}
-              </p>
-            </div>
-          </div>
-
-          <details className="border-b border-border py-3 text-sm text-muted">
-            <summary className="cursor-pointer text-fg">Criteria</summary>
-            <p className="mt-2 max-w-3xl">
-              Flags identify patterns for manual review: 80% lower-ranked picks or three top-versus-bottom-half upsets across at least 10 ranked votes. At 20 votes, rapid voting, repeated matchups, one-sided choices, and frequent rejections can also qualify. No votes are removed automatically.
+          {selectedSession ? (
+            <p className="flex flex-wrap gap-x-4 gap-y-1 py-3 text-xs text-muted">
+              <span>{metric(selectedSession.votes, "votes in 24h")}</span>
+              <span>{metric(selectedSession.upsets, "ranking upsets")}</span>
+              <span>Median gap {formatGap(selectedSession.medianGapSeconds)}</span>
+              <span>{votes.length.toLocaleString()} loaded · {selectedVoteIds.size.toLocaleString()} selected</span>
             </p>
-            <p className="mt-2 max-w-3xl">
-              Ranks use the current hourly snapshot{data?.rankingAt ? ` from ${formatDate(data.rankingAt)}` : ""}, so they are context, not vote-time proof.
-            </p>
-            <p className="mt-2 max-w-3xl">
-              IP matching uses existing hashes; locations approximate. <a className="font-medium text-fg underline-offset-4 hover:underline focus-visible:outline-none focus-visible:text-accent" href={PRIVACY_POLICY_URL} target="_blank" rel="noreferrer">Privacy policy</a>
-            </p>
-          </details>
-
-          <div className="flex flex-wrap items-center justify-between gap-3 border-b border-border py-3 text-xs text-muted">
-            <p>
-              {votes.length.toLocaleString()} loaded · {selectedVoteIds.size.toLocaleString()} selected
-            </p>
-            <div className="flex flex-wrap gap-2">
-              <button type="button" className="mb-btn mb-btn-ghost h-9 text-xs" disabled={busy || !selectedSessionId || !nextCursor} onClick={() => selectedSessionId && void loadVotes(selectedSessionId, nextCursor, true)}>
-                {votesLoading ? "Loading..." : "Load more"}
-              </button>
-            </div>
-          </div>
-
-          <div className="divide-y divide-border border-b border-border lg:min-h-0 lg:flex-1 lg:overflow-y-auto lg:overscroll-contain lg:pr-2">
+          ) : null}
+          <div className="divide-y divide-border">
             {votesLoading && votes.length === 0 ? <p className="py-8 text-sm text-muted">Loading history...</p> : null}
             {!votesLoading && selectedSession && votes.length === 0 ? <p className="py-8 text-sm text-muted">No retained public votes.</p> : null}
             {!selectedSession ? <p className="py-8 text-sm text-muted">Choose a session.</p> : null}
@@ -574,6 +506,22 @@ export function ArenaVoteReview({ refreshedAt }: { refreshedAt: string }) {
               />
             ))}
           </div>
+          {nextCursor ? (
+            <div className="flex justify-center py-4">
+              <button type="button" className="mb-btn h-10 px-5" disabled={busy || !selectedSessionId} onClick={() => selectedSessionId && void loadVotes(selectedSessionId, nextCursor, true)}>
+                {votesLoading ? "Loading..." : "Load more"}
+              </button>
+            </div>
+          ) : null}
+          <details className="mt-4 text-sm text-muted">
+            <summary className="min-h-11 cursor-pointer py-3 text-fg focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent">Review signals</summary>
+            <div className="space-y-3 pb-4 leading-relaxed">
+              {selectedSession ? <p>A {selectedSession.choiceA} · B {selectedSession.choiceB} · Tie {selectedSession.ties} · Both bad {selectedSession.bothBad}. {selectedSession.rankedVotes} ranked votes, {selectedSession.largeUpsets} large upsets, {selectedSession.fastVotes} fast votes, {selectedSession.repeatVotes} repeats.</p> : null}
+              <p>Ranking flags require at least 10 ranked votes: 80% lower-ranked picks, or three wins by bottom-half models against the top 15%. At 20 votes, flags also cover half of gaps below two seconds, 90% same-side decisive choices, 50% repeated matchups, or at least 10 both-bad votes making up 40% of votes.</p>
+              <p>These patterns need review; they do not establish abuse or remove votes automatically. Ranks use the latest snapshot{data?.rankingAt ? ` from ${formatDate(data.rankingAt)}` : ""}.</p>
+              <p>IP matches use retained hashes, not raw addresses. Shared IPs may include other visitors. <a className="text-fg underline underline-offset-4" href={PRIVACY_POLICY_URL} target="_blank" rel="noreferrer">Privacy policy</a></p>
+            </div>
+          </details>
         </section>
       </div>
       {data?.truncated ? <p className="text-xs text-muted">Showing the first 1,000 sessions plus retained restrictions.</p> : null}

--- a/components/arena/ArenaVoteReview.tsx
+++ b/components/arena/ArenaVoteReview.tsx
@@ -1,0 +1,582 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
+import {
+  blockArenaReviewSession,
+  loadArenaVotePage,
+  loadArenaVoteReview,
+  removeArenaReviewVotes,
+} from "@/app/admin/gallery/actions";
+import type {
+  VoteReviewData,
+  VoteReviewPage,
+  VoteReviewSession,
+} from "@/lib/arena/voteReview";
+
+type Filter = "suspicious" | "all" | "restricted";
+type Vote = VoteReviewPage["votes"][number];
+
+const MAX_SELECTED_VOTES = 1000;
+const PRIVACY_POLICY_URL = "https://github.com/Ammaar-Alam/minebench/blob/master/docs/privacy-policy.md";
+
+const dateTime = new Intl.DateTimeFormat("en-US", {
+  dateStyle: "medium",
+  timeStyle: "short",
+});
+
+function formatDate(value: string | null | undefined): string {
+  return value ? dateTime.format(new Date(value)) : "Unavailable";
+}
+
+function formatGap(value: number | null): string {
+  if (value == null) return "No gap";
+  if (value < 60) return `${value.toFixed(value < 10 ? 1 : 0)}s`;
+  return `${Math.round(value / 60)}m`;
+}
+
+function searchText(value: string): string {
+  return value.trim().toLocaleLowerCase();
+}
+
+function choiceLabel(choice: string): string {
+  if (choice === "BOTH_BAD") return "Both bad";
+  if (choice === "TIE") return "Tie";
+  return choice;
+}
+
+function rankLabel(rank: number | null): string {
+  return rank == null ? "unranked" : `#${rank}`;
+}
+
+function FilterButton({
+  active,
+  children,
+  onClick,
+}: {
+  active: boolean;
+  children: ReactNode;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      aria-pressed={active}
+      className={`relative min-h-10 px-1 text-sm transition-colors focus-visible:outline-none focus-visible:text-accent ${
+        active ? "font-semibold text-fg" : "text-muted hover:text-fg"
+      } after:absolute after:inset-x-1 after:bottom-0 after:h-px after:origin-left after:bg-fg after:transition-transform after:duration-200 after:ease-out motion-reduce:after:transition-none ${
+        active ? "after:scale-x-100" : "after:scale-x-0"
+      }`}
+      onClick={onClick}
+    >
+      {children}
+    </button>
+  );
+}
+
+function metric(value: number, label: string): string {
+  return `${value.toLocaleString()} ${label}`;
+}
+
+function sessionMatches(session: VoteReviewSession, query: string): boolean {
+  if (!query) return true;
+  return `${session.label} ${session.sessionId} ${session.location ?? ""} ${session.networkLabel ?? ""}`
+    .toLocaleLowerCase()
+    .includes(query);
+}
+
+function sessionMatchesFilter(session: VoteReviewSession, filter: Filter): boolean {
+  if (filter === "restricted") return session.blocked;
+  if (filter === "suspicious") return session.flags.length > 0;
+  return true;
+}
+
+function SessionRow({
+  session,
+  selected,
+  disabled,
+  onSelect,
+}: {
+  session: VoteReviewSession;
+  selected: boolean;
+  disabled: boolean;
+  onSelect: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      aria-pressed={selected}
+      disabled={disabled}
+      className={`w-full py-4 text-left transition-colors focus-visible:outline-none focus-visible:text-accent ${
+        selected ? "text-fg" : "text-muted hover:text-fg"
+      }`}
+      onClick={onSelect}
+    >
+      <span className="flex min-w-0 items-start justify-between gap-3">
+        <span className="min-w-0">
+          <span className="block truncate text-sm font-semibold text-fg" title={session.label}>{session.label}</span>
+          <span className="block truncate font-mono text-[11px] text-muted" title={session.sessionId}>{session.sessionId}</span>
+        </span>
+        <span className={`shrink-0 rounded px-1.5 py-0.5 text-[11px] font-medium ${
+          session.blocked
+            ? "border border-danger/35 bg-danger/10 text-danger"
+            : session.flags.length > 0
+              ? "border border-accent/30 bg-accent/10 text-accent"
+              : "border border-border/70 bg-bg/60 text-muted"
+        }`}>
+          {session.blocked ? "Restricted" : session.flags.length > 0 ? "Suspicious" : "Clear"}
+        </span>
+      </span>
+      <span className="mt-2 flex flex-wrap gap-x-3 gap-y-1 text-xs text-muted">
+        <span>{metric(session.votes, "votes")}</span>
+        <span>{metric(session.rankedVotes, "ranked")}</span>
+        <span>{metric(session.upsets, "upsets")}</span>
+        <span>{metric(session.largeUpsets, "large")}</span>
+        <span>{formatGap(session.medianGapSeconds)}</span>
+      </span>
+      <span className="mt-2 flex flex-wrap gap-x-3 gap-y-1 text-xs text-muted">
+        <span>{session.location ?? "Location unavailable"}</span>
+        <span>{session.networkLabel ?? "No network hash"}</span>
+        <span>{metric(session.matchingSessions, "matched sessions")}</span>
+      </span>
+      {session.flags.length > 0 ? (
+        <span className="mt-2 flex flex-wrap gap-1.5">
+          {session.flags.map((flag) => (
+            <span key={flag} className="rounded border border-border/70 bg-card/20 px-1.5 py-0.5 text-[11px] text-muted">
+              {flag}
+            </span>
+          ))}
+        </span>
+      ) : null}
+    </button>
+  );
+}
+
+function VoteCard({
+  checked,
+  disabled,
+  vote,
+  onToggle,
+}: {
+  checked: boolean;
+  disabled: boolean;
+  vote: Vote;
+  onToggle: () => void;
+}) {
+  return (
+    <article className="grid gap-3 py-4 sm:grid-cols-[auto_minmax(0,1fr)]">
+      <label className="flex min-h-11 items-start gap-3 text-sm text-fg">
+        <input
+          type="checkbox"
+          className="mt-1 h-4 w-4 accent-current"
+          checked={checked}
+          disabled={disabled}
+          onChange={onToggle}
+        />
+        <span className="sr-only">Select vote {vote.id}</span>
+      </label>
+      <div className="min-w-0 space-y-2">
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          <time className="text-xs tabular-nums text-muted" dateTime={vote.createdAt}>
+            {formatDate(vote.createdAt)}
+          </time>
+          <span className="rounded border border-border/70 bg-bg/60 px-1.5 py-0.5 text-[11px] font-medium text-muted">
+            {choiceLabel(vote.choice)}
+          </span>
+        </div>
+        <p className="break-words text-sm font-medium text-fg">{vote.prompt}</p>
+        <div className="grid gap-2 text-xs sm:grid-cols-2">
+          <span className={`min-w-0 rounded-md border px-2.5 py-2 ${
+            vote.choice === "A" ? "border-accent/45 bg-accent/10 text-accent" : "border-border/70 bg-card/20 text-muted"
+          }`}>
+            <span className="block truncate font-medium" title={vote.modelA}>A · {vote.modelA}</span>
+            <span className="mt-0.5 block tabular-nums">{rankLabel(vote.rankA)}</span>
+          </span>
+          <span className={`min-w-0 rounded-md border px-2.5 py-2 ${
+            vote.choice === "B" ? "border-accent/45 bg-accent/10 text-accent" : "border-border/70 bg-card/20 text-muted"
+          }`}>
+            <span className="block truncate font-medium" title={vote.modelB}>B · {vote.modelB}</span>
+            <span className="mt-0.5 block tabular-nums">{rankLabel(vote.rankB)}</span>
+          </span>
+        </div>
+        <p className="break-all font-mono text-[11px] text-muted">{vote.id}</p>
+      </div>
+    </article>
+  );
+}
+
+export function ArenaVoteReview({ refreshedAt }: { refreshedAt: string }) {
+  const [data, setData] = useState<VoteReviewData | null>(null);
+  const [filter, setFilter] = useState<Filter>("suspicious");
+  const [query, setQuery] = useState("");
+  const [selectedSessionId, setSelectedSessionId] = useState<string | null>(null);
+  const [votes, setVotes] = useState<Vote[]>([]);
+  const [pageVoteIds, setPageVoteIds] = useState<string[]>([]);
+  const [nextCursor, setNextCursor] = useState<VoteReviewPage["nextCursor"]>(null);
+  const [selectedVoteIds, setSelectedVoteIds] = useState<Set<string>>(new Set());
+  const [listLoading, setListLoading] = useState(true);
+  const [votesLoading, setVotesLoading] = useState(false);
+  const [pendingAction, setPendingAction] = useState<"remove" | "block" | null>(null);
+  const [notice, setNotice] = useState<string | null>(null);
+  const listRequest = useRef(0);
+  const votesRequest = useRef(0);
+
+  const loadList = useCallback(async () => {
+    const request = ++listRequest.current;
+    setListLoading(true);
+    setNotice(null);
+    try {
+      const result = await loadArenaVoteReview();
+      if (request !== listRequest.current) return;
+      if (result.ok) setData(result.data);
+      else setNotice(result.error);
+    } catch {
+      if (request === listRequest.current) setNotice("Could not load vote review.");
+    } finally {
+      if (request === listRequest.current) setListLoading(false);
+    }
+  }, []);
+
+  const loadVotes = useCallback(async (
+    sessionId: string,
+    cursor?: VoteReviewPage["nextCursor"],
+    append = false,
+  ) => {
+    const request = ++votesRequest.current;
+    setVotesLoading(true);
+    setNotice(null);
+    if (!append) {
+      setVotes([]);
+      setPageVoteIds([]);
+    }
+    try {
+      const result = await loadArenaVotePage(sessionId, cursor ?? undefined);
+      if (request !== votesRequest.current || sessionId !== selectedSessionId) return;
+      if (!result.ok) {
+        setNotice(result.error);
+        return;
+      }
+      const voteIds = result.data.votes.map((vote) => vote.id);
+      setVotes((current) => append ? [...current, ...result.data.votes] : result.data.votes);
+      setPageVoteIds(voteIds);
+      setNextCursor(result.data.nextCursor);
+      const liveIds = new Set(voteIds);
+      setSelectedVoteIds((current) => append
+        ? current
+        : new Set([...current].filter((id) => liveIds.has(id))));
+    } catch {
+      if (request === votesRequest.current) setNotice("Could not load vote history.");
+    } finally {
+      if (request === votesRequest.current) setVotesLoading(false);
+    }
+  }, [selectedSessionId]);
+
+  useEffect(() => {
+    void loadList();
+    return () => { listRequest.current += 1; };
+  }, [loadList, refreshedAt]);
+
+  useEffect(() => {
+    if (!data) return;
+    if (selectedSessionId && data.sessions.some((session) => session.sessionId === selectedSessionId)) return;
+    const firstSession = data.sessions.find((session) => session.flags.length > 0) ?? data.sessions[0] ?? null;
+    setSelectedSessionId(firstSession?.sessionId ?? null);
+    setSelectedVoteIds(new Set());
+    setVotes([]);
+    setPageVoteIds([]);
+    setNextCursor(null);
+  }, [data, selectedSessionId]);
+
+  useEffect(() => {
+    if (!selectedSessionId) return;
+    void loadVotes(selectedSessionId);
+    return () => { votesRequest.current += 1; };
+  }, [loadVotes, selectedSessionId, refreshedAt]);
+
+  const counts = useMemo(() => {
+    const sessions = data?.sessions ?? [];
+    return {
+      all: sessions.length,
+      suspicious: sessions.filter((session) => session.flags.length > 0).length,
+      restricted: sessions.filter((session) => session.blocked).length,
+    };
+  }, [data]);
+
+  const sessions = useMemo(() => {
+    const text = searchText(query);
+    return (data?.sessions ?? []).filter((session) => (
+      sessionMatchesFilter(session, filter) && sessionMatches(session, text)
+    ));
+  }, [data, filter, query]);
+
+  const selectedSession = useMemo(() => (
+    data?.sessions.find((session) => session.sessionId === selectedSessionId) ?? null
+  ), [data, selectedSessionId]);
+  const busy = listLoading || votesLoading || pendingAction !== null;
+  const pageSelected = pageVoteIds.length > 0 && pageVoteIds.every((id) => selectedVoteIds.has(id));
+
+  function selectSession(sessionId: string) {
+    votesRequest.current += 1;
+    setSelectedSessionId(sessionId);
+    setSelectedVoteIds(new Set());
+    setVotes([]);
+    setPageVoteIds([]);
+    setNextCursor(null);
+    setNotice(null);
+  }
+
+  function toggleVote(voteId: string) {
+    if (!selectedVoteIds.has(voteId) && selectedVoteIds.size >= MAX_SELECTED_VOTES) {
+      setNotice("Selection limit is 1,000 votes.");
+      return;
+    }
+    setSelectedVoteIds((current) => {
+      const next = new Set(current);
+      if (next.has(voteId)) next.delete(voteId);
+      else next.add(voteId);
+      return next;
+    });
+  }
+
+  function togglePage() {
+    if (!pageSelected) {
+      const newIds = pageVoteIds.filter((id) => !selectedVoteIds.has(id));
+      if (selectedVoteIds.size + newIds.length > MAX_SELECTED_VOTES) {
+        setNotice("Selection limit is 1,000 votes.");
+      }
+    }
+    setSelectedVoteIds((current) => {
+      const next = new Set(current);
+      if (pageSelected) {
+        pageVoteIds.forEach((id) => next.delete(id));
+        return next;
+      }
+      for (const id of pageVoteIds) {
+        if (next.size >= MAX_SELECTED_VOTES) break;
+        next.add(id);
+      }
+      return next;
+    });
+  }
+
+  async function refreshSelectedSession() {
+    await loadList();
+    if (selectedSessionId) await loadVotes(selectedSessionId);
+  }
+
+  async function removeSelectedVotes() {
+    if (!selectedSessionId || selectedVoteIds.size === 0 || busy) return;
+    const ids = [...selectedVoteIds];
+    if (!window.confirm(`Remove ${ids.length.toLocaleString()} selected votes? This is permanent.`)) return;
+    setPendingAction("remove");
+    setNotice(null);
+    try {
+      const result = await removeArenaReviewVotes(selectedSessionId, ids);
+      if (!result.ok) {
+        setNotice(result.error);
+        return;
+      }
+      setSelectedVoteIds(new Set());
+      await refreshSelectedSession();
+      setNotice(`Removed ${result.removed.toLocaleString()} votes.`);
+    } catch {
+      setNotice("Could not remove votes.");
+    } finally {
+      setPendingAction(null);
+    }
+  }
+
+  async function toggleRestriction() {
+    if (!selectedSession || busy) return;
+    const blocked = !selectedSession.blocked;
+    const action = blocked ? "Block" : "Unblock";
+    const explanation = "Restricts the account when known, plus recorded browser sessions and IP addresses. Shared IPs can affect other visitors.";
+    if (!window.confirm(`${explanation}\n\n${action} votes for ${selectedSession.label}?`)) return;
+    setPendingAction("block");
+    setNotice(null);
+    try {
+      const result = await blockArenaReviewSession(selectedSession.sessionId, blocked);
+      if (!result.ok) {
+        setNotice(result.error);
+        return;
+      }
+      await refreshSelectedSession();
+      setNotice(blocked ? "Votes restricted." : "Voting restriction removed.");
+    } catch {
+      setNotice("Could not update this restriction.");
+    } finally {
+      setPendingAction(null);
+    }
+  }
+
+  return (
+    <section className="flex min-h-0 flex-col gap-4 lg:flex-1" aria-labelledby="arena-vote-review-title">
+      {notice ? <p role="alert" className="text-sm text-danger">{notice}</p> : null}
+      <div className="flex flex-wrap items-end justify-between gap-4 border-b border-border pb-4">
+        <div className="min-w-0">
+          <h2 id="arena-vote-review-title" className="text-xl font-semibold text-fg">Votes</h2>
+          <p className="mt-1 text-sm text-muted">
+            {data ? `${formatDate(data.since)} - ${formatDate(data.until)}` : `Updated ${formatDate(refreshedAt)}`}
+          </p>
+        </div>
+        <div className="flex w-full flex-wrap items-center gap-3 sm:w-auto">
+          <label className="min-w-0 flex-1 sm:w-72 sm:flex-none">
+            <span className="sr-only">Search vote sessions</span>
+            <input
+              className="mb-field h-10"
+              type="search"
+              placeholder="Search sessions"
+              value={query}
+              onChange={(event) => setQuery(event.target.value)}
+            />
+          </label>
+          <button type="button" className="mb-btn mb-btn-ghost h-10" disabled={busy} onClick={() => void loadList()}>
+            {listLoading ? "Refreshing..." : "Refresh"}
+          </button>
+        </div>
+      </div>
+
+      <div className="flex flex-wrap gap-5 border-b border-border py-1" aria-label="Vote session filters">
+        {([
+          ["suspicious", "Suspicious", counts.suspicious],
+          ["all", "All", counts.all],
+          ["restricted", "Restricted", counts.restricted],
+        ] as const).map(([key, label, count]) => (
+          <FilterButton key={key} active={filter === key} onClick={() => setFilter(key)}>
+            {label} <span className="text-xs text-muted">{count.toLocaleString()}</span>
+          </FilterButton>
+        ))}
+      </div>
+
+      <div className="grid gap-8 lg:min-h-0 lg:flex-1 lg:grid-cols-[minmax(16rem,0.85fr)_minmax(0,1.4fr)] lg:overflow-hidden">
+        <section className="min-w-0 lg:flex lg:min-h-0 lg:flex-col" aria-label="Vote sessions">
+          <div className="divide-y divide-border border-b border-border lg:min-h-0 lg:flex-1 lg:overflow-y-auto lg:overscroll-contain lg:pr-2">
+            {listLoading && !data ? <p className="py-8 text-sm text-muted">Loading votes...</p> : null}
+            {sessions.map((session) => (
+              <SessionRow
+                key={session.sessionId}
+                session={session}
+                selected={session.sessionId === selectedSessionId}
+                disabled={pendingAction !== null}
+                onSelect={() => selectSession(session.sessionId)}
+              />
+            ))}
+            {!listLoading && data && sessions.length === 0 ? (
+              <div className="space-y-3 py-8">
+                <p className="text-sm text-muted">No matching sessions.</p>
+                {filter === "suspicious" && counts.all > 0 ? (
+                  <button type="button" className="mb-btn h-10" onClick={() => setFilter("all")}>Show all</button>
+                ) : null}
+              </div>
+            ) : null}
+          </div>
+        </section>
+
+        <section className="min-w-0 lg:flex lg:min-h-0 lg:flex-col" aria-labelledby="arena-vote-detail-title">
+          <div className="flex flex-wrap items-start justify-between gap-4 border-b border-border pb-4">
+            <div className="min-w-0 space-y-1">
+              <h3 id="arena-vote-detail-title" className="truncate text-lg font-semibold text-fg" title={selectedSession?.label ?? undefined}>
+                {selectedSession?.label ?? "Session"}
+              </h3>
+              <p className="max-w-2xl text-sm text-muted">
+                Restricts the account when known, plus recorded browser sessions and IP addresses. Shared IPs can affect other visitors.
+              </p>
+            </div>
+            <div className="flex flex-wrap gap-2">
+              <button type="button" className="mb-btn h-10" disabled={busy || pageVoteIds.length === 0} onClick={togglePage}>
+                {pageSelected ? "Clear page" : "Select page"}
+              </button>
+              <button type="button" className="mb-btn mb-btn-danger h-10" disabled={busy || selectedVoteIds.size === 0} onClick={() => void removeSelectedVotes()}>
+                {pendingAction === "remove" ? "Removing..." : `Remove ${selectedVoteIds.size.toLocaleString()}`}
+              </button>
+              {selectedSession ? (
+                <button
+                  type="button"
+                  className={`mb-btn h-10${selectedSession.blocked ? "" : " mb-btn-danger"}`}
+                  disabled={busy}
+                  onClick={() => void toggleRestriction()}
+                >
+                  {pendingAction === "block" ? "Saving..." : selectedSession.blocked ? "Unblock votes" : "Block votes"}
+                </button>
+              ) : null}
+            </div>
+          </div>
+
+          <div className="grid gap-3 border-b border-border py-4 text-xs sm:grid-cols-2 xl:grid-cols-4">
+            <div className="min-w-0 rounded-md border border-border/60 bg-card/20 p-2.5">
+              <p className="text-muted">Choices</p>
+              <p className="mt-1 font-medium text-fg">
+                A {selectedSession?.choiceA.toLocaleString() ?? 0} · B {selectedSession?.choiceB.toLocaleString() ?? 0}
+              </p>
+              <p className="mt-1 text-muted">
+                Tie {selectedSession?.ties.toLocaleString() ?? 0} · Both bad {selectedSession?.bothBad.toLocaleString() ?? 0}
+              </p>
+            </div>
+            <div className="min-w-0 rounded-md border border-border/60 bg-card/20 p-2.5">
+              <p className="text-muted">Ranking signals</p>
+              <p className="mt-1 font-medium text-fg">
+                {metric(selectedSession?.upsets ?? 0, "upsets")} · {metric(selectedSession?.largeUpsets ?? 0, "large")}
+              </p>
+              <p className="mt-1 text-muted">{metric(selectedSession?.rankedVotes ?? 0, "ranked votes")}</p>
+            </div>
+            <div className="min-w-0 rounded-md border border-border/60 bg-card/20 p-2.5">
+              <p className="text-muted">Pace</p>
+              <p className="mt-1 font-medium text-fg">
+                {metric(selectedSession?.repeatVotes ?? 0, "repeat")} · {metric(selectedSession?.fastVotes ?? 0, "fast")}
+              </p>
+              <p className="mt-1 text-muted">Median {formatGap(selectedSession?.medianGapSeconds ?? null)}</p>
+            </div>
+            <div className="min-w-0 rounded-md border border-border/60 bg-card/20 p-2.5">
+              <p className="text-muted">Network</p>
+              <p className="mt-1 truncate font-medium text-fg" title={selectedSession?.location ?? "Location unavailable"}>
+                {selectedSession?.location ?? "Location unavailable"}
+              </p>
+              <p className="mt-1 truncate text-muted" title={selectedSession?.networkLabel ?? "No network hash"}>
+                {selectedSession?.networkLabel ?? "No network hash"} · {metric(selectedSession?.matchingSessions ?? 0, "matched")}
+              </p>
+            </div>
+          </div>
+
+          <details className="border-b border-border py-3 text-sm text-muted">
+            <summary className="cursor-pointer text-fg">Criteria</summary>
+            <p className="mt-2 max-w-3xl">
+              Flags identify patterns for manual review: 80% lower-ranked picks or three top-versus-bottom-half upsets across at least 10 ranked votes. At 20 votes, rapid voting, repeated matchups, one-sided choices, and frequent rejections can also qualify. No votes are removed automatically.
+            </p>
+            <p className="mt-2 max-w-3xl">
+              Ranks use the current hourly snapshot{data?.rankingAt ? ` from ${formatDate(data.rankingAt)}` : ""}, so they are context, not vote-time proof.
+            </p>
+            <p className="mt-2 max-w-3xl">
+              IP matching uses existing hashes; locations approximate. <a className="font-medium text-fg underline-offset-4 hover:underline focus-visible:outline-none focus-visible:text-accent" href={PRIVACY_POLICY_URL} target="_blank" rel="noreferrer">Privacy policy</a>
+            </p>
+          </details>
+
+          <div className="flex flex-wrap items-center justify-between gap-3 border-b border-border py-3 text-xs text-muted">
+            <p>
+              {votes.length.toLocaleString()} loaded · {selectedVoteIds.size.toLocaleString()} selected
+            </p>
+            <div className="flex flex-wrap gap-2">
+              <button type="button" className="mb-btn mb-btn-ghost h-9 text-xs" disabled={busy || !selectedSessionId || !nextCursor} onClick={() => selectedSessionId && void loadVotes(selectedSessionId, nextCursor, true)}>
+                {votesLoading ? "Loading..." : "Load more"}
+              </button>
+            </div>
+          </div>
+
+          <div className="divide-y divide-border border-b border-border lg:min-h-0 lg:flex-1 lg:overflow-y-auto lg:overscroll-contain lg:pr-2">
+            {votesLoading && votes.length === 0 ? <p className="py-8 text-sm text-muted">Loading history...</p> : null}
+            {!votesLoading && selectedSession && votes.length === 0 ? <p className="py-8 text-sm text-muted">No retained public votes.</p> : null}
+            {!selectedSession ? <p className="py-8 text-sm text-muted">Choose a session.</p> : null}
+            {votes.map((vote) => (
+              <VoteCard
+                key={vote.id}
+                vote={vote}
+                checked={selectedVoteIds.has(vote.id)}
+                disabled={busy}
+                onToggle={() => toggleVote(vote.id)}
+              />
+            ))}
+          </div>
+        </section>
+      </div>
+      {data?.truncated ? <p className="text-xs text-muted">Showing the first 1,000 sessions plus retained restrictions.</p> : null}
+    </section>
+  );
+}

--- a/components/gallery/GalleryAdminDashboard.tsx
+++ b/components/gallery/GalleryAdminDashboard.tsx
@@ -8,6 +8,7 @@ import {
   mutateGalleryAdmin,
 } from "@/app/admin/gallery/actions";
 import { GalleryAdminGenerations } from "@/components/gallery/GalleryAdminGenerations";
+import { ArenaVoteReview } from "@/components/arena/ArenaVoteReview";
 import type {
   getGalleryAdminDashboard,
   getGalleryAdminPerson,
@@ -18,6 +19,7 @@ type Person = Awaited<ReturnType<typeof getGalleryAdminPerson>>;
 type PromptFilter = "latest" | "reported" | "hidden" | "selected";
 type PeopleFilter = "online" | "all" | "suspended";
 type Mutation =
+  | { type: "generation_published"; publicId: string }
   | { type: "candidate_hidden"; publicId: string; hidden: boolean }
   | { type: "example_hidden"; exampleId: string }
   | { type: "candidate_selected"; publicId: string; selected: boolean }
@@ -382,7 +384,7 @@ function PersonInspector({
 
 export function GalleryAdminDashboard({ dashboard }: { dashboard: Dashboard }) {
   const router = useRouter();
-  const [view, setView] = useState<"generations" | "prompts">("generations");
+  const [view, setView] = useState<"generations" | "prompts" | "votes">("generations");
   const [generationOwner, setGenerationOwner] = useState<{ id: string; label: string } | null>(null);
   const [promptFilter, setPromptFilter] = useState<PromptFilter>("latest");
   const [peopleFilter, setPeopleFilter] = useState<PeopleFilter>("online");
@@ -396,6 +398,17 @@ export function GalleryAdminDashboard({ dashboard }: { dashboard: Dashboard }) {
   const [suspendTarget, setSuspendTarget] = useState<{ userId: string; email: string } | null>(null);
   const [refreshing, startTransition] = useTransition();
   const personRequest = useRef(0);
+
+  useEffect(() => {
+    const desktop = window.matchMedia("(min-width: 1024px)");
+    const update = () => document.body.classList.toggle("mb-page-fixed", desktop.matches);
+    update();
+    desktop.addEventListener("change", update);
+    return () => {
+      desktop.removeEventListener("change", update);
+      document.body.classList.remove("mb-page-fixed");
+    };
+  }, []);
 
   useEffect(() => {
     const interval = window.setInterval(() => {
@@ -475,6 +488,7 @@ export function GalleryAdminDashboard({ dashboard }: { dashboard: Dashboard }) {
         <div className="flex min-w-0 flex-wrap items-center gap-x-5" aria-label="Admin views">
           <FilterButton active={view === "generations"} onClick={() => { setView("generations"); setGenerationOwner(null); }}>Generations</FilterButton>
           <FilterButton active={view === "prompts"} onClick={() => setView("prompts")}>Prompts</FilterButton>
+          <FilterButton active={view === "votes"} onClick={() => setView("votes")}>Votes</FilterButton>
           {view === "generations" && generationOwner ? <button type="button" className="max-w-48 truncate text-xs text-muted hover:text-fg" title="Show all generations" onClick={() => setGenerationOwner(null)}>{generationOwner.label} · Clear</button> : null}
         </div>
         <div className="flex items-center gap-4">
@@ -490,8 +504,8 @@ export function GalleryAdminDashboard({ dashboard }: { dashboard: Dashboard }) {
           </button>
         </div>
       </div>
-      <div className="grid items-start gap-8 lg:h-[max(36rem,calc(100dvh-22rem))] lg:grid-cols-[minmax(0,1.5fr)_minmax(0,1fr)] xl:grid-cols-[minmax(0,1.7fr)_minmax(0,1fr)]">
-        {view === "generations" ? <GalleryAdminGenerations ownerId={generationOwner?.id} refreshedAt={dashboard.refreshedAt} /> : (
+      {view === "votes" ? <ArenaVoteReview refreshedAt={dashboard.refreshedAt} /> : <div className="grid items-start gap-8 lg:min-h-0 lg:flex-1 lg:grid-cols-[minmax(0,1.5fr)_minmax(0,1fr)] xl:grid-cols-[minmax(0,1.7fr)_minmax(0,1fr)]">
+        {view === "generations" ? <GalleryAdminGenerations ownerId={generationOwner?.id} refreshedAt={dashboard.refreshedAt} onPublish={(publicId) => mutate({ type: "generation_published", publicId })} /> : (
         <section className="min-w-0 lg:flex lg:h-full lg:min-h-0 lg:flex-col" aria-labelledby="admin-prompts-title">
           <div className="flex flex-wrap items-end justify-between gap-5 border-b border-border pb-4">
             <div>
@@ -653,7 +667,7 @@ export function GalleryAdminDashboard({ dashboard }: { dashboard: Dashboard }) {
             </div>
           </section>
         </aside>
-      </div>
+      </div>}
 
       <SuspendDialog
         target={suspendTarget}

--- a/components/gallery/GalleryAdminGenerations.tsx
+++ b/components/gallery/GalleryAdminGenerations.tsx
@@ -8,7 +8,15 @@ import type { listAdminGenerations } from "@/lib/generations/service";
 type Page = Awaited<ReturnType<typeof listAdminGenerations>>;
 const dateTime = new Intl.DateTimeFormat("en-US", { dateStyle: "medium", timeStyle: "short" });
 
-export function GalleryAdminGenerations({ ownerId, refreshedAt }: { ownerId?: string; refreshedAt?: string }) {
+export function GalleryAdminGenerations({
+  ownerId,
+  refreshedAt,
+  onPublish,
+}: {
+  ownerId?: string;
+  refreshedAt?: string;
+  onPublish: (publicId: string) => Promise<boolean>;
+}) {
   const [page, setPage] = useState<Page>({ items: [], nextCursor: null });
   const [query, setQuery] = useState("");
   const [active, setActive] = useState(false);
@@ -16,6 +24,9 @@ export function GalleryAdminGenerations({ ownerId, refreshedAt }: { ownerId?: st
   const [pageCount, setPageCount] = useState(1);
   const [error, setError] = useState<string | null>(null);
   const [selected, setSelected] = useState<Page["items"][number] | null>(null);
+  const [previewedIds, setPreviewedIds] = useState<Set<string>>(() => new Set());
+  const [publishingId, setPublishingId] = useState<string | null>(null);
+  const [publishMessage, setPublishMessage] = useState<{ id: string; text: string } | null>(null);
   const [reload, setReload] = useState(0);
   const params = new URLSearchParams({ query, active: String(active), ...(ownerId ? { ownerId } : {}) }).toString();
 
@@ -58,6 +69,35 @@ export function GalleryAdminGenerations({ ownerId, refreshedAt }: { ownerId?: st
     return () => window.clearInterval(interval);
   }, []);
 
+  function viewGeneration(generation: Page["items"][number]) {
+    if (generation.canPublish) {
+      setPreviewedIds((current) => new Set(current).add(generation.id));
+    }
+    setSelected(generation);
+  }
+
+  async function publishGeneration(generation: Page["items"][number]) {
+    if (!window.confirm("Publish this build anonymously to Gallery? Confirm the prompt and build contain no personal or sensitive information.")) return;
+    setPublishingId(generation.id);
+    setPublishMessage(null);
+    try {
+      const ok = await onPublish(generation.id);
+      if (!ok) throw new Error("Build could not be published.");
+      setPage((current) => ({
+        ...current,
+        items: current.items.map((item) =>
+          item.id === generation.id ? { ...item, published: true, canPublish: false } : item
+        ),
+      }));
+      setPublishMessage({ id: generation.id, text: "Published anonymously." });
+      setReload((value) => value + 1);
+    } catch {
+      setPublishMessage({ id: generation.id, text: "Build could not be published." });
+    } finally {
+      setPublishingId(null);
+    }
+  }
+
 
   return (
     <section className="flex min-h-0 min-w-0 flex-1 flex-col lg:h-full" aria-label="Generations" aria-busy={loading}>
@@ -80,7 +120,14 @@ export function GalleryAdminGenerations({ ownerId, refreshedAt }: { ownerId?: st
           <article key={generation.id} className="space-y-2 py-4">
             <div className="flex flex-wrap items-start justify-between gap-3">
               <p className="min-w-0 flex-1 whitespace-pre-wrap break-words text-sm font-medium text-fg [overflow-wrap:anywhere]">{generation.prompt}</p>
-              {generation.viewerUrl ? <button type="button" className="mb-btn h-9 shrink-0 text-xs" onClick={() => setSelected(generation)}>View build</button> : null}
+              <div className="flex shrink-0 flex-wrap gap-2">
+                {generation.viewerUrl ? <button type="button" className="mb-btn h-9 text-xs" onClick={() => viewGeneration(generation)}>View build</button> : null}
+                {generation.canPublish && previewedIds.has(generation.id) ? (
+                  <button type="button" disabled={publishingId === generation.id} className="mb-btn mb-btn-primary h-9 text-xs" onClick={() => void publishGeneration(generation)}>
+                    {publishingId === generation.id ? "Publishing…" : "Publish anonymously"}
+                  </button>
+                ) : null}
+              </div>
             </div>
             <p className="break-all text-xs text-muted">{generation.owner?.email ?? "Guest"}{generation.owner?.publicNickname ? ` · ${generation.owner.publicNickname}` : ""}</p>
             <div className="flex flex-wrap gap-x-3 gap-y-1 text-xs text-muted">
@@ -93,6 +140,7 @@ export function GalleryAdminGenerations({ ownerId, refreshedAt }: { ownerId?: st
               <time dateTime={generation.createdAt}>{dateTime.format(new Date(generation.createdAt))}</time>
             </div>
             {generation.error ? <p className="break-words text-xs text-danger">{generation.error.message}</p> : null}
+            {publishMessage?.id === generation.id ? <p role="status" className="text-xs text-muted">{publishMessage.text}</p> : null}
           </article>
         ))}
         {page.items.length === 0 ? <p className="py-8 text-sm text-muted">{loading ? "Loading generations…" : "No matching generations"}</p> : null}

--- a/components/gallery/GalleryDetail.tsx
+++ b/components/gallery/GalleryDetail.tsx
@@ -244,6 +244,27 @@ export function GalleryDetail({ candidate }: { candidate: GalleryDetailPayload }
     }
   }
 
+  async function removeExample(exampleId: string) {
+    if (!window.confirm("Remove this build from Gallery? Your saved generation will remain.")) return;
+    setRemoving(true);
+    setActionError(null);
+    try {
+      const response = await fetch(`/api/gallery/candidates/${encodeURIComponent(candidate.id)}/examples`, {
+        method: "DELETE",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ exampleId }),
+      });
+      if (!response.ok) throw new Error("Build could not be removed");
+      setExamples((current) => current.filter((example) => example.id !== exampleId));
+      setSelectedIds((current) => current.filter((id) => id !== exampleId));
+      router.refresh();
+    } catch {
+      setActionError("Build could not be removed");
+    } finally {
+      setRemoving(false);
+    }
+  }
+
   async function loadMoreExamples() {
     if (!nextExamplesCursor || loadingMore) return;
     setLoadingMore(true);
@@ -625,6 +646,7 @@ export function GalleryDetail({ candidate }: { candidate: GalleryDetailPayload }
       )}
 
       <footer className="mt-8 flex flex-wrap items-center gap-5 text-sm text-muted sm:mt-10">
+        {selected?.canRemove ? <button type="button" disabled={removing} className="min-h-11 transition-colors hover:text-danger disabled:opacity-65 motion-reduce:transition-none" onClick={() => void removeExample(selected.id)}>{removing ? "Removing…" : "Remove build"}</button> : null}
         {candidate.canRemove ? <button type="button" disabled={removing} className="min-h-11 transition-colors hover:text-danger disabled:opacity-65 motion-reduce:transition-none" onClick={() => void removeCandidate()}>{removing ? "Removing…" : "Remove prompt"}</button> : null}
         <button type="button" className="min-h-11 transition-colors hover:text-fg motion-reduce:transition-none" onClick={() => setReportOpen(true)}>Report</button>
       </footer>

--- a/components/leaderboard/LeaderboardEfficiency.tsx
+++ b/components/leaderboard/LeaderboardEfficiency.tsx
@@ -231,7 +231,7 @@ export function LeaderboardEfficiency({ models, modelQuery }: {
       </div>
       <details className="mt-3 text-sm text-muted">
         <summary className="min-h-11 cursor-pointer py-3 font-medium text-fg focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent">Methodology</summary>
-        <div className="max-w-[85ch] space-y-3 pb-3 leading-relaxed">
+        <div className="space-y-3 pb-3 leading-relaxed">
           <p>A model is on the Pareto frontier when no included model has an equal or higher rating with equal or lower resource use, with at least one strict improvement. The frontier follows point estimates; overlapping confidence intervals can mean the differences are uncertain.</p>
           <p>Per-score values divide average resource use by the observed prompt score on a 0–100 scale: wins count as 1, ties as 0.5, and losses as 0, averaged equally over prompts with at least two votes. Both-bad votes are excluded. These ratios depend on sampled opponents and prompts; they describe the evidence rather than replace the rating.</p>
           <p>Cost is recorded cohort expenditure divided by finalized builds, including retries where recorded. Timing uses complete tracked cohorts or documented historical measurements. Block averages require complete public build coverage. Estimates are marked; missing measurements are omitted. New data follows the leaderboard’s regular refresh.</p>

--- a/docs/gallery.md
+++ b/docs/gallery.md
@@ -7,8 +7,12 @@ Gallery is MineBench's public collection of community prompts and builds.
 - Sign in to submit prompts and keep generated builds in your account
 - Add a saved build to Gallery publicly or anonymously
 
-Saved builds remain private until their owner adds them to Gallery. Gallery
-votes and examples are separate from Arena rankings and benchmark results.
+Saved builds remain outside Gallery until their owner publishes them or an admin
+reviews and publishes them anonymously. The original owner keeps control and can
+remove the example from Gallery. Admins should review the prompt and build for
+personal or sensitive content before publishing; anonymous attribution only hides
+the contributor name. Gallery votes and examples are separate from Arena rankings
+and benchmark results.
 MineBench reviews the highest-voted prompt proposals and can promote them into
 the official benchmark; votes guide that editorial decision rather than
 changing the benchmark automatically.
@@ -18,3 +22,22 @@ Each example keeps its original run date, so the Gallery can show later retests
 and run-to-run variation without replacing the canonical benchmark build.
 
 See [Architecture](./architecture.md) for the data and generation flow.
+
+## Admin vote review
+
+The Votes view summarizes public Arena sessions over the last 24 hours, with
+Suspicious, All, and Restricted filters. Selecting a session loads its full public
+vote history in pages of 100. Flags identify repeated rapid voting, one-sided
+choices, repeated matchups, frequent rejections, and ranking upsets for manual
+review. Ranking comparisons use the latest hourly snapshot, not vote-time ranks;
+a flag is not evidence of abuse by itself.
+
+Admins can remove explicitly selected votes and block the account when known,
+plus its recorded sessions and IPs. Anonymous restrictions use the browser
+session and its last recorded IP. IP matching uses existing HMAC hashes and retained approximate
+locations; it does not expose raw IPs or add device fingerprinting. Shared IP
+restrictions can affect other visitors.
+
+Removal updates public vote counters, processed coverage, and public leaderboard
+inputs atomically. Pending vote jobs are removed without decrementing unapplied
+counters. Historical Glicko state used for matchup selection is not replayed.

--- a/lib/arena/voteModeration.ts
+++ b/lib/arena/voteModeration.ts
@@ -1,0 +1,245 @@
+import { Prisma } from "@prisma/client";
+import { ARENA_COVERAGE_LOCK_KEY, ARENA_VOTE_JOB_DRAIN_LOCK_KEY } from "@/lib/arena/advisoryLocks";
+import { invalidateArenaCoverageCache } from "@/lib/arena/coverage";
+import { invalidateArenaStatsCache } from "@/lib/arena/stats";
+import { GalleryServiceError, requireMineBenchAdmin } from "@/lib/gallery/service";
+import { prisma } from "@/lib/prisma";
+import { PUBLIC_SESSION_RETENTION_MS } from "@/lib/publicPresence";
+import { hashVoteSession } from "@/lib/voteBlock";
+
+const MAX_VOTE_IDS = 1_000;
+const MAX_TEXT_ID_LENGTH = 191;
+const VALID_CHOICES = new Set(["A", "B", "TIE", "BOTH_BAD"]);
+
+type SelectedVoteRow = { id: string; sessionId: string; choice: string; stealthVariantId: string | null };
+type MutationCountRow = { expected: number; updated: number };
+
+function fail(code: string, message: string): never {
+  throw new GalleryServiceError(code, message);
+}
+
+function validateVoteRemovalInput(adminId: string, sessionId: string, voteIds: string[]): string[] {
+  if (!adminId) fail("forbidden", "MineBench admin access required.");
+  if (!sessionId || sessionId.length > MAX_TEXT_ID_LENGTH) fail("invalid_request", "Vote session is required.");
+  if (!Array.isArray(voteIds) || voteIds.length === 0) fail("invalid_request", "Select at least one arena vote to remove.");
+  if (voteIds.length > MAX_VOTE_IDS) fail("invalid_request", `Remove at most ${MAX_VOTE_IDS} arena votes at a time.`);
+
+  const seen = new Set<string>();
+  for (const id of voteIds) {
+    if (typeof id !== "string" || id.length === 0 || id.length > MAX_TEXT_ID_LENGTH) {
+      fail("invalid_request", "Vote IDs must be nonempty strings.");
+    }
+    if (seen.has(id)) fail("invalid_request", "Vote IDs must be unique.");
+    seen.add(id);
+  }
+  return [...voteIds];
+}
+
+function assertValidSelection(rows: SelectedVoteRow[], voteIds: string[], sessionId: string) {
+  const found = new Set(rows.map((row) => row.id));
+  if (
+    rows.length !== voteIds.length ||
+    voteIds.some((id) => !found.has(id)) ||
+    rows.some((row) => row.sessionId !== sessionId || row.stealthVariantId)
+  ) {
+    fail("not_found", "Vote selection does not match the reviewed public session.");
+  }
+  if (rows.some((row) => !VALID_CHOICES.has(row.choice))) {
+    fail("invalid_request", "Unsupported arena vote choice.");
+  }
+}
+
+async function assertMutation(tx: Prisma.TransactionClient, sql: Prisma.Sql, message: string) {
+  const [result] = await tx.$queryRaw<MutationCountRow[]>(sql);
+  if (Number(result?.updated ?? 0) !== Number(result?.expected ?? 0)) fail("conflict", message);
+}
+
+async function lockReviewedVotes(tx: Prisma.TransactionClient, idList: Prisma.Sql, voteIds: string[], sessionId: string) {
+  const rows = await tx.$queryRaw<SelectedVoteRow[]>(Prisma.sql`
+    SELECT vote.id, vote."sessionId", vote.choice, matchup."stealthVariantId"
+    FROM "Vote" vote
+    INNER JOIN "Matchup" matchup ON matchup.id = vote."matchupId"
+    WHERE vote.id IN (${idList})
+    ORDER BY vote.id ASC
+    FOR UPDATE OF vote, matchup
+  `);
+  assertValidSelection(rows, voteIds, sessionId);
+
+  await tx.$queryRaw<Array<{ id: string }>>(Prisma.sql`
+    SELECT job.id
+    FROM "ArenaVoteJob" job
+    WHERE job."voteId" IN (${idList})
+    ORDER BY job.id ASC
+    FOR UPDATE OF job
+  `);
+}
+
+async function reverseAppliedCounters(tx: Prisma.TransactionClient, idList: Prisma.Sql) {
+  await assertMutation(
+    tx,
+    Prisma.sql`
+      WITH applied_votes AS (
+        SELECT vote.choice, matchup."modelAId", matchup."modelBId"
+        FROM "Vote" vote
+        INNER JOIN "Matchup" matchup ON matchup.id = vote."matchupId"
+        LEFT JOIN "ArenaVoteJob" job ON job."voteId" = vote.id
+        WHERE vote.id IN (${idList}) AND (job.id IS NULL OR job."processedAt" IS NOT NULL)
+      ),
+      counter_deltas AS (
+        SELECT "modelId", SUM("win")::int AS "winCount", SUM("loss")::int AS "lossCount",
+          SUM("draw")::int AS "drawCount", SUM("bothBad")::int AS "bothBadCount"
+        FROM (
+          SELECT "modelAId" AS "modelId", (choice = 'A')::int AS "win", (choice = 'B')::int AS "loss",
+            (choice = 'TIE')::int AS "draw", (choice = 'BOTH_BAD')::int AS "bothBad"
+          FROM applied_votes
+          UNION ALL
+          SELECT "modelBId" AS "modelId", (choice = 'B')::int AS "win", (choice = 'A')::int AS "loss",
+            (choice = 'TIE')::int AS "draw", (choice = 'BOTH_BAD')::int AS "bothBad"
+          FROM applied_votes
+        ) rows GROUP BY "modelId"
+        HAVING SUM("win" + "loss" + "draw" + "bothBad") > 0
+      ),
+      updated AS (
+        UPDATE "Model" AS model
+        SET "winCount" = model."winCount" - delta."winCount", "lossCount" = model."lossCount" - delta."lossCount",
+          "drawCount" = model."drawCount" - delta."drawCount", "bothBadCount" = model."bothBadCount" - delta."bothBadCount",
+          "updatedAt" = CURRENT_TIMESTAMP
+        FROM counter_deltas delta
+        WHERE model.id = delta."modelId" AND model."winCount" >= delta."winCount"
+          AND model."lossCount" >= delta."lossCount" AND model."drawCount" >= delta."drawCount"
+          AND model."bothBadCount" >= delta."bothBadCount"
+        RETURNING 1
+      )
+      SELECT (SELECT COUNT(*)::int FROM counter_deltas) AS expected,
+        (SELECT COUNT(*)::int FROM updated) AS updated
+    `,
+    "Arena vote counters are lower than the applied removal.",
+  );
+}
+
+async function reverseAppliedCoverage(tx: Prisma.TransactionClient, idList: Prisma.Sql) {
+  await assertMutation(
+    tx,
+    Prisma.sql`
+      WITH decisive_votes AS (
+        SELECT matchup."promptId", matchup."modelAId", matchup."modelBId"
+        FROM "Vote" vote
+        INNER JOIN "Matchup" matchup ON matchup.id = vote."matchupId"
+        LEFT JOIN "ArenaVoteJob" job ON job."voteId" = vote.id
+        WHERE vote.id IN (${idList}) AND vote.choice IN ('A', 'B')
+          AND (job.id IS NULL OR job."processedAt" IS NOT NULL)
+      ),
+      model_prompt_deltas AS (
+        SELECT "modelId", "promptId", COUNT(*)::int AS count
+        FROM (
+          SELECT "modelAId" AS "modelId", "promptId" FROM decisive_votes
+          UNION ALL SELECT "modelBId" AS "modelId", "promptId" FROM decisive_votes
+        ) rows GROUP BY "modelId", "promptId"
+      ),
+      pair_deltas AS (
+        SELECT LEAST("modelAId", "modelBId") AS "modelLowId", GREATEST("modelAId", "modelBId") AS "modelHighId",
+          COUNT(*)::int AS count FROM decisive_votes GROUP BY 1, 2
+      ),
+      pair_prompt_deltas AS (
+        SELECT LEAST("modelAId", "modelBId") AS "modelLowId", GREATEST("modelAId", "modelBId") AS "modelHighId",
+          "promptId", COUNT(*)::int AS count FROM decisive_votes GROUP BY 1, 2, "promptId"
+      ),
+      updated_model_prompt AS (
+        UPDATE "ArenaCoverageModelPrompt" AS coverage
+        SET "decisiveVotes" = coverage."decisiveVotes" - delta.count
+        FROM model_prompt_deltas delta
+        WHERE coverage."modelId" = delta."modelId" AND coverage."promptId" = delta."promptId"
+          AND coverage."decisiveVotes" > delta.count
+        RETURNING 1
+      ),
+      deleted_zero_model_prompt AS (
+        DELETE FROM "ArenaCoverageModelPrompt" coverage
+        USING model_prompt_deltas delta
+        WHERE coverage."modelId" = delta."modelId" AND coverage."promptId" = delta."promptId"
+          AND coverage."decisiveVotes" = delta.count
+        RETURNING 1
+      ),
+      updated_pair AS (
+        UPDATE "ArenaCoveragePair" AS coverage
+        SET "decisiveVotes" = coverage."decisiveVotes" - delta.count
+        FROM pair_deltas delta
+        WHERE coverage."modelLowId" = delta."modelLowId" AND coverage."modelHighId" = delta."modelHighId"
+          AND coverage."decisiveVotes" > delta.count
+        RETURNING 1
+      ),
+      deleted_zero_pair AS (
+        DELETE FROM "ArenaCoveragePair" coverage
+        USING pair_deltas delta
+        WHERE coverage."modelLowId" = delta."modelLowId" AND coverage."modelHighId" = delta."modelHighId"
+          AND coverage."decisiveVotes" = delta.count
+        RETURNING 1
+      ),
+      updated_pair_prompt AS (
+        UPDATE "ArenaCoveragePairPrompt" AS coverage
+        SET "decisiveVotes" = coverage."decisiveVotes" - delta.count
+        FROM pair_prompt_deltas delta
+        WHERE coverage."modelLowId" = delta."modelLowId" AND coverage."modelHighId" = delta."modelHighId"
+          AND coverage."promptId" = delta."promptId"
+          AND coverage."decisiveVotes" > delta.count
+        RETURNING 1
+      ),
+      deleted_zero_pair_prompt AS (
+        DELETE FROM "ArenaCoveragePairPrompt" coverage
+        USING pair_prompt_deltas delta
+        WHERE coverage."modelLowId" = delta."modelLowId" AND coverage."modelHighId" = delta."modelHighId"
+          AND coverage."promptId" = delta."promptId"
+          AND coverage."decisiveVotes" = delta.count
+        RETURNING 1
+      )
+      SELECT (
+          (SELECT COUNT(*) FROM model_prompt_deltas) + (SELECT COUNT(*) FROM pair_deltas) +
+          (SELECT COUNT(*) FROM pair_prompt_deltas)
+        )::int AS expected,
+        (
+          (SELECT COUNT(*) FROM updated_model_prompt) + (SELECT COUNT(*) FROM deleted_zero_model_prompt) +
+          (SELECT COUNT(*) FROM updated_pair) + (SELECT COUNT(*) FROM deleted_zero_pair) +
+          (SELECT COUNT(*) FROM updated_pair_prompt) + (SELECT COUNT(*) FROM deleted_zero_pair_prompt)
+        )::int AS updated
+    `,
+    "Arena coverage is lower than the applied removal.",
+  );
+}
+
+export async function removePublicArenaVotes(adminId: string, sessionId: string, voteIds: string[]): Promise<{ removed: number }> {
+  const reviewedVoteIds = validateVoteRemovalInput(adminId, sessionId, voteIds);
+  await requireMineBenchAdmin(adminId);
+
+  const idList = Prisma.join(reviewedVoteIds);
+  const sessionHash = hashVoteSession(sessionId);
+  const removed = await prisma.$transaction(async (tx) => {
+    await tx.$executeRaw`SELECT pg_advisory_xact_lock(${ARENA_COVERAGE_LOCK_KEY})`;
+    await tx.$executeRaw`SELECT pg_advisory_xact_lock(${ARENA_VOTE_JOB_DRAIN_LOCK_KEY})`;
+    await lockReviewedVotes(tx, idList, reviewedVoteIds, sessionId);
+    await reverseAppliedCounters(tx, idList);
+    await reverseAppliedCoverage(tx, idList);
+
+    await tx.galleryModerationRecord.create({
+      data: {
+        kind: "ADMIN_ACTION",
+        target: "VOTE_BLOCK",
+        action: "arena_votes_removed",
+        actorUserId: adminId,
+        sessionHash,
+        note: `Removed ${reviewedVoteIds.length} public arena vote${reviewedVoteIds.length === 1 ? "" : "s"}.`,
+        safeSnapshot: { voteIds: reviewedVoteIds, removed: reviewedVoteIds.length },
+        purgeAt: new Date(Date.now() + PUBLIC_SESSION_RETENTION_MS),
+      },
+    });
+
+    const deleted = await tx.vote.deleteMany({ where: { id: { in: reviewedVoteIds } } });
+    if (deleted.count !== reviewedVoteIds.length) fail("conflict", "Vote selection changed during removal.");
+
+    const remainingJobs = await tx.arenaVoteJob.count({ where: { voteId: { in: reviewedVoteIds } } });
+    if (remainingJobs !== 0) fail("conflict", "Arena vote jobs were not removed.");
+    return deleted.count;
+  }, { maxWait: 5_000, timeout: 15_000 });
+
+  invalidateArenaCoverageCache();
+  invalidateArenaStatsCache();
+  return { removed };
+}

--- a/lib/arena/voteReview.ts
+++ b/lib/arena/voteReview.ts
@@ -1,0 +1,213 @@
+import { Prisma } from "@prisma/client";
+import { prisma } from "@/lib/prisma";
+import { createVoteBlock, hashVoteSession, reverseVoteBlock } from "@/lib/voteBlock";
+import { GalleryServiceError, requireMineBenchAdmin, setGalleryPersonVoteBlocked } from "@/lib/gallery/service";
+import { PUBLIC_SESSION_RETENTION_MS } from "@/lib/publicPresence";
+
+const SESSION_LIMIT = 1000;
+const PAGE_SIZE = 100;
+
+export type VoteReviewSession = {
+  sessionId: string;
+  label: string;
+  location: string | null;
+  lastVoteAt: string | null;
+  votes: number;
+  choiceA: number;
+  choiceB: number;
+  ties: number;
+  bothBad: number;
+  medianGapSeconds: number | null;
+  fastVotes: number;
+  repeatVotes: number;
+  rankedVotes: number;
+  upsets: number;
+  largeUpsets: number;
+  flags: string[];
+  blocked: boolean;
+  networkLabel: string | null;
+  matchingSessions: number;
+};
+export type VoteReviewData = {
+  sessions: VoteReviewSession[];
+  since: string;
+  until: string;
+  rankingAt: string | null;
+  truncated: boolean;
+};
+export type VoteReviewCursor = { id: string; createdAt: string };
+export type VoteReviewPage = {
+  votes: Array<{
+    id: string;
+    createdAt: string;
+    prompt: string;
+    modelA: string;
+    modelB: string;
+    rankA: number | null;
+    rankB: number | null;
+    choice: string;
+  }>;
+  nextCursor: VoteReviewCursor | null;
+};
+
+type Metrics = Pick<VoteReviewSession, "votes" | "choiceA" | "choiceB" | "bothBad" | "fastVotes" | "repeatVotes" | "rankedVotes" | "upsets" | "largeUpsets">;
+
+export function voteReviewFlags(row: Metrics): string[] {
+  const flags: string[] = [];
+  const decisive = row.choiceA + row.choiceB;
+  if (row.votes >= 20 && row.fastVotes >= (row.votes - 1) / 2) flags.push("Rapid voting");
+  if (decisive >= 20 && Math.max(row.choiceA, row.choiceB) / decisive >= 0.9) flags.push("One-sided voting");
+  if (row.rankedVotes >= 10 && row.upsets / row.rankedVotes >= 0.8) flags.push("Repeated ranking upsets");
+  if (row.rankedVotes >= 10 && row.largeUpsets >= 3) flags.push("Large ranking upsets");
+  if (row.votes >= 20 && row.bothBad >= 10 && row.bothBad / row.votes >= 0.4) flags.push("Frequent rejections");
+  if (row.votes >= 20 && row.repeatVotes / row.votes >= 0.5) flags.push("Repeated matchups");
+  return flags;
+}
+
+function checkSession(sessionId: string) {
+  if (!sessionId || sessionId.length > 191) throw new GalleryServiceError("invalid", "Invalid session.");
+}
+
+async function latestRanks() {
+  const latest = await prisma.modelRankSnapshot.findFirst({
+    where: { capturedAt: { lte: new Date() } }, orderBy: { capturedAt: "desc" }, select: { capturedAt: true },
+  });
+  const ranks = latest ? await prisma.modelRankSnapshot.findMany({
+    where: { capturedAt: latest.capturedAt }, select: { modelId: true, rank: true },
+  }) : [];
+  return { capturedAt: latest?.capturedAt ?? null, ranks: new Map(ranks.map(row => [row.modelId, row.rank])) };
+}
+
+export async function getArenaVoteReview(adminId: string): Promise<VoteReviewData> {
+  await requireMineBenchAdmin(adminId);
+  const now = new Date();
+  const since = new Date(now.getTime() - 24 * 60 * 60 * 1000);
+  const retainedSince = new Date(now.getTime() - PUBLIC_SESSION_RETENTION_MS);
+  const ranking = await latestRanks();
+  type Summary = Metrics & { sessionId: string; userId: string | null; lastVoteAt: Date | null; ties: number; medianGapSeconds: number | null };
+  const [rows, blocks] = await Promise.all([
+    prisma.$queryRaw<Summary[]>(Prisma.sql`
+      WITH ranks AS (
+        SELECT "modelId", rank FROM "ModelRankSnapshot" WHERE "capturedAt" = (${ranking.capturedAt}::timestamptz AT TIME ZONE 'UTC')
+      ), votes AS (
+        SELECT v.*, m."buildAId", m."buildBId", a.rank AS rank_a, b.rank AS rank_b,
+          EXTRACT(EPOCH FROM v."createdAt" - LAG(v."createdAt") OVER (
+            PARTITION BY v."sessionId" ORDER BY v."createdAt", v.id
+          ))::double precision AS gap
+        FROM "Vote" v JOIN "Matchup" m ON m.id = v."matchupId"
+        LEFT JOIN ranks a ON a."modelId" = m."modelAId"
+        LEFT JOIN ranks b ON b."modelId" = m."modelBId"
+        WHERE v."createdAt" >= (${since}::timestamptz AT TIME ZONE 'UTC')
+          AND v."createdAt" <= (${now}::timestamptz AT TIME ZONE 'UTC') AND m."stealthVariantId" IS NULL
+      )
+      SELECT "sessionId", MAX("userId"::text) AS "userId", MAX("createdAt") AS "lastVoteAt",
+        COUNT(*)::int AS votes,
+        COUNT(*) FILTER (WHERE choice = 'A')::int AS "choiceA",
+        COUNT(*) FILTER (WHERE choice = 'B')::int AS "choiceB",
+        COUNT(*) FILTER (WHERE choice = 'TIE')::int AS ties,
+        COUNT(*) FILTER (WHERE choice = 'BOTH_BAD')::int AS "bothBad",
+        PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY gap) AS "medianGapSeconds",
+        COUNT(*) FILTER (WHERE gap < 2)::int AS "fastVotes",
+        (COUNT(*) - COUNT(DISTINCT (LEAST("buildAId", "buildBId"), GREATEST("buildAId", "buildBId"))))::int AS "repeatVotes",
+        COUNT(*) FILTER (WHERE choice IN ('A', 'B') AND rank_a IS NOT NULL AND rank_b IS NOT NULL)::int AS "rankedVotes",
+        COUNT(*) FILTER (WHERE (choice = 'A' AND rank_a > rank_b) OR (choice = 'B' AND rank_b > rank_a))::int AS upsets,
+        COUNT(*) FILTER (WHERE
+          (choice = 'A' AND rank_b <= ${Math.max(1, Math.floor(ranking.ranks.size * 0.15))} AND rank_a > ${ranking.ranks.size / 2}) OR
+          (choice = 'B' AND rank_a <= ${Math.max(1, Math.floor(ranking.ranks.size * 0.15))} AND rank_b > ${ranking.ranks.size / 2})
+        )::int AS "largeUpsets"
+      FROM votes GROUP BY "sessionId" ORDER BY votes DESC, "sessionId" LIMIT ${SESSION_LIMIT + 1}
+    `),
+    prisma.galleryVoteBlock.findMany({ where: { reversedAt: null }, select: { userId: true, sessionHash: true, ipHmac: true } }),
+  ]);
+  const ipBlocks = blocks.flatMap(block => block.ipHmac ? [block.ipHmac] : []);
+  const sessions = await prisma.publicSessionActivity.findMany({
+    where: { lastSeenAt: { gte: retainedSince }, OR: [
+      { sessionId: { in: rows.slice(0, SESSION_LIMIT).map(row => row.sessionId) } },
+      ...(ipBlocks.length ? [{ ipHmac: { in: ipBlocks } }] : []),
+    ] },
+    orderBy: { lastSeenAt: "desc" }, take: SESSION_LIMIT + 1,
+    select: { sessionId: true, ipHmac: true, city: true, countryRegion: true, country: true },
+  });
+  const ips = [...new Set(sessions.flatMap(session => session.ipHmac ? [session.ipHmac] : []))];
+  const [networks, accounts] = await Promise.all([
+    prisma.publicSessionActivity.groupBy({ by: ["ipHmac"], where: { ipHmac: { in: ips }, lastSeenAt: { gte: retainedSince } }, _count: { _all: true } }),
+    prisma.user.findMany({ where: { id: { in: rows.flatMap(row => row.userId ? [row.userId] : []) } }, select: { id: true, publicNickname: true, email: true } }),
+  ]);
+  const presence = new Map(sessions.map(session => [session.sessionId, session]));
+  const networkCounts = new Map(networks.map(network => [network.ipHmac, network._count._all]));
+  const labels = new Map(accounts.map(account => [account.id, account.publicNickname ?? account.email]));
+  const blockedSessions = new Set(blocks.map(block => block.sessionHash));
+  const blockedIps = new Set(ipBlocks);
+  const blockedUsers = new Set(blocks.map(block => block.userId).filter(Boolean));
+  const summaries = new Map(rows.slice(0, SESSION_LIMIT).map(row => [row.sessionId, row]));
+  // keep restricted visitors visible after their votes are removed
+  for (const session of sessions) {
+    if (!summaries.has(session.sessionId) && session.ipHmac && blockedIps.has(session.ipHmac)) {
+      summaries.set(session.sessionId, { sessionId: session.sessionId, userId: null, lastVoteAt: null,
+        votes: 0, choiceA: 0, choiceB: 0, ties: 0, bothBad: 0, medianGapSeconds: null,
+        fastVotes: 0, repeatVotes: 0, rankedVotes: 0, upsets: 0, largeUpsets: 0 });
+    }
+  }
+  return {
+    since: since.toISOString(), until: now.toISOString(), rankingAt: ranking.capturedAt?.toISOString() ?? null,
+    truncated: rows.length > SESSION_LIMIT || sessions.length > SESSION_LIMIT,
+    sessions: [...summaries.values()].map(row => {
+      const session = presence.get(row.sessionId);
+      const sessionHash = hashVoteSession(row.sessionId)!;
+      const ip = session?.ipHmac;
+      return { ...row, lastVoteAt: row.lastVoteAt?.toISOString() ?? null,
+        label: (row.userId && labels.get(row.userId)) || `Guest ${sessionHash.slice(0, 6).toUpperCase()}`,
+        location: session ? [session.city, session.countryRegion, session.country].filter(Boolean).join(", ") || null : null,
+        networkLabel: ip ? `IP ${ip.slice(0, 8).toUpperCase()}` : null,
+        matchingSessions: ip ? networkCounts.get(ip) ?? 0 : 0,
+        blocked: blockedSessions.has(sessionHash) || Boolean(ip && blockedIps.has(ip)) || Boolean(row.userId && blockedUsers.has(row.userId)),
+        flags: voteReviewFlags(row),
+      };
+    }),
+  };
+}
+
+export async function getArenaVotePage(adminId: string, sessionId: string, cursor?: VoteReviewCursor): Promise<VoteReviewPage> {
+  await requireMineBenchAdmin(adminId);
+  checkSession(sessionId);
+  if (cursor && (!cursor.id || cursor.id.length > 191 || !Number.isFinite(Date.parse(cursor.createdAt)))) {
+    throw new GalleryServiceError("invalid", "Invalid vote cursor.");
+  }
+  const [votes, ranking] = await Promise.all([
+    prisma.vote.findMany({
+      where: { sessionId, matchup: { stealthVariantId: null }, ...(cursor ? { OR: [
+        { createdAt: { lt: new Date(cursor.createdAt) } },
+        { createdAt: new Date(cursor.createdAt), id: { lt: cursor.id } },
+      ] } : {}) },
+      orderBy: [{ createdAt: "desc" }, { id: "desc" }], take: PAGE_SIZE + 1,
+      select: { id: true, createdAt: true, choice: true, matchup: { select: {
+        prompt: { select: { text: true } }, modelA: { select: { id: true, displayName: true } }, modelB: { select: { id: true, displayName: true } },
+      } } },
+    }), latestRanks(),
+  ]);
+  const page = votes.slice(0, PAGE_SIZE);
+  const last = page.at(-1);
+  return {
+    votes: page.map(vote => ({ id: vote.id, createdAt: vote.createdAt.toISOString(), choice: vote.choice,
+      prompt: vote.matchup.prompt.text, modelA: vote.matchup.modelA.displayName, modelB: vote.matchup.modelB.displayName,
+      rankA: ranking.ranks.get(vote.matchup.modelA.id) ?? null, rankB: ranking.ranks.get(vote.matchup.modelB.id) ?? null })),
+    nextCursor: votes.length > PAGE_SIZE && last ? { id: last.id, createdAt: last.createdAt.toISOString() } : null,
+  };
+}
+
+export async function setArenaVoteSessionBlocked(adminId: string, sessionId: string, blocked: boolean) {
+  await requireMineBenchAdmin(adminId);
+  checkSession(sessionId);
+  const vote = await prisma.vote.findFirst({
+    where: { sessionId, userId: { not: null }, matchup: { stealthVariantId: null } },
+    orderBy: { createdAt: "desc" }, select: { userId: true },
+  });
+  if (vote?.userId) return setGalleryPersonVoteBlocked(adminId, `user:${vote.userId}`, blocked);
+  const presence = await prisma.publicSessionActivity.findUnique({ where: { sessionId }, select: { id: true } });
+  if (presence) return setGalleryPersonVoteBlocked(adminId, `session:${presence.id}`, blocked);
+  const sessionHash = hashVoteSession(sessionId)!;
+  const existing = await prisma.galleryVoteBlock.findMany({ where: { sessionHash, reversedAt: null }, select: { id: true } });
+  if (blocked && existing.length === 0) await createVoteBlock(adminId, { sessionId });
+  if (!blocked) for (const block of existing) await reverseVoteBlock(adminId, block.id);
+  return { blocked };
+}

--- a/lib/arena/voteReview.ts
+++ b/lib/arena/voteReview.ts
@@ -120,30 +120,40 @@ export async function getArenaVoteReview(adminId: string): Promise<VoteReviewDat
     prisma.galleryVoteBlock.findMany({ where: { reversedAt: null }, select: { userId: true, sessionHash: true, ipHmac: true } }),
   ]);
   const ipBlocks = blocks.flatMap(block => block.ipHmac ? [block.ipHmac] : []);
+  const blockedSessions = new Set(blocks.flatMap(block => block.sessionHash ? [block.sessionHash] : []));
+  const blockedUsers = new Set(blocks.flatMap(block => block.userId ? [block.userId] : []));
+  // ponytail: scan retained session IDs for hash matches until volume warrants an indexed hash
+  const blockedSessionIds = blockedSessions.size ? (await prisma.publicSessionActivity.findMany({
+    where: { lastSeenAt: { gte: retainedSince } }, select: { sessionId: true },
+  })).filter(session => blockedSessions.has(hashVoteSession(session.sessionId)!)).map(session => session.sessionId) : [];
+
   const sessions = await prisma.publicSessionActivity.findMany({
     where: { lastSeenAt: { gte: retainedSince }, OR: [
-      { sessionId: { in: rows.slice(0, SESSION_LIMIT).map(row => row.sessionId) } },
+      { sessionId: { in: [...rows.slice(0, SESSION_LIMIT).map(row => row.sessionId), ...blockedSessionIds] } },
+      ...(blockedUsers.size ? [{ userId: { in: [...blockedUsers] } }] : []),
       ...(ipBlocks.length ? [{ ipHmac: { in: ipBlocks } }] : []),
     ] },
     orderBy: { lastSeenAt: "desc" }, take: SESSION_LIMIT + 1,
-    select: { sessionId: true, ipHmac: true, city: true, countryRegion: true, country: true },
+    select: { sessionId: true, userId: true, ipHmac: true, city: true, countryRegion: true, country: true },
   });
   const ips = [...new Set(sessions.flatMap(session => session.ipHmac ? [session.ipHmac] : []))];
   const [networks, accounts] = await Promise.all([
     prisma.publicSessionActivity.groupBy({ by: ["ipHmac"], where: { ipHmac: { in: ips }, lastSeenAt: { gte: retainedSince } }, _count: { _all: true } }),
-    prisma.user.findMany({ where: { id: { in: rows.flatMap(row => row.userId ? [row.userId] : []) } }, select: { id: true, publicNickname: true, email: true } }),
+    prisma.user.findMany({ where: { id: { in: [...rows, ...sessions].flatMap(row => row.userId ? [row.userId] : []) } }, select: { id: true, publicNickname: true, email: true } }),
   ]);
   const presence = new Map(sessions.map(session => [session.sessionId, session]));
   const networkCounts = new Map(networks.map(network => [network.ipHmac, network._count._all]));
   const labels = new Map(accounts.map(account => [account.id, account.publicNickname ?? account.email]));
-  const blockedSessions = new Set(blocks.map(block => block.sessionHash));
   const blockedIps = new Set(ipBlocks);
-  const blockedUsers = new Set(blocks.map(block => block.userId).filter(Boolean));
   const summaries = new Map(rows.slice(0, SESSION_LIMIT).map(row => [row.sessionId, row]));
   // keep restricted visitors visible after their votes are removed
   for (const session of sessions) {
-    if (!summaries.has(session.sessionId) && session.ipHmac && blockedIps.has(session.ipHmac)) {
-      summaries.set(session.sessionId, { sessionId: session.sessionId, userId: null, lastVoteAt: null,
+    if (!summaries.has(session.sessionId) && (
+      blockedSessions.has(hashVoteSession(session.sessionId)!) ||
+      Boolean(session.userId && blockedUsers.has(session.userId)) ||
+      Boolean(session.ipHmac && blockedIps.has(session.ipHmac))
+    )) {
+      summaries.set(session.sessionId, { sessionId: session.sessionId, userId: session.userId, lastVoteAt: null,
         votes: 0, choiceA: 0, choiceB: 0, ties: 0, bothBad: 0, medianGapSeconds: null,
         fastVotes: 0, repeatVotes: 0, rankedVotes: 0, upsets: 0, largeUpsets: 0 });
     }
@@ -155,12 +165,13 @@ export async function getArenaVoteReview(adminId: string): Promise<VoteReviewDat
       const session = presence.get(row.sessionId);
       const sessionHash = hashVoteSession(row.sessionId)!;
       const ip = session?.ipHmac;
+      const userId = row.userId ?? session?.userId;
       return { ...row, lastVoteAt: row.lastVoteAt?.toISOString() ?? null,
-        label: (row.userId && labels.get(row.userId)) || `Guest ${sessionHash.slice(0, 6).toUpperCase()}`,
+        label: (userId && labels.get(userId)) || `Guest ${sessionHash.slice(0, 6).toUpperCase()}`,
         location: session ? [session.city, session.countryRegion, session.country].filter(Boolean).join(", ") || null : null,
         networkLabel: ip ? `IP ${ip.slice(0, 8).toUpperCase()}` : null,
         matchingSessions: ip ? networkCounts.get(ip) ?? 0 : 0,
-        blocked: blockedSessions.has(sessionHash) || Boolean(ip && blockedIps.has(ip)) || Boolean(row.userId && blockedUsers.has(row.userId)),
+        blocked: blockedSessions.has(sessionHash) || Boolean(ip && blockedIps.has(ip)) || Boolean(userId && blockedUsers.has(userId)),
         flags: voteReviewFlags(row),
       };
     }),
@@ -203,8 +214,8 @@ export async function setArenaVoteSessionBlocked(adminId: string, sessionId: str
     orderBy: { createdAt: "desc" }, select: { userId: true },
   });
   if (vote?.userId) return setGalleryPersonVoteBlocked(adminId, `user:${vote.userId}`, blocked);
-  const presence = await prisma.publicSessionActivity.findUnique({ where: { sessionId }, select: { id: true } });
-  if (presence) return setGalleryPersonVoteBlocked(adminId, `session:${presence.id}`, blocked);
+  const presence = await prisma.publicSessionActivity.findUnique({ where: { sessionId }, select: { id: true, userId: true } });
+  if (presence) return setGalleryPersonVoteBlocked(adminId, presence.userId ? `user:${presence.userId}` : `session:${presence.id}`, blocked);
   const sessionHash = hashVoteSession(sessionId)!;
   const existing = await prisma.galleryVoteBlock.findMany({ where: { sessionHash, reversedAt: null }, select: { id: true } });
   if (blocked && existing.length === 0) await createVoteBlock(adminId, { sessionId });

--- a/lib/gallery/service.ts
+++ b/lib/gallery/service.ts
@@ -106,6 +106,7 @@ const galleryModelSelect = {
 
 const exampleSelect = {
   id: true,
+  contributorId: true,
   candidateId: true,
   createdAt: true,
   postAnonymously: true,
@@ -163,10 +164,11 @@ function publicGalleryModel(model: GalleryModelRow) {
   };
 }
 
-function publicExample(example: ExampleRow) {
+function publicExample(example: ExampleRow, viewerUserId?: string | null) {
   const kinds = new Set(example.customBuild.artifacts.map((artifact) => artifact.kind));
   return {
     id: example.id,
+    canRemove: Boolean(viewerUserId && example.contributorId === viewerUserId),
     buildId: example.customBuild.publicId,
     attribution: galleryAttribution({
       postAnonymously: example.postAnonymously,
@@ -223,8 +225,8 @@ function publicCandidate(
     ),
     publishedAt: candidate.publishedAt.toISOString(),
     exampleCount,
-    cover: cover ? publicExample(cover) : null,
-    alternate: alternate ? publicExample(alternate) : null,
+    cover: cover ? publicExample(cover, viewerUserId) : null,
+    alternate: alternate ? publicExample(alternate, viewerUserId) : null,
     modelLabels,
     matchedModelLabels: [...new Set(matchedModels.map((model) => publicGalleryModel(model).label))],
   };
@@ -461,7 +463,7 @@ export async function getGalleryCandidate(
     ...publicCandidate(candidate, cover, exampleCount, Boolean(upvoted), options.userId),
     examples: [options.examplesCursor ? null : cover, ...page]
       .filter((value): value is ExampleRow => Boolean(value))
-      .map(publicExample),
+      .map((example) => publicExample(example, options.userId)),
     nextExamplesCursor: additional.length > limit && last
       ? encodeGalleryCursor({ score: 0, publishedAt: last.createdAt, id: last.id })
       : null,
@@ -704,6 +706,25 @@ export async function addGalleryExample(
       });
     }
     return { ...example, created };
+  });
+}
+
+export async function removeGalleryExample(userId: string, candidatePublicId: string, exampleId: string) {
+  const now = new Date();
+  const purgeAt = new Date(now.getTime() + RETENTION_MS);
+  return prisma.$transaction(async (tx) => {
+    const example = await tx.galleryExample.findFirst({
+      where: { id: exampleId, contributorId: userId, removedAt: null, candidate: { publicId: candidatePublicId } },
+      select: { id: true, candidateId: true },
+    });
+    if (!example) throw new GalleryServiceError("not_found", "Gallery build not found.");
+    await tx.galleryExample.update({ where: { id: example.id }, data: { removedAt: now, purgeAt } });
+    await tx.galleryModerationRecord.create({ data: {
+      kind: "ADMIN_ACTION", target: "EXAMPLE", action: "user_removed",
+      actorUserId: userId, subjectUserId: userId,
+      candidateId: example.candidateId, exampleId: example.id, purgeAt,
+    } });
+    return { removed: true };
   });
 }
 

--- a/lib/generations/service.ts
+++ b/lib/generations/service.ts
@@ -19,9 +19,18 @@ import { redactSensitiveText } from "@/lib/custom-builds/sanitize";
 import { deleteCustomBuildArtifact } from "@/lib/custom-builds/storage";
 import { resolveSavedGenerationModel } from "@/lib/generations/model";
 import { prisma } from "@/lib/prisma";
-import { publicCandidateWhere, publicExampleWhere, requireMineBenchAdmin } from "@/lib/gallery/service";
+import {
+  addGalleryExample,
+  GalleryServiceError,
+  publicCandidateWhere,
+  publicExampleWhere,
+  requireMineBenchAdmin,
+  submitGalleryCandidate,
+} from "@/lib/gallery/service";
+import { normalizeGalleryPrompt, publicGalleryTextError } from "@/lib/gallery/policy";
 
 const STORAGE_FAILSAFE_BYTES = 1024 * 1024 * 1024;
+const GALLERY_AUDIT_RETENTION_MS = 30 * 24 * 60 * 60 * 1000;
 const SECRET_TTL_MS = 24 * 60 * 60 * 1000;
 const GENERATE_JOB_MAX_ATTEMPTS = 2;
 const HOSTED_GEMINI_MODEL_KEY = "gemini_3_8_flash";
@@ -428,8 +437,9 @@ export async function listAdminGenerations(
     },
     select: {
       ...generationSelect,
-      owner: { select: { id: true, email: true, publicNickname: true } },
+      owner: { select: { id: true, email: true, publicNickname: true, gallerySuspendedAt: true } },
       galleryExamples: { where: { ...publicExampleWhere, candidate: publicCandidateWhere }, select: { id: true } },
+      _count: { select: { galleryExamples: true } },
     },
     orderBy: [{ createdAt: "desc" }, { id: "desc" }],
     take: limit + 1,
@@ -446,12 +456,132 @@ export async function listAdminGenerations(
         thumbnailUrl: generation.thumbnailUrl ? artifactUrl("thumbnail") : null,
         viewerUrl: generation.viewerUrl ? artifactUrl("viewer") : null,
         downloadUrl: generation.downloadUrl ? artifactUrl("download") : null,
-        owner: row.owner,
+        owner: row.owner ? {
+          id: row.owner.id,
+          email: row.owner.email,
+          publicNickname: row.owner.publicNickname,
+        } : null,
         published: row.galleryExamples.length > 0,
+        canPublish: Boolean(
+          row.owner &&
+          !row.owner.gallerySuspendedAt &&
+          generation.status === "succeeded" &&
+          generation.viewerUrl &&
+          row._count.galleryExamples === 0
+        ),
       };
     }),
     nextCursor: rows.length > limit && last ? encodeCursor({ createdAt: last.createdAt, id: last.id }) : null,
   };
+}
+
+export async function publishAdminGeneration(adminId: string, publicId: string) {
+  await requireMineBenchAdmin(adminId);
+  const now = new Date();
+  const purgeAt = new Date(now.getTime() + GALLERY_AUDIT_RETENTION_MS);
+  const build = await prisma.customBuild.findUnique({
+    where: { publicId },
+    select: {
+      id: true,
+      ownerId: true,
+      status: true,
+      removedAt: true,
+      objectsDeletedAt: true,
+      promptText: true,
+      modelKind: true,
+      modelDisplayName: true,
+      modelId: true,
+      owner: { select: { gallerySuspendedAt: true } },
+      artifacts: { where: { kind: "build_json" }, select: { id: true }, take: 1 },
+      galleryExamples: {
+        select: {
+          id: true,
+          removedAt: true,
+          adminHiddenAt: true,
+          candidate: {
+            select: {
+              publicId: true,
+              removedAt: true,
+              adminHiddenAt: true,
+              selectedAt: true,
+              uploader: { select: { gallerySuspendedAt: true } },
+            },
+          },
+        },
+      },
+    },
+  });
+  if (!build) throw new GalleryServiceError("not_found", "Saved generation not found.");
+  if (
+    !build.ownerId ||
+    build.status !== "succeeded" ||
+    build.removedAt ||
+    build.objectsDeletedAt ||
+    build.owner?.gallerySuspendedAt ||
+    build.artifacts.length === 0
+  ) {
+    throw new GalleryServiceError("generation_not_available", "Saved generation not available.");
+  }
+
+  for (const example of build.galleryExamples) {
+    const publicExample = !example.removedAt &&
+      !example.adminHiddenAt &&
+      !example.candidate.removedAt &&
+      !example.candidate.adminHiddenAt &&
+      (example.candidate.selectedAt || !example.candidate.uploader.gallerySuspendedAt);
+    if (publicExample) {
+      return { created: false, candidateId: example.candidate.publicId, exampleId: example.id };
+    }
+  }
+  if (build.galleryExamples.length > 0) {
+    throw new GalleryServiceError("generation_not_available", "Saved generation not available.");
+  }
+
+  const prompt = normalizeGalleryPrompt(build.promptText);
+  if (!prompt || prompt.length > 800) {
+    throw new GalleryServiceError("invalid_prompt", "Enter a prompt to submit.");
+  }
+  if (publicGalleryTextError(prompt)) {
+    throw new GalleryServiceError("prompt_rejected", "This prompt can't be submitted. Try a different prompt.");
+  }
+  if (
+    build.modelKind === "custom" &&
+    publicGalleryTextError(`${build.modelDisplayName} ${build.modelId}`)
+  ) {
+    throw new GalleryServiceError("model_label_rejected", "Choose a different public model label.");
+  }
+
+  const submission = await submitGalleryCandidate(build.ownerId, {
+    generationId: publicId,
+    postAnonymously: true,
+  });
+  const example = await addGalleryExample(build.ownerId, submission.candidate.id, {
+    generationId: publicId,
+    postAnonymously: true,
+  });
+  const changed = submission.created || example.created;
+  if (changed) {
+    await prisma.galleryModerationRecord.create({
+      data: {
+        kind: "ADMIN_ACTION",
+        target: "EXAMPLE",
+        action: "generation_published",
+        actorUserId: adminId,
+        subjectUserId: build.ownerId,
+        candidateId: (await prisma.galleryCandidate.findUniqueOrThrow({
+          where: { publicId: submission.candidate.id },
+          select: { id: true },
+        })).id,
+        exampleId: example.id,
+        safeSnapshot: {
+          prompt,
+          model: build.modelDisplayName,
+        },
+        purgeAt,
+      },
+    });
+  }
+  return { created: changed, candidateId: submission.candidate.id, exampleId: example.id };
 }
 
 export async function getAdminGenerationArtifact(

--- a/tests/integration/arena/vote-moderation.test.ts
+++ b/tests/integration/arena/vote-moderation.test.ts
@@ -1,0 +1,363 @@
+import assert from "node:assert/strict";
+import { randomUUID } from "node:crypto";
+import { PrismaClient } from "@prisma/client";
+import { GalleryServiceError } from "../../../lib/gallery/service";
+import { hashVoteSession } from "../../../lib/voteBlock";
+import { removePublicArenaVotes } from "../../../lib/arena/voteModeration";
+
+const db = new PrismaClient();
+
+type ArenaPair = Awaited<ReturnType<typeof createArenaPair>>;
+type JobState = "processed" | "pending" | "none";
+
+function orderedPair(modelAId: string, modelBId: string): [string, string] {
+  return modelAId < modelBId ? [modelAId, modelBId] : [modelBId, modelAId];
+}
+
+function serviceError(code: string, message: RegExp) {
+  return (error: unknown) =>
+    error instanceof GalleryServiceError && error.code === code && message.test(error.message);
+}
+
+async function createArenaPair(suffix: string, label: string) {
+  const prompt = await db.prompt.create({
+    data: { text: `Vote moderation ${label} ${suffix}`, active: true },
+  });
+  const modelA = await db.model.create({
+    data: {
+      key: `vote-mod-${label}-a-${suffix}`,
+      provider: "Test",
+      modelId: `vote-mod-${label}-a-${suffix}`,
+      displayName: `Vote Mod ${label} A`,
+    },
+  });
+  const modelB = await db.model.create({
+    data: {
+      key: `vote-mod-${label}-b-${suffix}`,
+      provider: "Test",
+      modelId: `vote-mod-${label}-b-${suffix}`,
+      displayName: `Vote Mod ${label} B`,
+    },
+  });
+  const buildA = await db.build.create({
+    data: {
+      promptId: prompt.id,
+      modelId: modelA.id,
+      gridSize: 256,
+      palette: "simple",
+      mode: "precise",
+      blockCount: 1,
+      generationTimeMs: 1,
+    },
+  });
+  const buildB = await db.build.create({
+    data: {
+      promptId: prompt.id,
+      modelId: modelB.id,
+      gridSize: 256,
+      palette: "simple",
+      mode: "precise",
+      blockCount: 1,
+      generationTimeMs: 1,
+    },
+  });
+  return { prompt, modelA, modelB, buildA, buildB };
+}
+
+async function createVote(
+  pair: ArenaPair,
+  sessionId: string,
+  choice: "A" | "B" | "TIE" | "BOTH_BAD",
+  jobState: JobState,
+  stealthVariantId?: string,
+) {
+  const matchup = await db.matchup.create({
+    data: {
+      promptId: pair.prompt.id,
+      modelAId: pair.modelA.id,
+      modelBId: pair.modelB.id,
+      buildAId: pair.buildA.id,
+      buildBId: pair.buildB.id,
+      stealthVariantId,
+    },
+  });
+  const vote = await db.vote.create({
+    data: { matchupId: matchup.id, sessionId, choice },
+  });
+  const job = jobState === "none"
+    ? null
+    : await db.arenaVoteJob.create({
+        data: {
+          voteId: vote.id,
+          matchupId: matchup.id,
+          promptId: pair.prompt.id,
+          modelAId: pair.modelA.id,
+          modelBId: pair.modelB.id,
+          choice,
+          processedAt: jobState === "processed" ? new Date() : null,
+          stealthVariantId,
+        },
+      });
+  return { matchup, vote, job };
+}
+
+async function seedCoverage(pair: ArenaPair, decisiveVotes: number) {
+  const [modelLowId, modelHighId] = orderedPair(pair.modelA.id, pair.modelB.id);
+  await db.arenaCoverageModelPrompt.createMany({
+    data: [
+      { modelId: pair.modelA.id, promptId: pair.prompt.id, decisiveVotes },
+      { modelId: pair.modelB.id, promptId: pair.prompt.id, decisiveVotes },
+    ],
+  });
+  await db.arenaCoveragePair.create({
+    data: { modelLowId, modelHighId, decisiveVotes },
+  });
+  await db.arenaCoveragePairPrompt.create({
+    data: { modelLowId, modelHighId, promptId: pair.prompt.id, decisiveVotes },
+  });
+}
+
+async function readCounts(pair: ArenaPair) {
+  const [modelA, modelB] = await Promise.all([
+    db.model.findUniqueOrThrow({ where: { id: pair.modelA.id } }),
+    db.model.findUniqueOrThrow({ where: { id: pair.modelB.id } }),
+  ]);
+  return {
+    a: {
+      shownCount: modelA.shownCount,
+      winCount: modelA.winCount,
+      lossCount: modelA.lossCount,
+      drawCount: modelA.drawCount,
+      bothBadCount: modelA.bothBadCount,
+    },
+    b: {
+      shownCount: modelB.shownCount,
+      winCount: modelB.winCount,
+      lossCount: modelB.lossCount,
+      drawCount: modelB.drawCount,
+      bothBadCount: modelB.bothBadCount,
+    },
+  };
+}
+
+async function readCoverage(pair: ArenaPair) {
+  const [modelLowId, modelHighId] = orderedPair(pair.modelA.id, pair.modelB.id);
+  const [modelA, modelB, pairRow, pairPrompt] = await Promise.all([
+    db.arenaCoverageModelPrompt.findUnique({
+      where: { modelId_promptId: { modelId: pair.modelA.id, promptId: pair.prompt.id } },
+    }),
+    db.arenaCoverageModelPrompt.findUnique({
+      where: { modelId_promptId: { modelId: pair.modelB.id, promptId: pair.prompt.id } },
+    }),
+    db.arenaCoveragePair.findUnique({
+      where: { modelLowId_modelHighId: { modelLowId, modelHighId } },
+    }),
+    db.arenaCoveragePairPrompt.findUnique({
+      where: {
+        modelLowId_modelHighId_promptId: { modelLowId, modelHighId, promptId: pair.prompt.id },
+      },
+    }),
+  ]);
+  return {
+    modelA: modelA?.decisiveVotes ?? 0,
+    modelB: modelB?.decisiveVotes ?? 0,
+    pair: pairRow?.decisiveVotes ?? 0,
+    pairPrompt: pairPrompt?.decisiveVotes ?? 0,
+  };
+}
+
+async function auditCount() {
+  return db.galleryModerationRecord.count({ where: { action: "arena_votes_removed" } });
+}
+
+async function main() {
+  if (!process.env.MINEBENCH_TEST_SCHEMA) {
+    console.log("arena vote moderation PostgreSQL checks require pnpm test:integration");
+    return;
+  }
+  const previousVoteSecret = process.env.VOTE_BLOCK_HMAC_SECRET;
+  process.env.VOTE_BLOCK_HMAC_SECRET = "vote-moderation-test-secret";
+  const suffix = randomUUID().replaceAll("-", "").slice(0, 12);
+  const adminId = randomUUID();
+  const memberId = randomUUID();
+  const sessionId = `vote-mod-session-${suffix}`;
+  const otherSessionId = `vote-mod-other-${suffix}`;
+
+  try {
+    await db.user.createMany({
+      data: [
+        { id: adminId, email: `vote-mod-admin-${suffix}@example.test`, isMineBenchAdmin: true },
+        { id: memberId, email: `vote-mod-member-${suffix}@example.test` },
+      ],
+    });
+
+    const blockedPair = await createArenaPair(suffix, "blocked");
+    const blockedVote = await createVote(blockedPair, sessionId, "A", "pending");
+    await assert.rejects(
+      () => removePublicArenaVotes(memberId, sessionId, [blockedVote.vote.id]),
+      serviceError("forbidden", /MineBench admin access required/),
+    );
+    assert.equal(await db.vote.count({ where: { id: blockedVote.vote.id } }), 1);
+    assert.equal(await auditCount(), 0);
+
+    const rollbackPair = await createArenaPair(suffix, "rollback");
+    const rollbackVote = await createVote(rollbackPair, sessionId, "A", "processed");
+    const wrongSessionVote = await createVote(rollbackPair, otherSessionId, "B", "processed");
+    await db.model.update({
+      where: { id: rollbackPair.modelA.id },
+      data: { winCount: 1, lossCount: 1 },
+    });
+    await db.model.update({
+      where: { id: rollbackPair.modelB.id },
+      data: { winCount: 1, lossCount: 1 },
+    });
+    await seedCoverage(rollbackPair, 2);
+    await assert.rejects(
+      () => removePublicArenaVotes(adminId, sessionId, [rollbackVote.vote.id, wrongSessionVote.vote.id]),
+      serviceError("not_found", /reviewed public session/),
+    );
+    assert.equal(await db.vote.count({ where: { id: { in: [rollbackVote.vote.id, wrongSessionVote.vote.id] } } }), 2);
+    assert.deepEqual(await readCoverage(rollbackPair), { modelA: 2, modelB: 2, pair: 2, pairPrompt: 2 });
+    assert.equal(await auditCount(), 0);
+
+    const privatePair = await createArenaPair(suffix, "private");
+    const organization = await db.organization.create({
+      data: { slug: `vote-mod-${suffix}`, name: "Vote moderation" },
+    });
+    const experiment = await db.stealthExperiment.create({
+      data: {
+        organizationId: organization.id,
+        slug: `vote-mod-${suffix}`,
+        name: "Vote moderation",
+        status: "ACTIVE",
+      },
+    });
+    const variant = await db.stealthVariant.create({
+      data: {
+        experimentId: experiment.id,
+        codename: "Private",
+        status: "ACTIVE",
+        modelId: privatePair.modelB.id,
+        winCount: 3,
+      },
+    });
+    const publicBeforePrivate = await createVote(privatePair, sessionId, "A", "pending");
+    const privateVote = await createVote(privatePair, sessionId, "B", "processed", variant.id);
+    await assert.rejects(
+      () => removePublicArenaVotes(adminId, sessionId, [publicBeforePrivate.vote.id, privateVote.vote.id]),
+      serviceError("not_found", /reviewed public session/),
+    );
+    assert.equal(await db.vote.count({ where: { id: { in: [publicBeforePrivate.vote.id, privateVote.vote.id] } } }), 2);
+    assert.equal((await db.stealthVariant.findUniqueOrThrow({ where: { id: variant.id } })).winCount, 3);
+    assert.equal(await auditCount(), 0);
+
+    await assert.rejects(
+      () => removePublicArenaVotes(adminId, sessionId, [publicBeforePrivate.vote.id, `missing-${suffix}`]),
+      serviceError("not_found", /reviewed public session/),
+    );
+    assert.equal(await db.vote.count({ where: { id: publicBeforePrivate.vote.id } }), 1);
+    assert.equal(await auditCount(), 0);
+
+    const undercountPair = await createArenaPair(suffix, "undercount");
+    const undercountVote = await createVote(undercountPair, sessionId, "A", "processed");
+    await db.model.update({
+      where: { id: undercountPair.modelA.id },
+      data: { winCount: 1 },
+    });
+    await db.model.update({
+      where: { id: undercountPair.modelB.id },
+      data: { lossCount: 1 },
+    });
+    await assert.rejects(
+      () => removePublicArenaVotes(adminId, sessionId, [undercountVote.vote.id]),
+      serviceError("conflict", /Arena coverage is lower/),
+    );
+    assert.equal(await db.vote.count({ where: { id: undercountVote.vote.id } }), 1);
+    assert.deepEqual((await readCounts(undercountPair)).a, {
+      shownCount: 0,
+      winCount: 1,
+      lossCount: 0,
+      drawCount: 0,
+      bothBadCount: 0,
+    });
+    assert.equal(await auditCount(), 0);
+
+    const removalPair = await createArenaPair(suffix, "remove");
+    const selectedA = await createVote(removalPair, sessionId, "A", "processed");
+    const selectedBNoJob = await createVote(removalPair, sessionId, "B", "none");
+    const selectedTie = await createVote(removalPair, sessionId, "TIE", "processed");
+    const selectedBothBad = await createVote(removalPair, sessionId, "BOTH_BAD", "processed");
+    const selectedPending = await createVote(removalPair, sessionId, "A", "pending");
+    const retained = await createVote(removalPair, otherSessionId, "A", "processed");
+    await db.model.update({
+      where: { id: removalPair.modelA.id },
+      data: { shownCount: 10, winCount: 2, lossCount: 1, drawCount: 1, bothBadCount: 1 },
+    });
+    await db.model.update({
+      where: { id: removalPair.modelB.id },
+      data: { shownCount: 20, winCount: 1, lossCount: 2, drawCount: 1, bothBadCount: 1 },
+    });
+    await seedCoverage(removalPair, 3);
+    const selectedVoteIds = [
+      selectedA.vote.id,
+      selectedBNoJob.vote.id,
+      selectedTie.vote.id,
+      selectedBothBad.vote.id,
+      selectedPending.vote.id,
+    ];
+
+    assert.deepEqual(
+      await removePublicArenaVotes(adminId, sessionId, selectedVoteIds),
+      { removed: selectedVoteIds.length },
+    );
+    assert.equal(await db.vote.count({ where: { id: { in: selectedVoteIds } } }), 0);
+    assert.equal(await db.vote.count({ where: { id: retained.vote.id } }), 1);
+    assert.equal(await db.arenaVoteJob.count({ where: { voteId: { in: selectedVoteIds } } }), 0);
+    assert.equal(await db.arenaVoteJob.count({ where: { voteId: retained.vote.id } }), 1);
+    assert.equal(
+      await db.matchup.count({
+        where: {
+          id: {
+            in: [
+              selectedA.matchup.id,
+              selectedBNoJob.matchup.id,
+              selectedTie.matchup.id,
+              selectedBothBad.matchup.id,
+              selectedPending.matchup.id,
+            ],
+          },
+        },
+      }),
+      selectedVoteIds.length,
+    );
+    assert.deepEqual(await readCounts(removalPair), {
+      a: { shownCount: 10, winCount: 1, lossCount: 0, drawCount: 0, bothBadCount: 0 },
+      b: { shownCount: 20, winCount: 0, lossCount: 1, drawCount: 0, bothBadCount: 0 },
+    });
+    assert.deepEqual(await readCoverage(removalPair), { modelA: 1, modelB: 1, pair: 1, pairPrompt: 1 });
+
+    const audit = await db.galleryModerationRecord.findFirstOrThrow({
+      where: { action: "arena_votes_removed" },
+      orderBy: { createdAt: "desc" },
+    });
+    assert.equal(await auditCount(), 1);
+    assert.equal(audit.kind, "ADMIN_ACTION");
+    assert.equal(audit.target, "VOTE_BLOCK");
+    assert.equal(audit.actorUserId, adminId);
+    assert.equal(audit.sessionHash, hashVoteSession(sessionId));
+    assert.match(audit.note ?? "", new RegExp(String(selectedVoteIds.length)));
+    assert.deepEqual(audit.safeSnapshot, { voteIds: selectedVoteIds, removed: selectedVoteIds.length });
+    assert.ok(audit.purgeAt);
+
+    console.log("arena vote moderation checks passed");
+  } finally {
+    if (previousVoteSecret === undefined) delete process.env.VOTE_BLOCK_HMAC_SECRET;
+    else process.env.VOTE_BLOCK_HMAC_SECRET = previousVoteSecret;
+    await db.$disconnect();
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/tests/integration/arena/vote-moderation.test.ts
+++ b/tests/integration/arena/vote-moderation.test.ts
@@ -353,7 +353,17 @@ async function main() {
   } finally {
     if (previousVoteSecret === undefined) delete process.env.VOTE_BLOCK_HMAC_SECRET;
     else process.env.VOTE_BLOCK_HMAC_SECRET = previousVoteSecret;
-    await db.$disconnect();
+    try {
+      const prompt = { text: { startsWith: "Vote moderation ", endsWith: suffix } };
+      await db.matchup.deleteMany({ where: { prompt } });
+      await db.prompt.deleteMany({ where: prompt });
+      await db.organization.deleteMany({ where: { slug: `vote-mod-${suffix}` } });
+      await db.model.deleteMany({ where: { key: { startsWith: "vote-mod-", endsWith: suffix } } });
+      await db.galleryModerationRecord.deleteMany({ where: { actorUserId: adminId } });
+      await db.user.deleteMany({ where: { id: { in: [adminId, memberId] } } });
+    } finally {
+      await db.$disconnect();
+    }
   }
 }
 

--- a/tests/integration/arena/vote-review.test.ts
+++ b/tests/integration/arena/vote-review.test.ts
@@ -1,0 +1,94 @@
+import assert from "node:assert/strict";
+import { randomUUID } from "node:crypto";
+import { PrismaClient } from "@prisma/client";
+
+async function main() {
+  if (!process.env.MINEBENCH_TEST_SCHEMA) return;
+  const db = new PrismaClient();
+  const { getArenaVoteReview, getArenaVotePage, setArenaVoteSessionBlocked } = await import("../../../lib/arena/voteReview");
+  const { hashVoteSession } = await import("../../../lib/voteBlock");
+  const adminId = randomUUID(), memberId = randomUUID(), suffix = randomUUID();
+  const sessionId = `review-${suffix}`, peerSession = `review-peer-${suffix}`;
+  const oldBlockedSession = `review-restricted-${suffix}`;
+  const now = new Date();
+  const capturedAt = new Date(now.getTime() - 60_000);
+  try {
+    await db.user.createMany({ data: [
+      { id: adminId, email: `${adminId}@example.test`, isMineBenchAdmin: true },
+      { id: memberId, email: `${memberId}@example.test` },
+    ] });
+    await assert.rejects(() => getArenaVoteReview(memberId), /admin access/);
+    await assert.rejects(() => getArenaVotePage(memberId, sessionId), /admin access/);
+    await assert.rejects(() => setArenaVoteSessionBlocked(memberId, sessionId, true), /admin access/);
+    const models = await Promise.all(Array.from({ length: 8 }, (_, i) => db.model.create({ data: {
+      key: `review-${suffix}-${i}`, provider: "test", modelId: `review-${i}`, displayName: `Review ${i}`,
+      rankSnapshots: { create: { capturedAt, rank: i + 1, rankScore: 1500 - i, confidence: 80 } },
+    } })));
+    const prompt = await db.prompt.create({ data: { text: `Review ${suffix}` } });
+    const builds = await Promise.all([models[0], models[7]].map(model => db.build.create({ data: {
+      modelId: model.id, promptId: prompt.id, gridSize: 256, palette: "simple", mode: "precise", blockCount: 1, generationTimeMs: 1,
+    } })));
+    const matchup = await db.matchup.create({ data: {
+      modelAId: models[0].id, modelBId: models[7].id, buildAId: builds[0].id, buildBId: builds[1].id, promptId: prompt.id,
+    } });
+    await db.publicSessionActivity.createMany({ data: [
+      { sessionId, city: "Review City", country: "BE", ipHmac: `review-ip-${suffix}`, lastSeenAt: capturedAt },
+      { sessionId: peerSession, ipHmac: `review-ip-${suffix}`, lastSeenAt: capturedAt },
+      { sessionId: oldBlockedSession, ipHmac: `review-old-ip-${suffix}`, lastSeenAt: capturedAt },
+    ] });
+    // use distinct matchups because one vote per matchup/session is enforced
+    for (let i = 0; i < 21; i++) {
+      const match = i === 0 ? matchup : await db.matchup.create({ data: {
+        modelAId: models[0].id, modelBId: models[7].id, buildAId: builds[0].id, buildBId: builds[1].id, promptId: prompt.id,
+      } });
+      await db.vote.create({ data: { sessionId, matchupId: match.id, choice: i < 11 ? "B" : "BOTH_BAD", createdAt: new Date(now.getTime() - (22 - i) * 1000) } });
+    }
+    await db.vote.create({ data: { sessionId, matchupId: (await db.matchup.create({ data: {
+      modelAId: models[0].id, modelBId: models[7].id, buildAId: builds[0].id, buildBId: builds[1].id, promptId: prompt.id,
+    } })).id, choice: "A", createdAt: new Date(now.getTime() - 48 * 60 * 60 * 1000) } });
+    await setArenaVoteSessionBlocked(adminId, oldBlockedSession, true);
+    const review = await getArenaVoteReview(adminId);
+    const row = review.sessions.find(row => row.sessionId === sessionId)!;
+    assert.equal(row.votes, 21);
+    assert.equal(row.upsets, 11);
+    assert.equal(row.largeUpsets, 11);
+    assert.equal(row.matchingSessions, 2);
+    assert.equal(row.medianGapSeconds, 1);
+    assert(row.flags.includes("Rapid voting"));
+    assert(row.flags.includes("Repeated ranking upsets"));
+    assert(row.flags.includes("Large ranking upsets"));
+    assert.equal(review.sessions.find(row => row.sessionId === oldBlockedSession)?.blocked, true);
+    assert.equal(review.sessions.find(row => row.sessionId === oldBlockedSession)?.votes, 0);
+    const page = await getArenaVotePage(adminId, sessionId);
+    assert.equal(page.votes.length, 22);
+    assert.equal(page.votes[0].rankA, 1);
+    assert.equal(page.votes[0].rankB, 8);
+    const before = page.votes[10];
+    const older = await getArenaVotePage(adminId, sessionId, { id: before.id, createdAt: before.createdAt });
+    assert.equal(older.votes.length, 11);
+    assert(!older.votes.some(vote => vote.id === before.id));
+    await setArenaVoteSessionBlocked(adminId, sessionId, true);
+    await setArenaVoteSessionBlocked(adminId, sessionId, true);
+    assert.equal(await db.galleryVoteBlock.count({ where: { createdById: adminId, sessionHash: hashVoteSession(sessionId), reversedAt: null } }), 1);
+    assert.equal((await getArenaVoteReview(adminId)).sessions.find(row => row.sessionId === sessionId)?.blocked, true);
+    await setArenaVoteSessionBlocked(adminId, sessionId, false);
+    assert.equal((await getArenaVoteReview(adminId)).sessions.find(row => row.sessionId === sessionId)?.blocked, false);
+    await db.vote.updateMany({ where: { sessionId }, data: { userId: memberId } });
+    await db.publicSessionActivity.update({ where: { sessionId }, data: { userId: memberId } });
+    await setArenaVoteSessionBlocked(adminId, sessionId, true);
+    assert.equal(await db.galleryVoteBlock.count({ where: { userId: memberId, reversedAt: null } }), 1);
+    await setArenaVoteSessionBlocked(adminId, sessionId, false);
+    assert.equal(await db.galleryVoteBlock.count({ where: { userId: memberId, reversedAt: null } }), 0);
+    console.log("vote review database checks passed");
+  } finally {
+    await db.galleryVoteBlock.deleteMany({ where: { createdById: adminId } });
+    await db.galleryModerationRecord.deleteMany({ where: { actorUserId: adminId } });
+    await db.publicSessionActivity.deleteMany({ where: { sessionId: { in: [sessionId, peerSession, oldBlockedSession] } } });
+    await db.prompt.deleteMany({ where: { text: `Review ${suffix}` } });
+    await db.model.deleteMany({ where: { key: { startsWith: `review-${suffix}` } } });
+    await db.user.deleteMany({ where: { id: { in: [adminId, memberId] } } });
+    await db.$disconnect();
+  }
+}
+
+main().catch(error => { console.error(error); process.exitCode = 1; });

--- a/tests/integration/arena/vote-review.test.ts
+++ b/tests/integration/arena/vote-review.test.ts
@@ -10,6 +10,7 @@ async function main() {
   const adminId = randomUUID(), memberId = randomUUID(), suffix = randomUUID();
   const sessionId = `review-${suffix}`, peerSession = `review-peer-${suffix}`;
   const oldBlockedSession = `review-restricted-${suffix}`;
+  const hashOnlySession = `review-hash-${suffix}`, accountOnlySession = `review-account-${suffix}`;
   const now = new Date();
   const capturedAt = new Date(now.getTime() - 60_000);
   try {
@@ -34,6 +35,8 @@ async function main() {
     await db.publicSessionActivity.createMany({ data: [
       { sessionId, city: "Review City", country: "BE", ipHmac: `review-ip-${suffix}`, lastSeenAt: capturedAt },
       { sessionId: peerSession, ipHmac: `review-ip-${suffix}`, lastSeenAt: capturedAt },
+      { sessionId: hashOnlySession, lastSeenAt: capturedAt },
+      { sessionId: accountOnlySession, userId: memberId, lastSeenAt: capturedAt },
       { sessionId: oldBlockedSession, ipHmac: `review-old-ip-${suffix}`, lastSeenAt: capturedAt },
     ] });
     // use distinct matchups because one vote per matchup/session is enforced
@@ -47,7 +50,20 @@ async function main() {
       modelAId: models[0].id, modelBId: models[7].id, buildAId: builds[0].id, buildBId: builds[1].id, promptId: prompt.id,
     } })).id, choice: "A", createdAt: new Date(now.getTime() - 48 * 60 * 60 * 1000) } });
     await setArenaVoteSessionBlocked(adminId, oldBlockedSession, true);
+    await db.galleryVoteBlock.createMany({ data: [
+      { sessionHash: hashVoteSession(hashOnlySession), createdById: adminId },
+      { userId: memberId, createdById: adminId },
+    ] });
     const review = await getArenaVoteReview(adminId);
+    for (const id of [hashOnlySession, accountOnlySession]) {
+      const restricted = review.sessions.find(row => row.sessionId === id);
+      assert.equal(restricted?.blocked, true, "retain restrictions without votes or IPs");
+      assert.equal(restricted?.votes, 0);
+    }
+    assert.equal(review.sessions.find(row => row.sessionId === accountOnlySession)?.label, `${memberId}@example.test`);
+    await setArenaVoteSessionBlocked(adminId, hashOnlySession, false);
+    assert.equal(await db.galleryVoteBlock.count({ where: { sessionHash: hashVoteSession(hashOnlySession), reversedAt: null } }), 0);
+
     const row = review.sessions.find(row => row.sessionId === sessionId)!;
     assert.equal(row.votes, 21);
     assert.equal(row.upsets, 11);
@@ -77,13 +93,19 @@ async function main() {
     await db.publicSessionActivity.update({ where: { sessionId }, data: { userId: memberId } });
     await setArenaVoteSessionBlocked(adminId, sessionId, true);
     assert.equal(await db.galleryVoteBlock.count({ where: { userId: memberId, reversedAt: null } }), 1);
+    await db.vote.deleteMany({ where: { sessionId } });
+    const cleared = (await getArenaVoteReview(adminId)).sessions.find(row => row.sessionId === sessionId);
+    assert.equal(cleared?.blocked, true);
+    assert.equal(cleared?.votes, 0);
     await setArenaVoteSessionBlocked(adminId, sessionId, false);
     assert.equal(await db.galleryVoteBlock.count({ where: { userId: memberId, reversedAt: null } }), 0);
+    assert.equal(await db.galleryVoteBlock.count({ where: { sessionHash: hashVoteSession(accountOnlySession), reversedAt: null } }), 0);
+
     console.log("vote review database checks passed");
   } finally {
     await db.galleryVoteBlock.deleteMany({ where: { createdById: adminId } });
     await db.galleryModerationRecord.deleteMany({ where: { actorUserId: adminId } });
-    await db.publicSessionActivity.deleteMany({ where: { sessionId: { in: [sessionId, peerSession, oldBlockedSession] } } });
+    await db.publicSessionActivity.deleteMany({ where: { sessionId: { in: [sessionId, peerSession, oldBlockedSession, hashOnlySession, accountOnlySession] } } });
     await db.prompt.deleteMany({ where: { text: `Review ${suffix}` } });
     await db.model.deleteMany({ where: { key: { startsWith: `review-${suffix}` } } });
     await db.user.deleteMany({ where: { id: { in: [adminId, memberId] } } });

--- a/tests/integration/gallery/admin-generation-publish.test.ts
+++ b/tests/integration/gallery/admin-generation-publish.test.ts
@@ -1,0 +1,253 @@
+import assert from "node:assert/strict";
+import { randomUUID } from "node:crypto";
+import { PrismaClient, type CustomBuildStatus } from "@prisma/client";
+
+async function main() {
+  if (!process.env.MINEBENCH_TEST_SCHEMA) {
+    console.log("Admin generation publish checks require pnpm test:integration");
+    return;
+  }
+
+  const db = new PrismaClient();
+  const suffix = randomUUID().slice(0, 8);
+  const adminId = randomUUID();
+  const ownerId = randomUUID();
+  const nonAdminId = randomUUID();
+  const suspendedId = randomUUID();
+  const now = new Date("2026-09-05T16:00:00.000Z");
+  const userIds = [adminId, ownerId, nonAdminId, suspendedId];
+
+  const {
+    getGalleryCandidate,
+    GalleryServiceError,
+    removeGalleryExample,
+  } = await import("../../../lib/gallery/service");
+  const {
+    listAdminGenerations,
+    publishAdminGeneration,
+    removeSavedGeneration,
+  } = await import("../../../lib/generations/service");
+
+  async function createBuild(
+    label: string,
+    input: {
+      targetOwnerId?: string;
+      status?: CustomBuildStatus;
+      removedAt?: Date | null;
+      withArtifacts?: boolean;
+    } = {},
+  ) {
+    const status = input.status ?? "succeeded";
+    const publicId = `cst_publish_${label}_${suffix}`;
+    return db.customBuild.create({
+      data: {
+        publicId,
+        ownerId: input.targetOwnerId ?? ownerId,
+        status,
+        currentStage: status === "succeeded" ? "complete" : status,
+        completedAt: status === "succeeded" ? now : null,
+        removedAt: input.removedAt,
+        promptText: `Admin publish prompt ${label} ${suffix}`,
+        promptSha256: "a".repeat(64),
+        gridSize: 64,
+        palette: "simple",
+        modelKind: "catalog",
+        modelKey: "openai_gpt_5_4_mini",
+        modelProvider: "openai",
+        modelId: "gpt-5.4-mini",
+        modelDisplayName: "GPT 5.4 Mini",
+        blockCount: status === "succeeded" ? 4 : null,
+        generationTimeMs: status === "succeeded" ? 125_000 : null,
+        buildSha256: "b".repeat(64),
+        buildByteSize: 100,
+        buildCompressedByteSize: 60,
+        storedByteSize: 120,
+        artifacts: input.withArtifacts === false ? undefined : {
+          create: [
+            {
+              kind: "build_json",
+              format: "json.gz",
+              bucket: "builds",
+              path: `admin-publish/${suffix}/${label}.json.gz`,
+              encoding: "gzip",
+              contentType: "application/gzip",
+              fileName: "build.json.gz",
+              sha256: "c".repeat(64),
+              sourceBuildSha256: "b".repeat(64),
+              byteSize: 100,
+              compressedByteSize: 60,
+              storedByteSize: 60,
+            },
+            {
+              kind: "viewer_mbv4",
+              format: "mbv4",
+              bucket: "builds",
+              path: `admin-publish/${suffix}/${label}.mbv4`,
+              contentType: "application/octet-stream",
+              fileName: "viewer.mbv4",
+              sha256: "d".repeat(64),
+              sourceBuildSha256: "b".repeat(64),
+              byteSize: 60,
+              storedByteSize: 60,
+            },
+          ],
+        },
+      },
+    });
+  }
+
+  try {
+    await db.user.createMany({
+      data: [
+        { id: adminId, email: `publish-admin-${suffix}@example.test`, isMineBenchAdmin: true },
+        { id: ownerId, email: `publish-owner-${suffix}@example.test` },
+        { id: nonAdminId, email: `publish-reviewer-${suffix}@example.test` },
+        { id: suspendedId, email: `publish-suspended-${suffix}@example.test`, gallerySuspendedAt: now },
+      ],
+    });
+
+    const build = await createBuild("ready");
+    assert.equal(
+      (await listAdminGenerations(adminId, { ownerId })).items.find((item) => item.id === build.publicId)?.canPublish,
+      true,
+    );
+
+    await assert.rejects(
+      () => publishAdminGeneration(nonAdminId, build.publicId),
+      (error: unknown) => error instanceof GalleryServiceError && error.code === "forbidden",
+    );
+
+    const published = await publishAdminGeneration(adminId, build.publicId);
+    assert.equal(published.created, true);
+    const repeated = await publishAdminGeneration(adminId, build.publicId);
+    assert.deepEqual(repeated, { ...published, created: false });
+    assert.equal(await db.galleryExample.count({ where: { customBuildId: build.id } }), 1);
+    assert.equal(await db.galleryModerationRecord.count({
+      where: { action: "generation_published", actorUserId: adminId, subjectUserId: ownerId },
+    }), 1);
+
+    const candidateRow = await db.galleryCandidate.findUniqueOrThrow({
+      where: { publicId: published.candidateId },
+      select: { uploaderId: true, postAnonymously: true },
+    });
+    const exampleRow = await db.galleryExample.findUniqueOrThrow({
+      where: { id: published.exampleId },
+      select: { contributorId: true, postAnonymously: true },
+    });
+    assert.deepEqual(candidateRow, { uploaderId: ownerId, postAnonymously: true });
+    assert.deepEqual(exampleRow, { contributorId: ownerId, postAnonymously: true });
+    assert.equal((await db.customBuild.findUniqueOrThrow({ where: { id: build.id } })).ownerId, ownerId);
+
+    const publicCandidate = await getGalleryCandidate(published.candidateId, { userId: ownerId });
+    assert.equal(publicCandidate?.attribution, "Anonymous");
+    assert.equal(publicCandidate?.canRemove, true);
+    assert.equal(publicCandidate?.cover?.attribution, "Anonymous");
+    assert.equal(publicCandidate?.cover?.buildId, build.publicId);
+    assert.equal(
+      (await listAdminGenerations(adminId, { ownerId })).items.find((item) => item.id === build.publicId)?.canPublish,
+      false,
+    );
+
+    await assert.rejects(
+      () => removeGalleryExample(adminId, published.candidateId, published.exampleId),
+      (error: unknown) => error instanceof GalleryServiceError && error.code === "not_found",
+    );
+    assert.deepEqual(await removeGalleryExample(ownerId, published.candidateId, published.exampleId), { removed: true });
+    const retainedBuild = await db.customBuild.findUniqueOrThrow({
+      where: { id: build.id },
+      select: { ownerId: true, removedAt: true, objectsDeletedAt: true },
+    });
+    assert.deepEqual(retainedBuild, { ownerId, removedAt: null, objectsDeletedAt: null });
+    assert.equal((await db.galleryExample.findUniqueOrThrow({ where: { id: published.exampleId } })).removedAt instanceof Date, true);
+    assert.equal((await getGalleryCandidate(published.candidateId))?.exampleCount, 0);
+    assert.equal(
+      (await listAdminGenerations(adminId, { ownerId })).items.find((item) => item.id === build.publicId)?.canPublish,
+      false,
+    );
+    await assert.rejects(
+      () => publishAdminGeneration(adminId, build.publicId),
+      (error: unknown) => error instanceof GalleryServiceError && error.code === "generation_not_available",
+    );
+
+    const removableBuild = await createBuild("remove_saved");
+    const removablePublished = await publishAdminGeneration(adminId, removableBuild.publicId);
+    await assert.rejects(
+      () => removeSavedGeneration(ownerId, removableBuild.publicId, { deleteArtifact: async () => undefined }),
+      (error: unknown) =>
+        error instanceof Error &&
+        "code" in error &&
+        error.code === "public_examples_require_confirmation",
+    );
+    assert.deepEqual(
+      await removeSavedGeneration(ownerId, removableBuild.publicId, {
+        acknowledgePublicExamples: true,
+        deleteArtifact: async () => undefined,
+      }),
+      { removed: true, publicExamplesRemoved: 1 },
+    );
+    assert.equal((await db.galleryExample.findUniqueOrThrow({ where: { id: removablePublished.exampleId } })).removedAt instanceof Date, true);
+    assert.equal((await getGalleryCandidate(removablePublished.candidateId))?.exampleCount, 0);
+
+    for (const status of ["queued", "running", "failed", "canceled"] as const) {
+      const invalid = await createBuild(status, { status });
+      await assert.rejects(
+        () => publishAdminGeneration(adminId, invalid.publicId),
+        (error: unknown) => error instanceof GalleryServiceError && error.code === "generation_not_available",
+      );
+    }
+    const removed = await createBuild("removed", { removedAt: now });
+    await assert.rejects(
+      () => publishAdminGeneration(adminId, removed.publicId),
+      (error: unknown) => error instanceof GalleryServiceError && error.code === "generation_not_available",
+    );
+    const suspended = await createBuild("suspended", { targetOwnerId: suspendedId });
+    await assert.rejects(
+      () => publishAdminGeneration(adminId, suspended.publicId),
+      (error: unknown) => error instanceof GalleryServiceError && error.code === "generation_not_available",
+    );
+
+    const hidden = await createBuild("hidden");
+    const hiddenCandidate = await db.galleryCandidate.create({
+      data: {
+        publicId: `gal_publish_hidden_${suffix}`,
+        promptText: hidden.promptText,
+        promptKey: `admin-publish-hidden-${suffix}`,
+        uploaderId: ownerId,
+      },
+    });
+    await db.galleryExample.create({
+      data: {
+        candidateId: hiddenCandidate.id,
+        customBuildId: hidden.id,
+        contributorId: ownerId,
+        postAnonymously: true,
+        removedAt: now,
+      },
+    });
+    assert.equal(
+      (await listAdminGenerations(adminId, { ownerId })).items.find((item) => item.id === hidden.publicId)?.canPublish,
+      false,
+    );
+    await assert.rejects(
+      () => publishAdminGeneration(adminId, hidden.publicId),
+      (error: unknown) => error instanceof GalleryServiceError && error.code === "generation_not_available",
+    );
+
+    console.log("Admin generation publish checks passed");
+  } finally {
+    await db.galleryModerationRecord.deleteMany({
+      where: { OR: [{ actorUserId: { in: userIds } }, { subjectUserId: { in: userIds } }] },
+    });
+    await db.galleryCandidate.deleteMany({
+      where: { OR: [{ uploaderId: { in: userIds } }, { promptText: { contains: suffix } }] },
+    });
+    await db.customBuild.deleteMany({ where: { ownerId: { in: userIds } } });
+    await db.user.deleteMany({ where: { id: { in: userIds } } });
+    await db.$disconnect();
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/tests/unit/arena/vote-review.test.ts
+++ b/tests/unit/arena/vote-review.test.ts
@@ -1,0 +1,14 @@
+import assert from "node:assert/strict";
+import { voteReviewFlags } from "../../../lib/arena/voteReview";
+
+const ordinary = { votes: 30, choiceA: 14, choiceB: 14, bothBad: 2, fastVotes: 0, repeatVotes: 2, rankedVotes: 28, upsets: 8, largeUpsets: 1 };
+assert.deepEqual(voteReviewFlags(ordinary), []);
+assert.deepEqual(voteReviewFlags({ ...ordinary, fastVotes: 15 }), ["Rapid voting"]);
+assert.deepEqual(voteReviewFlags({ ...ordinary, choiceA: 26, choiceB: 2 }), ["One-sided voting"]);
+assert.deepEqual(voteReviewFlags({ ...ordinary, upsets: 23 }), ["Repeated ranking upsets"]);
+assert.deepEqual(voteReviewFlags({ ...ordinary, largeUpsets: 3 }), ["Large ranking upsets"]);
+assert.deepEqual(voteReviewFlags({ ...ordinary, repeatVotes: 15 }), ["Repeated matchups"]);
+assert.deepEqual(voteReviewFlags({ votes: 3, choiceA: 0, choiceB: 3, bothBad: 0, fastVotes: 2, repeatVotes: 2, rankedVotes: 3, upsets: 3, largeUpsets: 3 }), []);
+assert.deepEqual(voteReviewFlags({ votes: 21, choiceA: 6, choiceB: 5, bothBad: 10, fastVotes: 0, repeatVotes: 2, rankedVotes: 11, upsets: 10, largeUpsets: 4 }), ["Repeated ranking upsets", "Large ranking upsets", "Frequent rejections"]);
+assert.deepEqual(voteReviewFlags({ ...ordinary, rankedVotes: 0, upsets: 0, largeUpsets: 0 }), []);
+console.log("vote review signal checks passed");


### PR DESCRIPTION
Adds an admin Votes view with Suspicious, All, and Restricted filters, complete paginated session history, explicit vote selection/removal, and account/session/IP restrictions. Ranking signals use the latest hourly snapshot and require manual review. Restrictions remain discoverable and reversible through retained account/session identities even after votes are cleared or aged out. Removal reverses applied public counters and coverage; historical Glicko state used for matchup selection is not replayed.

Admins can preview and publish eligible saved generations anonymously using the existing Gallery publishing flow. Ownership is preserved, removed publications are not revived, and contributors can remove their Gallery example without deleting the saved generation. The desktop admin layout uses the existing fixed-viewport shell with a scrolling vote detail pane, compact summaries, and pagination after the history. Leaderboard Methodology paragraphs use the available width.

Validation: TypeScript, ESLint/build, vote-signal and Gallery action checks, and focused PostgreSQL integration checks for review, removal, publishing authorization, anonymity, ownership, and removal. Browser verification is deferred to Alpha testing.

*(PR written by Codex)*

