### PR TITLE
fix(admin): stabilize vote review and show recent activity first

### DIFF
--- a/components/arena/ArenaVoteReview.tsx
+++ b/components/arena/ArenaVoteReview.tsx
@@ -323,7 +323,8 @@ export function ArenaVoteReview({ refreshedAt }: { refreshedAt: string }) {
   const busy = votesLoading || pendingAction !== null;
   const pageSelected = pageVoteIds.length > 0 && pageVoteIds.every((id) => selectedVoteIds.has(id));
   const hasNewVotes = loadedSessionId === selectedSessionId && selectedSession?.lastVoteAt &&
-    (!votes[0] || selectedSession.lastVoteAt > votes[0].createdAt);
+    (!votes[0] || selectedSession.lastVoteAt > votes[0].createdAt ||
+      (selectedSession.lastVoteAt === votes[0].createdAt && (selectedSession.lastVoteId ?? "") > votes[0].id));
 
   function toggleVote(voteId: string) {
     if (!selectedVoteIds.has(voteId) && selectedVoteIds.size >= MAX_SELECTED_VOTES) {
@@ -434,10 +435,17 @@ export function ArenaVoteReview({ refreshedAt }: { refreshedAt: string }) {
         </div>
       </div>
 
-      <div className="grid gap-8 lg:min-h-0 lg:flex-1 lg:grid-cols-[minmax(15rem,0.7fr)_minmax(0,1.6fr)] lg:overflow-hidden">
+      {sessions.length === 0 ? (
+        <div className="flex min-h-48 flex-1 flex-col items-center justify-center gap-3 py-8 text-center">
+          {listLoading && !data ? <p role="status" className="text-sm text-muted">Loading votes...</p> : null}
+          {data ? <p className="text-sm text-muted">No matching sessions.</p> : null}
+          {data && filter === "suspicious" && counts.all > 0 ? (
+            <button type="button" className="mb-btn h-10" onClick={() => setFilter("all")}>Show all</button>
+          ) : null}
+        </div>
+      ) : <div className="grid gap-8 lg:min-h-0 lg:flex-1 lg:grid-cols-[minmax(15rem,0.7fr)_minmax(0,1.6fr)] lg:overflow-hidden">
         <section className="min-w-0 lg:flex lg:min-h-0 lg:flex-col" aria-label="Vote sessions">
           <div className="divide-y divide-border border-b border-border lg:min-h-0 lg:flex-1 lg:overflow-y-auto lg:overscroll-contain lg:pr-2">
-            {listLoading && !data ? <p className="py-8 text-sm text-muted">Loading votes...</p> : null}
             {sessions.map((session) => (
               <SessionRow
                 key={session.sessionId}
@@ -447,18 +455,10 @@ export function ArenaVoteReview({ refreshedAt }: { refreshedAt: string }) {
                 onSelect={() => selectSession(session.sessionId)}
               />
             ))}
-            {!listLoading && data && sessions.length === 0 ? (
-              <div className="space-y-3 py-8">
-                <p className="text-sm text-muted">No matching sessions.</p>
-                {filter === "suspicious" && counts.all > 0 ? (
-                  <button type="button" className="mb-btn h-10" onClick={() => setFilter("all")}>Show all</button>
-                ) : null}
-              </div>
-            ) : null}
           </div>
         </section>
 
-        <section className="min-w-0 lg:min-h-0 lg:overflow-y-auto lg:overscroll-contain lg:pr-2" aria-labelledby="arena-vote-detail-title">
+        {selectedSession ? <section className="min-w-0 lg:min-h-0 lg:overflow-y-auto lg:overscroll-contain lg:pr-2" aria-labelledby="arena-vote-detail-title">
           <div className="flex flex-wrap items-center justify-between gap-3 border-b border-border bg-bg px-1 pb-3 pt-2 lg:sticky lg:top-0 lg:z-10">
             <div className="min-w-0 space-y-1">
               <h3 id="arena-vote-detail-title" className="truncate text-lg font-semibold text-fg" title={selectedSession?.label ?? undefined}>
@@ -498,7 +498,6 @@ export function ArenaVoteReview({ refreshedAt }: { refreshedAt: string }) {
             {selectedSession && !votesError && (votesLoading || loadedSessionId !== selectedSessionId) && votes.length === 0 ? <p role="status" className="py-8 text-sm text-muted">Loading votes...</p> : null}
             {votesError ? <div className="flex items-center gap-3 py-4"><p role="alert" className="text-sm text-danger">{votesError}</p><button type="button" className="mb-btn h-10" disabled={busy} onClick={() => selectedSessionId && void loadVotes(selectedSessionId)}>Retry</button></div> : null}
             {!votesLoading && !votesError && selectedSession && loadedSessionId === selectedSessionId && votes.length === 0 ? <p className="py-8 text-sm text-muted">No votes in this session.</p> : null}
-            {!selectedSession ? <p className="py-8 text-sm text-muted">Choose a session.</p> : null}
             {votes.map((vote) => (
               <VoteCard
                 key={vote.id}
@@ -525,8 +524,8 @@ export function ArenaVoteReview({ refreshedAt }: { refreshedAt: string }) {
               <p>IP matches use retained hashes, not raw addresses. Shared IPs may include other visitors. <a className="text-fg underline underline-offset-4" href={PRIVACY_POLICY_URL} target="_blank" rel="noreferrer">Privacy policy</a></p>
             </div>
           </details>
-        </section>
-      </div>
+        </section> : null}
+      </div>}
       {data?.truncated ? <p className="text-xs text-muted">Showing the first 1,000 sessions plus retained restrictions.</p> : null}
     </section>
   );

--- a/components/arena/ArenaVoteReview.tsx
+++ b/components/arena/ArenaVoteReview.tsx
@@ -113,8 +113,8 @@ function SessionRow({
     >
       <span className="flex min-w-0 items-start justify-between gap-3">
         <span className="min-w-0">
-          <span className="block truncate text-sm font-semibold text-fg" title={session.label}>{session.label}</span>
-          <span className="block truncate font-mono text-[11px] text-muted" title={session.sessionId}>{session.sessionId}</span>
+          <span className="block truncate text-sm font-semibold text-fg" title={`${session.label} · ${session.sessionId}`}>{session.label}</span>
+          {session.lastVoteAt ? <time className="block text-xs text-muted" dateTime={session.lastVoteAt}>{formatDate(session.lastVoteAt)}</time> : <span className="block text-xs text-muted">No recent votes</span>}
         </span>
         <span className={`shrink-0 rounded px-1.5 py-0.5 text-[11px] font-medium ${
           session.blocked
@@ -215,10 +215,13 @@ export function ArenaVoteReview({ refreshedAt }: { refreshedAt: string }) {
   const [selectedVoteIds, setSelectedVoteIds] = useState<Set<string>>(new Set());
   const [listLoading, setListLoading] = useState(true);
   const [votesLoading, setVotesLoading] = useState(false);
+  const [votesError, setVotesError] = useState<string | null>(null);
+  const [loadedSessionId, setLoadedSessionId] = useState<string | null>(null);
   const [pendingAction, setPendingAction] = useState<"remove" | "block" | null>(null);
   const [notice, setNotice] = useState<string | null>(null);
   const listRequest = useRef(0);
   const votesRequest = useRef(0);
+  const activeSession = useRef<string | null>(null);
 
   const loadList = useCallback(async () => {
     const request = ++listRequest.current;
@@ -241,34 +244,46 @@ export function ArenaVoteReview({ refreshedAt }: { refreshedAt: string }) {
     cursor?: VoteReviewPage["nextCursor"],
     append = false,
   ) => {
+    if (sessionId !== activeSession.current) return;
     const request = ++votesRequest.current;
     setVotesLoading(true);
-    setNotice(null);
-    if (!append) {
-      setVotes([]);
-      setPageVoteIds([]);
-    }
+    setVotesError(null);
     try {
       const result = await loadArenaVotePage(sessionId, cursor ?? undefined);
-      if (request !== votesRequest.current || sessionId !== selectedSessionId) return;
+      if (request !== votesRequest.current || sessionId !== activeSession.current) return;
       if (!result.ok) {
-        setNotice(result.error);
+        setVotesError(result.error);
         return;
       }
       const voteIds = result.data.votes.map((vote) => vote.id);
       setVotes((current) => append ? [...current, ...result.data.votes] : result.data.votes);
+      setLoadedSessionId(sessionId);
       setPageVoteIds(voteIds);
       setNextCursor(result.data.nextCursor);
-      const liveIds = new Set(voteIds);
-      setSelectedVoteIds((current) => append
-        ? current
-        : new Set([...current].filter((id) => liveIds.has(id))));
+      if (!append) {
+        const liveIds = new Set(voteIds);
+        setSelectedVoteIds((current) => new Set([...current].filter((id) => liveIds.has(id))));
+      }
     } catch {
-      if (request === votesRequest.current) setNotice("Could not load vote history.");
+      if (request === votesRequest.current) setVotesError("Could not load vote history.");
     } finally {
       if (request === votesRequest.current) setVotesLoading(false);
     }
-  }, [selectedSessionId]);
+  }, []);
+
+  const selectSession = useCallback((sessionId: string | null) => {
+    if (sessionId === activeSession.current) return;
+    activeSession.current = sessionId;
+    votesRequest.current += 1;
+    setLoadedSessionId(null);
+    setVotesError(null);
+    setSelectedSessionId(sessionId);
+    setSelectedVoteIds(new Set());
+    setVotes([]);
+    setPageVoteIds([]);
+    setNextCursor(null);
+    setNotice(null);
+  }, []);
 
   useEffect(() => {
     void loadList();
@@ -276,21 +291,10 @@ export function ArenaVoteReview({ refreshedAt }: { refreshedAt: string }) {
   }, [loadList, refreshedAt]);
 
   useEffect(() => {
-    if (!data) return;
-    if (selectedSessionId && data.sessions.some((session) => session.sessionId === selectedSessionId)) return;
-    const firstSession = data.sessions.find((session) => session.flags.length > 0) ?? data.sessions[0] ?? null;
-    setSelectedSessionId(firstSession?.sessionId ?? null);
-    setSelectedVoteIds(new Set());
-    setVotes([]);
-    setPageVoteIds([]);
-    setNextCursor(null);
-  }, [data, selectedSessionId]);
-
-  useEffect(() => {
     if (!selectedSessionId) return;
     void loadVotes(selectedSessionId);
     return () => { votesRequest.current += 1; };
-  }, [loadVotes, selectedSessionId, refreshedAt]);
+  }, [loadVotes, selectedSessionId]);
 
   const counts = useMemo(() => {
     const sessions = data?.sessions ?? [];
@@ -308,21 +312,18 @@ export function ArenaVoteReview({ refreshedAt }: { refreshedAt: string }) {
     ));
   }, [data, filter, query]);
 
+  useEffect(() => {
+    if (selectedSessionId && sessions.some((session) => session.sessionId === selectedSessionId)) return;
+    selectSession(sessions[0]?.sessionId ?? null);
+  }, [sessions, selectedSessionId, selectSession]);
+
   const selectedSession = useMemo(() => (
     data?.sessions.find((session) => session.sessionId === selectedSessionId) ?? null
   ), [data, selectedSessionId]);
-  const busy = listLoading || votesLoading || pendingAction !== null;
+  const busy = votesLoading || pendingAction !== null;
   const pageSelected = pageVoteIds.length > 0 && pageVoteIds.every((id) => selectedVoteIds.has(id));
-
-  function selectSession(sessionId: string) {
-    votesRequest.current += 1;
-    setSelectedSessionId(sessionId);
-    setSelectedVoteIds(new Set());
-    setVotes([]);
-    setPageVoteIds([]);
-    setNextCursor(null);
-    setNotice(null);
-  }
+  const hasNewVotes = loadedSessionId === selectedSessionId && selectedSession?.lastVoteAt &&
+    (!votes[0] || selectedSession.lastVoteAt > votes[0].createdAt);
 
   function toggleVote(voteId: string) {
     if (!selectedVoteIds.has(voteId) && selectedVoteIds.size >= MAX_SELECTED_VOTES) {
@@ -458,7 +459,7 @@ export function ArenaVoteReview({ refreshedAt }: { refreshedAt: string }) {
         </section>
 
         <section className="min-w-0 lg:min-h-0 lg:overflow-y-auto lg:overscroll-contain lg:pr-2" aria-labelledby="arena-vote-detail-title">
-          <div className="flex flex-wrap items-center justify-between gap-3 border-b border-border bg-bg pb-3 lg:sticky lg:top-0 lg:z-10">
+          <div className="flex flex-wrap items-center justify-between gap-3 border-b border-border bg-bg px-1 pb-3 pt-2 lg:sticky lg:top-0 lg:z-10">
             <div className="min-w-0 space-y-1">
               <h3 id="arena-vote-detail-title" className="truncate text-lg font-semibold text-fg" title={selectedSession?.label ?? undefined}>
                 {selectedSession?.label ?? "Session"}
@@ -490,11 +491,13 @@ export function ArenaVoteReview({ refreshedAt }: { refreshedAt: string }) {
               <span>{metric(selectedSession.upsets, "ranking upsets")}</span>
               <span>Median gap {formatGap(selectedSession.medianGapSeconds)}</span>
               <span>{votes.length.toLocaleString()} loaded · {selectedVoteIds.size.toLocaleString()} selected</span>
+              {hasNewVotes && !votesError ? <button type="button" className="font-medium text-accent underline underline-offset-4" disabled={busy} onClick={() => selectedSessionId && void loadVotes(selectedSessionId)}>New votes</button> : null}
             </p>
           ) : null}
           <div className="divide-y divide-border">
-            {votesLoading && votes.length === 0 ? <p className="py-8 text-sm text-muted">Loading history...</p> : null}
-            {!votesLoading && selectedSession && votes.length === 0 ? <p className="py-8 text-sm text-muted">No retained public votes.</p> : null}
+            {selectedSession && !votesError && (votesLoading || loadedSessionId !== selectedSessionId) && votes.length === 0 ? <p role="status" className="py-8 text-sm text-muted">Loading votes...</p> : null}
+            {votesError ? <div className="flex items-center gap-3 py-4"><p role="alert" className="text-sm text-danger">{votesError}</p><button type="button" className="mb-btn h-10" disabled={busy} onClick={() => selectedSessionId && void loadVotes(selectedSessionId)}>Retry</button></div> : null}
+            {!votesLoading && !votesError && selectedSession && loadedSessionId === selectedSessionId && votes.length === 0 ? <p className="py-8 text-sm text-muted">No votes in this session.</p> : null}
             {!selectedSession ? <p className="py-8 text-sm text-muted">Choose a session.</p> : null}
             {votes.map((vote) => (
               <VoteCard

--- a/docs/gallery.md
+++ b/docs/gallery.md
@@ -26,7 +26,9 @@ See [Architecture](./architecture.md) for the data and generation flow.
 ## Admin vote review
 
 The Votes view summarizes public Arena sessions over the last 24 hours, with
-Suspicious, All, and Restricted filters. Selecting a session loads its full public
+Suspicious, All, and Restricted filters, ordered by latest vote. Background refreshes
+update the session list without resetting a review; New votes loads newer history
+on request. Selecting a session loads its full public
 vote history in pages of 100. Flags identify repeated rapid voting, one-sided
 choices, repeated matchups, frequent rejections, and ranking upsets for manual
 review. Ranking comparisons use the latest hourly snapshot, not vote-time ranks;

--- a/lib/arena/voteReview.ts
+++ b/lib/arena/voteReview.ts
@@ -115,7 +115,7 @@ export async function getArenaVoteReview(adminId: string): Promise<VoteReviewDat
           (choice = 'A' AND rank_b <= ${Math.max(1, Math.floor(ranking.ranks.size * 0.15))} AND rank_a > ${ranking.ranks.size / 2}) OR
           (choice = 'B' AND rank_a <= ${Math.max(1, Math.floor(ranking.ranks.size * 0.15))} AND rank_b > ${ranking.ranks.size / 2})
         )::int AS "largeUpsets"
-      FROM votes GROUP BY "sessionId" ORDER BY votes DESC, "sessionId" LIMIT ${SESSION_LIMIT + 1}
+      FROM votes GROUP BY "sessionId" ORDER BY "lastVoteAt" DESC, "sessionId" LIMIT ${SESSION_LIMIT + 1}
     `),
     prisma.galleryVoteBlock.findMany({ where: { reversedAt: null }, select: { userId: true, sessionHash: true, ipHmac: true } }),
   ]);

--- a/lib/arena/voteReview.ts
+++ b/lib/arena/voteReview.ts
@@ -12,6 +12,7 @@ export type VoteReviewSession = {
   label: string;
   location: string | null;
   lastVoteAt: string | null;
+  lastVoteId: string | null;
   votes: number;
   choiceA: number;
   choiceB: number;
@@ -84,13 +85,14 @@ export async function getArenaVoteReview(adminId: string): Promise<VoteReviewDat
   const since = new Date(now.getTime() - 24 * 60 * 60 * 1000);
   const retainedSince = new Date(now.getTime() - PUBLIC_SESSION_RETENTION_MS);
   const ranking = await latestRanks();
-  type Summary = Metrics & { sessionId: string; userId: string | null; lastVoteAt: Date | null; ties: number; medianGapSeconds: number | null };
+  type Summary = Metrics & { sessionId: string; userId: string | null; lastVoteAt: Date | null; lastVoteId: string | null; ties: number; medianGapSeconds: number | null };
   const [rows, blocks] = await Promise.all([
     prisma.$queryRaw<Summary[]>(Prisma.sql`
       WITH ranks AS (
         SELECT "modelId", rank FROM "ModelRankSnapshot" WHERE "capturedAt" = (${ranking.capturedAt}::timestamptz AT TIME ZONE 'UTC')
       ), votes AS (
         SELECT v.*, m."buildAId", m."buildBId", a.rank AS rank_a, b.rank AS rank_b,
+          FIRST_VALUE(v.id) OVER (PARTITION BY v."sessionId" ORDER BY v."createdAt" DESC, v.id DESC) AS latest_id,
           EXTRACT(EPOCH FROM v."createdAt" - LAG(v."createdAt") OVER (
             PARTITION BY v."sessionId" ORDER BY v."createdAt", v.id
           ))::double precision AS gap
@@ -101,6 +103,7 @@ export async function getArenaVoteReview(adminId: string): Promise<VoteReviewDat
           AND v."createdAt" <= (${now}::timestamptz AT TIME ZONE 'UTC') AND m."stealthVariantId" IS NULL
       )
       SELECT "sessionId", MAX("userId"::text) AS "userId", MAX("createdAt") AS "lastVoteAt",
+        MAX(latest_id) AS "lastVoteId",
         COUNT(*)::int AS votes,
         COUNT(*) FILTER (WHERE choice = 'A')::int AS "choiceA",
         COUNT(*) FILTER (WHERE choice = 'B')::int AS "choiceB",
@@ -153,7 +156,7 @@ export async function getArenaVoteReview(adminId: string): Promise<VoteReviewDat
       Boolean(session.userId && blockedUsers.has(session.userId)) ||
       Boolean(session.ipHmac && blockedIps.has(session.ipHmac))
     )) {
-      summaries.set(session.sessionId, { sessionId: session.sessionId, userId: session.userId, lastVoteAt: null,
+      summaries.set(session.sessionId, { sessionId: session.sessionId, userId: session.userId, lastVoteAt: null, lastVoteId: null,
         votes: 0, choiceA: 0, choiceB: 0, ties: 0, bothBad: 0, medianGapSeconds: null,
         fastVotes: 0, repeatVotes: 0, rankedVotes: 0, upsets: 0, largeUpsets: 0 });
     }

--- a/tests/integration/arena/vote-review.test.ts
+++ b/tests/integration/arena/vote-review.test.ts
@@ -49,12 +49,14 @@ async function main() {
     await db.vote.create({ data: { sessionId, matchupId: (await db.matchup.create({ data: {
       modelAId: models[0].id, modelBId: models[7].id, buildAId: builds[0].id, buildBId: builds[1].id, promptId: prompt.id,
     } })).id, choice: "A", createdAt: new Date(now.getTime() - 48 * 60 * 60 * 1000) } });
+    await db.vote.create({ data: { sessionId: peerSession, matchupId: matchup.id, choice: "A", createdAt: new Date(now.getTime() - 1000) } });
     await setArenaVoteSessionBlocked(adminId, oldBlockedSession, true);
     await db.galleryVoteBlock.createMany({ data: [
       { sessionHash: hashVoteSession(hashOnlySession), createdById: adminId },
       { userId: memberId, createdById: adminId },
     ] });
     const review = await getArenaVoteReview(adminId);
+    assert.equal(review.sessions[0]?.sessionId, peerSession, "the latest vote sorts ahead of a higher-volume session");
     for (const id of [hashOnlySession, accountOnlySession]) {
       const restricted = review.sessions.find(row => row.sessionId === id);
       assert.equal(restricted?.blocked, true, "retain restrictions without votes or IPs");

--- a/tests/integration/arena/vote-review.test.ts
+++ b/tests/integration/arena/vote-review.test.ts
@@ -57,6 +57,16 @@ async function main() {
     ] });
     const review = await getArenaVoteReview(adminId);
     assert.equal(review.sessions[0]?.sessionId, peerSession, "the latest vote sorts ahead of a higher-volume session");
+    const peerVote = (await getArenaVotePage(adminId, peerSession)).votes[0];
+    assert.equal(review.sessions[0]?.lastVoteId, peerVote.id);
+    const tiedVote = await db.vote.create({ data: {
+      id: `z-${suffix}`, sessionId: peerSession, choice: "B", createdAt: new Date(peerVote.createdAt),
+      matchupId: (await db.matchup.findFirstOrThrow({ where: { promptId: prompt.id, id: { not: matchup.id } } })).id,
+    } });
+    const refreshed = (await getArenaVoteReview(adminId)).sessions.find(row => row.sessionId === peerSession)!;
+    assert.equal(refreshed.lastVoteAt, peerVote.createdAt);
+    assert.equal(refreshed.lastVoteId, tiedVote.id, "summary and history use the same cursor for tied timestamps");
+    assert.equal((await getArenaVotePage(adminId, peerSession)).votes[0].id, refreshed.lastVoteId);
     for (const id of [hashOnlySession, accountOnlySession]) {
       const restricted = review.sessions.find(row => row.sessionId === id);
       assert.equal(restricted?.blocked, true, "retain restrictions without votes or IPs");

--- a/tests/ui/arena-vote-review.test.ts
+++ b/tests/ui/arena-vote-review.test.ts
@@ -1,0 +1,70 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { runInNewContext } from "node:vm";
+import ts from "typescript";
+
+const source = ts.createSourceFile("ArenaVoteReview.tsx", readFileSync("components/arena/ArenaVoteReview.tsx", "utf8"), ts.ScriptTarget.Latest, true, ts.ScriptKind.TSX);
+const state: Record<string, unknown> = {
+  votes: [{ id: "retained" }], selectedVoteIds: new Set(["retained"]), loadedSessionId: "session-a",
+};
+const activeSession = { current: "session-a" as string | null };
+const votesRequest = { current: 0 };
+let calls = 0;
+let respond: (value: unknown) => void = () => { throw new Error("No request pending"); };
+const context: Record<string, unknown> = {
+  Set, activeSession, votesRequest, selectedSessionId: "session-a",
+  loadArenaVotePage: () => { calls += 1; return new Promise(resolve => { respond = resolve; }); },
+};
+for (const key of ["Votes", "SelectedVoteIds", "SelectedSessionId", "PageVoteIds", "NextCursor", "Notice", "VotesLoading", "VotesError", "LoadedSessionId"]) {
+  const field = key[0].toLowerCase() + key.slice(1);
+  context[`set${key}`] = (value: unknown) => {
+    state[field] = typeof value === "function" ? value(state[field]) : value;
+  };
+}
+
+function callback(name: string): (...args: unknown[]) => unknown {
+  let expression = "";
+  function visit(node: ts.Node) {
+    if (ts.isFunctionDeclaration(node) && node.name?.text === name) expression = node.getText(source);
+    if (ts.isVariableDeclaration(node) && node.name.getText(source) === name && node.initializer && ts.isCallExpression(node.initializer)) {
+      expression = node.initializer.arguments[0].getText(source);
+    }
+    ts.forEachChild(node, visit);
+  }
+  visit(source);
+  assert(expression, `${name} callback exists`);
+  return runInNewContext(ts.transpileModule(`(${expression})`, { compilerOptions: { target: ts.ScriptTarget.ES2022 } }).outputText, context);
+}
+
+async function main() {
+  const select = callback("selectSession"), load = callback("loadVotes");
+  select("session-a");
+  assert.equal((state.votes as unknown[]).length, 1, "reselecting the current session must keep its history");
+  assert.equal(votesRequest.current, 0, "reselecting must not invalidate an in-flight request");
+
+  const failed = load("session-a");
+  assert.equal((state.votes as unknown[]).length, 1, "a refresh keeps loaded history until it succeeds");
+  respond({ ok: false, error: "Temporary failure" });
+  await failed;
+  assert.equal((state.votes as unknown[]).length, 1);
+  assert.equal(state.votesError, "Temporary failure");
+
+  const stale = load("session-a");
+  const resolveStale = respond;
+  select("session-b");
+  const current = load("session-b");
+  resolveStale({ ok: true, data: { votes: [{ id: "wrong-session" }], nextCursor: null } });
+  await stale;
+  assert.equal((state.votes as unknown[]).length, 0, "stale responses cannot populate the new session");
+  respond({ ok: true, data: { votes: [{ id: "current" }], nextCursor: null } });
+  await current;
+  assert.equal((state.votes as Array<{ id: string }>)[0].id, "current");
+  assert.equal(state.loadedSessionId, "session-b");
+  assert.equal(state.votesError, null);
+  const callsBefore = calls;
+  await load("session-a");
+  assert.equal(calls, callsBefore, "a stale refresh must not start another request");
+  console.log("vote review selection and request checks passed");
+}
+
+main().catch(error => { console.error(error); process.exitCode = 1; });

--- a/tests/ui/arena-vote-review.test.ts
+++ b/tests/ui/arena-vote-review.test.ts
@@ -22,22 +22,22 @@ for (const key of ["Votes", "SelectedVoteIds", "SelectedSessionId", "PageVoteIds
   };
 }
 
-function callback(name: string): (...args: unknown[]) => unknown {
+function evaluate<T>(name: string): T {
   let expression = "";
   function visit(node: ts.Node) {
     if (ts.isFunctionDeclaration(node) && node.name?.text === name) expression = node.getText(source);
-    if (ts.isVariableDeclaration(node) && node.name.getText(source) === name && node.initializer && ts.isCallExpression(node.initializer)) {
-      expression = node.initializer.arguments[0].getText(source);
+    if (ts.isVariableDeclaration(node) && node.name.getText(source) === name && node.initializer) {
+      expression = (ts.isCallExpression(node.initializer) ? node.initializer.arguments[0] : node.initializer).getText(source);
     }
     ts.forEachChild(node, visit);
   }
   visit(source);
-  assert(expression, `${name} callback exists`);
+  assert(expression, `${name} exists`);
   return runInNewContext(ts.transpileModule(`(${expression})`, { compilerOptions: { target: ts.ScriptTarget.ES2022 } }).outputText, context);
 }
 
 async function main() {
-  const select = callback("selectSession"), load = callback("loadVotes");
+  const select = evaluate<(id: string) => void>("selectSession"), load = evaluate<(id: string) => Promise<void>>("loadVotes");
   select("session-a");
   assert.equal((state.votes as unknown[]).length, 1, "reselecting the current session must keep its history");
   assert.equal(votesRequest.current, 0, "reselecting must not invalidate an in-flight request");
@@ -64,6 +64,12 @@ async function main() {
   const callsBefore = calls;
   await load("session-a");
   assert.equal(calls, callsBefore, "a stale refresh must not start another request");
+  const createdAt = "2026-09-05T12:00:00.000Z";
+  Object.assign(context, { loadedSessionId: "session-a", votes: [{ id: "b", createdAt }] });
+  for (const [lastVoteId, expected] of [["c", true], ["b", false], ["a", false]] as const) {
+    context.selectedSession = { lastVoteId, lastVoteAt: createdAt };
+    assert.equal(evaluate("hasNewVotes"), expected, "equal timestamps must use the vote ID tie-breaker");
+  }
   console.log("vote review selection and request checks passed");
 }
 


### PR DESCRIPTION
Order vote sessions by their latest vote and show that timestamp in the list. Keep toolbar outlines inside the scroll area so Remove and Block votes remain fully visible. Center empty results across the review area and hide session controls until a session is selected.

Fix reselecting the active session clearing its history without fetching again. Background refreshes update the session list while preserving loaded pages and selections; New votes explicitly loads newer history, comparing both timestamp and vote ID to detect concurrent votes. Failed requests retain existing votes and offer Retry, and stale responses cannot populate another session. Filtering keeps the detail pane on a visible session.

Validation: ESLint, TypeScript, production build, client regressions covering selection, stale responses, and timestamp ties, plus the shared PostgreSQL sequence covering vote moderation, review ordering and cursors, and private vote boundaries. The original timestamp-only indicator fails the tied-vote regression.

*(PR written by Codex)*
