### PR TITLE
(fix) stream OpenRouter requests to prevent gateway timeouts

### DIFF
--- a/lib/ai/providers/openrouter.ts
+++ b/lib/ai/providers/openrouter.ts
@@ -21,6 +21,7 @@ type OpenRouterChatResponse = {
 
 type OpenRouterStreamChunk = {
   choices?: { delta?: { content?: unknown } }[];
+  error?: { message?: string } | string;
 };
 
 type TextVerbosity = "low" | "medium" | "high";
@@ -291,7 +292,7 @@ export async function openrouterGenerateText(params: {
                 "Content-Type": "application/json",
                 "HTTP-Referer": "https://minebench.dev",
                 "X-Title": "MineBench",
-                ...(params.onDelta ? { Accept: "text/event-stream" } : {}),
+                Accept: "text/event-stream, application/json",
               }, params.customHeaders),
               signal: controller.signal,
               body: JSON.stringify(mergeCustomRequestBody({
@@ -307,7 +308,7 @@ export async function openrouterGenerateText(params: {
                       },
                     }
                   : {}),
-                stream: Boolean(params.onDelta),
+                stream: true,
                 ...openRouterTemperaturePayload(params.modelId, params.temperature),
                 ...openRouterTopPPayload(modelRecommendedTopP(params.modelId)),
                 max_tokens: tok,
@@ -440,7 +441,10 @@ export async function openrouterGenerateText(params: {
       }
     }
 
-    if (params.onDelta) {
+    const contentType = res.headers.get("content-type") ?? "";
+    const isEventStream = contentType.includes("text/event-stream");
+
+    if (isEventStream || params.onDelta) {
       let text = "";
       await consumeSseStream(res, (evt) => {
         if (evt.data === "[DONE]") return;
@@ -450,10 +454,25 @@ export async function openrouterGenerateText(params: {
         } catch {
           return;
         }
+        if (parsed?.error) {
+          const message =
+            typeof parsed.error === "object" ? parsed.error.message : String(parsed.error);
+          throw new Error(`OpenRouter stream error: ${message || "Unknown error"}`);
+        }
         const chunk = parsed?.choices?.[0]?.delta?.content;
-        if (typeof chunk === "string" && chunk) {
-          text += chunk;
-          params.onDelta?.(chunk);
+        const deltaText =
+          typeof chunk === "string"
+            ? chunk
+            : Array.isArray(chunk)
+              ? chunk
+                  .map((c) =>
+                    c && typeof c === "object" ? String((c as { text?: unknown }).text ?? "") : "",
+                  )
+                  .join("")
+              : "";
+        if (deltaText) {
+          text += deltaText;
+          params.onDelta?.(deltaText);
         }
       });
       return { text };

--- a/tests/unit/providers/openrouter-streaming.test.ts
+++ b/tests/unit/providers/openrouter-streaming.test.ts
@@ -1,0 +1,83 @@
+import assert from "node:assert/strict";
+import { openrouterGenerateText } from "../../../lib/ai/providers/openrouter";
+
+const originalFetch = globalThis.fetch;
+
+async function main() {
+  process.env.OPENROUTER_BASE_URL = "https://openrouter.test/api";
+
+  // 1. Verify stream: true is sent and SSE stream is accumulated without onDelta
+  {
+    let capturedBody: Record<string, unknown> | null = null;
+
+    globalThis.fetch = (async (_input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+      capturedBody = JSON.parse(init?.body as string) as Record<string, unknown>;
+
+      const ssePayload = [
+        ": OPENROUTER PROCESSING\n\n",
+        'data: {"choices":[{"delta":{"content":"{\\"version\\":\\""}}]}\n\n',
+        ": OPENROUTER PROCESSING\n\n",
+        'data: {"choices":[{"delta":{"content":"1.0\\",\\"blocks\\":[]}"}}]}\n\n',
+        "data: [DONE]\n\n",
+      ].join("");
+
+      return new Response(ssePayload, {
+        status: 200,
+        headers: { "Content-Type": "text/event-stream" },
+      });
+    }) as typeof fetch;
+
+    try {
+      const result = await openrouterGenerateText({
+        modelId: "openai/gpt-6-astra-pro",
+        apiKey: "test-openrouter-key",
+        system: "Return JSON.",
+        user: "Build a shrine.",
+      });
+
+      assert.equal(capturedBody?.stream, true, "OpenRouter request should have stream: true");
+      assert.equal(
+        result.text,
+        '{"version":"1.0","blocks":[]}',
+        "Should accumulate SSE chunks into full text even when onDelta is omitted",
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  }
+
+  // 2. Verify mid-stream error raises cleanly
+  {
+    globalThis.fetch = (async (): Promise<Response> => {
+      const ssePayload = [
+        'data: {"error":{"message":"Rate limit reached while streaming"}}\n\n',
+      ].join("");
+
+      return new Response(ssePayload, {
+        status: 200,
+        headers: { "Content-Type": "text/event-stream" },
+      });
+    }) as typeof fetch;
+
+    try {
+      await assert.rejects(
+        openrouterGenerateText({
+          modelId: "openai/gpt-6-astra-pro",
+          apiKey: "test-openrouter-key",
+          system: "Return JSON.",
+          user: "Build a shrine.",
+        }),
+        /OpenRouter stream error: Rate limit reached while streaming/,
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  }
+
+  console.log("openrouter streaming checks passed");
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
### Summary of Changes

- **Enable Server-Sent Events (SSE) streaming by default for OpenRouter**: Previously, `stream: Boolean(params.onDelta)` meant background generation jobs (which run without a client `onDelta` callback) made synchronous non-streaming HTTP requests.
- **Prevent 10-minute gateway / proxy timeouts**: Long-horizon reasoning models (e.g. GPT-6 Astra Pro and GPT-5.6 Sol Pro) require 20–40 minutes of inference for full voxel scenes. In non-streaming mode, intermediate reverse proxies (Cloudflare Enterprise on OpenRouter) terminate the idle socket at 600 seconds (10 minutes), returning empty content and causing repeated `generation_failed` failures.
- **Accumulate streamed tokens**: When `Content-Type: text/event-stream` is returned, the provider client streams via `consumeSseStream`, accumulating delta text even when `onDelta` is not provided, while skipping keepalive comments (`: OPENROUTER PROCESSING`) and gracefully handling mid-stream error events.
- **Preserve JSON fallback**: Retains fallback handling for non-streaming / mock JSON responses so existing unit tests and mock endpoints continue to work seamlessly.

### Verification

- Added `tests/unit/providers/openrouter-streaming.test.ts` verifying that OpenRouter requests send `stream: true` and accumulate SSE chunks into full text when `onDelta` is omitted.
- Ran the full provider test suite (`tests/unit/providers`), passing all 16 test files.
- Ran `pnpm lint` with 0 errors and 0 warnings.

*(PR written by Codex)*