### PR TITLE
fix(worker): contain dense-build failures and recover interrupted generations

### DIFF
--- a/app/api/admin/seed/route.ts
+++ b/app/api/admin/seed/route.ts
@@ -12,6 +12,7 @@ import {
   modelCatalogSeedUpsertArgs,
 } from "@/lib/admin/seedModelCatalog";
 import { isLoopbackDatabaseUrl } from "@/lib/db/identity";
+import { toObjectBackedVoxelBuild } from "@/lib/voxel/packedBlocks";
 
 export const runtime = "nodejs";
 
@@ -368,7 +369,8 @@ export async function POST(req: Request) {
       );
     }
 
-    const buildJson = JSON.stringify(r.build);
+    const build = toObjectBackedVoxelBuild(r.build);
+    const buildJson = JSON.stringify(build);
     const saved = await prisma.build.create({
       data: {
         promptId: job.promptId,
@@ -376,7 +378,7 @@ export async function POST(req: Request) {
         gridSize: ARENA_SETTINGS.gridSize,
         palette: ARENA_SETTINGS.palette,
         mode: ARENA_SETTINGS.mode,
-        voxelData: r.build,
+        voxelData: build,
         voxelByteSize: Buffer.byteLength(buildJson),
         voxelSha256: createHash("sha256").update(buildJson).digest("hex"),
         blockCount: r.blockCount,

--- a/components/sandbox/SandboxGifExportButton.tsx
+++ b/components/sandbox/SandboxGifExportButton.tsx
@@ -831,13 +831,19 @@ async function buildGifBlob(
     resolveResult = resolve;
     rejectResult = (e) => reject(e);
   });
+  // worker errors can arrive before the result is awaited
+  void resultPromise.catch(() => {});
 
+  let workerError: Error | null = null;
   const failAll = (err: Error) => {
+    workerError = err;
+    worker.terminate();
     for (const waiter of ackWaiters.values()) waiter.reject(err);
     ackWaiters.clear();
     rejectReady?.(err);
     rejectResult?.(err);
   };
+  const onAbort = () => failAll(createAbortError());
 
   worker.onmessage = (event: MessageEvent<WorkerOut>) => {
     const msg = event.data;
@@ -870,27 +876,30 @@ async function buildGifBlob(
     failAll(new Error("GIF worker crashed"));
   };
 
-  worker.postMessage({ type: "start" });
-  await readyPromise;
-  throwIfAborted(signal);
-
-  const paletteSamples = await buildPaletteSamples(targets, format, profile, runtime, rotationBases, signal);
-  throwIfAborted(signal);
-  if (paletteSamples.length > 0) {
-    worker.postMessage({ type: "palette", samples: paletteSamples }, paletteSamples);
-  }
-
-  const layout = buildExportLayout(
-    frameCtx,
-    targets.length,
-    width,
-    height,
-    promptText,
-    format,
-    runtime.socialSafe ? "social-safe" : "full",
-  );
-
   try {
+    signal?.addEventListener("abort", onAbort, { once: true });
+    throwIfAborted(signal);
+    worker.postMessage({ type: "start" });
+    await readyPromise;
+    throwIfAborted(signal);
+
+    const paletteSamples = await buildPaletteSamples(targets, format, profile, runtime, rotationBases, signal);
+    throwIfAborted(signal);
+    if (workerError) throw workerError;
+    if (paletteSamples.length > 0) {
+      worker.postMessage({ type: "palette", samples: paletteSamples }, paletteSamples);
+    }
+
+    const layout = buildExportLayout(
+      frameCtx,
+      targets.length,
+      width,
+      height,
+      promptText,
+      format,
+      runtime.socialSafe ? "social-safe" : "full",
+    );
+
     const inFlight: Promise<void>[] = [];
     let completed = 0;
 
@@ -919,6 +928,7 @@ async function buildGifBlob(
         completed += 1;
         onProgress?.(completed, runtime.frameCount);
       });
+      void tracked.catch(() => {});
       inFlight.push(tracked);
 
       if (inFlight.length >= MAX_IN_FLIGHT_FRAMES) {
@@ -941,6 +951,7 @@ async function buildGifBlob(
     throwIfAborted(signal);
     return new Blob([bytes], { type: "image/gif" });
   } finally {
+    signal?.removeEventListener("abort", onAbort);
     worker.terminate();
   }
 }
@@ -1156,6 +1167,7 @@ export function SandboxGifExportButton({ targets, promptText, label, iconOnly, e
 
   useEffect(() => {
     exportAbortRef.current?.abort();
+    return () => exportAbortRef.current?.abort();
   }, [cancelKey]);
 
   async function handleExport() {

--- a/lib/ai/generateVoxelBuild.ts
+++ b/lib/ai/generateVoxelBuild.ts
@@ -1,11 +1,9 @@
-import type { BlockDefinition } from "@/lib/blocks/palettes";
 import { getPalette } from "@/lib/blocks/palettes";
 import {
   customProviderMaxOutputTokens,
   type CustomRequestBody,
   type CustomRequestHeaders,
 } from "@/lib/ai/customProviderConfig";
-import { extractBestVoxelBuildJson, extractFirstJsonObject } from "@/lib/ai/jsonExtract";
 import { modelOutputCeiling, modelUsesDefaultSampling } from "@/lib/ai/modelRequestProfiles";
 import { buildRepairPrompt, buildSystemPrompt, buildUserPrompt } from "@/lib/ai/prompts";
 import { getModelByKey, ModelKey, ModelCatalogEntry } from "@/lib/ai/modelCatalog";
@@ -39,12 +37,8 @@ import {
   xaiReasoningEffortAttempts,
   zaiReasoningEffortAttempts,
 } from "@/lib/ai/reasoningProfiles";
-import {
-  parseVoxelBuildSpec,
-  validateVoxelBuild,
-  validateVoxelBuildSpec,
-} from "@/lib/voxel/validate";
-import type { VoxelBuild } from "@/lib/voxel/types";
+import { processVoxelBuildResponse, type ProcessVoxelBuildResponse } from "@/lib/ai/processVoxelBuildResponse";
+import type { RenderableVoxelBuild } from "@/lib/voxel/packedBlocks";
 import { MAX_BLOCKS_BY_GRID, MIN_BLOCKS_BY_GRID } from "@/lib/ai/limits";
 import type {
   AcceptedProviderRequestConfiguration,
@@ -54,10 +48,8 @@ import type {
 } from "@/lib/ai/types";
 import { DEFAULT_MAX_OUTPUT_TOKENS } from "@/lib/ai/tokenBudgets";
 import {
-  runVoxelExec,
   VOXEL_EXEC_TOOL_NAME,
   voxelExecToolCallJsonSchema,
-  voxelExecToolCallSchema,
 } from "@/lib/ai/tools/voxelExec";
 import { getErrorMessage } from "@/lib/errorMessage";
 
@@ -501,17 +493,18 @@ export type GenerateVoxelBuildParams = {
   onProviderRequest?: (attempt: number) => void;
   onRetry?: (attempt: number, reason: string) => unknown;
   // Fired after response text returns and before parsing or execution
-  onRawResponse?: (attempt: number, rawText: string) => void;
+  onRawResponse?: (attempt: number, rawText: string) => void | Promise<void>;
   onDelta?: (delta: string) => void;
   onProviderTrace?: (message: string) => void;
   acquireBuildProcessing?: () => Promise<() => void>;
-  returnExpandedBuild?: boolean;
+  buildOutput?: "source" | "objects" | "packed";
+  processResponse?: ProcessVoxelBuildResponse;
 };
 
 export type GenerateVoxelBuildResult =
   | {
       ok: true;
-      build: VoxelBuild;
+      build: RenderableVoxelBuild;
       warnings: string[];
       blockCount: number;
       generationTimeMs: number;
@@ -1066,38 +1059,6 @@ async function providerGenerateText(args: {
   });
 }
 
-function validateParsedJson(json: unknown, palette: BlockDefinition[], gridSize: 64 | 256 | 512) {
-  return validateVoxelBuild(json, {
-    palette,
-    gridSize,
-    maxBlocks: MAX_BLOCKS_BY_GRID[gridSize],
-  });
-}
-
-function buildBounds(build: VoxelBuild) {
-  if (build.blocks.length === 0) return null;
-  let minX = Infinity;
-  let minY = Infinity;
-  let minZ = Infinity;
-  let maxX = -Infinity;
-  let maxY = -Infinity;
-  let maxZ = -Infinity;
-
-  for (const b of build.blocks) {
-    if (b.x < minX) minX = b.x;
-    if (b.y < minY) minY = b.y;
-    if (b.z < minZ) minZ = b.z;
-    if (b.x > maxX) maxX = b.x;
-    if (b.y > maxY) maxY = b.y;
-    if (b.z > maxZ) maxZ = b.z;
-  }
-
-  const spanX = maxX - minX + 1;
-  const spanY = maxY - minY + 1;
-  const spanZ = maxZ - minZ + 1;
-  return { minX, minY, minZ, maxX, maxY, maxZ, spanX, spanY, spanZ };
-}
-
 export async function generateVoxelBuild(
   params: GenerateVoxelBuildParams,
 ): Promise<GenerateVoxelBuildResult> {
@@ -1261,14 +1222,17 @@ export async function generateVoxelBuild(
         },
       });
       previousText = text;
-      try {
-        invokeCallback(params.onRawResponse, attempt, text);
-      } catch (err) {
-        const message = getErrorMessage(err, String(err));
-        invokeCallback(
-          params.onProviderTrace,
-          `Raw response callback failed for attempt ${attempt}: ${message}`,
-        );
+      if (params.onRawResponse) {
+        const callbackStartedAt = performance.now();
+        try {
+          await params.onRawResponse(attempt, text);
+        } catch (error) {
+          const message = getErrorMessage(error, String(error));
+          if (message.includes("custom_build_artifact_persistence_failed")) throw error;
+          invokeCallback(params.onProviderTrace, `Raw response callback failed for attempt ${attempt}: ${message}`);
+        } finally {
+          callbackDurationMs += performance.now() - callbackStartedAt;
+        }
       }
       let releaseBuildProcessing: (() => void) | undefined;
       if (params.acquireBuildProcessing) {
@@ -1284,103 +1248,29 @@ export async function generateVoxelBuild(
       let keepBuildProcessingLease = false;
       try {
         params.abortSignal?.throwIfAborted();
-        const json = enableTools ? extractFirstJsonObject(text) : extractBestVoxelBuildJson(text);
-        if (!json) {
-          lastError = "Could not find a valid JSON object in the response";
+        const responseOptions = {
+          gridSize: params.gridSize,
+          palette: params.palette,
+          enableTools,
+          minBlocks,
+          buildOutput: params.buildOutput ?? "source" as const,
+        };
+        const processed = params.processResponse
+          ? await params.processResponse(text, responseOptions, params.abortSignal)
+          : processVoxelBuildResponse(text, responseOptions);
+        if (!processed.ok) {
+          lastError = processed.error;
+          if (lastError.includes("heap_limit_exceeded")) break;
           continue;
-        }
-
-        const buildJson: unknown = enableTools
-          ? (() => {
-              const parsedCall = voxelExecToolCallSchema.safeParse(json);
-              if (!parsedCall.success) {
-                lastError = parsedCall.error.message;
-                return null;
-              }
-
-              const call = parsedCall.data;
-              if (call.input.gridSize !== params.gridSize) {
-                lastError = `Tool call gridSize mismatch (${call.input.gridSize} vs ${params.gridSize})`;
-                return null;
-              }
-              if (call.input.palette !== params.palette) {
-                lastError = `Tool call palette mismatch (${call.input.palette} vs ${params.palette})`;
-                return null;
-              }
-
-              const run = runVoxelExec({
-                code: call.input.code,
-                gridSize: params.gridSize,
-                palette: params.palette,
-                seed: call.input.seed,
-              });
-
-              return run.build;
-            })()
-          : json;
-
-        if (!buildJson) continue;
-
-        const validated = enableTools
-          ? validateVoxelBuildSpec(buildJson as VoxelBuild, {
-              palette: paletteDefs,
-              gridSize: params.gridSize,
-              maxBlocks: MAX_BLOCKS_BY_GRID[params.gridSize],
-            })
-          : validateParsedJson(buildJson, paletteDefs, params.gridSize);
-        if (!validated.ok) {
-          lastError = validated.error;
-          continue;
-        }
-
-        const expandedBuild = validated.value.build;
-        const blockCount = expandedBuild.blocks.length;
-
-        if (blockCount === 0) {
-          lastError =
-            "No valid blocks after validation. Use ONLY in-bounds coordinates and ONLY block IDs from the available list.";
-          continue;
-        }
-
-        if (blockCount < minBlocks) {
-          lastError = `Build too small (${blockCount} blocks). Create at least ~${minBlocks} blocks so the result is recognizable.`;
-          continue;
-        }
-
-        const bounds = buildBounds(expandedBuild);
-        if (bounds) {
-          const minFootprint = Math.max(6, Math.floor(params.gridSize * 0.15));
-          const minHeight = Math.max(4, Math.floor(params.gridSize * 0.1));
-          const maxFootprintSpan = Math.max(bounds.spanX, bounds.spanZ);
-
-          if (maxFootprintSpan < minFootprint) {
-            lastError = `Build footprint too small (span ${maxFootprintSpan}). Expand the build to span at least ~${minFootprint} blocks across x or z for more detail.`;
-            continue;
-          }
-
-          if (bounds.spanY < minHeight) {
-            lastError = `Build height too small (span ${bounds.spanY}). Add more vertical structure (span at least ~${minHeight}) so it reads clearly.`;
-            continue;
-          }
-        }
-
-        let build = expandedBuild;
-        if (!params.returnExpandedBuild) {
-          const spec = parseVoxelBuildSpec(buildJson);
-          if (!spec.ok) {
-            lastError = spec.error;
-            continue;
-          }
-          build = spec.value;
         }
 
         const generationTimeMs = measuredInferenceTimeMs();
         keepBuildProcessingLease = true;
         return {
           ok: true,
-          build,
-          warnings: validated.value.warnings,
-          blockCount,
+          build: processed.build,
+          warnings: processed.warnings,
+          blockCount: processed.blockCount,
           generationTimeMs,
           acceptedOutputTokens,
           providerRoute,
@@ -1394,6 +1284,8 @@ export async function generateVoxelBuild(
     } catch (err) {
       lastError = getErrorMessage(err, "Provider request failed");
       if (params.abortSignal?.aborted) break;
+      if (lastError.includes("heap_limit_exceeded")) break;
+      if (lastError.includes("custom_build_artifact_persistence_failed")) break;
       // Retry transient work that failed safely before an outbound request
       if (
         !providerRequestStarted &&

--- a/lib/ai/generateVoxelBuild.ts
+++ b/lib/ai/generateVoxelBuild.ts
@@ -15,7 +15,7 @@ import { minimaxGenerateText } from "@/lib/ai/providers/minimax";
 import { metaGenerateText } from "@/lib/ai/providers/meta";
 import { moonshotGenerateText } from "@/lib/ai/providers/moonshot";
 import { openAiCompatibleGenerateText } from "@/lib/ai/providers/openaiCompatible";
-import { openaiGenerateText } from "@/lib/ai/providers/openai";
+import { openaiGenerateText, OpenAIResponseCheckpointError, type OpenAIBackgroundResponseOptions } from "@/lib/ai/providers/openai";
 import { openrouterGenerateText } from "@/lib/ai/providers/openrouter";
 import { xaiGenerateText } from "@/lib/ai/providers/xai";
 import { zaiGenerateText } from "@/lib/ai/providers/zai";
@@ -37,7 +37,7 @@ import {
   xaiReasoningEffortAttempts,
   zaiReasoningEffortAttempts,
 } from "@/lib/ai/reasoningProfiles";
-import { processVoxelBuildResponse, type ProcessVoxelBuildResponse } from "@/lib/ai/processVoxelBuildResponse";
+import { isVoxelBuildResourceError, processVoxelBuildResponse, type ProcessVoxelBuildResponse } from "@/lib/ai/processVoxelBuildResponse";
 import type { RenderableVoxelBuild } from "@/lib/voxel/packedBlocks";
 import { MAX_BLOCKS_BY_GRID, MIN_BLOCKS_BY_GRID } from "@/lib/ai/limits";
 import type {
@@ -499,7 +499,7 @@ export type GenerateVoxelBuildParams = {
   acquireBuildProcessing?: () => Promise<() => void>;
   buildOutput?: "source" | "objects" | "packed";
   processResponse?: ProcessVoxelBuildResponse;
-};
+} & OpenAIBackgroundResponseOptions;
 
 export type GenerateVoxelBuildResult =
   | {
@@ -560,7 +560,7 @@ async function callDirectProvider(args: {
   onDelta?: (delta: string) => void;
   onTrace?: (message: string) => void;
   onAcceptedOutputTokens?: (tokens: number) => void;
-} & ProviderTelemetryCallbacks): Promise<{ text: string }> {
+} & ProviderTelemetryCallbacks & OpenAIBackgroundResponseOptions): Promise<{ text: string }> {
   if (args.provider === "openai") {
     return openaiGenerateText({
       modelId: args.modelId,
@@ -579,6 +579,8 @@ async function callDirectProvider(args: {
       onTrace: args.onTrace,
       onAcceptedOutputTokens: args.onAcceptedOutputTokens,
       onProviderRequest: args.onProviderRequest,
+      openaiResponseId: args.openaiResponseId,
+      onOpenAIResponseCreated: args.onOpenAIResponseCreated,
       onAcceptedRequestConfiguration: args.onAcceptedRequestConfiguration,
     });
   }
@@ -801,7 +803,7 @@ async function providerGenerateText(args: {
     configuration: AcceptedRequestConfigurationRecord,
   ) => void;
   onProviderRequest?: () => void;
-}): Promise<{ text: string }> {
+} & OpenAIBackgroundResponseOptions): Promise<{ text: string }> {
   const { model } = args;
   const forceOpenRouter = Boolean(model.forceOpenRouter);
   const preferOpenRouter = Boolean(args.preferOpenRouter);
@@ -819,6 +821,10 @@ async function providerGenerateText(args: {
   });
   const hasDirect = Boolean(directKey);
   const hasOpenRouter = Boolean(openRouterKey);
+
+  if (args.openaiResponseId && (model.provider !== "openai" || !hasDirect || forceOpenRouter || preferOpenRouter)) {
+    throw new Error("Stored OpenAI responses require the original direct provider route");
+  }
 
   if (preferOpenRouter && !model.openRouterModelId) {
     throw new Error(
@@ -946,6 +952,8 @@ async function providerGenerateText(args: {
         onTrace: args.onProviderTrace,
         onAcceptedOutputTokens: args.onAcceptedOutputTokens,
         onProviderRequest: args.onProviderRequest,
+        openaiResponseId: args.openaiResponseId,
+        onOpenAIResponseCreated: args.onOpenAIResponseCreated,
         onAcceptedRequestConfiguration: (configuration) => {
           args.onAcceptedRequestConfiguration?.(
             acceptedProviderRequestConfigurationLine(configuration),
@@ -1088,7 +1096,7 @@ export async function generateVoxelBuild(
   }
   const paletteDefs = getPalette(params.palette);
   const enableTools = params.enableTools ?? true;
-  const maxAttempts = params.maxAttempts ?? (enableTools ? 8 : 3);
+  const maxAttempts = params.openaiResponseId ? 1 : (params.maxAttempts ?? (enableTools ? 8 : 3));
   const allowServerKeys = params.allowServerKeys ?? true;
 
   const minBlocks = MIN_BLOCKS_BY_GRID[params.gridSize] ?? 80;
@@ -1198,6 +1206,17 @@ export async function generateVoxelBuild(
         allowServerKeys,
         preferOpenRouter: params.preferOpenRouter,
         signal: params.abortSignal,
+        openaiResponseId: params.openaiResponseId,
+        onOpenAIResponseCreated: params.onOpenAIResponseCreated
+          ? async (responseId) => {
+              const callbackStartedAt = performance.now();
+              try {
+                await params.onOpenAIResponseCreated!(responseId);
+              } finally {
+                callbackDurationMs += performance.now() - callbackStartedAt;
+              }
+            }
+          : undefined,
         onDelta: params.onDelta
           ? (delta) => invokeCallback(params.onDelta, delta)
           : undefined,
@@ -1260,7 +1279,7 @@ export async function generateVoxelBuild(
           : processVoxelBuildResponse(text, responseOptions);
         if (!processed.ok) {
           lastError = processed.error;
-          if (lastError.includes("heap_limit_exceeded")) break;
+          if (isVoxelBuildResourceError(lastError)) break;
           continue;
         }
 
@@ -1283,8 +1302,9 @@ export async function generateVoxelBuild(
       }
     } catch (err) {
       lastError = getErrorMessage(err, "Provider request failed");
-      if (params.abortSignal?.aborted) break;
-      if (lastError.includes("heap_limit_exceeded")) break;
+      if (params.abortSignal?.aborted || err instanceof OpenAIResponseCheckpointError) break;
+      if (err && typeof err === "object" && "code" in err && err.code === "ERR_SCRIPT_EXECUTION_TIMEOUT") break;
+      if (isVoxelBuildResourceError(lastError)) break;
       if (lastError.includes("custom_build_artifact_persistence_failed")) break;
       // Retry transient work that failed safely before an outbound request
       if (

--- a/lib/ai/processVoxelBuildResponse.ts
+++ b/lib/ai/processVoxelBuildResponse.ts
@@ -33,6 +33,10 @@ export type ProcessVoxelBuildResponse = (
   signal?: AbortSignal,
 ) => Promise<ProcessedVoxelBuildResponse>;
 
+export function isVoxelBuildResourceError(message: string): boolean {
+  return /heap_limit_exceeded|processing_capacity_exceeded/.test(message);
+}
+
 function buildBounds(build: RenderableVoxelBuild) {
   let minX = Infinity;
   let minY = Infinity;
@@ -82,7 +86,9 @@ export function processVoxelBuildResponse(
   const validationOptions = {
     palette: getPalette(opts.palette),
     gridSize: opts.gridSize,
-    maxBlocks: MAX_BLOCKS_BY_GRID[opts.gridSize],
+    maxBlocks: opts.gridSize === 512 && opts.buildOutput === "packed"
+      ? MAX_BLOCKS_BY_GRID[256]
+      : MAX_BLOCKS_BY_GRID[opts.gridSize],
     output: opts.buildOutput === "packed" ? "packed" as const : "objects" as const,
   };
   const validated = opts.buildOutput === "source"
@@ -90,7 +96,12 @@ export function processVoxelBuildResponse(
       ? validateVoxelBuildSpec(buildJson as VoxelBuild, validationOptions)
       : validateVoxelBuild(buildJson, validationOptions)
     : validateOwnedVoxelBuild(buildJson, validationOptions);
-  if (!validated.ok) return validated;
+  if (!validated.ok) {
+    if (opts.gridSize === 512 && opts.buildOutput === "packed" && validated.error.startsWith("Too many blocks")) {
+      return { ok: false, error: "processing_capacity_exceeded" };
+    }
+    return validated;
+  }
 
   const expandedBuild = validated.value.build;
   const blockCount = voxelBuildBlockCount(expandedBuild);

--- a/lib/ai/processVoxelBuildResponse.ts
+++ b/lib/ai/processVoxelBuildResponse.ts
@@ -1,0 +1,125 @@
+import { getPalette } from "@/lib/blocks/palettes";
+import { extractBestVoxelBuildJson, extractFirstJsonObject } from "@/lib/ai/jsonExtract";
+import { MAX_BLOCKS_BY_GRID, type GridSize } from "@/lib/ai/limits";
+import { runVoxelExec, voxelExecToolCallSchema } from "@/lib/ai/tools/voxelExec";
+import {
+  parseVoxelBuildSpec,
+  validateOwnedVoxelBuild,
+  validateVoxelBuild,
+  validateVoxelBuildSpec,
+} from "@/lib/voxel/validate";
+import {
+  voxelBuildBlockAt,
+  voxelBuildBlockCount,
+  type RenderableVoxelBuild,
+} from "@/lib/voxel/packedBlocks";
+import type { VoxelBuild } from "@/lib/voxel/types";
+
+export type VoxelBuildResponseOptions = {
+  gridSize: GridSize;
+  palette: "simple" | "advanced";
+  enableTools: boolean;
+  minBlocks: number;
+  buildOutput: "source" | "objects" | "packed";
+};
+
+export type ProcessedVoxelBuildResponse =
+  | { ok: true; build: RenderableVoxelBuild; warnings: string[]; blockCount: number }
+  | { ok: false; error: string };
+
+export type ProcessVoxelBuildResponse = (
+  text: string,
+  opts: VoxelBuildResponseOptions,
+  signal?: AbortSignal,
+) => Promise<ProcessedVoxelBuildResponse>;
+
+function buildBounds(build: RenderableVoxelBuild) {
+  let minX = Infinity;
+  let minY = Infinity;
+  let minZ = Infinity;
+  let maxX = -Infinity;
+  let maxY = -Infinity;
+  let maxZ = -Infinity;
+  const count = voxelBuildBlockCount(build);
+  for (let index = 0; index < count; index += 1) {
+    const block = voxelBuildBlockAt(build, index)!;
+    minX = Math.min(minX, block.x);
+    minY = Math.min(minY, block.y);
+    minZ = Math.min(minZ, block.z);
+    maxX = Math.max(maxX, block.x);
+    maxY = Math.max(maxY, block.y);
+    maxZ = Math.max(maxZ, block.z);
+  }
+  return { spanX: maxX - minX + 1, spanY: maxY - minY + 1, spanZ: maxZ - minZ + 1 };
+}
+
+export function processVoxelBuildResponse(
+  text: string,
+  opts: VoxelBuildResponseOptions,
+): ProcessedVoxelBuildResponse {
+  const json = opts.enableTools ? extractFirstJsonObject(text) : extractBestVoxelBuildJson(text);
+  if (!json) return { ok: false, error: "Could not find a valid JSON object in the response" };
+
+  let buildJson: unknown = json;
+  if (opts.enableTools) {
+    const parsedCall = voxelExecToolCallSchema.safeParse(json);
+    if (!parsedCall.success) return { ok: false, error: parsedCall.error.message };
+    const call = parsedCall.data;
+    if (call.input.gridSize !== opts.gridSize) {
+      return { ok: false, error: `Tool call gridSize mismatch (${call.input.gridSize} vs ${opts.gridSize})` };
+    }
+    if (call.input.palette !== opts.palette) {
+      return { ok: false, error: `Tool call palette mismatch (${call.input.palette} vs ${opts.palette})` };
+    }
+    buildJson = runVoxelExec({
+      code: call.input.code,
+      gridSize: opts.gridSize,
+      palette: opts.palette,
+      seed: call.input.seed,
+    }).build;
+  }
+
+  const validationOptions = {
+    palette: getPalette(opts.palette),
+    gridSize: opts.gridSize,
+    maxBlocks: MAX_BLOCKS_BY_GRID[opts.gridSize],
+    output: opts.buildOutput === "packed" ? "packed" as const : "objects" as const,
+  };
+  const validated = opts.buildOutput === "source"
+    ? opts.enableTools
+      ? validateVoxelBuildSpec(buildJson as VoxelBuild, validationOptions)
+      : validateVoxelBuild(buildJson, validationOptions)
+    : validateOwnedVoxelBuild(buildJson, validationOptions);
+  if (!validated.ok) return validated;
+
+  const expandedBuild = validated.value.build;
+  const blockCount = voxelBuildBlockCount(expandedBuild);
+  if (blockCount === 0) {
+    return {
+      ok: false,
+      error: "No valid blocks after validation. Use ONLY in-bounds coordinates and ONLY block IDs from the available list.",
+    };
+  }
+  if (blockCount < opts.minBlocks) {
+    return { ok: false, error: `Build too small (${blockCount} blocks). Create at least ~${opts.minBlocks} blocks so the result is recognizable.` };
+  }
+
+  const bounds = buildBounds(expandedBuild);
+  const minFootprint = Math.max(6, Math.floor(opts.gridSize * 0.15));
+  const minHeight = Math.max(4, Math.floor(opts.gridSize * 0.1));
+  const maxFootprintSpan = Math.max(bounds.spanX, bounds.spanZ);
+  if (maxFootprintSpan < minFootprint) {
+    return { ok: false, error: `Build footprint too small (span ${maxFootprintSpan}). Expand the build to span at least ~${minFootprint} blocks across x or z for more detail.` };
+  }
+  if (bounds.spanY < minHeight) {
+    return { ok: false, error: `Build height too small (span ${bounds.spanY}). Add more vertical structure (span at least ~${minHeight}) so it reads clearly.` };
+  }
+
+  let build = expandedBuild;
+  if (opts.buildOutput === "source") {
+    const spec = parseVoxelBuildSpec(buildJson);
+    if (!spec.ok) return spec;
+    build = spec.value;
+  }
+  return { ok: true, build, warnings: validated.value.warnings, blockCount };
+}

--- a/lib/ai/providers/openai.ts
+++ b/lib/ai/providers/openai.ts
@@ -51,6 +51,17 @@ type OpenAIChatCompletionsStreamChunk = {
 
 type TextVerbosity = "low" | "medium" | "high";
 
+export type OpenAIBackgroundResponseOptions = {
+  openaiResponseId?: string;
+  onOpenAIResponseCreated?: (responseId: string) => Promise<void>;
+};
+
+export class OpenAIResponseCheckpointError extends Error {
+  constructor(responseId: string, cause: unknown) {
+    super(`openai_response_checkpoint_failed: ${responseId}`, { cause });
+  }
+}
+
 function parseIntEnv(name: string, defaultValue: number): number {
   const raw = process.env[name];
   if (!raw) return defaultValue;
@@ -332,6 +343,29 @@ async function pollBackgroundResponse(opts: {
   return current;
 }
 
+function completedResponseText(
+  data: OpenAIResponsesBackgroundResponse,
+  onTrace?: (message: string) => void,
+): string {
+  const finalStatus = backgroundStatusOf(data.status);
+  if (finalStatus && finalStatus !== "completed") {
+    const reason = summarizeBackgroundError(data);
+    if (isIncompleteMaxOutputTokensResponse(data)) {
+      onTrace?.(
+        `OpenAI Responses ended with status incomplete: ${reason ?? "max_output_tokens"}; ${formatUsageNumbers(data)}. ` +
+          "The current max_output_tokens budget was fully exhausted.",
+      );
+      throw new Error(
+        `OpenAI background response ended with status incomplete: ${reason ?? "max_output_tokens"} (${formatUsageNumbers(data)})`,
+      );
+    }
+    throw new Error(
+      `OpenAI background response ended with status ${finalStatus}${reason ? `: ${reason}` : ""}`,
+    );
+  }
+  return extractTextFromResponses(data);
+}
+
 type ReasoningConfigAttempt =
   | { kind: "effort"; effort: string }
   | { kind: "max_tokens"; maxTokens: number }
@@ -440,11 +474,28 @@ export async function openaiGenerateText(params: {
   onAcceptedOutputTokens?: (tokens: number) => void;
   customHeaders?: CustomRequestHeaders;
   customBody?: CustomRequestBody;
-} & ProviderTelemetryCallbacks): Promise<{ text: string }> {
+} & ProviderTelemetryCallbacks & OpenAIBackgroundResponseOptions): Promise<{ text: string }> {
   const apiKey = params.apiKey ?? process.env.OPENAI_API_KEY;
   if (!apiKey) throw new Error("Missing OPENAI_API_KEY");
 
   if (!params.jsonSchema) throw new Error("Missing jsonSchema for OpenAI structured output");
+
+  if (params.openaiResponseId) {
+    if (!/^resp_[A-Za-z0-9_-]{1,200}$/.test(params.openaiResponseId)) {
+      throw new Error("Invalid OpenAI response id");
+    }
+    const data = await pollBackgroundResponse({
+      apiKey,
+      responseId: params.openaiResponseId,
+      signal: params.signal ?? new AbortController().signal,
+      pollIntervalMs: parseIntEnv("OPENAI_BACKGROUND_POLL_MS", 15_000),
+      onTrace: params.onTrace,
+      customHeaders: params.customHeaders,
+    });
+    const text = completedResponseText(data, params.onTrace);
+    if (!text) throw new Error("OpenAI background response returned no output text");
+    return { text };
+  }
 
   const isGpt5Family = params.modelId.startsWith("gpt-5");
   const isGptOssFamily = params.modelId.startsWith("gpt-oss-");
@@ -643,6 +694,13 @@ export async function openaiGenerateText(params: {
             if (useBackgroundMode) {
               const initialStatus = backgroundStatusOf(data.status);
               const responseId = typeof data.id === "string" ? data.id : null;
+              if (responseId && params.onOpenAIResponseCreated) {
+                try {
+                  await params.onOpenAIResponseCreated(responseId);
+                } catch (error) {
+                  throw new OpenAIResponseCheckpointError(responseId, error);
+                }
+              }
               if (isBackgroundPending(initialStatus)) {
                 if (!responseId) throw new Error("OpenAI background response missing id");
                 data = await pollBackgroundResponse({
@@ -656,26 +714,10 @@ export async function openaiGenerateText(params: {
               }
             }
 
-            const finalStatus = backgroundStatusOf(data.status);
-            if (finalStatus && finalStatus !== "completed") {
-              const reason = summarizeBackgroundError(data);
-              if (isIncompleteMaxOutputTokensResponse(data)) {
-                params.onTrace?.(
-                  `OpenAI Responses ended with status incomplete: ${reason ?? "max_output_tokens"}; ${formatUsageNumbers(data)}. ` +
-                    "The current max_output_tokens budget was fully exhausted.",
-                );
-                throw new Error(
-                  `OpenAI background response ended with status incomplete: ${reason ?? "max_output_tokens"} (${formatUsageNumbers(data)})`,
-                );
-              }
-              throw new Error(
-                `OpenAI background response ended with status ${finalStatus}${reason ? `: ${reason}` : ""}`,
-              );
-            }
-
-            const text = extractTextFromResponses(data);
+            const text = completedResponseText(data, params.onTrace);
             if (text) return { text };
             if (useBackgroundMode) {
+              const finalStatus = backgroundStatusOf(data.status);
               throw new Error(
                 `OpenAI background response returned no output text${finalStatus ? ` (status ${finalStatus})` : ""}`,
               );
@@ -747,6 +789,7 @@ export async function openaiGenerateText(params: {
       }
     }
   } catch (err) {
+    if (err instanceof OpenAIResponseCheckpointError) throw err;
     // If Responses fails (unsupported endpoint/model), try chat/completions below.
     if (err instanceof Error && err.name === "AbortError") {
       throw new Error("OpenAI request timed out");

--- a/lib/arena/buildArtifacts.ts
+++ b/lib/arena/buildArtifacts.ts
@@ -8,6 +8,12 @@ import {
 } from "@/lib/arena/buildDeliveryPolicy";
 import type { VoxelBlock, VoxelBuild } from "@/lib/voxel/types";
 import { filterRenderableVoxelBuild } from "@/lib/voxel/renderVisibility";
+import { SpatialBlockTable } from "@/lib/voxel/ambientOcclusion";
+import {
+  voxelBuildBlockAt,
+  voxelBuildBlockCount,
+  type RenderableVoxelBuild,
+} from "@/lib/voxel/packedBlocks";
 import { parseVoxelBuildSpec, validateVoxelBuild } from "@/lib/voxel/validate";
 import { resolveBuildPayload } from "@/lib/storage/buildPayload";
 import { normalizeArenaBuildChecksum } from "@/lib/arena/buildChecksum";
@@ -92,8 +98,8 @@ export type PreparedArenaBuild = {
   buildId: string;
   payloadIdentity: ArenaBuildPayloadIdentity;
   checksum: string | null;
-  fullBuild: VoxelBuild;
-  previewBuild: VoxelBuild;
+  fullBuild: RenderableVoxelBuild;
+  previewBuild: RenderableVoxelBuild;
   hints: ArenaBuildLoadHints;
   buildRef: ArenaBuildRef;
   previewRef: ArenaBuildRef;
@@ -107,7 +113,7 @@ type CachedArtifact = {
 };
 
 type ParsedArenaBuild = {
-  build: VoxelBuild;
+  build: RenderableVoxelBuild;
   payloadEstimatedBytes: number | null;
 };
 
@@ -329,10 +335,6 @@ const NEIGHBOR_DIRS: ReadonlyArray<readonly [number, number, number]> = [
   [0, 0, -1],
 ];
 
-function encodePosition(x: number, y: number, z: number): number {
-  return (x & 1023) | ((y & 1023) << 10) | ((z & 1023) << 20);
-}
-
 function hashBlock(block: VoxelBlock): number {
   let h = (block.x * 73856093) ^ (block.y * 19349663) ^ (block.z * 83492791);
   h ^= h >>> 13;
@@ -340,83 +342,103 @@ function hashBlock(block: VoxelBlock): number {
   return (h ^ (h >>> 16)) >>> 0;
 }
 
-function extractSurfaceBlocks(blocks: VoxelBlock[]): VoxelBlock[] {
-  // previews should show visible shape, not hidden interior volume
-  const occupied = new Set<number>();
-  for (const block of blocks) {
-    occupied.add(encodePosition(block.x, block.y, block.z));
+function buildBlockAt(build: RenderableVoxelBuild, index: number): VoxelBlock {
+  const block = voxelBuildBlockAt(build, index);
+  if (!block) throw new Error(`Missing voxel block at index ${index}`);
+  return block;
+}
+
+function hashBuildBlockAt(build: RenderableVoxelBuild, index: number): number {
+  return hashBlock(buildBlockAt(build, index));
+}
+
+function extractSurfaceBlockIndices(build: RenderableVoxelBuild): number[] {
+  const blockCount = voxelBuildBlockCount(build);
+  const occupied = new SpatialBlockTable(blockCount);
+  for (let index = 0; index < blockCount; index += 1) {
+    const block = buildBlockAt(build, index);
+    occupied.set(block.x, block.y, block.z, 0);
   }
 
-  const surface: VoxelBlock[] = [];
-  for (const block of blocks) {
+  const surface: number[] = [];
+  for (let index = 0; index < blockCount; index += 1) {
+    const block = buildBlockAt(build, index);
     let exposed = false;
     for (const [dx, dy, dz] of NEIGHBOR_DIRS) {
-      const neighborKey = encodePosition(block.x + dx, block.y + dy, block.z + dz);
-      if (!occupied.has(neighborKey)) {
+      if (occupied.get(block.x + dx, block.y + dy, block.z + dz) === -1) {
         exposed = true;
         break;
       }
     }
-
-    if (exposed) {
-      surface.push(block);
-    }
+    if (exposed) surface.push(index);
   }
-
   return surface;
 }
 
-function deterministicSampleBlocks(blocks: VoxelBlock[], targetBlockCount: number): VoxelBlock[] {
-  if (blocks.length <= targetBlockCount) return blocks;
+function deterministicSampleBlockIndices(
+  build: RenderableVoxelBuild,
+  indices: number[],
+  targetBlockCount: number,
+): number[] {
+  if (indices.length <= targetBlockCount) return indices;
   if (targetBlockCount <= 0) return [];
 
   // stable sampling avoids preview churn between requests
-  const keepRatio = targetBlockCount / blocks.length;
-  const sampled = blocks.filter((block) => hashBlock(block) / 0xffffffff <= keepRatio);
-  if (sampled.length >= targetBlockCount) {
-    return sampled.slice(0, targetBlockCount);
-  }
+  const keepRatio = targetBlockCount / indices.length;
+  const sampled = indices.filter(
+    (index) => hashBuildBlockAt(build, index) / 0xffffffff <= keepRatio,
+  );
+  if (sampled.length >= targetBlockCount) return sampled.slice(0, targetBlockCount);
 
-  const sampledKeys = new Set(sampled.map((block) => encodePosition(block.x, block.y, block.z)));
+  const sampledIndices = new Set(sampled);
   const remainder = targetBlockCount - sampled.length;
-  const stride = Math.max(1, Math.floor(blocks.length / Math.max(1, remainder)));
-  for (let i = 0; i < blocks.length && sampled.length < targetBlockCount; i += stride) {
-    const block = blocks[i];
-    if (!block) continue;
-    const key = encodePosition(block.x, block.y, block.z);
-    if (sampledKeys.has(key)) continue;
-    sampled.push(block);
-    sampledKeys.add(key);
+  const stride = Math.max(1, Math.floor(indices.length / Math.max(1, remainder)));
+  for (let i = 0; i < indices.length && sampled.length < targetBlockCount; i += stride) {
+    const index = indices[i]!;
+    if (sampledIndices.has(index)) continue;
+    sampled.push(index);
+    sampledIndices.add(index);
   }
 
   return sampled.slice(0, targetBlockCount);
 }
 
-function buildPreviewBuild(fullBuild: VoxelBuild, targetBlockCount: number): { build: VoxelBuild; stride: number } {
-  const sourceBlocks = fullBuild.blocks;
-  if (sourceBlocks.length <= targetBlockCount) {
+function buildPreviewSubset(
+  build: RenderableVoxelBuild,
+  indices: readonly number[],
+): VoxelBuild {
+  const blocks: VoxelBlock[] = [];
+  for (const index of indices) blocks.push(buildBlockAt(build, index));
+  return { version: "1.0", blocks };
+}
+
+function buildPreviewBuild(
+  fullBuild: RenderableVoxelBuild,
+  targetBlockCount: number,
+): { build: RenderableVoxelBuild; stride: number } {
+  const sourceBlockCount = voxelBuildBlockCount(fullBuild);
+  if (sourceBlockCount <= targetBlockCount) {
     return { build: fullBuild, stride: 1 };
   }
 
-  const surfaceBlocks = extractSurfaceBlocks(sourceBlocks);
-  const previewBlocks =
-    surfaceBlocks.length > targetBlockCount
-      ? deterministicSampleBlocks(surfaceBlocks, targetBlockCount)
-      : surfaceBlocks;
+  const surfaceIndices = extractSurfaceBlockIndices(fullBuild);
+  const previewIndices =
+    surfaceIndices.length > targetBlockCount
+      ? deterministicSampleBlockIndices(fullBuild, surfaceIndices, targetBlockCount)
+      : surfaceIndices;
 
   return {
-    build: {
-      version: "1.0",
-      blocks: previewBlocks,
-    },
+    build: buildPreviewSubset(fullBuild, previewIndices),
     stride: 1,
   };
 }
 
-function computeBuildChecksum(fullBuild: VoxelBuild): string {
+function computeBuildChecksum(fullBuild: RenderableVoxelBuild): string {
+  const blockCount = voxelBuildBlockCount(fullBuild);
   const hash = createHash("sha256");
-  hash.update(`v=${fullBuild.version};n=${fullBuild.blocks.length};`);
-  for (const block of fullBuild.blocks) {
+  hash.update(`v=${fullBuild.version};n=${blockCount};`);
+  for (let index = 0; index < blockCount; index += 1) {
+    const block = buildBlockAt(fullBuild, index);
     hash.update(`${block.x},${block.y},${block.z},${block.type};`);
   }
   return hash.digest("hex");
@@ -424,13 +446,13 @@ function computeBuildChecksum(fullBuild: VoxelBuild): string {
 
 function createPrepared(
   source: ArenaBuildSource,
-  fullBuild: VoxelBuild,
+  fullBuild: RenderableVoxelBuild,
   payloadEstimatedBytes: number | null,
   checksumOverride?: string | null,
 ): PreparedArenaBuild {
   const renderBuild = filterRenderableVoxelBuild(fullBuild);
   const hintsFromMetadata = deriveArenaBuildLoadHints({
-    blockCount: renderBuild.blocks.length,
+    blockCount: voxelBuildBlockCount(renderBuild),
     voxelByteSize: source.voxelByteSize,
     voxelCompressedByteSize: source.voxelCompressedByteSize,
   });
@@ -441,13 +463,16 @@ function createPrepared(
     ? buildPreviewBuild(renderBuild, PREVIEW_TARGET_BLOCKS)
     : { build: renderBuild, stride: 1 };
   const initialVariant: ArenaBuildVariant =
-    preferPreview && preview.build.blocks.length < renderBuild.blocks.length ? "preview" : "full";
+    preferPreview && voxelBuildBlockCount(preview.build) < voxelBuildBlockCount(renderBuild)
+      ? "preview"
+      : "full";
   const previewEstimatedBytes = estimateArenaBuildBytes({
-    blockCount: preview.build.blocks.length,
+    blockCount: voxelBuildBlockCount(preview.build),
   });
   const initialEstimatedBytes =
     initialVariant === "preview" ? previewEstimatedBytes : fullEstimatedBytes;
-  const checksum = checksumOverride ?? normalizeStoredChecksum(source) ?? computeBuildChecksum(renderBuild);
+  const checksum =
+    checksumOverride ?? normalizeStoredChecksum(source) ?? computeBuildChecksum(renderBuild);
 
   return {
     buildId: source.id,
@@ -461,7 +486,7 @@ function createPrepared(
       fullEstimatedBytes,
       deliveryClass,
       initialVariant,
-      previewBlockCount: preview.build.blocks.length,
+      previewBlockCount: voxelBuildBlockCount(preview.build),
       previewStride: preview.stride,
       initialEstimatedBytes,
     },
@@ -480,7 +505,7 @@ function createPrepared(
 
 export function prepareArenaBuildFromBuild(
   source: ArenaBuildSource,
-  fullBuild: VoxelBuild,
+  fullBuild: RenderableVoxelBuild,
   opts?: { payloadEstimatedBytes?: number | null; checksum?: string | null },
 ): PreparedArenaBuild {
   return createPrepared(
@@ -687,13 +712,13 @@ export async function prepareArenaBuild(
   return awaitPreparedWithCallerAbort(promise, opts?.signal);
 }
 
-export function pickInitialBuild(prepared: PreparedArenaBuild): VoxelBuild {
+export function pickInitialBuild(prepared: PreparedArenaBuild): RenderableVoxelBuild {
   return prepared.hints.initialVariant === "preview" ? prepared.previewBuild : prepared.fullBuild;
 }
 
 export function pickBuildVariant(
   prepared: PreparedArenaBuild,
   variant: ArenaBuildVariant,
-): VoxelBuild {
+): RenderableVoxelBuild {
   return variant === "preview" ? prepared.previewBuild : prepared.fullBuild;
 }

--- a/lib/arena/buildSnapshotArtifacts.ts
+++ b/lib/arena/buildSnapshotArtifacts.ts
@@ -17,7 +17,11 @@ import {
   uploadArenaBuildArtifact,
 } from "@/lib/arena/artifactOwnership";
 import { withServerSpanSync } from "@/lib/observability/serverTracing";
-import { packVoxelBlocks } from "@/lib/voxel/packedBlocks";
+import {
+  packVoxelBlocks,
+  toObjectBackedVoxelBuild,
+  voxelBuildBlockCount,
+} from "@/lib/voxel/packedBlocks";
 import { createVoxelMeshFacts, encodeVoxelMeshFacts } from "@/lib/voxel/meshFacts";
 import { gunzipSync, gzipSync } from "node:zlib";
 
@@ -260,7 +264,14 @@ function createSnapshotArtifactPayload(
 }
 
 function encodeSnapshotArtifactPayload(payload: SnapshotArtifactPayload): Uint8Array {
-  return gzipSync(ENCODER.encode(JSON.stringify(payload)));
+  return gzipSync(
+    ENCODER.encode(
+      JSON.stringify({
+        ...payload,
+        voxelBuild: toObjectBackedVoxelBuild(payload.voxelBuild),
+      }),
+    ),
+  );
 }
 
 // same envelope, blocks moved into the binary encoding
@@ -269,14 +280,14 @@ function encodeBinarySnapshotArtifactPayload(payload: SnapshotArtifactPayload): 
   return gzipSync(
     encodeBinaryArtifact(
       { ...envelope, version: voxelBuild.version },
-      voxelBuild.blocks,
+      voxelBuild.packed ?? voxelBuild.blocks,
       payload.checksum,
     ),
   );
 }
 
 function encodeMeshFactsSnapshotArtifactPayload(payload: SnapshotArtifactPayload): Uint8Array {
-  const packed = packVoxelBlocks(payload.voxelBuild.blocks);
+  const packed = payload.voxelBuild.packed ?? packVoxelBlocks(payload.voxelBuild.blocks);
   return gzipSync(encodeVoxelMeshFacts(createVoxelMeshFacts(packed)));
 }
 
@@ -284,7 +295,7 @@ export function expectedSnapshotArtifactTargets(
   prepared: PreparedArenaBuild,
 ): ArenaSnapshotArtifactTarget[] {
   const previewNeeded =
-    prepared.previewBuild.blocks.length < prepared.fullBuild.blocks.length;
+    voxelBuildBlockCount(prepared.previewBuild) < voxelBuildBlockCount(prepared.fullBuild);
   const isSnapshotClass =
     prepared.hints.deliveryClass === "snapshot" ||
     prepared.hints.deliveryClass === "inline";
@@ -297,7 +308,7 @@ export function expectedSnapshotArtifactTargets(
   if (previewNeeded) targets.push({ variant: "preview", format: "binary" });
   // Binary full builds are small enough to serve whole for every class
   targets.push({ variant: "full", format: "binary" });
-  if (prepared.fullBuild.blocks.length >= ARENA_MESH_FACTS_MIN_BLOCKS) {
+  if (voxelBuildBlockCount(prepared.fullBuild) >= ARENA_MESH_FACTS_MIN_BLOCKS) {
     targets.push({ variant: "full", format: "mesh-facts" });
   }
 

--- a/lib/custom-builds/artifacts.ts
+++ b/lib/custom-builds/artifacts.ts
@@ -1,3 +1,7 @@
+import { createHash } from "node:crypto";
+import { PassThrough } from "node:stream";
+import { pipeline } from "node:stream/promises";
+import { createGunzip } from "node:zlib";
 import type { CustomBuildArtifact, Prisma, PrismaClient } from "@prisma/client";
 import { gzipSync } from "fflate";
 import { sha256Hex } from "@/lib/custom-builds/hash";
@@ -7,12 +11,15 @@ import {
   getCustomBuildArtifactPath,
   getCustomBuildStorageBucket,
   deleteCustomBuildArtifact,
+  downloadCustomBuildArtifactStream,
   uploadCustomBuildArtifact,
   uploadCustomBuildArtifactFile,
 } from "@/lib/custom-builds/storage";
 import type { CustomBuildArtifactKind, CustomBuildStorageEncoding } from "@/lib/custom-builds/types";
 import { decodeStoredBuildText } from "@/lib/storage/buildPayload";
 import type { VoxelBuild } from "@/lib/voxel/types";
+import { voxelBuildBlockAt, voxelBuildBlockCount, type RenderableVoxelBuild } from "@/lib/voxel/packedBlocks";
+import { parseVoxelBuildStream } from "@/lib/voxel/sourceStream";
 
 export { writeCanonicalBuildArtifact } from "@/lib/voxel/canonicalArtifact";
 
@@ -68,12 +75,81 @@ export function decodeAndVerifyCustomBuildArtifactText(args: {
   return text;
 }
 
-export function buildCustomBuildPreview(build: VoxelBuild, targetBlocks = getCustomBuildPreviewTargetBlocks()): VoxelBuild {
-  if (build.blocks.length <= targetBlocks) return build;
+export async function readStoredBuildSource(
+  artifact: Pick<CustomBuildArtifact,
+    "bucket" | "path" | "encoding" | "sha256" | "sourceBuildSha256" | "blockCount" | "byteSize" | "storedByteSize"
+  >,
+  opts: { signal?: AbortSignal; maxBlocks: number },
+): Promise<RenderableVoxelBuild> {
+  opts.signal?.throwIfAborted();
+  if (
+    artifact.encoding !== "gzip" || !artifact.sha256 || !artifact.sourceBuildSha256 ||
+    artifact.blockCount == null || !Number.isSafeInteger(artifact.blockCount) || artifact.blockCount < 0 ||
+    !Number.isSafeInteger(opts.maxBlocks) || opts.maxBlocks < 0 || artifact.blockCount > opts.maxBlocks ||
+    !Number.isSafeInteger(artifact.byteSize) || artifact.byteSize <= 0 ||
+    !Number.isSafeInteger(artifact.storedByteSize) || artifact.storedByteSize <= 0
+  ) throw new Error("Stored canonical artifact metadata is incomplete or invalid");
+  const chunks = downloadCustomBuildArtifactStream({ ...artifact, signal: opts.signal });
+  const storedHash = createHash("sha256");
+  const sourceHash = createHash("sha256");
+  let storedByteSize = 0;
+  let byteSize = 0;
+  try {
+    let header = Buffer.alloc(0);
+    while (header.length < 2) {
+      const next = await chunks.next();
+      if (next.done) break;
+      header = Buffer.concat([header, next.value]);
+    }
+    const isGzip = hasGzipMagic(header);
+    const build = await pipeline(
+      (async function* () {
+        for await (const bytes of (async function* () { yield header; yield* chunks; })()) {
+          storedByteSize += bytes.byteLength;
+          if (storedByteSize > (isGzip ? artifact.storedByteSize : artifact.byteSize)) {
+            throw new Error("Stored custom build artifact byte size does not match");
+          }
+          storedHash.update(bytes);
+          yield bytes;
+        }
+      })(),
+      isGzip ? createGunzip() : new PassThrough(),
+      async (source) => parseVoxelBuildStream((async function* () {
+        for await (const bytes of source) {
+          byteSize += bytes.byteLength;
+          if (byteSize > artifact.byteSize) {
+            throw new Error("Stored custom build source byte size does not match");
+          }
+          sourceHash.update(bytes);
+          yield bytes;
+        }
+      })(), { maxBlocks: artifact.blockCount! }),
+      { signal: opts.signal },
+    );
+    // fetch may already have decoded a gzip response
+    if (isGzip && storedHash.digest("hex") !== artifact.sha256) {
+      throw new Error("Stored custom build artifact checksum does not match");
+    }
+    if (sourceHash.digest("hex") !== artifact.sourceBuildSha256) {
+      throw new Error("Stored custom build source checksum does not match");
+    }
+    if (byteSize !== artifact.byteSize || (isGzip && storedByteSize !== artifact.storedByteSize)) {
+      throw new Error("Stored custom build artifact byte size does not match");
+    }
+    return build;
+  } finally {
+    await chunks.return(undefined);
+  }
+}
+
+export function buildCustomBuildPreview(build: RenderableVoxelBuild, targetBlocks = getCustomBuildPreviewTargetBlocks()): VoxelBuild {
+  const count = voxelBuildBlockCount(build);
+  if (!build.packed && count <= targetBlocks) return build;
   const blocks = [];
-  const stride = build.blocks.length / targetBlocks;
-  for (let i = 0; i < targetBlocks; i += 1) {
-    const block = build.blocks[Math.floor(i * stride)];
+  const previewCount = Math.min(count, targetBlocks);
+  const stride = count / previewCount;
+  for (let i = 0; i < previewCount; i += 1) {
+    const block = voxelBuildBlockAt(build, Math.floor(i * stride));
     if (block) blocks.push(block);
   }
   return { version: "1.0", blocks };

--- a/lib/custom-builds/generateJob.ts
+++ b/lib/custom-builds/generateJob.ts
@@ -5,9 +5,9 @@ import {
   type SavedGenerationRequestConfig,
 } from "@/lib/ai/customProviderConfig";
 import type { Provider } from "@/lib/ai/modelCatalog";
-import type { ProcessVoxelBuildResponse } from "@/lib/ai/processVoxelBuildResponse";
+import { isVoxelBuildResourceError, processVoxelBuildResponse, type ProcessVoxelBuildResponse } from "@/lib/ai/processVoxelBuildResponse";
 import { generateVoxelBuild, type GenerateVoxelBuildParams } from "@/lib/ai/generateVoxelBuild";
-import { MAX_BLOCKS_BY_GRID, type GridSize } from "@/lib/ai/limits";
+import { MAX_BLOCKS_BY_GRID, MIN_BLOCKS_BY_GRID, type GridSize } from "@/lib/ai/limits";
 import type { ProviderApiKeys } from "@/lib/ai/types";
 import { encodeBinaryArtifact } from "@/lib/arena/binaryArtifact";
 import { recordGenerationError, recordGenerationSuccess } from "@/lib/observability/cloudwatch";
@@ -15,6 +15,7 @@ import { ARENA_MESH_FACTS_MIN_BLOCKS } from "@/lib/arena/types";
 import { getPalette } from "@/lib/blocks/palettes";
 import {
   buildCustomBuildPreview,
+  decodeAndVerifyCustomBuildArtifactText,
   gzipBytes,
   readStoredBuildSource,
   sha256Hex,
@@ -31,6 +32,7 @@ import { decryptProviderKey, decryptSecretValue } from "@/lib/custom-builds/secr
 import { redactSensitiveText, safeCustomBuildRetryReason } from "@/lib/custom-builds/sanitize";
 import {
   assertCustomBuildStorageConfigured,
+  downloadCustomBuildArtifactStream,
 } from "@/lib/custom-builds/storage";
 import { prisma } from "@/lib/prisma";
 import { buildGalleryPreviewSvg } from "@/lib/gallery/preview";
@@ -42,6 +44,7 @@ import { generationProviderSignal } from "@/lib/generation-worker/providerSignal
 
 type GenerateJobPayload = {
   stubBuild?: unknown;
+  openaiResponseId?: string;
 };
 
 type GenerateVoxelBuildModel = NonNullable<GenerateVoxelBuildParams["model"]>;
@@ -66,6 +69,7 @@ export type ImportedCustomBuildResult = Required<Pick<
 >>;
 
 const CUSTOM_BUILD_MODEL_MAX_ATTEMPTS = 2;
+const MAX_RECOVERED_RAW_RESPONSE_BYTES = 8 * 1024 * 1024;
 
 export function customBuildProviderSignal(
   signal?: AbortSignal,
@@ -86,6 +90,10 @@ class CustomBuildGenerationFailedError extends Error {
 
 function asGenerateJobPayload(payload: Prisma.JsonValue | null): GenerateJobPayload {
   if (!payload || typeof payload !== "object" || Array.isArray(payload)) return {};
+  if (payload.openaiResponseId !== undefined &&
+      (typeof payload.openaiResponseId !== "string" || !/^resp_[A-Za-z0-9_-]{1,200}$/.test(payload.openaiResponseId))) {
+    throw new Error("Invalid saved OpenAI response id");
+  }
   return payload as GenerateJobPayload;
 }
 
@@ -174,6 +182,12 @@ function safeGenerateFailure(error: unknown, message: string) {
   if (message.includes("heap_limit_exceeded")) {
     return { code: "heap_limit_exceeded", message: "This build exceeded the processing memory limit." };
   }
+  if (message.includes("processing_capacity_exceeded")) {
+    return { code: "processing_capacity_exceeded", message: "This build exceeds the current processing capacity." };
+  }
+  if (message.includes("openai_response_checkpoint_failed")) {
+    return { code: "provider_checkpoint_failed", message: "The provider response could not be saved." };
+  }
   if (isCustomBuildArtifactPersistenceError(error) || message.includes("custom_build_artifact_persistence_failed")) {
     return { code: "artifact_persistence_failed", message: "The generated result could not be saved." };
   }
@@ -200,7 +214,7 @@ async function persistCustomBuildArtifact(args: Parameters<typeof uploadAndRecor
 export function isTerminalCustomBuildGenerateError(message: string): boolean {
   const normalized = message.trim().toLowerCase();
   if (normalized.includes("custom_build_artifact_persistence_failed")) return true;
-  if (normalized.includes("heap_limit_exceeded")) return true;
+  if (isVoxelBuildResourceError(normalized)) return true;
   if (normalized === "provider_key_expired") return true;
   if (normalized.includes("invalid_api_key")) return true;
   if (normalized.includes("invalid api key") || normalized.includes("incorrect api key")) return true;
@@ -330,6 +344,15 @@ async function generateBuild(
       onProviderRequest: (attempt) => {
         providerAttempts = Math.max(providerAttempts, attempt);
       },
+      openaiResponseId: payload.openaiResponseId,
+      onOpenAIResponseCreated: async (responseId) => {
+        throwIfCustomBuildLeaseLost(opts.signal);
+        const checkpoint = await prisma.customBuildJob.updateMany({
+          where: { id: job.id, status: "running", lockedBy: job.lockedBy },
+          data: { payload: { ...(job.payload as Prisma.InputJsonObject), openaiResponseId: responseId } },
+        });
+        if (checkpoint.count !== 1) throw new CustomBuildLeaseLostError();
+      },
       onRawResponse: async (attempt, text) => {
         const bytes = new TextEncoder().encode(text);
         const sha256 = sha256Hex(bytes);
@@ -373,7 +396,7 @@ async function generateBuild(
     build: result.build,
     warnings: result.warnings,
     blockCount: result.blockCount,
-    generationTimeMs: result.generationTimeMs,
+    generationTimeMs: payload.openaiResponseId ? null : result.generationTimeMs,
   };
 }
 
@@ -381,6 +404,99 @@ function persistedWarnings(value: Prisma.JsonValue | null): string[] {
   return Array.isArray(value)
     ? value.filter((warning): warning is string => typeof warning === "string")
     : [];
+}
+
+async function recoverStoredRawBuild(
+  customBuild: CustomBuild,
+  opts: {
+    signal?: AbortSignal;
+    acquireBuildProcessing?: () => Promise<() => void>;
+    processResponse?: ProcessVoxelBuildResponse;
+  },
+): Promise<GeneratedBuildResult | null> {
+  const artifact = await prisma.customBuildArtifact.findFirst({
+    where: { customBuildId: customBuild.id, kind: "raw_text_debug" },
+    select: {
+      bucket: true,
+      path: true,
+      encoding: true,
+      sha256: true,
+      sourceBuildSha256: true,
+      storedByteSize: true,
+      exportStats: true,
+    },
+    orderBy: [{ createdAt: "desc" }, { id: "desc" }],
+  });
+  if (!artifact) return null;
+  try {
+    await opts.acquireBuildProcessing?.();
+    throwIfCustomBuildLeaseLost(opts.signal);
+    if (!artifact.sha256 || !artifact.sourceBuildSha256) {
+      throw new Error("Stored raw response metadata is incomplete");
+    }
+    if (artifact.encoding && artifact.encoding !== "identity") {
+      throw new Error("Stored raw response encoding is unsupported");
+    }
+    if (artifact.storedByteSize > MAX_RECOVERED_RAW_RESPONSE_BYTES) {
+      throw new Error("Stored raw response exceeds the 8 MiB recovery limit");
+    }
+    const chunks: Uint8Array[] = [];
+    let byteLength = 0;
+    for await (const chunk of downloadCustomBuildArtifactStream({ ...artifact, signal: opts.signal })) {
+      throwIfCustomBuildLeaseLost(opts.signal);
+      byteLength += chunk.byteLength;
+      if (byteLength > MAX_RECOVERED_RAW_RESPONSE_BYTES) {
+        throw new Error("Stored raw response exceeds the 8 MiB recovery limit");
+      }
+      chunks.push(chunk);
+    }
+    const text = decodeAndVerifyCustomBuildArtifactText({
+      bytes: Buffer.concat(chunks, byteLength),
+      encoding: artifact.encoding,
+      storedSha256: artifact.sha256,
+      sourceSha256: artifact.sourceBuildSha256,
+    });
+    throwIfCustomBuildLeaseLost(opts.signal);
+    const finalizing = await prisma.customBuild.updateMany({
+      where: { id: customBuild.id, removedAt: null, status: "running" },
+      data: { currentStage: "finalizing" },
+    });
+    if (finalizing.count !== 1) throw new CustomBuildLeaseLostError();
+    const stats = artifact.exportStats;
+    const attempt = stats && typeof stats === "object" && !Array.isArray(stats) &&
+      typeof stats.attempt === "number" && Number.isInteger(stats.attempt) && stats.attempt > 0
+      ? stats.attempt
+      : 1;
+    try {
+      throwIfCustomBuildLeaseLost(opts.signal);
+      const responseOptions = {
+        gridSize: assertGridSize(customBuild.gridSize),
+        palette: customBuild.palette === "advanced" ? "advanced" as const : "simple" as const,
+        buildOutput: "packed" as const,
+        enableTools: true,
+        minBlocks: MIN_BLOCKS_BY_GRID[assertGridSize(customBuild.gridSize)],
+      };
+      const result = opts.processResponse
+        ? await opts.processResponse(text, responseOptions, opts.signal)
+        : processVoxelBuildResponse(text, responseOptions);
+      throwIfCustomBuildLeaseLost(opts.signal);
+      if (!result.ok) throw new Error(result.error);
+      return {
+        build: result.build,
+        warnings: Array.from(new Set([...persistedWarnings(customBuild.warnings), ...result.warnings])),
+        blockCount: result.blockCount,
+        generationTimeMs: customBuild.generationTimeMs,
+        sourceArtifactSha256: artifact.sourceBuildSha256,
+      };
+    } catch (error) {
+      throwIfCustomBuildLeaseLost(opts.signal);
+      throw new CustomBuildGenerationFailedError(redactSensitiveText(error, 1_000), attempt);
+    }
+  } catch (error) {
+    throwIfCustomBuildLeaseLost(opts.signal);
+    if (isCustomBuildLeaseLostError(error) || error instanceof CustomBuildGenerationFailedError) throw error;
+    throw new CustomBuildArtifactBookkeepingError(error);
+  }
 }
 
 async function recoverStoredBuild(
@@ -405,7 +521,7 @@ async function recoverStoredBuild(
     },
     orderBy: { createdAt: "desc" },
   });
-  if (!artifact) return null;
+  if (!artifact) return recoverStoredRawBuild(customBuild, opts);
   try {
     await opts.acquireBuildProcessing?.();
     throwIfCustomBuildLeaseLost(opts.signal);
@@ -681,7 +797,7 @@ export async function runCustomBuildGenerateJob(
     const manuallyRetryable =
       isCustomBuildArtifactBookkeepingError(effectiveError) ||
       (effectiveError instanceof CustomBuildGenerationFailedError &&
-        (!isTerminalCustomBuildGenerateError(message) || message.includes("heap_limit_exceeded")));
+        (!isTerminalCustomBuildGenerateError(message) || isVoxelBuildResourceError(message)));
     const terminal =
       isCustomBuildArtifactPersistenceError(effectiveError) ||
       effectiveError instanceof CustomBuildGenerationFailedError ||

--- a/lib/custom-builds/generateJob.ts
+++ b/lib/custom-builds/generateJob.ts
@@ -5,6 +5,7 @@ import {
   type SavedGenerationRequestConfig,
 } from "@/lib/ai/customProviderConfig";
 import type { Provider } from "@/lib/ai/modelCatalog";
+import type { ProcessVoxelBuildResponse } from "@/lib/ai/processVoxelBuildResponse";
 import { generateVoxelBuild, type GenerateVoxelBuildParams } from "@/lib/ai/generateVoxelBuild";
 import { MAX_BLOCKS_BY_GRID, type GridSize } from "@/lib/ai/limits";
 import type { ProviderApiKeys } from "@/lib/ai/types";
@@ -14,8 +15,8 @@ import { ARENA_MESH_FACTS_MIN_BLOCKS } from "@/lib/arena/types";
 import { getPalette } from "@/lib/blocks/palettes";
 import {
   buildCustomBuildPreview,
-  decodeAndVerifyCustomBuildArtifactText,
   gzipBytes,
+  readStoredBuildSource,
   sha256Hex,
   uploadAndRecordCustomBuildArtifact,
   writeCanonicalBuildArtifact,
@@ -30,13 +31,12 @@ import { decryptProviderKey, decryptSecretValue } from "@/lib/custom-builds/secr
 import { redactSensitiveText, safeCustomBuildRetryReason } from "@/lib/custom-builds/sanitize";
 import {
   assertCustomBuildStorageConfigured,
-  downloadCustomBuildArtifactBytes,
 } from "@/lib/custom-builds/storage";
 import { prisma } from "@/lib/prisma";
 import { buildGalleryPreviewSvg } from "@/lib/gallery/preview";
-import { packVoxelBlocks } from "@/lib/voxel/packedBlocks";
+import { packVoxelBlocks, sortPackedVoxelBlocks, voxelBuildBlockCount, type RenderableVoxelBuild } from "@/lib/voxel/packedBlocks";
 import { createVoxelMeshFacts, encodeVoxelMeshFacts } from "@/lib/voxel/meshFacts";
-import { validateVoxelBuild } from "@/lib/voxel/validate";
+import { validateOwnedVoxelBuild, validateVoxelBuild } from "@/lib/voxel/validate";
 import type { VoxelBuild } from "@/lib/voxel/types";
 import { generationProviderSignal } from "@/lib/generation-worker/providerSignal";
 
@@ -47,12 +47,17 @@ type GenerateJobPayload = {
 type GenerateVoxelBuildModel = NonNullable<GenerateVoxelBuildParams["model"]>;
 
 type GeneratedBuildResult = {
-  build: VoxelBuild;
+  build: RenderableVoxelBuild;
   warnings: string[];
   blockCount: number;
   generationTimeMs: number | null;
   completedAt?: Date;
   sourceArtifactSha256?: string;
+  canonicalArtifact?: {
+    sourceSha256: string;
+    byteSize: number;
+    storedByteSize: number;
+  };
 };
 
 export type ImportedCustomBuildResult = Required<Pick<
@@ -166,7 +171,10 @@ function safeGenerateFailure(error: unknown, message: string) {
   if (message === "provider_key_expired") {
     return { code: "provider_key_expired", message: "Provider key expired before the worker could start." };
   }
-  if (isCustomBuildArtifactPersistenceError(error)) {
+  if (message.includes("heap_limit_exceeded")) {
+    return { code: "heap_limit_exceeded", message: "This build exceeded the processing memory limit." };
+  }
+  if (isCustomBuildArtifactPersistenceError(error) || message.includes("custom_build_artifact_persistence_failed")) {
     return { code: "artifact_persistence_failed", message: "The generated result could not be saved." };
   }
   if (isCustomBuildArtifactBookkeepingError(error)) {
@@ -192,6 +200,7 @@ async function persistCustomBuildArtifact(args: Parameters<typeof uploadAndRecor
 export function isTerminalCustomBuildGenerateError(message: string): boolean {
   const normalized = message.trim().toLowerCase();
   if (normalized.includes("custom_build_artifact_persistence_failed")) return true;
+  if (normalized.includes("heap_limit_exceeded")) return true;
   if (normalized === "provider_key_expired") return true;
   if (normalized.includes("invalid_api_key")) return true;
   if (normalized.includes("invalid api key") || normalized.includes("incorrect api key")) return true;
@@ -244,6 +253,7 @@ async function generateBuild(
   opts: {
     signal?: AbortSignal;
     acquireBuildProcessing?: () => Promise<() => void>;
+    processResponse?: ProcessVoxelBuildResponse;
   } = {},
 ): Promise<GeneratedBuildResult> {
   throwIfCustomBuildLeaseLost(opts.signal);
@@ -320,6 +330,19 @@ async function generateBuild(
       onProviderRequest: (attempt) => {
         providerAttempts = Math.max(providerAttempts, attempt);
       },
+      onRawResponse: async (attempt, text) => {
+        const bytes = new TextEncoder().encode(text);
+        const sha256 = sha256Hex(bytes);
+        await persistCustomBuildArtifact({
+          customBuildId: customBuild.id,
+          publicId: customBuild.publicId,
+          kind: "raw_text_debug",
+          bytes,
+          sha256,
+          sourceBuildSha256: sha256,
+          exportStats: { attempt },
+        });
+      },
       onRetry: async (attempt, reason) => {
         const safeReason = safeCustomBuildRetryReason(reason, configuredSecrets);
         const retrying = await prisma.customBuild.updateMany({
@@ -333,7 +356,8 @@ async function generateBuild(
         await appendCustomBuildEvent(customBuild.id, "retry", { attempt, reason: safeReason });
       },
       acquireBuildProcessing: opts.acquireBuildProcessing,
-      returnExpandedBuild: true,
+      processResponse: opts.processResponse,
+      buildOutput: "packed",
     },
   );
 
@@ -364,6 +388,7 @@ async function recoverStoredBuild(
   opts: {
     signal?: AbortSignal;
     acquireBuildProcessing?: () => Promise<() => void>;
+    processResponse?: ProcessVoxelBuildResponse;
   } = {},
 ): Promise<GeneratedBuildResult | null> {
   const artifact = await prisma.customBuildArtifact.findFirst({
@@ -375,6 +400,8 @@ async function recoverStoredBuild(
       sha256: true,
       sourceBuildSha256: true,
       blockCount: true,
+      byteSize: true,
+      storedByteSize: true,
     },
     orderBy: { createdAt: "desc" },
   });
@@ -385,27 +412,39 @@ async function recoverStoredBuild(
     if (artifact.encoding !== "gzip" || !artifact.sourceBuildSha256) {
       throw new Error("Stored canonical artifact metadata is incomplete");
     }
-    const bytes = await downloadCustomBuildArtifactBytes(artifact);
-    const canonicalText = decodeAndVerifyCustomBuildArtifactText({
-      bytes,
-      encoding: artifact.encoding,
-      storedSha256: artifact.sha256,
-      sourceSha256: artifact.sourceBuildSha256,
+    const gridSize = assertGridSize(customBuild.gridSize);
+    const build = await readStoredBuildSource(artifact, {
+      signal: opts.signal,
+      maxBlocks: MAX_BLOCKS_BY_GRID[gridSize],
     });
-    const validated = validateGeneratedBuildForArtifacts(JSON.parse(canonicalText), customBuild);
-    if (artifact.blockCount != null && artifact.blockCount !== validated.build.blocks.length) {
+    throwIfCustomBuildLeaseLost(opts.signal);
+    const validated = validateOwnedVoxelBuild(build, {
+      gridSize,
+      palette: getPalette(customBuild.palette === "advanced" ? "advanced" : "simple"),
+      maxBlocks: artifact.blockCount!,
+      output: "packed",
+    });
+    if (!validated.ok) throw new Error(`Stored custom build is invalid: ${validated.error}`);
+    const blockCount = voxelBuildBlockCount(validated.value.build);
+    if (artifact.blockCount !== blockCount) {
       throw new Error("Stored canonical block count does not match");
     }
     return {
-      build: validated.build,
+      build: validated.value.build,
       warnings: Array.from(new Set([
         ...persistedWarnings(customBuild.warnings),
-        ...validated.warnings,
+        ...validated.value.warnings,
       ])),
-      blockCount: validated.build.blocks.length,
+      blockCount,
       generationTimeMs: customBuild.generationTimeMs,
+      canonicalArtifact: {
+        sourceSha256: artifact.sourceBuildSha256,
+        byteSize: artifact.byteSize,
+        storedByteSize: artifact.storedByteSize,
+      },
     };
   } catch (error) {
+    throwIfCustomBuildLeaseLost(opts.signal);
     if (isCustomBuildLeaseLostError(error)) throw error;
     throw new CustomBuildArtifactBookkeepingError(error);
   }
@@ -416,6 +455,7 @@ export async function runCustomBuildGenerateJob(
   opts: {
     signal?: AbortSignal;
     acquireBuildProcessing?: () => Promise<() => void>;
+    processResponse?: ProcessVoxelBuildResponse;
     beforeSynchronousArtifactPackaging?: () => Promise<void> | void;
     importedBuild?: ImportedCustomBuildResult;
   } = {},
@@ -452,38 +492,44 @@ export async function runCustomBuildGenerateJob(
       throw new CustomBuildArtifactPersistenceError(error);
     }
     const recovered = opts.importedBuild ? null : await recoverStoredBuild(customBuild, opts);
-    const generated = opts.importedBuild ?? recovered ?? await generateBuild(customBuild, job, opts);
+    const generated: GeneratedBuildResult = opts.importedBuild ?? recovered ?? await generateBuild(customBuild, job, opts);
     if (recovered) emitCustomBuildEvent(customBuild.id, "recovered", { stage: "finalizing" });
     throwIfCustomBuildLeaseLost(opts.signal);
     await opts.beforeSynchronousArtifactPackaging?.();
     throwIfCustomBuildLeaseLost(opts.signal);
-    const canonicalBuild: VoxelBuild = {
-      version: "1.0",
-      blocks: generated.build.blocks.sort(
+    const canonicalBuild = generated.build;
+    if (!generated.canonicalArtifact) {
+      if (canonicalBuild.packed) sortPackedVoxelBlocks(canonicalBuild.packed);
+      else canonicalBuild.blocks.sort(
         (a, b) => a.x - b.x || a.y - b.y || a.z - b.z || a.type.localeCompare(b.type),
-      ),
-    };
-    const canonicalArtifact = await writeCanonicalBuildArtifact(canonicalBuild);
-    const buildByteSize = canonicalArtifact.byteSize;
-    const buildCompressedByteSize = canonicalArtifact.storedByteSize;
-    const fullSha = canonicalArtifact.sourceSha256;
-    try {
-      throwIfCustomBuildLeaseLost(opts.signal);
-      await persistCustomBuildArtifact({
-        customBuildId: customBuild.id,
-        publicId: customBuild.publicId,
-        kind: "build_json",
-        filePath: canonicalArtifact.filePath,
-        storedByteSize: canonicalArtifact.storedByteSize,
-        uncompressedByteSize: canonicalArtifact.byteSize,
-        sha256: canonicalArtifact.sha256,
-        sourceBuildSha256: fullSha,
-        blockCount: generated.blockCount,
-        encoding: "gzip",
-      });
-    } finally {
-      await canonicalArtifact.cleanup();
+      );
     }
+    const canonicalBlockCount = voxelBuildBlockCount(canonicalBuild);
+    let sourceArtifact = generated.canonicalArtifact;
+    if (!sourceArtifact) {
+      const canonicalArtifact = await writeCanonicalBuildArtifact(canonicalBuild);
+      try {
+        throwIfCustomBuildLeaseLost(opts.signal);
+        await persistCustomBuildArtifact({
+          customBuildId: customBuild.id,
+          publicId: customBuild.publicId,
+          kind: "build_json",
+          filePath: canonicalArtifact.filePath,
+          storedByteSize: canonicalArtifact.storedByteSize,
+          uncompressedByteSize: canonicalArtifact.byteSize,
+          sha256: canonicalArtifact.sha256,
+          sourceBuildSha256: canonicalArtifact.sourceSha256,
+          blockCount: generated.blockCount,
+          encoding: "gzip",
+        });
+        sourceArtifact = canonicalArtifact;
+      } finally {
+        await canonicalArtifact.cleanup();
+      }
+    }
+    const buildByteSize = sourceArtifact.byteSize;
+    const buildCompressedByteSize = sourceArtifact.storedByteSize;
+    const fullSha = sourceArtifact.sourceSha256;
     artifactsPersisted = true;
     emitCustomBuildEvent(customBuild.id, "artifact_ready", { kind: "build_json" });
 
@@ -518,12 +564,12 @@ export async function runCustomBuildGenerateJob(
 
     throwIfCustomBuildLeaseLost(opts.signal);
     const viewerKind =
-      canonicalBuild.blocks.length >= ARENA_MESH_FACTS_MIN_BLOCKS
+      canonicalBlockCount >= ARENA_MESH_FACTS_MIN_BLOCKS
         ? "viewer_mbf1"
         : "viewer_mbv4";
     const viewerBytes =
       viewerKind === "viewer_mbf1"
-        ? encodeVoxelMeshFacts(createVoxelMeshFacts(packVoxelBlocks(canonicalBuild.blocks)))
+        ? encodeVoxelMeshFacts(createVoxelMeshFacts(canonicalBuild.packed ?? packVoxelBlocks(canonicalBuild.blocks)))
         : encodeBinaryArtifact(
             {
               buildId: customBuild.publicId,
@@ -532,7 +578,7 @@ export async function runCustomBuildGenerateJob(
               serverValidated: true,
               version: canonicalBuild.version,
             },
-            canonicalBuild.blocks,
+            canonicalBuild.packed ?? canonicalBuild.blocks,
             fullSha,
           );
     const viewerGzip = gzipBytes(viewerBytes);
@@ -544,7 +590,7 @@ export async function runCustomBuildGenerateJob(
       uncompressedByteSize: viewerBytes.byteLength,
       sha256: sha256Hex(viewerGzip),
       sourceBuildSha256: fullSha,
-      blockCount: canonicalBuild.blocks.length,
+      blockCount: canonicalBlockCount,
       encoding: "gzip",
     });
     emitCustomBuildEvent(customBuild.id, "artifact_ready", { kind: viewerKind });
@@ -558,7 +604,7 @@ export async function runCustomBuildGenerateJob(
       bytes: previewSvg,
       sha256: sha256Hex(previewSvg),
       sourceBuildSha256: fullSha,
-      blockCount: canonicalBuild.blocks.length,
+      blockCount: canonicalBlockCount,
     });
     emitCustomBuildEvent(customBuild.id, "artifact_ready", { kind: "preview_svg" });
     artifactsPersisted = true;
@@ -633,8 +679,9 @@ export async function runCustomBuildGenerateJob(
       });
     }
     const manuallyRetryable =
-      effectiveError instanceof CustomBuildGenerationFailedError &&
-      !isTerminalCustomBuildGenerateError(message);
+      isCustomBuildArtifactBookkeepingError(effectiveError) ||
+      (effectiveError instanceof CustomBuildGenerationFailedError &&
+        (!isTerminalCustomBuildGenerateError(message) || message.includes("heap_limit_exceeded")));
     const terminal =
       isCustomBuildArtifactPersistenceError(effectiveError) ||
       effectiveError instanceof CustomBuildGenerationFailedError ||

--- a/lib/custom-builds/storage.ts
+++ b/lib/custom-builds/storage.ts
@@ -338,14 +338,11 @@ export async function deleteCustomBuildArtifact(args: {
   if (error) throw new Error(`Custom build artifact deletion failed: ${error.message}`);
 }
 
-export async function downloadCustomBuildArtifactBytes(args: {
+async function fetchCustomBuildArtifact(args: {
   bucket: string;
   path: string;
-}): Promise<Uint8Array> {
-  if (args.bucket.trim() === LOCAL_BUILD_STORAGE_BUCKET) {
-    return readLocalCustomBuildArtifact(resolveLocalCustomBuildStoragePath(args.path));
-  }
-
+  signal?: AbortSignal;
+}): Promise<Response> {
   const config = getSupabaseStorageConfig();
   const encodedPath = encodeStoragePath(args.path);
   const url = `${config.url}/storage/v1/object/${encodeURIComponent(args.bucket)}/${encodedPath}`;
@@ -356,10 +353,46 @@ export async function downloadCustomBuildArtifactBytes(args: {
       apikey: config.serviceRoleKey,
     },
     cache: "no-store",
+    signal: args.signal,
   });
   if (!resp.ok) {
     const text = await resp.text().catch(() => "");
     throw new Error(`Custom build artifact download failed (${resp.status}): ${text || "empty response"}`);
   }
-  return new Uint8Array(await resp.arrayBuffer());
+  return resp;
+}
+
+export async function downloadCustomBuildArtifactBytes(args: {
+  bucket: string;
+  path: string;
+}): Promise<Uint8Array> {
+  if (args.bucket.trim() === LOCAL_BUILD_STORAGE_BUCKET) {
+    return readLocalCustomBuildArtifact(resolveLocalCustomBuildStoragePath(args.path));
+  }
+  return new Uint8Array(await (await fetchCustomBuildArtifact(args)).arrayBuffer());
+}
+
+export async function* downloadCustomBuildArtifactStream(args: {
+  bucket: string;
+  path: string;
+  signal?: AbortSignal;
+}): AsyncGenerator<Uint8Array> {
+  if (args.bucket.trim() === LOCAL_BUILD_STORAGE_BUCKET) {
+    const { createReadStream } = await import("node:fs");
+    yield* createReadStream(resolveLocalCustomBuildStoragePath(args.path), { signal: args.signal });
+    return;
+  }
+  const response = await fetchCustomBuildArtifact(args);
+  if (!response.body) throw new Error("Custom build artifact download returned an empty body");
+  const reader = response.body.getReader();
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) return;
+      yield value;
+    }
+  } finally {
+    await reader.cancel().catch(() => {});
+    reader.releaseLock();
+  }
 }

--- a/lib/custom-builds/worker.ts
+++ b/lib/custom-builds/worker.ts
@@ -1,7 +1,9 @@
 import { randomUUID } from "node:crypto";
 import { hostname } from "node:os";
 import { setTimeout as sleep } from "node:timers/promises";
-import type { CustomBuildJob } from "@prisma/client";
+import { Prisma, type CustomBuildJob } from "@prisma/client";
+import type { ProcessVoxelBuildResponse } from "@/lib/ai/processVoxelBuildResponse";
+import { isDatabaseUnavailableError } from "@/lib/db/errors";
 import {
   claimNextCustomBuildJob,
   completeCustomBuildJob,
@@ -213,6 +215,7 @@ async function runJob(
   workerId: string,
   signal: AbortSignal,
   processingGate: ReturnType<typeof createCustomBuildProcessingGate>,
+  processResponse?: ProcessVoxelBuildResponse,
 ): Promise<void> {
   let releaseProcessing: (() => void) | undefined;
   const acquireProcessing = async () => {
@@ -235,6 +238,7 @@ async function runJob(
       await runCustomBuildGenerateJob(job, {
         signal,
         acquireBuildProcessing: acquireProcessing,
+        processResponse,
         beforeSynchronousArtifactPackaging: async () => {
           throwIfCustomBuildLeaseLost(signal);
           await extendLeaseForSynchronousWork(job, workerId);
@@ -260,6 +264,7 @@ async function processClaimedJob(
   job: CustomBuildJob,
   workerId: string,
   processingGate: ReturnType<typeof createCustomBuildProcessingGate>,
+  processResponse?: ProcessVoxelBuildResponse,
 ): Promise<{
   processed: boolean;
   jobId?: string;
@@ -269,7 +274,7 @@ async function processClaimedJob(
   const heartbeat = startCustomBuildJobHeartbeat(job, workerId, leaseAbort);
 
   try {
-    await runJob(job, workerId, leaseAbort.signal, processingGate);
+    await runJob(job, workerId, leaseAbort.signal, processingGate, processResponse);
     throwIfCustomBuildLeaseLost(leaseAbort.signal);
     await completeCustomBuildJob(job.id, workerId);
     return { processed: true, jobId: job.id, jobType: job.type };
@@ -296,6 +301,7 @@ async function processClaimedStealthJob(
   job: StealthGenerationJob,
   workerId: string,
   processingGate: ReturnType<typeof createCustomBuildProcessingGate>,
+  processResponse?: ProcessVoxelBuildResponse,
 ): Promise<void> {
   const leaseAbort = new AbortController();
   const heartbeat = startStealthGenerationJobHeartbeat(job, workerId, leaseAbort);
@@ -321,6 +327,7 @@ async function processClaimedStealthJob(
       workerId,
       signal: leaseAbort.signal,
       acquireBuildProcessing: acquireProcessing,
+      processResponse,
     });
     throwIfGenerationWorkerLeaseLost(leaseAbort.signal);
     await finishStealthGenerationRun(job.runId);
@@ -390,8 +397,13 @@ async function checkAndReportQueueHealth(): Promise<void> {
   }
 }
 
-export async function runCustomBuildWorkerLoop(workerId = getCustomBuildWorkerId()): Promise<void> {
+export async function runCustomBuildWorkerLoop(
+  workerId = getCustomBuildWorkerId(),
+  opts: { processResponse?: ProcessVoxelBuildResponse } = {},
+): Promise<void> {
   let shutdownRequested = false;
+  const pollAbort = new AbortController();
+  let retryDelayMs = getCustomBuildWorkerPollMs();
   const concurrency = getCustomBuildWorkerConcurrency();
   const processingGate = createCustomBuildProcessingGate();
   const activeJobs = new Set<Promise<unknown>>();
@@ -409,61 +421,88 @@ export async function runCustomBuildWorkerLoop(workerId = getCustomBuildWorkerId
   const stop = () => {
     if (shutdownRequested) return;
     shutdownRequested = true;
+    pollAbort.abort();
     recordActiveGenerations(activeJobs.size, "worker", undefined, false);
   };
   process.once("SIGINT", stop);
   process.once("SIGTERM", stop);
+  const waitForPoll = async (delayMs: number, wakeOn: Iterable<Promise<unknown>> = []) => {
+    const wake = new AbortController();
+    try {
+      await Promise.race([
+        sleep(delayMs, undefined, { signal: AbortSignal.any([pollAbort.signal, wake.signal]), ref: false }),
+        ...wakeOn,
+      ]);
+    } catch (error) {
+      if (!shutdownRequested) throw error;
+    } finally {
+      wake.abort();
+    }
+  };
 
   try {
     while (!shutdownRequested) {
-      await recoverStaleCustomBuildJobLeases();
-      const recovered = await recoverStaleStealthGenerationJobLeases(
-        getCustomBuildJobLeaseSeconds(),
-      );
-      await Promise.all(recovered.failedRunIds.map(finishStealthGenerationRun));
       let claimed = false;
-      while (!shutdownRequested && activeJobs.size < concurrency) {
-        const stealthFirst = preferStealth;
-        preferStealth = !preferStealth;
-        const stealthJob = stealthFirst
-          ? await claimNextStealthGenerationJob(
-              workerId,
-              getCustomBuildJobLeaseSeconds(),
-            )
-          : null;
-        const customJob = stealthJob ? null : await claimNextCustomBuildJob(workerId);
-        const fallbackStealthJob =
-          !stealthJob && !customJob && !stealthFirst
+      try {
+        await recoverStaleCustomBuildJobLeases();
+        const recovered = await recoverStaleStealthGenerationJobLeases(
+          getCustomBuildJobLeaseSeconds(),
+        );
+        await Promise.all(recovered.failedRunIds.map(finishStealthGenerationRun));
+        while (!shutdownRequested && activeJobs.size < concurrency) {
+          const stealthFirst = preferStealth;
+          preferStealth = !preferStealth;
+          const stealthJob = stealthFirst
             ? await claimNextStealthGenerationJob(
                 workerId,
                 getCustomBuildJobLeaseSeconds(),
               )
             : null;
-        if (!customJob && !stealthJob && !fallbackStealthJob) break;
-        claimed = true;
-        const privateJob = stealthJob ?? fallbackStealthJob;
-        const active = privateJob
-          ? processClaimedStealthJob(privateJob, workerId, processingGate)
-          : processClaimedJob(customJob!, workerId, processingGate);
-        activeJobs.add(active);
-        void active.then(
-          () => activeJobs.delete(active),
-          () => activeJobs.delete(active),
-        );
+          const customJob = stealthJob ? null : await claimNextCustomBuildJob(workerId);
+          const fallbackStealthJob =
+            !stealthJob && !customJob && !stealthFirst
+              ? await claimNextStealthGenerationJob(
+                  workerId,
+                  getCustomBuildJobLeaseSeconds(),
+                )
+              : null;
+          if (!customJob && !stealthJob && !fallbackStealthJob) break;
+          claimed = true;
+          const privateJob = stealthJob ?? fallbackStealthJob;
+          const active = privateJob
+            ? processClaimedStealthJob(privateJob, workerId, processingGate, opts.processResponse)
+            : processClaimedJob(customJob!, workerId, processingGate, opts.processResponse);
+          activeJobs.add(active);
+          void active.then(
+            () => activeJobs.delete(active),
+            () => activeJobs.delete(active),
+          );
+        }
+        retryDelayMs = getCustomBuildWorkerPollMs();
+      } catch (error) {
+        if (!isDatabaseUnavailableError(error) && !(error instanceof Prisma.PrismaClientKnownRequestError && ["P2028", "P2034"].includes(error.code))) throw error;
+        console.warn(`worker queue poll failed; retrying in ${retryDelayMs}ms: ${redactSensitiveText(error)}`);
+        await waitForPoll(retryDelayMs);
+        retryDelayMs = Math.min(60_000, retryDelayMs * 2);
+        continue;
       }
 
       if (shutdownRequested) break;
       if (activeJobs.size >= concurrency) {
         await Promise.race(activeJobs);
       } else if (!claimed) {
-        await Promise.race([sleep(getCustomBuildWorkerPollMs()), ...activeJobs]);
+        await waitForPoll(getCustomBuildWorkerPollMs(), activeJobs);
       }
     }
 
     await Promise.all(activeJobs);
   } finally {
+    stop();
+    await Promise.allSettled(activeJobs);
     clearInterval(heartbeat);
     clearInterval(queueHeartbeat);
+    process.off("SIGINT", stop);
+    process.off("SIGTERM", stop);
     await prisma.$disconnect();
   }
 }

--- a/lib/gallery/preview.ts
+++ b/lib/gallery/preview.ts
@@ -1,5 +1,6 @@
 import { getVoxelExportMaterial } from "@/lib/voxel/export/materials";
 import type { VoxelBuild } from "@/lib/voxel/types";
+import { voxelBuildBlockAt, voxelBuildBlockCount, type RenderableVoxelBuild } from "@/lib/voxel/packedBlocks";
 
 const WIDTH = 640;
 const HEIGHT = 400;
@@ -31,15 +32,21 @@ function framedRange(values: number[]): [number, number] {
   return [Math.max(fullMin, coreMin - padding), Math.min(fullMax, coreMax + padding)];
 }
 
-function compactBlocks(blocks: PreviewBlock[]): PreviewBlock[] {
-  if (blocks.length <= MAX_PREVIEW_BLOCKS) return blocks;
+function compactBlocks(build: RenderableVoxelBuild): PreviewBlock[] {
+  const count = voxelBuildBlockCount(build);
+  if (count <= MAX_PREVIEW_BLOCKS) {
+    return build.packed
+      ? Array.from({ length: count }, (_, index) => voxelBuildBlockAt(build, index)!)
+      : build.blocks;
+  }
   let minX = Infinity;
   let minY = Infinity;
   let minZ = Infinity;
   let maxX = -Infinity;
   let maxY = -Infinity;
   let maxZ = -Infinity;
-  for (const block of blocks) {
+  for (let index = 0; index < count; index += 1) {
+    const block = voxelBuildBlockAt(build, index)!;
     minX = Math.min(minX, block.x);
     minY = Math.min(minY, block.y);
     minZ = Math.min(minZ, block.z);
@@ -52,7 +59,8 @@ function compactBlocks(blocks: PreviewBlock[]): PreviewBlock[] {
     const yBins = Math.floor((maxY - minY) / cellSize) + 1;
     const zBins = Math.floor((maxZ - minZ) / cellSize) + 1;
     const bins = new Map<number, PreviewBlock & { score: number }>();
-    for (const block of blocks) {
+    for (let index = 0; index < count; index += 1) {
+      const block = voxelBuildBlockAt(build, index)!;
       const x = Math.floor((block.x - minX) / cellSize);
       const y = Math.floor((block.y - minY) / cellSize);
       const z = Math.floor((block.z - minZ) / cellSize);
@@ -69,8 +77,8 @@ function compactBlocks(blocks: PreviewBlock[]): PreviewBlock[] {
   }
 }
 
-export function buildGalleryPreviewSvg(build: VoxelBuild): string {
-  const ordered = compactBlocks(build.blocks).sort(
+export function buildGalleryPreviewSvg(build: RenderableVoxelBuild): string {
+  const ordered = compactBlocks(build).sort(
     (a, b) => a.x + a.z - (b.x + b.z) || a.y - b.y || a.x - b.x || a.z - b.z,
   );
   const points = ordered.map((block) => ({

--- a/lib/stealth/generation.ts
+++ b/lib/stealth/generation.ts
@@ -14,7 +14,11 @@ import {
   uploadSupabaseStorageFile,
 } from "@/lib/storage/buildPayload";
 import { writeCanonicalBuildArtifact } from "@/lib/voxel/canonicalArtifact";
-import type { VoxelBuild } from "@/lib/voxel/types";
+import {
+  toObjectBackedVoxelBuild,
+  voxelBuildBlockCount,
+  type RenderableVoxelBuild,
+} from "@/lib/voxel/packedBlocks";
 
 const GRID_SIZE = 256;
 const PALETTE = "simple";
@@ -73,7 +77,7 @@ function storageConfig(): { url: string; key: string; bucket: string } | null {
 function preparePayload(params: {
   variantId: string;
   promptSlug: string;
-  build: VoxelBuild;
+  build: RenderableVoxelBuild;
   sha256: string;
   target?: { bucket: string; path: string };
 }): PreparedPayload {
@@ -81,7 +85,7 @@ function preparePayload(params: {
   if (isLoopbackDatabaseUrl(databaseUrl)) {
     return {
       stored: {
-        voxelData: params.build as unknown as Prisma.InputJsonValue,
+        voxelData: toObjectBackedVoxelBuild(params.build) as unknown as Prisma.InputJsonValue,
         voxelStorageBucket: null,
         voxelStoragePath: null,
         voxelStorageEncoding: null,
@@ -166,7 +170,7 @@ function retryPayloadTarget(build: ExistingBuild): { bucket: string; path: strin
 
 async function maybePrecomputeRemoteArtifacts(
   build: ExistingBuild,
-  fullBuild?: VoxelBuild,
+  fullBuild?: RenderableVoxelBuild,
 ): Promise<void> {
   const databaseUrl = process.env.DATABASE_URL ?? process.env.DIRECT_URL ?? "";
   if (!isLoopbackDatabaseUrl(databaseUrl)) {
@@ -190,12 +194,12 @@ export async function persistStealthBuild(params: {
   modelId: string;
   promptSlug: string;
   promptText: string;
-  build: VoxelBuild;
+  build: RenderableVoxelBuild;
   generationTimeMs: number;
 }): Promise<{ id: string; blockCount: number; created: boolean }> {
   const artifact = await writeCanonicalBuildArtifact(params.build);
   const sha256 = artifact.sourceSha256;
-  const blockCount = params.build.blocks.length;
+  const blockCount = voxelBuildBlockCount(params.build);
   try {
     const prompt = await prisma.prompt.upsert({
       where: { text: params.promptText },

--- a/lib/stealth/generationRun.ts
+++ b/lib/stealth/generationRun.ts
@@ -1,5 +1,6 @@
 import { Prisma, type StealthGenerationResultStatus } from "@prisma/client";
 import { generateVoxelBuild } from "@/lib/ai/generateVoxelBuild";
+import type { ProcessVoxelBuildResponse } from "@/lib/ai/processVoxelBuildResponse";
 import { BENCHMARK_PROMPT_COHORT_ID } from "@/lib/benchmark/prompts";
 import { getPalette } from "@/lib/blocks/palettes";
 import { prisma } from "@/lib/prisma";
@@ -494,6 +495,7 @@ export async function generateStealthPromptForRun(params: {
   workerId?: string;
   signal?: AbortSignal;
   acquireBuildProcessing?: () => Promise<() => void>;
+  processResponse?: ProcessVoxelBuildResponse;
 }): Promise<void> {
   const identity = await prisma.stealthGenerationRun.findUnique({
     where: { id: params.runId },
@@ -734,7 +736,8 @@ export async function generateStealthPromptForRun(params: {
         gridSize: GRID_SIZE,
         palette: PALETTE,
         maxAttempts,
-        returnExpandedBuild: true,
+        buildOutput: "packed",
+        processResponse: params.processResponse,
         abortSignal: generationProviderSignal(params.signal),
         acquireBuildProcessing: params.acquireBuildProcessing,
         onProviderRequest: (attempt) => {

--- a/lib/voxel/canonicalArtifact.ts
+++ b/lib/voxel/canonicalArtifact.ts
@@ -6,14 +6,15 @@ import path from "node:path";
 import { Readable, Transform } from "node:stream";
 import { pipeline } from "node:stream/promises";
 import { createGzip } from "node:zlib";
-import type { VoxelBuild } from "@/lib/voxel/types";
+import { voxelBuildBlockAt, voxelBuildBlockCount, type RenderableVoxelBuild } from "@/lib/voxel/packedBlocks";
 
 const ENCODER = new TextEncoder();
 
-function* canonicalBuildJsonChunks(build: VoxelBuild): Generator<Uint8Array> {
+function* canonicalBuildJsonChunks(build: RenderableVoxelBuild): Generator<Uint8Array> {
   let chunk = '{"version":"1.0","blocks":[';
-  for (let index = 0; index < build.blocks.length; index += 1) {
-    const block = `${index === 0 ? "" : ","}${JSON.stringify(build.blocks[index])}`;
+  const count = voxelBuildBlockCount(build);
+  for (let index = 0; index < count; index += 1) {
+    const block = `${index === 0 ? "" : ","}${JSON.stringify(voxelBuildBlockAt(build, index))}`;
     if (chunk.length + block.length > 64 * 1024) {
       yield ENCODER.encode(chunk);
       chunk = block;
@@ -41,7 +42,7 @@ async function removeArtifactFile(directory: string, filePath: string): Promise<
   }
 }
 
-export async function writeCanonicalBuildArtifact(build: VoxelBuild): Promise<{
+export async function writeCanonicalBuildArtifact(build: RenderableVoxelBuild): Promise<{
   filePath: string;
   byteSize: number;
   storedByteSize: number;

--- a/lib/voxel/packedBlocks.ts
+++ b/lib/voxel/packedBlocks.ts
@@ -14,15 +14,36 @@ export type PackedVoxelBlocks = {
   count: number;
 };
 
-// A build whose blocks may live in packed form. Server-side builds and anything
-// coming out of validation stay object-backed, so both shapes flow through the
-// same viewer and mesh entry points.
+// A build whose blocks may live in packed form
 export type RenderableVoxelBuild = VoxelBuild & {
   packed?: PackedVoxelBlocks;
   meshFacts?: VoxelMeshFacts;
 };
 
 const MIN_PACKED_CAPACITY = 1024;
+
+export function isPackedVoxelBlocks(value: unknown): value is PackedVoxelBlocks {
+  if (typeof value !== "object" || value === null) return false;
+  const packed = value as Partial<PackedVoxelBlocks>;
+  if (
+    !(packed.positions instanceof Int16Array) ||
+    !(packed.typeIds instanceof Uint16Array) ||
+    !Array.isArray(packed.typeNames) ||
+    packed.typeNames.length > 65_536 ||
+    !Number.isSafeInteger(packed.count) ||
+    packed.count === undefined ||
+    packed.count < 0 ||
+    packed.count > packed.typeIds.length ||
+    packed.count * 3 > packed.positions.length
+  ) return false;
+  for (const type of packed.typeNames) {
+    if (typeof type !== "string" || !type) return false;
+  }
+  for (let index = 0; index < packed.count; index += 1) {
+    if (packed.typeIds[index]! >= packed.typeNames.length) return false;
+  }
+  return true;
+}
 
 // An exact request is honoured exactly: consumers that transfer these arrays
 // read them to their full length, so trailing slack would render as blocks that
@@ -143,6 +164,59 @@ export function copyPackedVoxelBlocks(
 export function voxelBuildBlockCount(build: RenderableVoxelBuild | null | undefined): number {
   if (!build) return 0;
   return build.packed ? build.packed.count : build.blocks.length;
+}
+
+export function voxelBuildBlockAt(
+  build: RenderableVoxelBuild,
+  index: number,
+): VoxelBlock | undefined {
+  if (!Number.isInteger(index) || index < 0 || index >= voxelBuildBlockCount(build)) {
+    return undefined;
+  }
+  if (!build.packed) return build.blocks[index];
+  const { positions, typeIds, typeNames } = build.packed;
+  return {
+    x: positions[index * 3]!,
+    y: positions[index * 3 + 1]!,
+    z: positions[index * 3 + 2]!,
+    type: typeNames[typeIds[index]!]!,
+  };
+}
+
+export function sortPackedVoxelBlocks(packed: PackedVoxelBlocks): void {
+  const { positions, typeIds, typeNames, count } = packed;
+  const order = new Uint32Array(count);
+  for (let index = 0; index < count; index += 1) order[index] = index;
+  order.sort((a, b) =>
+    positions[a * 3]! - positions[b * 3]! ||
+    positions[a * 3 + 1]! - positions[b * 3 + 1]! ||
+    positions[a * 3 + 2]! - positions[b * 3 + 2]! ||
+    typeNames[typeIds[a]!]!.localeCompare(typeNames[typeIds[b]!]!),
+  );
+
+  // Apply permutation cycles without allocating another set of block buffers
+  for (let start = 0; start < count; start += 1) {
+    if (order[start] === start) continue;
+    const x = positions[start * 3]!;
+    const y = positions[start * 3 + 1]!;
+    const z = positions[start * 3 + 2]!;
+    const typeId = typeIds[start]!;
+    let current = start;
+    while (order[current] !== start) {
+      const next = order[current]!;
+      positions[current * 3] = positions[next * 3]!;
+      positions[current * 3 + 1] = positions[next * 3 + 1]!;
+      positions[current * 3 + 2] = positions[next * 3 + 2]!;
+      typeIds[current] = typeIds[next]!;
+      order[current] = current;
+      current = next;
+    }
+    positions[current * 3] = x;
+    positions[current * 3 + 1] = y;
+    positions[current * 3 + 2] = z;
+    typeIds[current] = typeId;
+    order[current] = current;
+  }
 }
 
 // Reference used to tell one build apart from another. Streaming mutates the

--- a/lib/voxel/renderVisibility.ts
+++ b/lib/voxel/renderVisibility.ts
@@ -1,4 +1,6 @@
 import { getRenderKind } from "@/lib/blocks/registry";
+import { computeVisibleFaceMask, SpatialBlockTable } from "@/lib/voxel/ambientOcclusion";
+import { createPackedVoxelBlocks, type RenderableVoxelBuild } from "@/lib/voxel/packedBlocks";
 import type { VoxelBuild } from "@/lib/voxel/types";
 
 const FACE_OFFSETS: ReadonlyArray<readonly [number, number, number]> = [
@@ -34,7 +36,73 @@ export function canVoxelBlockEmitAnyFace(
   return false;
 }
 
-export function filterRenderableVoxelBuild(build: VoxelBuild): VoxelBuild {
+function packedVisibilityContext(packed: NonNullable<RenderableVoxelBuild["packed"]>) {
+  const table = new SpatialBlockTable(packed.count);
+  const materialOccluding = new Uint8Array(packed.typeNames.length);
+  for (let typeId = 0; typeId < packed.typeNames.length; typeId += 1) {
+    materialOccluding[typeId] = isVoxelOccluder(packed.typeNames[typeId] ?? "") ? 1 : 0;
+  }
+  for (let index = 0; index < packed.count; index += 1) {
+    table.set(
+      packed.positions[index * 3]!,
+      packed.positions[index * 3 + 1]!,
+      packed.positions[index * 3 + 2]!,
+      packed.typeIds[index]!,
+    );
+  }
+  return { table, materialOccluding };
+}
+
+function packedBlockIsRenderable(
+  packed: NonNullable<RenderableVoxelBuild["packed"]>,
+  index: number,
+  context: ReturnType<typeof packedVisibilityContext>,
+): boolean {
+  return computeVisibleFaceMask(
+    packed.positions[index * 3]!,
+    packed.positions[index * 3 + 1]!,
+    packed.positions[index * 3 + 2]!,
+    packed.typeIds[index]!,
+    context.table,
+    context.materialOccluding,
+  ) !== 0;
+}
+
+function filterPackedRenderableVoxelBuild(build: RenderableVoxelBuild): RenderableVoxelBuild {
+  const packed = build.packed;
+  if (!packed || packed.count <= 0) return build;
+
+  const context = packedVisibilityContext(packed);
+  let visibleCount = 0;
+  for (let index = 0; index < packed.count; index += 1) {
+    if (packedBlockIsRenderable(packed, index, context)) visibleCount += 1;
+  }
+  if (visibleCount === packed.count) return build;
+
+  const visible = createPackedVoxelBlocks(visibleCount);
+  visible.typeNames = packed.typeNames.slice();
+  let write = 0;
+  for (let index = 0; index < packed.count; index += 1) {
+    if (!packedBlockIsRenderable(packed, index, context)) continue;
+    visible.positions[write * 3] = packed.positions[index * 3]!;
+    visible.positions[write * 3 + 1] = packed.positions[index * 3 + 1]!;
+    visible.positions[write * 3 + 2] = packed.positions[index * 3 + 2]!;
+    visible.typeIds[write] = packed.typeIds[index]!;
+    write += 1;
+  }
+  visible.count = write;
+
+  return {
+    version: "1.0",
+    blocks: [],
+    packed: visible,
+  };
+}
+
+export function filterRenderableVoxelBuild(build: VoxelBuild): VoxelBuild;
+export function filterRenderableVoxelBuild(build: RenderableVoxelBuild): RenderableVoxelBuild;
+export function filterRenderableVoxelBuild(build: RenderableVoxelBuild): RenderableVoxelBuild {
+  if (build.packed) return filterPackedRenderableVoxelBuild(build);
   if (build.blocks.length <= 0) return build;
 
   const blocksByPos = new Map<number, string>();

--- a/lib/voxel/sourceStream.ts
+++ b/lib/voxel/sourceStream.ts
@@ -1,0 +1,172 @@
+import { appendPackedVoxelBlocks, createPackedVoxelBlocks, type RenderableVoxelBuild } from "@/lib/voxel/packedBlocks";
+import { parseOwnedVoxelBuildSpec } from "@/lib/voxel/validate";
+
+// read one primitive at a time so source files never become a single JS string
+export async function parseVoxelBuildStream(
+  chunks: AsyncIterable<Uint8Array>,
+  opts: { maxBlocks?: number } = {},
+): Promise<RenderableVoxelBuild> {
+  if (opts.maxBlocks !== undefined && (!Number.isSafeInteger(opts.maxBlocks) || opts.maxBlocks < 0)) {
+    throw new Error("Invalid build block limit");
+  }
+  const build: RenderableVoxelBuild = { version: "1.0", boxes: [], lines: [], blocks: [], packed: createPackedVoxelBlocks(0) };
+  const batch: unknown[] = [];
+  let batchChars = 0;
+  const fields = new Set<string>();
+  const decoder = new TextDecoder("utf-8", { fatal: true });
+  let buffer = "";
+  let cursor = 0;
+  let state: "root" | "key" | "colon" | "value" | "ignored-value" | "item" | "separator" | "field-separator" | "done" = "root";
+  let field = "";
+  let tokenStart = -1;
+  let depth = 0;
+  let quoted = false;
+  let escaped = false;
+  let afterComma = false;
+  let primitive = false;
+
+  const flush = () => {
+    if (!batch.length) return;
+    const candidate = {
+      version: "1.0",
+      blocks: field === "blocks" ? batch : [],
+      ...(field === "boxes" ? { boxes: batch } : {}),
+      ...(field === "lines" ? { lines: batch } : {}),
+    };
+    const parsed = parseOwnedVoxelBuildSpec(candidate);
+    if (!parsed.ok) throw new Error(`Invalid ${field} entry: ${parsed.error}`);
+    if (field === "boxes") {
+      for (const { x1, y1, z1, x2, y2, z2, type } of parsed.value.boxes!) {
+        build.boxes!.push({ x1, y1, z1, x2, y2, z2, type });
+      }
+    } else if (field === "lines") {
+      for (const { from, to, type } of parsed.value.lines!) {
+        build.lines!.push({
+          from: { x: from.x, y: from.y, z: from.z },
+          to: { x: to.x, y: to.y, z: to.z },
+          type,
+        });
+      }
+    } else {
+      const typeNames = new Set(build.packed!.typeNames);
+      for (const block of parsed.value.blocks) {
+        typeNames.add(block.type);
+        if (typeNames.size > 65_536) throw new Error("Too many packed block types");
+        if (block.x < -32768 || block.x > 32767 || block.y < -32768 || block.y > 32767 || block.z < -32768 || block.z > 32767) {
+          throw new Error("Block coordinate is outside the supported integer range");
+        }
+      }
+      appendPackedVoxelBlocks(build.packed!, parsed.value.blocks);
+    }
+    batch.length = 0;
+    batchChars = 0;
+  };
+
+  const scan = () => {
+    while (cursor < buffer.length) {
+      const ch = buffer[cursor]!;
+      if (tokenStart >= 0) {
+        const primitiveEnded = primitive && (ch === "," || ch === "}" || " \t\r\n".includes(ch));
+        if (!primitiveEnded) {
+          if (quoted) {
+            if (escaped) escaped = false;
+            else if (ch === "\\") escaped = true;
+            else if (ch === '"') quoted = false;
+          } else if (ch === '"') quoted = true;
+          else if (ch === "{" || ch === "[") depth += 1;
+          else if (ch === "}" || ch === "]") depth -= 1;
+          cursor += 1;
+        }
+        if (cursor - tokenStart > 1_000_000) throw new Error("Build entry is too large");
+        if (!primitiveEnded && (primitive || quoted || depth > 0)) continue;
+        const tokenLength = cursor - tokenStart;
+        const value: unknown = JSON.parse(buffer.slice(tokenStart, cursor));
+        tokenStart = -1;
+        primitive = false;
+        if (state === "key") {
+          if (typeof value !== "string") throw new Error("Expected a build field");
+          if (fields.has(value)) throw new Error(`Duplicate build field: ${value}`);
+          fields.add(value);
+          field = value;
+          state = "colon";
+        } else if (state === "value") {
+          if (value !== "1.0") throw new Error("Unsupported build version");
+          state = "field-separator";
+        } else if (state === "ignored-value") {
+          state = "field-separator";
+        } else {
+          batch.push(value);
+          batchChars += tokenLength;
+          if (batch.length >= 4096 || batchChars >= 64 * 1024) flush();
+          state = "separator";
+        }
+        continue;
+      }
+      if (" \t\r\n".includes(ch)) { cursor += 1; continue; }
+      if (state === "root") {
+        if (ch !== "{") throw new Error("Expected a build JSON object");
+        state = "key";
+      } else if (state === "key") {
+        if (ch === "}" && !afterComma) state = "done";
+        else if (ch === '"') {
+          tokenStart = cursor;
+          quoted = true;
+          depth = 0;
+        } else throw new Error("Expected a build field name");
+      } else if (state === "colon") {
+        if (ch !== ":") throw new Error("Expected a colon after the build field");
+        state = "value";
+      } else if (state === "value") {
+        if (!["version", "boxes", "lines", "blocks"].includes(field)) {
+          state = "ignored-value";
+          tokenStart = cursor;
+          quoted = ch === '"';
+          depth = ch === "{" || ch === "[" ? 1 : 0;
+          primitive = !quoted && depth === 0;
+        } else if (field === "version" && ch === '"') {
+          tokenStart = cursor;
+          quoted = true;
+          depth = 0;
+        } else if (field !== "version" && ch === "[") {
+          state = "item";
+          afterComma = false;
+        } else throw new Error("Invalid build field value");
+      } else if (state === "item") {
+        if (ch === "]" && !afterComma) state = "field-separator";
+        else if (ch === "{") {
+          if (field === "blocks" && opts.maxBlocks !== undefined && build.packed!.count + batch.length >= opts.maxBlocks) {
+            throw new Error("Stored canonical block count does not match");
+          }
+          tokenStart = cursor;
+          depth = 1;
+          quoted = false;
+        } else throw new Error(`Expected an object in ${field}`);
+      } else if (state === "separator") {
+        if (ch === "]") { flush(); state = "field-separator"; }
+        else if (ch === ",") { state = "item"; afterComma = true; }
+        else throw new Error(`Expected a comma in ${field}`);
+      } else if (state === "field-separator") {
+        if (ch === "}") state = "done";
+        else if (ch === ",") { state = "key"; afterComma = true; }
+        else throw new Error("Expected a comma between build fields");
+      } else throw new Error("Unexpected content after the build");
+      cursor += 1;
+    }
+    const consumed = tokenStart >= 0 ? tokenStart : cursor;
+    buffer = buffer.slice(consumed);
+    cursor -= consumed;
+    if (tokenStart >= 0) tokenStart = 0;
+  };
+
+  for await (const bytes of chunks) {
+    buffer += decoder.decode(bytes, { stream: true });
+    scan();
+  }
+  buffer += decoder.decode();
+  scan();
+  if ((state as string) !== "done" || tokenStart >= 0 || !fields.has("version") || !fields.has("blocks")) {
+    throw new Error("Incomplete build JSON");
+  }
+  flush();
+  return build;
+}

--- a/lib/voxel/validate.ts
+++ b/lib/voxel/validate.ts
@@ -1,6 +1,11 @@
 import { z } from "zod";
 import type { BlockDefinition } from "@/lib/blocks/palettes";
-import type { VoxelBuild } from "@/lib/voxel/types";
+import type { VoxelBlock, VoxelBuild } from "@/lib/voxel/types";
+import {
+  createPackedVoxelBlocks,
+  isPackedVoxelBlocks,
+  type RenderableVoxelBuild,
+} from "@/lib/voxel/packedBlocks";
 
 const blockSchema = z.object({
   x: z.number().int(),
@@ -42,12 +47,17 @@ export type ValidateVoxelOptions = {
   gridSize: number;
   palette: BlockDefinition[];
   maxBlocks: number;
+  output?: "objects" | "packed";
 };
 
-export type ValidatedVoxelBuild = {
-  build: VoxelBuild;
+export type ValidatedVoxelBuild<Build extends VoxelBuild = RenderableVoxelBuild> = {
+  build: Build;
   warnings: string[];
 };
+
+type VoxelValidationResult<Build extends VoxelBuild = RenderableVoxelBuild> =
+  | { ok: true; value: ValidatedVoxelBuild<Build> }
+  | { ok: false; error: string };
 
 function normalizeParsedBuild(data: z.infer<typeof buildSchema>): VoxelBuild {
   return {
@@ -111,10 +121,13 @@ function clampInt(n: number, min: number, max: number): number {
 }
 
 function validateVoxelBuildSpecInternal(
-  build: VoxelBuild,
+  build: RenderableVoxelBuild,
   opts: ValidateVoxelOptions,
   releaseInput: boolean,
-): { ok: true; value: ValidatedVoxelBuild } | { ok: false; error: string } {
+): VoxelValidationResult {
+  if (build.packed !== undefined && !isPackedVoxelBlocks(build.packed)) {
+    return { ok: false, error: "Invalid packed blocks" };
+  }
   const allowed = new Set(opts.palette.map((b) => b.id));
   const paletteIndex = new Map(opts.palette.map((block, index) => [block.id, index + 1]));
   const warnings: string[] = [];
@@ -264,6 +277,20 @@ function validateVoxelBuildSpecInternal(
       }
       put(b.x, b.y, b.z, normalizedType);
     }
+    if (build.packed) {
+      const { positions, typeIds, typeNames, count } = build.packed;
+      const normalizedTypes = typeNames.map((type) => normalizeBlockType(type, allowed));
+      charge(count);
+      for (let index = 0; index < count; index += 1) {
+        const typeId = typeIds[index]!;
+        const normalizedType = normalizedTypes[typeId];
+        if (!normalizedType) {
+          bumpUnknownType(typeNames[typeId]!, 1);
+          continue;
+        }
+        put(positions[index * 3]!, positions[index * 3 + 1]!, positions[index * 3 + 2]!, normalizedType);
+      }
+    }
   } catch (e) {
     return { ok: false, error: e instanceof Error ? e.message : "Failed to expand primitives" };
   }
@@ -288,41 +315,76 @@ function validateVoxelBuildSpecInternal(
     build.blocks.length = 0;
     if (build.boxes) build.boxes.length = 0;
     if (build.lines) build.lines.length = 0;
+    delete build.packed;
   }
-  const blocks = Array.from({ length: occupiedCount }, (_, index) => {
+  const packed = opts.output === "packed" ? createPackedVoxelBlocks(occupiedCount) : undefined;
+  const packedTypeIds = packed ? new Int32Array(opts.palette.length).fill(-1) : undefined;
+  const blocks: VoxelBlock[] = packed ? [] : new Array(occupiedCount);
+  for (let index = 0; index < occupiedCount; index += 1) {
     const key = occupied[index]!;
     const x = key & 1023;
     const y = (key >>> 10) & 1023;
     const z = (key >>> 20) & 1023;
     const chunkKey = (x >> 4) | ((y >> 4) << 6) | ((z >> 4) << 12);
     const localIndex = (x & 15) | ((y & 15) << 4) | ((z & 15) << 8);
-    const type = opts.palette[(chunks.get(chunkKey)?.[localIndex] ?? 1) - 1]!.id;
-    return { x, y, z, type };
-  });
-  if (blocks.length > opts.maxBlocks) {
-    return {
-      ok: false,
-      error: `Too many blocks (${blocks.length}) > maxBlocks (${opts.maxBlocks})`,
-    };
+    const paletteId = (chunks.get(chunkKey)?.[localIndex] ?? 1) - 1;
+    const type = opts.palette[paletteId]!.id;
+    if (packed) {
+      let typeId = packedTypeIds![paletteId]!;
+      if (typeId < 0) {
+        typeId = packed.typeNames.length;
+        packed.typeNames.push(type);
+        packedTypeIds![paletteId] = typeId;
+      }
+      packed.positions[index * 3] = x;
+      packed.positions[index * 3 + 1] = y;
+      packed.positions[index * 3 + 2] = z;
+      packed.typeIds[index] = typeId;
+    } else {
+      blocks[index] = { x, y, z, type };
+    }
   }
 
-  return { ok: true, value: { build: { version: "1.0", blocks }, warnings } };
+  const normalizedBuild: RenderableVoxelBuild = { version: "1.0", blocks };
+  if (packed) {
+    packed.count = occupiedCount;
+    normalizedBuild.packed = packed;
+  }
+  return { ok: true, value: { build: normalizedBuild, warnings } };
 }
 
 export function validateVoxelBuildSpec(
-  build: VoxelBuild,
+  build: RenderableVoxelBuild,
+  opts: ValidateVoxelOptions & { output?: "objects" },
+): VoxelValidationResult<VoxelBuild>;
+export function validateVoxelBuildSpec(
+  build: RenderableVoxelBuild,
   opts: ValidateVoxelOptions,
-): { ok: true; value: ValidatedVoxelBuild } | { ok: false; error: string } {
+): VoxelValidationResult;
+export function validateVoxelBuildSpec(
+  build: RenderableVoxelBuild,
+  opts: ValidateVoxelOptions,
+): VoxelValidationResult {
   return validateVoxelBuildSpecInternal(build, opts, false);
 }
 
 export function validateVoxelBuild(
   input: unknown,
+  opts: ValidateVoxelOptions & { output?: "objects" },
+): VoxelValidationResult<VoxelBuild>;
+export function validateVoxelBuild(
+  input: unknown,
   opts: ValidateVoxelOptions,
-): { ok: true; value: ValidatedVoxelBuild } | { ok: false; error: string } {
-  const parsed = buildSchema.safeParse(input);
-  if (!parsed.success) return { ok: false, error: parsed.error.message };
-  return validateVoxelBuildSpec(normalizeParsedBuild(parsed.data), opts);
+): VoxelValidationResult;
+export function validateVoxelBuild(
+  input: unknown,
+  opts: ValidateVoxelOptions,
+): VoxelValidationResult {
+  const parsed = isRecord(input) && input.packed !== undefined
+    ? parseOwnedVoxelBuildSpec(input)
+    : parseVoxelBuildSpec(input);
+  if (!parsed.ok) return parsed;
+  return validateVoxelBuildSpec(parsed.value, opts);
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -338,11 +400,9 @@ function isPoint(value: unknown): boolean {
   );
 }
 
-// Large uploaded builds are already owned by the worker, so avoid Zod's deep copy
-export function validateOwnedVoxelBuild(
+export function parseOwnedVoxelBuildSpec(
   input: unknown,
-  opts: ValidateVoxelOptions,
-): { ok: true; value: ValidatedVoxelBuild } | { ok: false; error: string } {
+): { ok: true; value: RenderableVoxelBuild } | { ok: false; error: string } {
   if (!isRecord(input) || input.version !== "1.0" || !Array.isArray(input.blocks)) {
     return { ok: false, error: "Build must contain version 1.0 and a blocks list" };
   }
@@ -386,5 +446,26 @@ export function validateOwnedVoxelBuild(
       }
     }
   }
-  return validateVoxelBuildSpecInternal(input as VoxelBuild, opts, true);
+  if (input.packed !== undefined && !isPackedVoxelBlocks(input.packed)) {
+    return { ok: false, error: "Invalid packed blocks" };
+  }
+  return { ok: true, value: input as RenderableVoxelBuild };
+}
+
+// Large uploaded builds are already owned by the worker, so avoid Zod's deep copy
+export function validateOwnedVoxelBuild(
+  input: unknown,
+  opts: ValidateVoxelOptions & { output?: "objects" },
+): VoxelValidationResult<VoxelBuild>;
+export function validateOwnedVoxelBuild(
+  input: unknown,
+  opts: ValidateVoxelOptions,
+): VoxelValidationResult;
+export function validateOwnedVoxelBuild(
+  input: unknown,
+  opts: ValidateVoxelOptions,
+): VoxelValidationResult {
+  const parsed = parseOwnedVoxelBuildSpec(input);
+  if (!parsed.ok) return parsed;
+  return validateVoxelBuildSpecInternal(parsed.value, opts, true);
 }

--- a/scripts/custom-build-worker.ts
+++ b/scripts/custom-build-worker.ts
@@ -1,7 +1,8 @@
 import "dotenv/config";
 import { runCustomBuildWorkerLoop } from "@/lib/custom-builds/worker";
+import { processVoxelBuildResponseInWorker } from "./process-voxel-build-response";
 
-runCustomBuildWorkerLoop().catch((error) => {
+runCustomBuildWorkerLoop(undefined, { processResponse: processVoxelBuildResponseInWorker }).catch((error) => {
   console.error(error);
   process.exit(1);
 });

--- a/scripts/process-voxel-build-response-worker.cjs
+++ b/scripts/process-voxel-build-response-worker.cjs
@@ -1,0 +1,2 @@
+require("tsx/cjs");
+require("./process-voxel-build-response-worker.ts");

--- a/scripts/process-voxel-build-response-worker.ts
+++ b/scripts/process-voxel-build-response-worker.ts
@@ -1,0 +1,13 @@
+import { parentPort, workerData } from "node:worker_threads";
+import {
+  processVoxelBuildResponse,
+  type VoxelBuildResponseOptions,
+} from "@/lib/ai/processVoxelBuildResponse";
+
+if (!parentPort) throw new Error("Voxel response processing requires a worker thread");
+const { text, opts } = workerData as { text: string; opts: VoxelBuildResponseOptions };
+const result = processVoxelBuildResponse(text, opts);
+const packed = result.ok ? result.build.packed : undefined;
+parentPort.postMessage(result, packed
+  ? [packed.positions.buffer as ArrayBuffer, packed.typeIds.buffer as ArrayBuffer]
+  : []);

--- a/scripts/process-voxel-build-response.ts
+++ b/scripts/process-voxel-build-response.ts
@@ -1,0 +1,62 @@
+import path from "node:path";
+import { Worker } from "node:worker_threads";
+import type {
+  ProcessedVoxelBuildResponse,
+  ProcessVoxelBuildResponse,
+} from "@/lib/ai/processVoxelBuildResponse";
+
+export const processVoxelBuildResponseInWorker: ProcessVoxelBuildResponse = async (text, opts, signal) => {
+  signal?.throwIfAborted();
+  const worker = new Worker(path.join(__dirname, "process-voxel-build-response-worker.cjs"), {
+    workerData: {
+      text,
+      opts: {
+        gridSize: opts.gridSize,
+        palette: opts.palette,
+        enableTools: opts.enableTools,
+        minBlocks: opts.minBlocks,
+        buildOutput: opts.buildOutput,
+      },
+    },
+    // parent heap flags override this and it does not cap ArrayBuffers or process RSS
+    resourceLimits: { maxOldGenerationSizeMb: 640 },
+  });
+
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    const finish = async (result?: ProcessedVoxelBuildResponse, error?: unknown) => {
+      if (settled) return;
+      settled = true;
+      try {
+        await worker.terminate();
+        signal?.throwIfAborted();
+        if (error !== undefined) throw error;
+        resolve(result!);
+      } catch (cause) {
+        reject(cause);
+      } finally {
+        signal?.removeEventListener("abort", onAbort);
+        worker.off("message", onMessage);
+        worker.off("messageerror", onError);
+        worker.off("error", onError);
+        worker.off("exit", onExit);
+      }
+    };
+    const onMessage = (result: ProcessedVoxelBuildResponse) => { void finish(result); };
+    const onError = (error: Error & { code?: string }) => {
+      void finish(undefined, error.code === "ERR_WORKER_OUT_OF_MEMORY"
+        ? Object.assign(new Error("heap_limit_exceeded", { cause: error }), { code: error.code })
+        : error);
+    };
+    const onExit = (code: number) => {
+      void finish(undefined, new Error(`Voxel response worker exited without a result (${code})`));
+    };
+    const onAbort = () => { void finish(undefined, signal?.reason); };
+    worker.once("message", onMessage);
+    worker.once("messageerror", onError);
+    worker.once("error", onError);
+    worker.once("exit", onExit);
+    signal?.addEventListener("abort", onAbort, { once: true });
+    if (signal?.aborted) onAbort();
+  });
+};

--- a/tests/ui/gif-export-lifecycle.test.ts
+++ b/tests/ui/gif-export-lifecycle.test.ts
@@ -1,0 +1,148 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { runInNewContext } from "node:vm";
+import ts from "typescript";
+
+const path = "components/sandbox/SandboxGifExportButton.tsx";
+const source = ts.createSourceFile(path, readFileSync(path, "utf8"), ts.ScriptTarget.Latest, true, ts.ScriptKind.TSX);
+const functionText = (name: string) => {
+  const node = source.statements.find((statement) => ts.isFunctionDeclaration(statement) && statement.name?.text === name);
+  assert.ok(node, `${name} should exist`);
+  return node.getText(source);
+};
+const code = ts.transpileModule(
+  ["createAbortError", "throwIfAborted", "buildPaletteSampleFrames", "buildPaletteSamples", "buildGifBlob"]
+    .map(functionText).join("\n").replace("import.meta.url", '"https://minebench.test/export.js"') + "\nbuildGifBlob;",
+  { compilerOptions: { target: ts.ScriptTarget.ES2022 } },
+).outputText;
+
+function exportEffect(exportAbortRef: { current: AbortController | null }) {
+  let callback: ts.Expression | undefined;
+  const visit = (node: ts.Node) => {
+    if (ts.isCallExpression(node) && node.expression.getText(source) === "useEffect" && node.arguments[1]?.getText(source) === "[cancelKey]") {
+      callback = node.arguments[0];
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(source);
+  assert.ok(callback, "the export cancellation effect should exist");
+  return runInNewContext(`(${callback.getText(source)})()`, { exportAbortRef }) as (() => void) | undefined;
+}
+
+type Mode = "success" | "start-error" | "start-throw" | "start-wait" | "ack-wait" | "result-wait";
+function createHarness(mode: Mode = "success", onCapture?: () => void) {
+  const workers: FakeWorker[] = [];
+  let captures = 0;
+  class FakeWorker {
+    terminated = false;
+    messages: string[] = [];
+    onmessage?: (event: { data: unknown }) => void;
+    onerror?: () => void;
+    constructor() { workers.push(this); }
+    terminate() { this.terminated = true; }
+    postMessage(message: { type: string; frameIndex?: number }) {
+      this.messages.push(message.type);
+      if (message.type === "start" && mode === "start-throw") throw new Error("Worker start failed");
+      queueMicrotask(() => {
+        if (this.terminated) return;
+        if (message.type === "start") {
+          if (mode === "start-error") this.onerror?.();
+          else if (mode !== "start-wait") this.onmessage?.({ data: { type: "ready" } });
+        } else if (message.type === "frame" && mode !== "ack-wait") {
+          this.onmessage?.({ data: { type: "ack", frameIndex: message.frameIndex } });
+        } else if (message.type === "finish" && mode !== "result-wait") {
+          this.onmessage?.({ data: { type: "result", bytes: new Uint8Array([71, 73, 70]).buffer } });
+        }
+      });
+    }
+  }
+  const render = runInNewContext(code, {
+    Worker: FakeWorker, URL, Blob, DOMException, MAX_IN_FLIGHT_FRAMES: 4, YIELD_EVERY_FRAMES: 24,
+    document: { createElement: () => ({ getContext: () => ({ getImageData: () => ({ data: new Uint8ClampedArray(16) }) }) }) },
+    getExportRotationBases: () => [0], getPaletteSampleSize: () => ({ width: 2, height: 2 }),
+    buildExportLayout: () => ({}), waitForNextPaint: () => new Promise<void>((resolve) => setImmediate(resolve)),
+    renderCompositeFrame: () => { captures += 1; onCapture?.(); },
+  }) as (...args: unknown[]) => Promise<Blob>;
+  return {
+    workers,
+    get captures() { return captures; },
+    run: (signal?: AbortSignal, paletteSampleCount = 0) => render([], "", "single", { width: 2, height: 2 }, {
+      frameCount: 8, frameDelayMs: 40, frameDelaysMs: [], paletteSampleCount, socialSafe: false,
+    }, undefined, signal),
+  };
+}
+
+async function withDeadline<T>(promise: Promise<T>): Promise<T> {
+  let timer: ReturnType<typeof setTimeout>;
+  try {
+    return await Promise.race([promise, new Promise<never>((_, reject) => {
+      timer = setTimeout(() => reject(new Error("Export did not settle after cancellation")), 1000);
+    })]);
+  } finally {
+    clearTimeout(timer!);
+  }
+}
+
+async function main() {
+  const unhandled: unknown[] = [];
+  const onUnhandled = (error: unknown) => { unhandled.push(error); };
+  process.on("unhandledRejection", onUnhandled);
+  try {
+    for (const mode of ["start-throw", "start-error"] as const) {
+      const harness = createHarness(mode);
+      await assert.rejects(withDeadline(harness.run()), /Worker start failed|GIF worker crashed/);
+      assert.equal(harness.workers[0].terminated, true, `${mode} must terminate its worker`);
+    }
+
+    for (const mode of ["start-wait", "ack-wait", "result-wait"] as const) {
+      const controller = new AbortController();
+      const harness = createHarness(mode);
+      const pending = harness.run(controller.signal);
+      const rejected = assert.rejects(withDeadline(pending), { name: "AbortError" });
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      controller.abort();
+      await rejected;
+      assert.equal(harness.workers[0].terminated, true, `${mode} cancellation must terminate its worker`);
+    }
+
+    for (const unmount of [false, true]) {
+      const controller = new AbortController();
+      const exportAbortRef = { current: null as AbortController | null };
+      const cleanup = exportEffect(exportAbortRef);
+      exportAbortRef.current = controller;
+      if (unmount) assert.equal(typeof cleanup, "function", "unmount must abort the active export");
+      const harness = createHarness("success", () => {
+        if (unmount) cleanup?.();
+        else controller.abort();
+      });
+      await assert.rejects(withDeadline(harness.run(controller.signal, 6)), { name: "AbortError" });
+      assert.equal(harness.captures, 1, "cancellation must stop palette captures");
+      assert.equal(harness.workers[0].terminated, true, "palette cancellation must terminate its worker");
+      assert.deepEqual(harness.workers[0].messages, ["start"]);
+    }
+
+    const captureFailure = createHarness("success", () => { throw new Error("Capture failed"); });
+    await assert.rejects(withDeadline(captureFailure.run(undefined, 6)), /Capture failed/);
+    assert.equal(captureFailure.workers[0].terminated, true);
+
+    const workerFailure = createHarness("success", () => queueMicrotask(() => workerFailure.workers[0].onerror?.()));
+    await assert.rejects(withDeadline(workerFailure.run(undefined, 6)), /GIF worker crashed/);
+    assert.equal(workerFailure.workers[0].terminated, true);
+    assert.deepEqual(workerFailure.workers[0].messages, ["start"], "palette worker failure must stop encoding");
+
+    const success = createHarness();
+    const blob = await withDeadline(success.run(undefined, 2));
+    assert.equal(blob.type, "image/gif");
+    assert.equal(blob.size, 3);
+    assert.equal(success.captures, 10);
+    assert.equal(success.workers[0].messages[1], "palette");
+    assert.equal(success.workers[0].terminated, true);
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    assert.deepEqual(unhandled, [], "worker failures must not leave unhandled promise rejections");
+    console.log("GIF export lifecycle checks passed");
+  } finally {
+    process.removeListener("unhandledRejection", onUnhandled);
+  }
+}
+
+void main().catch((error) => { console.error(error); process.exitCode = 1; });

--- a/tests/unit/ai/generate-voxel-build-processing-lease.test.ts
+++ b/tests/unit/ai/generate-voxel-build-processing-lease.test.ts
@@ -41,6 +41,7 @@ async function main() {
 
   let acquired = 0;
   let released = 0;
+  let persistedResponse = false;
   let releaseSuccessfulBuild: (() => void) | undefined;
   const result = await generateVoxelBuild({
     modelKey: "qwen_qwen3_8_max",
@@ -51,8 +52,14 @@ async function main() {
     enableTools: true,
     providerKeys: { openrouter: "test-openrouter-key" },
     allowServerKeys: false,
-    returnExpandedBuild: true,
+    buildOutput: "objects",
+    onRawResponse: async () => {
+      persistedResponse = false;
+      await Promise.resolve();
+      persistedResponse = true;
+    },
     acquireBuildProcessing: async () => {
+      assert.equal(persistedResponse, true, "response persistence must finish before execution");
       acquired += 1;
       let didRelease = false;
       const release = () => {
@@ -76,6 +83,26 @@ async function main() {
 
   releaseSuccessfulBuild?.();
   assert.equal(released, 2, "the caller should release a successful build after artifact packaging");
+
+  const requestsBeforeFailure = requestCount;
+  const heapFailure = await generateVoxelBuild({
+    modelKey: "qwen_qwen3_8_max",
+    prompt: "stone tower",
+    gridSize: 64,
+    palette: "simple",
+    maxAttempts: 2,
+    providerKeys: { openrouter: "test-openrouter-key" },
+    allowServerKeys: false,
+    buildOutput: "packed",
+    processResponse: async () => { throw new Error("heap_limit_exceeded"); },
+    acquireBuildProcessing: async () => () => { released += 1; },
+  });
+  assert.equal(heapFailure.ok, false);
+  if (heapFailure.ok) throw new Error("expected a contained heap failure");
+  assert.equal(heapFailure.error, "heap_limit_exceeded");
+  assert.equal(requestCount, requestsBeforeFailure + 1, "heap failure must not buy another response");
+  assert.equal(released, 3, "isolated failure must release the finalization gate");
+  assert.equal(heapFailure.rawText, validToolCall);
 
   console.log("voxel build processing lease checks passed");
 }

--- a/tests/unit/ai/voxel-build-response-worker.test.ts
+++ b/tests/unit/ai/voxel-build-response-worker.test.ts
@@ -1,0 +1,90 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { getEventListeners } from "node:events";
+import { fileURLToPath } from "node:url";
+import type { VoxelBuildResponseOptions } from "../../../lib/ai/processVoxelBuildResponse";
+import { processVoxelBuildResponseInWorker } from "../../../scripts/process-voxel-build-response";
+
+const options: VoxelBuildResponseOptions = {
+  gridSize: 256, palette: "simple", enableTools: true, minBlocks: 1, buildOutput: "packed",
+};
+const response = (code: string) => JSON.stringify({
+  tool: "voxel.exec", input: { code, gridSize: options.gridSize, palette: options.palette, seed: 1 },
+});
+const smallResponse = response('box(0, 0, 0, 63, 31, 63, "stone");');
+const densePoints = response('for(let x=0;x<256;x++) for(let y=0;y<256;y++) for(let z=0;z<256;z++) block(x,y,z,"stone");');
+const bufferedPoints = response('const points=[]; for(let x=0;x<256;x++) for(let y=0;y<64;y++) for(let z=0;z<256;z++) points.push({x,y,z}); for(const point of points) block(point.x,point.y,point.z,"stone");');
+
+async function heapFailure() {
+  let heartbeats = 0;
+  const heartbeat = setInterval(() => { heartbeats += 1; }, 10);
+  try {
+    await assert.rejects(processVoxelBuildResponseInWorker(bufferedPoints, options), (error: unknown) => {
+      assert.ok(error instanceof Error);
+      assert.equal(error.message, "heap_limit_exceeded");
+      assert.equal((error as NodeJS.ErrnoException).code, "ERR_WORKER_OUT_OF_MEMORY");
+      return true;
+    });
+  } finally {
+    clearInterval(heartbeat);
+  }
+  assert.ok(heartbeats > 2, "parent remains responsive through isolated heap exhaustion");
+  const recovered = await processVoxelBuildResponseInWorker(smallResponse, options);
+  assert.ok(recovered.ok, "a subsequent job succeeds in the same parent");
+  assert.equal(recovered.blockCount, 64 * 32 * 64);
+  console.log("voxel response worker heap containment checks passed");
+}
+
+async function main() {
+  let heartbeats = 0;
+  const heartbeat = setInterval(() => { heartbeats += 1; }, 10);
+  const denseSignal = AbortSignal.timeout(10_000);
+  const dense = await processVoxelBuildResponseInWorker(
+    response('box(0, 0, 0, 255, 63, 255, "stone");'), options, denseSignal,
+  ).finally(() => clearInterval(heartbeat));
+  assert.ok(dense.ok);
+  assert.equal(dense.blockCount, 256 * 64 * 256);
+  assert.deepEqual(dense.build.blocks, []);
+  const packed = dense.build.packed!;
+  assert.ok(packed.positions instanceof Int16Array);
+  assert.ok(packed.typeIds instanceof Uint16Array);
+  assert.equal(packed.count, dense.blockCount);
+  assert.equal(packed.positions.byteLength + packed.typeIds.byteLength, packed.count * 8);
+  assert.deepEqual(packed.typeNames, ["stone"]);
+  assert.deepEqual(Array.from(packed.positions.slice(0, 3)), [0, 0, 0]);
+  assert.deepEqual(Array.from(packed.positions.slice(-3)), [255, 63, 255]);
+  assert.ok(heartbeats > 2, "processing leaves the parent event loop available");
+  assert.equal(getEventListeners(denseSignal, "abort").length, 0, "completed jobs release abort listeners");
+
+  const invalid = await processVoxelBuildResponseInWorker("not a build", options);
+  assert.equal(invalid.ok, false, "validation failures remain ordinary results");
+  await assert.rejects(processVoxelBuildResponseInWorker(
+    response('throw new Error("ordinary generated-program error");'), options,
+  ), /ordinary generated-program error/);
+
+  const reason = new Error("generation lease lost");
+  const preAborted = new AbortController();
+  preAborted.abort(reason);
+  await assert.rejects(processVoxelBuildResponseInWorker(smallResponse, options, preAborted.signal), (error) => error === reason);
+  const controller = new AbortController();
+  const pending = processVoxelBuildResponseInWorker(densePoints, options, controller.signal);
+  const abort = setTimeout(() => controller.abort(reason), 200);
+  try {
+    await assert.rejects(pending, (error) => error === reason);
+  } finally {
+    clearTimeout(abort);
+  }
+  assert.equal(getEventListeners(controller.signal, "abort").length, 0);
+
+  const child = spawnSync(process.execPath, [
+    "--max-old-space-size=64", "--import", "tsx", fileURLToPath(import.meta.url), "--heap-child",
+  ], { env: process.env, encoding: "utf8", timeout: 20_000 });
+  assert.equal(child.status, 0, `isolated heap failure did not recover\n${child.stdout}\n${child.stderr}`);
+  console.log(child.stdout.trim());
+  console.log("voxel response worker runtime checks passed");
+}
+
+(process.argv.includes("--heap-child") ? heapFailure() : main()).catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/tests/unit/ai/voxel-build-response-worker.test.ts
+++ b/tests/unit/ai/voxel-build-response-worker.test.ts
@@ -8,8 +8,8 @@ import { processVoxelBuildResponseInWorker } from "../../../scripts/process-voxe
 const options: VoxelBuildResponseOptions = {
   gridSize: 256, palette: "simple", enableTools: true, minBlocks: 1, buildOutput: "packed",
 };
-const response = (code: string) => JSON.stringify({
-  tool: "voxel.exec", input: { code, gridSize: options.gridSize, palette: options.palette, seed: 1 },
+const response = (code: string, gridSize = options.gridSize) => JSON.stringify({
+  tool: "voxel.exec", input: { code, gridSize, palette: options.palette, seed: 1 },
 });
 const smallResponse = response('box(0, 0, 0, 63, 31, 63, "stone");');
 const densePoints = response('for(let x=0;x<256;x++) for(let y=0;y<256;y++) for(let z=0;z<256;z++) block(x,y,z,"stone");');
@@ -55,6 +55,11 @@ async function main() {
   assert.deepEqual(Array.from(packed.positions.slice(-3)), [255, 63, 255]);
   assert.ok(heartbeats > 2, "processing leaves the parent event loop available");
   assert.equal(getEventListeners(denseSignal, "abort").length, 0, "completed jobs release abort listeners");
+
+  const overCapacity = await processVoxelBuildResponseInWorker(
+    response('box(0, 0, 0, 511, 511, 511, "stone");', 512), { ...options, gridSize: 512 },
+  );
+  assert.deepEqual(overCapacity, { ok: false, error: "processing_capacity_exceeded" });
 
   const invalid = await processVoxelBuildResponseInWorker("not a build", options);
   assert.equal(invalid.ok, false, "validation failures remain ordinary results");

--- a/tests/unit/arena/packed-build-adapters.test.ts
+++ b/tests/unit/arena/packed-build-adapters.test.ts
@@ -1,0 +1,161 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { decodeBinaryArtifact, encodeBinaryArtifact } from "../../../lib/arena/binaryArtifact";
+import {
+  expectedSnapshotArtifactTargets,
+} from "../../../lib/arena/buildSnapshotArtifacts";
+import {
+  pickBuildVariant,
+  prepareArenaBuildFromBuild,
+  type ArenaBuildSource,
+  type PreparedArenaBuild,
+} from "../../../lib/arena/buildArtifacts";
+import { ARENA_MESH_FACTS_MIN_BLOCKS } from "../../../lib/arena/types";
+import { createVoxelMeshFacts } from "../../../lib/voxel/meshFacts";
+import {
+  createPackedVoxelBlocks,
+  packVoxelBlocks,
+  toObjectBackedVoxelBuild,
+  voxelBuildBlockCount,
+  type RenderableVoxelBuild,
+} from "../../../lib/voxel/packedBlocks";
+import type { VoxelBlock, VoxelBuild } from "../../../lib/voxel/types";
+
+function source(blockCount: number): ArenaBuildSource {
+  return {
+    id: `packed-build-${blockCount}`,
+    gridSize: 256,
+    palette: "simple",
+    blockCount,
+    voxelByteSize: null,
+    voxelCompressedByteSize: null,
+    voxelSha256: "a".repeat(64),
+    voxelData: null,
+    voxelStorageBucket: null,
+    voxelStoragePath: null,
+    voxelStorageEncoding: null,
+  };
+}
+
+function packedBuild(blocks: VoxelBlock[]): RenderableVoxelBuild {
+  return { version: "1.0", blocks: [], packed: packVoxelBlocks(blocks) };
+}
+
+function planeBlocks(count: number): VoxelBlock[] {
+  return Array.from({ length: count }, (_, index) => ({
+    x: index % 128,
+    y: 0,
+    z: Math.floor(index / 128),
+    type: "stone",
+  }));
+}
+
+function packedCountBuild(count: number): RenderableVoxelBuild {
+  const packed = createPackedVoxelBlocks(count);
+  packed.typeNames = ["stone"];
+  packed.count = count;
+  return { version: "1.0", blocks: [], packed };
+}
+
+function preparedForTargets(fullBuild: RenderableVoxelBuild): PreparedArenaBuild {
+  const blockCount = voxelBuildBlockCount(fullBuild);
+  return {
+    buildId: "packed-targets",
+    payloadIdentity: { id: "packed-targets", voxelSha256: "b".repeat(64) },
+    checksum: "b".repeat(64),
+    fullBuild,
+    previewBuild: { version: "1.0", blocks: [] },
+    hints: {
+      initialVariant: "full",
+      initialDeliveryClass: "snapshot",
+      deliveryClass: "snapshot",
+      fullBlockCount: blockCount,
+      previewBlockCount: 0,
+      previewStride: 1,
+      initialEstimatedBytes: blockCount * 34,
+      fullEstimatedBytes: blockCount * 34,
+    },
+    buildRef: { buildId: "packed-targets", variant: "full", checksum: "b".repeat(64) },
+    previewRef: { buildId: "packed-targets", variant: "preview", checksum: "b".repeat(64) },
+  };
+}
+
+async function main() {
+  const cube: VoxelBuild = {
+    version: "1.0",
+    blocks: [],
+  };
+  for (let x = 0; x < 4; x += 1) {
+    for (let y = 0; y < 4; y += 1) {
+      for (let z = 0; z < 4; z += 1) {
+        cube.blocks.push({ x, y, z, type: "stone" });
+      }
+    }
+  }
+
+  const objectPrepared = prepareArenaBuildFromBuild(source(cube.blocks.length), cube);
+  const packedPrepared = prepareArenaBuildFromBuild(
+    source(cube.blocks.length),
+    packedBuild(cube.blocks),
+  );
+  assert.equal(packedPrepared.fullBuild.blocks.length, 0);
+  assert.ok(packedPrepared.fullBuild.packed);
+  assert.deepEqual(
+    toObjectBackedVoxelBuild(packedPrepared.fullBuild).blocks,
+    objectPrepared.fullBuild.blocks,
+    "packed visibility filtering must match object-backed filtering order",
+  );
+
+  const previewSource = planeBlocks(10_000);
+  const objectPreview = prepareArenaBuildFromBuild(source(previewSource.length), {
+    version: "1.0",
+    blocks: previewSource,
+  });
+  const packedPreview = prepareArenaBuildFromBuild(
+    source(previewSource.length),
+    packedBuild(previewSource),
+  );
+  assert.equal(packedPreview.previewBuild.packed, undefined);
+  assert.ok(packedPreview.previewBuild.blocks.length > 0);
+  assert.equal(
+    voxelBuildBlockCount(packedPreview.previewBuild),
+    voxelBuildBlockCount(objectPreview.previewBuild),
+  );
+  assert.deepEqual(
+    toObjectBackedVoxelBuild(packedPreview.previewBuild).blocks,
+    objectPreview.previewBuild.blocks,
+    "packed preview sampling must match object-backed sampling order",
+  );
+
+  const fullVariant = pickBuildVariant(packedPreview, "full");
+  assert.ok(fullVariant.packed, "packed prepared builds must retain packed full variants");
+  const binary = encodeBinaryArtifact({ version: fullVariant.version }, fullVariant.packed);
+  assert.equal(decodeBinaryArtifact(binary).blocks.count, voxelBuildBlockCount(fullVariant));
+  assert.equal(createVoxelMeshFacts(fullVariant.packed).blocks.count, voxelBuildBlockCount(fullVariant));
+
+  const targets = expectedSnapshotArtifactTargets(
+    preparedForTargets(packedCountBuild(ARENA_MESH_FACTS_MIN_BLOCKS)),
+  );
+  assert.ok(
+    targets.some((target) => target.variant === "full" && target.format === "mesh-facts"),
+    "mesh-facts eligibility must use packed block counts",
+  );
+
+  const snapshotSource = readFileSync("lib/arena/buildSnapshotArtifacts.ts", "utf8");
+  assert.match(snapshotSource, /voxelBuild\.packed \?\? voxelBuild\.blocks/);
+  assert.match(snapshotSource, /toObjectBackedVoxelBuild\(payload\.voxelBuild\)/);
+
+  const generationRun = readFileSync("lib/stealth/generationRun.ts", "utf8");
+  assert.match(generationRun, /buildOutput: "packed"/);
+  assert.match(
+    generationRun,
+    /processResponse: params\.processResponse/,
+  );
+
+  console.log("packed build adapter checks passed");
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/tests/unit/custom-builds/canonical-artifact-memory.test.ts
+++ b/tests/unit/custom-builds/canonical-artifact-memory.test.ts
@@ -3,14 +3,23 @@ import { spawnSync } from "node:child_process";
 import { createRequire } from "node:module";
 import { fileURLToPath } from "node:url";
 import { writeCanonicalBuildArtifact } from "../../../lib/custom-builds/artifacts";
+import { createPackedVoxelBlocks } from "../../../lib/voxel/packedBlocks";
 
 const MEMORY_CHILD = "MINEBENCH_CANONICAL_ARTIFACT_MEMORY_CHILD";
 
 async function streamLargeArtifact() {
-  const block = { x: 511, y: 511, z: 511, type: "oak_planks" };
+  const packed = createPackedVoxelBlocks(1_500_000);
+  packed.count = 1_500_000;
+  packed.typeNames.push("oak_planks");
+  for (let index = 0; index < packed.count; index += 1) {
+    packed.positions[index * 3] = index >> 18;
+    packed.positions[index * 3 + 1] = (index >> 9) & 511;
+    packed.positions[index * 3 + 2] = index & 511;
+  }
   const artifact = await writeCanonicalBuildArtifact({
     version: "1.0",
-    blocks: Array(1_500_000).fill(block),
+    blocks: [],
+    packed,
   });
   try {
     assert.ok(artifact.byteSize > 60 * 1024 * 1024);

--- a/tests/unit/custom-builds/generate-job-raw-recovery.test.ts
+++ b/tests/unit/custom-builds/generate-job-raw-recovery.test.ts
@@ -1,0 +1,317 @@
+import assert from "node:assert/strict";
+import { rm } from "node:fs/promises";
+
+const customBuildId = "raw-recovery-row";
+const publicId = "cb_123456789012345678901234";
+const storageDir = ".custom-build-storage/unit-raw-recovery";
+const previousEnv = Object.fromEntries([
+  "CUSTOM_BUILD_STORAGE_BUCKET", "CUSTOM_BUILD_LOCAL_STORAGE_DIR", "CUSTOM_BUILD_STUB_PROVIDER",
+  "SUPABASE_URL", "SUPABASE_SECRET_KEY", "OPENROUTER_BASE_URL", "MINEBENCH_TOOL_TIMEOUT_MS",
+  "CUSTOM_BUILD_KEY_ENCRYPTION_SECRET", "OPENAI_BACKGROUND_POLL_MS", "OPENAI_USE_BACKGROUND_MODE",
+].map((name) => [name, process.env[name]]));
+const originalFetch = globalThis.fetch;
+const artifacts: Array<Record<string, unknown>> = [];
+const updates: Array<Record<string, unknown>> = [];
+const queries: string[] = [];
+let keyLookups = 0;
+let providerRequests = 0;
+let expiredKey = false;
+let savedSecret: Record<string, unknown> | null = null;
+let savedJobPayload: Record<string, unknown> = {};
+let eventSeq = 0;
+let current: Record<string, unknown>;
+const initial = {
+  id: customBuildId, publicId, status: "queued", currentStage: "queued", removedAt: null,
+  promptText: "A seeded stone tower", promptSha256: "raw-recovery-prompt",
+  gridSize: 256, palette: "simple", modelKind: "catalog", modelKey: "qwen_qwen3_8_max",
+  modelProvider: "openrouter", modelId: "qwen/qwen3.8-max", modelDisplayName: "Qwen 3.8 Max",
+  openRouterModelId: "qwen/qwen3.8-max", preferOpenRouter: true, reasoning: null,
+  customBaseUrl: null, startedAt: null, generationTimeMs: 1234, warnings: ["stored warning"],
+};
+const fakePrisma = {
+  customBuild: {
+    findUnique: async () => current,
+    update: async ({ data }: { data: Record<string, unknown> }) => {
+      updates.push(data);
+      current = { ...current, ...data };
+      return current;
+    },
+    updateMany: async ({ data }: { data: Record<string, unknown> }) => {
+      updates.push(data);
+      current = { ...current, ...data };
+      return { count: 1 };
+    },
+  },
+  customBuildArtifact: {
+    findFirst: async (args: { where: { kind: string }; orderBy: unknown }) => {
+      queries.push(args.where.kind);
+      if (args.where.kind === "raw_text_debug") {
+        assert.deepEqual(args.orderBy, [{ createdAt: "desc" }, { id: "desc" }]);
+      }
+      return artifacts.findLast((artifact) => artifact.kind === args.where.kind) ?? null;
+    },
+    findUnique: async () => null,
+    upsert: async ({ create }: { create: Record<string, unknown> }) => {
+      const index = artifacts.findIndex((artifact) => artifact.kind === create.kind &&
+        artifact.sourceBuildSha256 === create.sourceBuildSha256);
+      if (index < 0) artifacts.push(create);
+      else artifacts[index] = create;
+      return create;
+    },
+    aggregate: async () => ({ _sum: {
+      storedByteSize: artifacts.reduce((sum, artifact) => sum + Number(artifact.storedByteSize), 0),
+    } }),
+  },
+  customBuildSecret: {
+    findUnique: async () => {
+      keyLookups += 1;
+      return savedSecret ?? (expiredKey ? { expiresAt: new Date(0) } : null);
+    },
+    deleteMany: async () => ({ count: 0 }),
+  },
+  customBuildJob: {
+    updateMany: async ({ where, data }: { where: Record<string, unknown>; data: { payload: Record<string, unknown> } }) => {
+      assert.deepEqual(where, { id: job.id, status: "running", lockedBy: "unit-background-worker" });
+      savedJobPayload = data.payload;
+      return { count: 1 };
+    },
+  },
+  customBuildStatsDaily: { upsert: async () => ({}) },
+  customBuildEvent: {
+    aggregate: async () => ({ _max: { seq: eventSeq } }),
+    create: async ({ data }: { data: { seq: number } }) => { eventSeq = data.seq; return data; },
+  },
+  $queryRaw: async () => [{ id: customBuildId }],
+  $transaction: async <T>(callback: (tx: unknown) => Promise<T>) => callback(fakePrisma),
+};
+(globalThis as unknown as { prisma?: unknown }).prisma = fakePrisma;
+
+const toolCall = (code: string, gridSize = 256, palette = "simple") => JSON.stringify({
+  tool: "voxel.exec", input: { code, gridSize, palette, seed: 123 },
+});
+const validText = toolCall([
+  "box(0, 0, 0, 79, 51, 1, 'stone');",
+  "block(Math.floor(rng() * 80), 52, 0, 'gold_block');",
+  "block(-1, 0, 0, 'stone'); block(0, 0, 0, 'unknown_material');",
+].join("\n"));
+const job = { id: "raw-recovery-job", customBuildId, type: "generate", status: "running",
+  attempts: 1, maxAttempts: 3, payload: {} };
+
+function reset() {
+  current = { ...initial };
+  artifacts.length = 0;
+  updates.length = 0;
+  queries.length = 0;
+  keyLookups = 0;
+  providerRequests = 0;
+  savedSecret = null;
+  savedJobPayload = {};
+  globalThis.fetch = async () => {
+    providerRequests += 1;
+    throw new Error("Replay must not contact a provider");
+  };
+}
+
+async function main() {
+  process.env.CUSTOM_BUILD_STORAGE_BUCKET = "__local_fs__";
+  process.env.CUSTOM_BUILD_LOCAL_STORAGE_DIR = storageDir;
+  delete process.env.CUSTOM_BUILD_STUB_PROVIDER;
+  process.env.MINEBENCH_TOOL_TIMEOUT_MS = "250";
+  const { processVoxelBuildResponseInWorker } = await import("../../../scripts/process-voxel-build-response");
+  const { runCustomBuildGenerateJob } = await import("../../../lib/custom-builds/generateJob");
+  const { generateVoxelBuild } = await import("../../../lib/ai/generateVoxelBuild");
+  const { uploadAndRecordCustomBuildArtifact, writeCanonicalBuildArtifact, gzipBytes, sha256Hex } =
+    await import("../../../lib/custom-builds/artifacts");
+  const { setMetricLogWriter } = await import("../../../lib/observability/cloudwatch");
+  const { CustomBuildLeaseLostError } = await import("../../../lib/custom-builds/lease");
+  setMetricLogWriter(() => {});
+  const saveRaw = async (text: string, gzip = false) => {
+    const bytes = new TextEncoder().encode(text);
+    return uploadAndRecordCustomBuildArtifact({ customBuildId, publicId, kind: "raw_text_debug",
+      bytes: gzip ? gzipBytes(bytes) : bytes, sourceBuildSha256: sha256Hex(bytes),
+      uncompressedByteSize: bytes.length, encoding: gzip ? "gzip" : "identity", exportStats: { attempt: 2 },
+    });
+  };
+  const assertNoProvider = () => {
+    assert.equal(keyLookups, 0, "saved responses must be processed before provider key lookup");
+    assert.equal(providerRequests, 0, "saved response failures must not buy another generation");
+  };
+
+  reset();
+  process.env.OPENROUTER_BASE_URL = "https://openrouter.test/api";
+  globalThis.fetch = async () => Response.json({ choices: [{ message: { content: validText } }] });
+  const fresh = await generateVoxelBuild({ modelKey: "qwen_qwen3_8_max", prompt: initial.promptText,
+    gridSize: 256, palette: "simple", maxAttempts: 1, buildOutput: "packed",
+    providerKeys: { openrouter: "unit-raw-recovery-key" }, allowServerKeys: false,
+  });
+  if (!fresh.ok) throw new Error(fresh.error);
+  assert.ok(fresh.warnings.length > 0, "fixture should exercise validation warnings");
+  const { sortPackedVoxelBlocks } = await import("../../../lib/voxel/packedBlocks");
+  sortPackedVoxelBlocks(fresh.build.packed!);
+  const expected = await writeCanonicalBuildArtifact(fresh.build);
+  const expectedSourceSha = expected.sourceSha256;
+  await expected.cleanup();
+
+  for (const mode of ["missing-key", "expired-key", "decoded-http"] as const) {
+    reset();
+    expiredKey = mode === "expired-key";
+    if (mode === "missing-key") current.generationTimeMs = null;
+    const raw = await saveRaw(validText);
+    let gateCalls = 0;
+    if (mode === "decoded-http") {
+      raw.bucket = "raw-recovery-private";
+      process.env.SUPABASE_URL = "http://127.0.0.1:43198";
+      process.env.SUPABASE_SECRET_KEY = "unit-raw-recovery-storage-key";
+      globalThis.fetch = async (input, init) => {
+        assert.equal(gateCalls, 1, "recovery should acquire processing before downloading");
+        assert.equal(String(input), `http://127.0.0.1:43198/storage/v1/object/${raw.bucket}/${raw.path}`);
+        assert.equal(new Headers(init?.headers).get("authorization"), "Bearer unit-raw-recovery-storage-key");
+        return new Response(validText, { headers: { "content-encoding": "gzip" } });
+      };
+    }
+    await runCustomBuildGenerateJob(job as never, {
+      acquireBuildProcessing: async () => { gateCalls += 1; return () => {}; },
+      processResponse: processVoxelBuildResponseInWorker,
+    });
+    assertNoProvider();
+    assert.equal(gateCalls, 1);
+    assert.equal(current.status, "succeeded");
+    assert.equal(current.blockCount, fresh.blockCount);
+    assert.equal(current.buildSha256, expectedSourceSha, "replay must match fresh seeded generation exactly");
+    assert.equal(current.generationTimeMs, mode === "missing-key" ? null : 1234);
+    assert.deepEqual(current.warnings, ["stored warning", ...fresh.warnings]);
+    assert.equal((current.metrics as Record<string, unknown>).sourceArtifactSha256, raw.sourceBuildSha256);
+    for (const kind of ["raw_text_debug", "build_json", "viewer_mbv4", "preview_mbv4", "preview_svg"]) {
+      assert.ok(artifacts.some((artifact) => artifact.kind === kind), `${mode} should preserve ${kind}`);
+    }
+    assert.ok(updates.some((update) => update.currentStage === "finalizing"));
+  }
+
+  const completedArtifacts = [...artifacts];
+  reset();
+  artifacts.push(...completedArtifacts);
+  await saveRaw("invalid newer raw response");
+  await runCustomBuildGenerateJob(job as never);
+  assertNoProvider();
+  assert.deepEqual(queries, ["build_json"], "canonical recovery must take precedence over raw responses");
+  assert.equal(current.buildSha256, expectedSourceSha);
+
+  for (const text of ["invalid JSON", "{}", toolCall("block(0,0,0,'stone');"),
+    toolCall("box(0,0,0,15,60,1,'stone');"), toolCall("box(0,0,0,79,5,1,'stone');"),
+    toolCall("box(0,0,0,79,51,1,'stone');", 4096),
+    toolCall("box(0,0,0,79,51,1,'stone');", 256, "advanced"),
+    toolCall("const = 1;"), toolCall("while (true) {}")]) {
+    reset();
+    await saveRaw(validText);
+    const raw = await saveRaw(text);
+    await assert.rejects(runCustomBuildGenerateJob(job as never), /generation_failed/);
+    assertNoProvider();
+    assert.equal(current.status, "failed");
+    assert.equal(current.errorRetryable, true);
+    assert.equal(current.deletionPendingAt, null, "failed execution must retain the saved response");
+    assert.equal((current.progress as Record<string, unknown>).attempt, 2);
+    assert.equal(artifacts.length, 2, "recovery should neither replace the raw response nor package invalid geometry");
+    assert.equal(artifacts[1], raw, "recovery must use the latest response");
+    assert.equal(updates.some((update) => update.status === "queued"), false);
+  }
+
+  for (const mode of ["stored-sha", "source-sha", "missing-sha", "stored-size", "gzip-size"] as const) {
+    reset();
+    const raw = await saveRaw(mode === "gzip-size" ? " ".repeat(8 * 1024 * 1024 + 1) : validText, mode === "gzip-size");
+    if (mode === "stored-sha") raw.sha256 = "0".repeat(64);
+    if (mode === "source-sha") raw.sourceBuildSha256 = "0".repeat(64);
+    if (mode === "missing-sha") raw.sourceBuildSha256 = "";
+    if (mode === "stored-size") raw.storedByteSize = 8 * 1024 * 1024 + 1;
+    await assert.rejects(runCustomBuildGenerateJob(job as never), /generation_retryable/);
+    assertNoProvider();
+    assert.equal(current.status, "queued", `${mode} should retry only saved artifact recovery`);
+    assert.equal(artifacts.length, 1);
+  }
+
+  for (const mode of ["stream-size", "stream-error", "stream-abort"] as const) {
+    reset();
+    const raw = await saveRaw(validText);
+    raw.bucket = "raw-recovery-private";
+    const streamAbort = new AbortController();
+    let canceled = false;
+    globalThis.fetch = async () => new Response(new ReadableStream<Uint8Array>({
+      start(controller) {
+        if (mode === "stream-error") controller.error(new Error("Storage read interrupted"));
+        else {
+          controller.enqueue(new Uint8Array(mode === "stream-size" ? 8 * 1024 * 1024 + 1 : 1));
+          if (mode === "stream-abort") streamAbort.abort(new CustomBuildLeaseLostError());
+        }
+      },
+      cancel() { canceled = true; },
+    }));
+    await assert.rejects(runCustomBuildGenerateJob(job as never, { signal: streamAbort.signal }),
+      mode === "stream-abort" ? /lease is no longer owned/ : /generation_retryable/);
+    assertNoProvider();
+    assert.equal(artifacts.length, 1);
+    if (mode !== "stream-error") assert.equal(canceled, true, "incomplete recovery must cancel its reader");
+    if (mode === "stream-abort") {
+      assert.equal(updates.some((update) => ["queued", "failed", "succeeded"].includes(String(update.status))), false);
+    }
+  }
+
+  reset();
+  await saveRaw(validText);
+  const abort = new AbortController();
+  await assert.rejects(runCustomBuildGenerateJob(job as never, {
+    signal: abort.signal,
+    acquireBuildProcessing: async () => { abort.abort(new CustomBuildLeaseLostError()); return () => {}; },
+  }), /lease is no longer owned/);
+  assertNoProvider();
+  assert.equal(artifacts.length, 1);
+  assert.equal(updates.some((update) => ["queued", "failed", "succeeded"].includes(String(update.status))), false);
+
+  reset();
+  process.env.CUSTOM_BUILD_KEY_ENCRYPTION_SECRET = "unit-background-response-recovery-secret";
+  process.env.OPENAI_BACKGROUND_POLL_MS = "0";
+  process.env.OPENAI_USE_BACKGROUND_MODE = "1";
+  const { encryptProviderKey } = await import("../../../lib/custom-builds/secrets");
+  savedSecret = { ...encryptProviderKey("unit-openai-background-key", { provider: "openai", binding: customBuildId }),
+    expiresAt: new Date(Date.now() + 60_000) };
+  current = { ...initial, modelKey: "openai_gpt_6_astra", modelProvider: "openai",
+    modelId: "gpt-6-astra", preferOpenRouter: false, generationTimeMs: null };
+  const interrupted = new AbortController();
+  const backgroundJob = { ...job, lockedBy: "unit-background-worker" };
+  const responseId = "resp_interrupted_generation";
+  const methods: string[] = [];
+  globalThis.fetch = async (_input, init) => {
+    methods.push(init?.method ?? "GET");
+    if (init?.method === "POST") return Response.json({ id: responseId, status: "queued" });
+    assert.equal(savedJobPayload.openaiResponseId, responseId, "the response ID must be durable before polling");
+    interrupted.abort(new CustomBuildLeaseLostError());
+    throw new DOMException("Interrupted", "AbortError");
+  };
+  await assert.rejects(runCustomBuildGenerateJob(backgroundJob as never, { signal: interrupted.signal }), /lease is no longer owned/);
+  assert.deepEqual(methods, ["POST", "GET"]);
+  assert.equal(artifacts.length, 0);
+  methods.length = 0;
+  current = { ...current, status: "queued", currentStage: "queued" };
+  globalThis.fetch = async (input, init) => {
+    methods.push(init?.method ?? "GET");
+    assert.equal(String(input), `https://api.openai.com/v1/responses/${responseId}`);
+    return Response.json({ id: responseId, status: "completed", output_text: validText });
+  };
+  await runCustomBuildGenerateJob({ ...backgroundJob, payload: savedJobPayload } as never, {
+    processResponse: processVoxelBuildResponseInWorker,
+  });
+  assert.deepEqual(methods, ["GET"], "reclaimed jobs must retrieve the original response without a new generation");
+  assert.equal(current.status, "succeeded");
+  assert.equal(current.buildSha256, expectedSourceSha);
+  assert.equal(current.generationTimeMs, null, "interrupted inference timing is unknown");
+  assert.ok(artifacts.some((artifact) => artifact.kind === "raw_text_debug"));
+  assert.ok(artifacts.some((artifact) => artifact.kind === "viewer_mbv4"));
+  console.log("saved raw response recovery checks passed");
+}
+
+void main().finally(async () => {
+  globalThis.fetch = originalFetch;
+  for (const [name, value] of Object.entries(previousEnv)) {
+    if (value === undefined) delete process.env[name];
+    else process.env[name] = value;
+  }
+  await rm(storageDir, { recursive: true, force: true });
+}).catch((error) => { console.error(error); process.exitCode = 1; });

--- a/tests/unit/custom-builds/generate-job.test.ts
+++ b/tests/unit/custom-builds/generate-job.test.ts
@@ -205,7 +205,7 @@ async function main() {
 
   assert.ok(
     generateJobSource.includes("buildGalleryPreviewSvg(canonicalBuild)") &&
-      generateJobSource.includes("blockCount: canonicalBuild.blocks.length"),
+      generateJobSource.includes("blockCount: canonicalBlockCount"),
     "static thumbnails should derive from the canonical build rather than the sampled viewer preview",
   );
   assert.ok(

--- a/tests/unit/custom-builds/worker-loop.test.ts
+++ b/tests/unit/custom-builds/worker-loop.test.ts
@@ -1,0 +1,127 @@
+import assert from "node:assert/strict";
+import { Prisma } from "@prisma/client";
+import { resetMetricLogWriter, setMetricLogWriter } from "../../../lib/observability/cloudwatch";
+
+const previousPoll = process.env.CUSTOM_BUILD_WORKER_POLL_MS;
+const previousConcurrency = process.env.CUSTOM_BUILD_WORKER_CONCURRENCY;
+process.env.CUSTOM_BUILD_WORKER_POLL_MS = "250";
+process.env.CUSTOM_BUILD_WORKER_CONCURRENCY = "2";
+
+const transient = (code: string) => new Prisma.PrismaClientKnownRequestError("Transaction already closed", {
+  code, clientVersion: Prisma.prismaVersion.client,
+});
+const operations: string[] = [];
+const recoveries: number[] = [];
+let claimed = false;
+let claimFailed = false;
+let disconnects = 0;
+let fatal = false;
+let unavailable = false;
+let releaseBuild!: (value: unknown) => void;
+let recovered!: () => void;
+const build = new Promise((resolve) => { releaseBuild = resolve; });
+const retried = new Promise<void>((resolve) => { recovered = resolve; });
+const transaction = {
+  customBuildSecret: {
+    deleteMany: async () => {
+      recoveries.push(Date.now());
+      if (fatal) throw new Error("Invalid queue configuration");
+      if (unavailable || recoveries.length === 2) throw transient("P2028");
+      if (recoveries.length === 4) recovered();
+      return { count: 0 };
+    },
+  },
+  $queryRaw: async () => [],
+  customBuildEvent: {
+    aggregate: async () => ({ _max: { seq: 0 } }),
+    create: async () => { operations.push("export_complete"); return {}; },
+  },
+};
+const fakePrisma = {
+  $transaction: async <T>(callback: (tx: unknown) => Promise<T>) => callback(transaction),
+  $queryRaw: async (parts: TemplateStringsArray) => {
+    const sql = parts.join("?");
+    if (!sql.includes("WITH candidate") || !sql.includes('FROM "CustomBuildJob"')) return [];
+    if (recoveries.length === 3 && !claimFailed) {
+      claimFailed = true;
+      throw transient("P1001");
+    }
+    if (claimed) return [];
+    claimed = true;
+    return [{ id: "active-export", customBuildId: "build-row", type: "export", payload: { format: "glb" } }];
+  },
+  customBuild: { findUnique: async () => build },
+  customBuildArtifact: { findFirst: async () => ({ id: "existing-export" }) },
+  customBuildJob: {
+    findFirst: async () => null,
+    count: async () => 0,
+    updateMany: async () => { operations.push("job_complete"); return { count: 1 }; },
+  },
+  stealthGenerationResult: { findFirst: async () => null, count: async () => 0 },
+  $disconnect: async () => { disconnects += 1; operations.push("disconnect"); },
+};
+(globalThis as unknown as { prisma?: unknown }).prisma = fakePrisma;
+
+async function main() {
+  const { runCustomBuildWorkerLoop } = await import("../../../lib/custom-builds/worker");
+  const originalListeners = process.listeners("SIGTERM");
+  const initialListeners = originalListeners.length;
+  // invoke the registered handler without signaling the test runner
+  const signalWorker = () => process.listeners("SIGTERM")
+    .filter((listener) => !originalListeners.includes(listener))
+    .forEach((listener) => listener("SIGTERM"));
+  const warnings: string[] = [];
+  const originalWarn = console.warn;
+  let onWarning = () => {};
+  let loop: Promise<void> | undefined;
+  const timeout = setTimeout(() => { console.error("worker loop regression timed out"); process.exit(1); }, 10_000);
+  setMetricLogWriter(() => {});
+  console.warn = (message: unknown) => { warnings.push(String(message)); onWarning(); };
+  try {
+    loop = runCustomBuildWorkerLoop("loop-test");
+    await Promise.race([retried, loop.then(() => { throw new Error("Worker exited before retrying"); })]);
+    assert.equal(claimed, true);
+    assert.equal(claimFailed, true);
+    assert.equal(disconnects, 0, "poll failures must not disconnect an active job");
+    assert.ok(recoveries[2]! - recoveries[1]! >= 200, "recovery retries must back off");
+    assert.ok(recoveries[3]! - recoveries[2]! >= 450, "consecutive claim failures must increase the delay");
+    assert.match(warnings[0]!, /retrying in 250ms/);
+    assert.match(warnings[1]!, /retrying in 500ms/);
+    signalWorker();
+    assert.equal(disconnects, 0, "SIGTERM must drain the active job");
+    releaseBuild({ id: "build-row", publicId: "cb_existing", status: "succeeded", buildSha256: "a".repeat(64) });
+    await loop;
+    assert.deepEqual(operations, ["export_complete", "job_complete", "disconnect"]);
+    assert.equal(process.listenerCount("SIGTERM"), initialListeners);
+
+    unavailable = true;
+    process.env.CUSTOM_BUILD_WORKER_POLL_MS = "60000";
+    const waiting = new Promise<void>((resolve) => { onWarning = resolve; });
+    loop = runCustomBuildWorkerLoop("shutdown-test");
+    await waiting;
+    signalWorker();
+    await loop;
+    assert.equal(disconnects, 2, "shutdown must interrupt a long retry delay");
+    assert.equal(process.listenerCount("SIGTERM"), initialListeners);
+
+    fatal = true;
+    loop = runCustomBuildWorkerLoop("fatal-test");
+    await assert.rejects(loop, /Invalid queue configuration/);
+    assert.equal(disconnects, 3);
+    assert.equal(process.listenerCount("SIGTERM"), initialListeners);
+    console.log("custom build worker loop recovery checks passed");
+  } finally {
+    signalWorker();
+    releaseBuild(null);
+    await loop?.catch(() => {});
+    clearTimeout(timeout);
+    console.warn = originalWarn;
+    resetMetricLogWriter();
+    if (previousPoll === undefined) delete process.env.CUSTOM_BUILD_WORKER_POLL_MS;
+    else process.env.CUSTOM_BUILD_WORKER_POLL_MS = previousPoll;
+    if (previousConcurrency === undefined) delete process.env.CUSTOM_BUILD_WORKER_CONCURRENCY;
+    else process.env.CUSTOM_BUILD_WORKER_CONCURRENCY = previousConcurrency;
+  }
+}
+
+main().catch((error) => { console.error(error); process.exit(1); });

--- a/tests/unit/gallery/preview.test.ts
+++ b/tests/unit/gallery/preview.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { packVoxelBlocks } from "../../../lib/voxel/packedBlocks";
 import { buildGalleryPreviewSvg } from "../../../lib/gallery/preview";
 
 const build = {
@@ -13,6 +14,7 @@ const build = {
 const first = buildGalleryPreviewSvg(build);
 const second = buildGalleryPreviewSvg(build);
 assert.equal(first, second);
+assert.equal(first, buildGalleryPreviewSvg({ version: "1.0", blocks: [], packed: packVoxelBlocks(build.blocks) }));
 assert.match(first, /^<svg[^>]+viewBox="0 0 640 400"/);
 assert.match(first, /aria-hidden="true"/);
 assert.equal(first.includes("<script"), false);

--- a/tests/unit/providers/openai-background-recovery.test.ts
+++ b/tests/unit/providers/openai-background-recovery.test.ts
@@ -1,0 +1,77 @@
+import assert from "node:assert/strict";
+import { generateVoxelBuild, type GenerateVoxelBuildParams } from "../../../lib/ai/generateVoxelBuild";
+
+const previousPoll = process.env.OPENAI_BACKGROUND_POLL_MS;
+const previousBackground = process.env.OPENAI_USE_BACKGROUND_MODE;
+const originalFetch = globalThis.fetch;
+const responseId = "resp_saved_background_generation";
+const text = JSON.stringify({ tool: "voxel.exec", input: {
+  code: "box(0, 0, 0, 15, 7, 15, 'stone');", gridSize: 64, palette: "simple",
+} });
+const requests: string[] = [];
+const options: GenerateVoxelBuildParams & {
+  openaiResponseId?: string;
+  onOpenAIResponseCreated?: (id: string) => Promise<void>;
+} = {
+  modelKey: "openai_gpt_6_astra", prompt: "A stone cube", gridSize: 64, palette: "simple",
+  providerKeys: { openai: "unit-background-recovery-key" }, allowServerKeys: false, maxAttempts: 3,
+};
+
+async function main() {
+  process.env.OPENAI_BACKGROUND_POLL_MS = "0";
+  process.env.OPENAI_USE_BACKGROUND_MODE = "1";
+  let checkpointed = false;
+  let checkpointedBeforePoll = false;
+  let status = "completed";
+  globalThis.fetch = async (input, init) => {
+    const method = init?.method ?? "GET";
+    requests.push(`${method} ${input}`);
+    if (method === "POST") return Response.json({ id: responseId, status: "queued" });
+    checkpointedBeforePoll = checkpointed;
+    return Response.json({ id: responseId, status, output_text: text });
+  };
+  options.onOpenAIResponseCreated = async (id) => {
+    assert.equal(id, responseId);
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    checkpointed = true;
+  };
+  const fresh = await generateVoxelBuild(options);
+  assert.ok(fresh.ok, fresh.ok ? "" : fresh.error);
+  assert.equal(checkpointedBeforePoll, true, "persist the response ID before polling");
+  assert.deepEqual(requests.map((request) => request.split(" ")[0]), ["POST", "GET"]);
+
+  requests.length = 0;
+  options.openaiResponseId = responseId;
+  options.onOpenAIResponseCreated = async () => { throw new Error("resume must reuse the saved checkpoint"); };
+  const resumed = await generateVoxelBuild(options);
+  assert.ok(resumed.ok, resumed.ok ? "" : resumed.error);
+  assert.deepEqual(resumed.ok && resumed.build, fresh.ok && fresh.build);
+  assert.deepEqual(requests, [`GET https://api.openai.com/v1/responses/${responseId}`]);
+
+  requests.length = 0;
+  status = "failed";
+  const failed = await generateVoxelBuild(options);
+  assert.equal(failed.ok, false);
+  assert.deepEqual(requests, [`GET https://api.openai.com/v1/responses/${responseId}`], "failed recovery must not buy a replacement");
+
+  requests.length = 0;
+  options.openaiResponseId = "../another-response";
+  const invalid = await generateVoxelBuild(options);
+  assert.equal(invalid.ok, false);
+  assert.equal(requests.length, 0);
+
+  requests.length = 0;
+  delete options.openaiResponseId;
+  const checkpointFailure = await generateVoxelBuild(options);
+  assert.equal(checkpointFailure.ok, false);
+  assert.deepEqual(requests, ["POST https://api.openai.com/v1/responses"], "checkpoint failure must stop paid retries");
+  console.log("OpenAI background response recovery checks passed");
+}
+
+void main().finally(() => {
+  globalThis.fetch = originalFetch;
+  if (previousPoll === undefined) delete process.env.OPENAI_BACKGROUND_POLL_MS;
+  else process.env.OPENAI_BACKGROUND_POLL_MS = previousPoll;
+  if (previousBackground === undefined) delete process.env.OPENAI_USE_BACKGROUND_MODE;
+  else process.env.OPENAI_USE_BACKGROUND_MODE = previousBackground;
+}).catch((error) => { console.error(error); process.exitCode = 1; });

--- a/tests/unit/providers/openrouter-streaming.test.ts
+++ b/tests/unit/providers/openrouter-streaming.test.ts
@@ -8,10 +8,10 @@ async function main() {
 
   // 1. Verify stream: true is sent and SSE stream is accumulated without onDelta
   {
-    let capturedBody: Record<string, unknown> | null = null;
+    const captured: { body: Record<string, unknown> | null } = { body: null };
 
     globalThis.fetch = (async (_input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
-      capturedBody = JSON.parse(init?.body as string) as Record<string, unknown>;
+      captured.body = JSON.parse(init?.body as string) as Record<string, unknown>;
 
       const ssePayload = [
         ": OPENROUTER PROCESSING\n\n",
@@ -35,7 +35,7 @@ async function main() {
         user: "Build a shrine.",
       });
 
-      assert.equal(capturedBody?.stream, true, "OpenRouter request should have stream: true");
+      assert.equal(captured.body?.stream, true, "OpenRouter request should have stream: true");
       assert.equal(
         result.text,
         '{"version":"1.0","blocks":[]}',

--- a/tests/unit/stealth/review-regressions.test.ts
+++ b/tests/unit/stealth/review-regressions.test.ts
@@ -112,7 +112,8 @@ assert.match(
 assert.match(generationRun, /promptCohortId !== BENCHMARK_PROMPT_COHORT_ID/);
 assert.match(generationRun, /abortSignal:/);
 assert.match(generationRun, /generationProviderSignal\(params\.signal\)/);
-assert.match(generationRun, /returnExpandedBuild: true/);
+assert.match(generationRun, /buildOutput: "packed"/);
+assert.match(generationRun, /processResponse: params\.processResponse/);
 assert.match(generationRun, /existing && run\.variant\.source !== "UPLOAD"/);
 assert.match(providerSignal, /90 \* 60 \* 1000/);
 for (const functionName of [
@@ -143,6 +144,7 @@ assert.match(
   generationSource,
   /writeCanonicalBuildArtifact\(params\.build\)/,
 );
+assert.match(generationSource, /toObjectBackedVoxelBuild\(params\.build\)/);
 assert.match(generationSource, /uploadSupabaseStorageFile\(/);
 assert.doesNotMatch(generationSource, /gzipSync\(|JSON\.stringify\(params\.build\)/);
 assert.match(generationRun, /isMissingStealthBuildPayload\(error\)/);

--- a/tests/unit/voxel/source-stream.test.ts
+++ b/tests/unit/voxel/source-stream.test.ts
@@ -1,0 +1,77 @@
+import assert from "node:assert/strict";
+import { parseVoxelBuildStream } from "../../../lib/voxel/sourceStream";
+import { unpackVoxelBlocks } from "../../../lib/voxel/packedBlocks";
+import { parseVoxelBuildSpec } from "../../../lib/voxel/validate";
+
+async function* chunks(text: string, width: number) {
+  const bytes = new TextEncoder().encode(text);
+  for (let index = 0; index < bytes.length; index += width) yield bytes.subarray(index, index + width);
+}
+
+async function main() {
+  const source = {
+    version: "1.0",
+    metadata: { label: 'ignored " Unicode 日', flags: [true, false, null], nested: {} },
+    enabled: true,
+    ratio: -1.25e3,
+    note: "ignored",
+    extra: null,
+    boxes: [
+      { x1: 0, y1: 0, z1: 0, x2: 1, y2: 0, z2: 0, type: "stone", extra: true },
+      { x1: 2, y1: 0, z1: 0, x2: 3, y2: 0, z2: 0, type: "stone" },
+    ],
+    lines: [{ from: { x: 0, y: 0, z: 0, extra: true }, to: { x: 4, y: 2, z: 1, extra: true }, type: "glass", extra: true }],
+    blocks: [{ x: 0, y: 0, z: 0, type: "stone", extra: true }, { x: 8191, y: 2, z: 40, type: 'escaped " Unicode 日' }],
+  };
+  const normalized = parseVoxelBuildSpec(source);
+  assert.equal(normalized.ok, true);
+  for (const width of [1, 7, 4096]) {
+    const parsed = await parseVoxelBuildStream(chunks(JSON.stringify(source, null, 2), width));
+    assert.deepEqual(unpackVoxelBlocks(parsed.packed!), normalized.value.blocks);
+    assert.deepEqual(parsed.lines, normalized.value.lines);
+    assert.deepEqual(parsed.boxes, normalized.value.boxes);
+    assert.deepEqual(parsed.blocks, []);
+    assert.equal("metadata" in parsed, false);
+  }
+  for (const [field, entry] of [
+    ["blocks", { x: "0", y: 0, z: 0, type: "stone" }],
+    ["blocks", { x: 0, y: 0.5, z: 0, type: "stone" }],
+    ["blocks", { x: 0, y: 0, z: null, type: "stone" }],
+    ["blocks", { x: 0, y: 0, z: 0, type: "" }],
+    ["blocks", { x: 0, y: 0, z: 0, type: 1 }],
+    ["boxes", { x1: 0, y1: 0, z1: 0, x2: 1, y2: 0, type: "stone" }],
+    ["boxes", { x1: 0.5, y1: 0, z1: 0, x2: 1, y2: 0, z2: 0, type: "stone" }],
+    ["boxes", { x1: 0, y1: 0, z1: 0, x2: 1, y2: 0, z2: 0, type: "" }],
+    ["lines", { from: null, to: { x: 1, y: 0, z: 0 }, type: "stone" }],
+    ["lines", { from: { x: 0, y: 0, z: 0 }, to: { x: 1, y: 0, z: "0" }, type: "stone" }],
+    ["lines", { from: { x: 0, y: 0, z: 0 }, to: { x: 1, y: 0, z: 0 }, type: "" }],
+  ] as const) {
+    const invalid = { version: "1.0", blocks: [], [field]: [entry] };
+    assert.equal(parseVoxelBuildSpec(invalid).ok, false);
+    await assert.rejects(parseVoxelBuildStream(chunks(JSON.stringify(invalid), 7)));
+  }
+  const repeatedBlocks = Array.from({ length: 4100 }, (_, index) => ({
+    x: index % 8, y: 0, z: 0, type: index % 2 === 0 ? "stone" : "glass",
+  }));
+  const repeated = await parseVoxelBuildStream(chunks(JSON.stringify({ version: "1.0", blocks: repeatedBlocks }), 4096));
+  assert.deepEqual(unpackVoxelBlocks(repeated.packed!), repeatedBlocks, "batch reuse must preserve the complete paint order");
+  for (const text of [
+    '\u00a0{"version":"1.0","blocks":[]}',
+    '{"version":"1.0","blocks":[],"extra":truex}',
+    '{"version":"1.0","blocks":[],"extra":[1,]}',
+    '{"version":"1.0","blocks":[}',
+    '{"version":"1.0","blocks":[],}',
+    '{"version":"1.0","blocks":[],"blocks":[]}',
+    '{"version":"1.0","blocks":[]} garbage',
+    '{"version":"1.0","blocks":[{"x":32768,"y":0,"z":0,"type":"stone"}]}',
+    '{"version":"1.0","blocks":[{"x":0.5,"y":0,"z":0,"type":"stone"}]}',
+    '{"version":"1.0","blocks":[]',
+  ]) await assert.rejects(parseVoxelBuildStream(chunks(text, 3)));
+  const bounded = JSON.stringify({ version: "1.0", blocks: repeatedBlocks });
+  await assert.rejects(parseVoxelBuildStream(chunks(bounded, 17), { maxBlocks: 4099 }), /block count/);
+  const exact = await parseVoxelBuildStream(chunks(bounded, 17), { maxBlocks: 4100 });
+  assert.equal(exact.packed?.count, 4100);
+  console.log("streamed build source checks passed");
+}
+
+void main().catch((error) => { console.error(error); process.exitCode = 1; });

--- a/tests/unit/voxel/validate-packed.test.ts
+++ b/tests/unit/voxel/validate-packed.test.ts
@@ -1,0 +1,239 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { createRequire } from "node:module";
+import { fileURLToPath } from "node:url";
+
+import { getPalette } from "../../../lib/blocks/palettes";
+import {
+  appendPackedVoxelBlocks,
+  createPackedVoxelBlocks,
+  isPackedVoxelBlocks,
+  packVoxelBlocks,
+  sortPackedVoxelBlocks,
+  toObjectBackedVoxelBuild,
+  unpackVoxelBlocks,
+  voxelBuildBlockAt,
+  type RenderableVoxelBuild,
+} from "../../../lib/voxel/packedBlocks";
+import type { VoxelBlock, VoxelBuild } from "../../../lib/voxel/types";
+import {
+  parseOwnedVoxelBuildSpec,
+  parseVoxelBuildSpec,
+  validateOwnedVoxelBuild,
+  validateVoxelBuild,
+  validateVoxelBuildSpec,
+  type ValidatedVoxelBuild,
+} from "../../../lib/voxel/validate";
+
+const MEMORY_CHILD = "MINEBENCH_PACKED_VALIDATE_MEMORY_CHILD";
+const options = { gridSize: 8, palette: getPalette("simple"), maxBlocks: 8 ** 3 };
+const compareBlocks = (a: VoxelBlock, b: VoxelBlock) =>
+  a.x - b.x || a.y - b.y || a.z - b.z || a.type.localeCompare(b.type);
+
+function validated(result: ReturnType<typeof validateVoxelBuild>): ValidatedVoxelBuild {
+  if (!result.ok) throw new Error(result.error);
+  return result.value;
+}
+
+function validatePackedBox() {
+  const startedAt = performance.now();
+  const { build } = validated(validateOwnedVoxelBuild(
+    {
+      version: "1.0",
+      blocks: [],
+      boxes: [{ x1: 0, y1: 0, z1: 0, x2: 255, y2: 255, z2: 255, type: "stone" }],
+    },
+    { gridSize: 256, palette: options.palette, maxBlocks: 256 ** 3, output: "packed" },
+  ));
+  assert.deepEqual(build.blocks, []);
+  assert.equal(build.packed?.count, 256 ** 3);
+  assert.equal(build.packed?.positions.length, 256 ** 3 * 3);
+  assert.equal(build.packed?.typeIds.length, 256 ** 3);
+  assert.deepEqual(build.packed?.typeNames, ["stone"]);
+  for (const index of [0, 255, 256, 65_536, 256 ** 3 - 1]) {
+    assert.deepEqual(voxelBuildBlockAt(build, index), {
+      x: index >>> 16,
+      y: (index >>> 8) & 255,
+      z: index & 255,
+      type: "stone",
+    });
+  }
+  const memory = process.memoryUsage();
+  console.log(JSON.stringify({
+    node: process.version,
+    blockCount: build.packed?.count,
+    elapsedMs: Math.round(performance.now() - startedAt),
+    heapUsedBytes: memory.heapUsed,
+    externalBytes: memory.external,
+    peakRssKiB: process.resourceUsage().maxRSS,
+  }));
+}
+
+async function main() {
+  const fixture: VoxelBuild = {
+    version: "1.0",
+    boxes: [
+      { x1: 4, y1: 1, z1: 2, x2: 3, y2: 1, z2: 2, type: "stone" },
+      { x1: 6, y1: 0, z1: 0, x2: 6, y2: 0, z2: 1, type: "unknown_crystal" },
+    ],
+    lines: [{ from: { x: 4, y: 1, z: 2 }, to: { x: 2, y: 1, z: 2 }, type: "oak-plank" }],
+    blocks: [
+      { x: 3, y: 1, z: 2, type: "minecraft:gold" },
+      { x: 0, y: 5, z: 1, type: "minecraft:oak_wood" },
+      { x: -1, y: 0, z: 0, type: "stone" },
+      { x: 8, y: 0, z: 0, type: "stone" },
+      { x: 0, y: 0, z: 0, type: "unknown_crystal" },
+      { x: 0, y: 0, z: 0, type: "unknown_metal" },
+    ],
+  };
+  const original = structuredClone(fixture);
+  const objectResult = validated(validateVoxelBuild(fixture, options));
+  const packedResult = validated(validateVoxelBuild(fixture, { ...options, output: "packed" }));
+  assert.deepEqual(fixture, original);
+  assert.deepEqual(packedResult.warnings, objectResult.warnings);
+  assert.deepEqual(packedResult.warnings, [
+    "Dropped 1 blocks with negative coordinates",
+    "Dropped 1 blocks outside the grid bounds",
+    "Dropped unknown block type: unknown_crystal (3)",
+    "Dropped unknown block type: unknown_metal (1)",
+  ]);
+  assert.deepEqual(packedResult.build.blocks, []);
+  assert.deepEqual(packedResult.build.packed, packVoxelBlocks(objectResult.build.blocks));
+
+  const privateBytes = JSON.stringify(objectResult.build);
+  assert.equal(JSON.stringify(toObjectBackedVoxelBuild(packedResult.build)), privateBytes);
+  assert.deepEqual(voxelBuildBlockAt(packedResult.build, 0), { x: 3, y: 1, z: 2, type: "gold_block" });
+  assert.equal(voxelBuildBlockAt(objectResult.build, 0), objectResult.build.blocks[0]);
+  for (const index of [-1, 0.5, Number.NaN, Infinity, 4]) {
+    assert.equal(voxelBuildBlockAt(packedResult.build, index), undefined);
+  }
+
+  sortPackedVoxelBlocks(packedResult.build.packed!);
+  const customBytes = JSON.stringify({
+    version: "1.0",
+    blocks: objectResult.build.blocks.slice().sort(compareBlocks),
+  });
+  assert.equal(JSON.stringify(toObjectBackedVoxelBuild(packedResult.build)), customBytes);
+  assert.notEqual(privateBytes, customBytes);
+
+  const packedSource: RenderableVoxelBuild = {
+    ...structuredClone(fixture),
+    packed: packVoxelBlocks([
+      { x: 3, y: 1, z: 2, type: "minecraft:grass" },
+      { x: -2, y: 0, z: 0, type: "stone" },
+      { x: 0, y: 0, z: 9, type: "stone" },
+      { x: 0, y: 0, z: 0, type: "unknown_metal" },
+      { x: 7, y: 7, z: 7, type: "glass" },
+    ]),
+  };
+  const expandedSource = {
+    ...fixture,
+    blocks: [...fixture.blocks, ...unpackVoxelBlocks(packedSource.packed!)],
+  };
+  const expected = validated(validateVoxelBuild(expandedSource, options));
+  for (const validate of [validateVoxelBuild, validateVoxelBuildSpec]) {
+    const result = validated(validate(packedSource, { ...options, output: "packed" }));
+    assert.deepEqual(toObjectBackedVoxelBuild(result.build), expected.build);
+    assert.deepEqual(result.warnings, expected.warnings);
+    assert.deepEqual(validated(validate(packedSource, options)), expected);
+  }
+  const owned = structuredClone(packedSource);
+  const ownedResult = validated(validateOwnedVoxelBuild(owned, { ...options, output: "packed" }));
+  assert.deepEqual(toObjectBackedVoxelBuild(ownedResult.build), expected.build);
+  assert.deepEqual(ownedResult.warnings, expected.warnings);
+  assert.deepEqual(owned.blocks, []);
+  assert.deepEqual(owned.boxes, []);
+  assert.deepEqual(owned.lines, []);
+  assert.equal(owned.packed, undefined);
+  assert.equal(packedSource.packed?.count, 5);
+  assert.equal(parseOwnedVoxelBuildSpec(packedSource).ok, true);
+  const publicSpec = parseVoxelBuildSpec(packedSource);
+  assert.equal(publicSpec.ok && "packed" in publicSpec.value, false);
+  assert.deepEqual(publicSpec.ok && publicSpec.value, fixture);
+
+  const validPacked = packVoxelBlocks([{ x: 1, y: 2, z: 3, type: "stone" }]);
+  for (const packed of [
+    null,
+    { ...validPacked, positions: [1, 2, 3] },
+    { ...validPacked, typeIds: new Int16Array([0]) },
+    { ...validPacked, count: -1 },
+    { ...validPacked, count: 0.5 },
+    { ...validPacked, count: 2 },
+    { ...validPacked, positions: new Int16Array(2) },
+    { ...validPacked, typeNames: [] },
+    { ...validPacked, typeNames: [""] },
+    { ...validPacked, typeNames: new Array(1) },
+    { ...validPacked, typeIds: new Uint16Array([1]) },
+  ]) {
+    assert.equal(isPackedVoxelBlocks(packed), false);
+    const input = { version: "1.0" as const, blocks: [], packed } as RenderableVoxelBuild;
+    assert.deepEqual(parseOwnedVoxelBuildSpec(input), { ok: false, error: "Invalid packed blocks" });
+    for (const validate of [validateVoxelBuild, validateVoxelBuildSpec, validateOwnedVoxelBuild]) {
+      assert.deepEqual(validate(input, { ...options, output: "packed" }), {
+        ok: false,
+        error: "Invalid packed blocks",
+      });
+    }
+  }
+
+  assert.equal(isPackedVoxelBlocks(createPackedVoxelBlocks(0)), true);
+  for (const source of [
+    [],
+    [{ x: 1, y: 2, z: 3, type: "stone" }],
+    ...[3, 11, 97].map((count) => Array.from({ length: count }, (_, index) => ({
+      x: (index * 17) % 7 - 3,
+      y: (index * 11) % 5,
+      z: index % 3,
+      type: ["stone", "glass", "dirt"][index % 3]!,
+    }))),
+    [
+      { x: 1, y: 1, z: 1, type: "stone" },
+      { x: 1, y: 1, z: 1, type: "glass" },
+      { x: 1, y: 1, z: 1, type: "dirt" },
+    ],
+  ]) {
+    const packed = createPackedVoxelBlocks(source.length + 1);
+    appendPackedVoxelBlocks(packed, source);
+    packed.positions.fill(-30000, source.length * 3);
+    packed.typeIds[source.length] = 65_535;
+    const positions = packed.positions;
+    const typeIds = packed.typeIds;
+    assert.equal(isPackedVoxelBlocks(packed), true);
+    sortPackedVoxelBlocks(packed);
+    assert.deepEqual(unpackVoxelBlocks(packed), source.slice().sort(compareBlocks));
+    assert.equal(packed.positions, positions);
+    assert.equal(packed.typeIds, typeIds);
+    assert.equal(packed.positions[source.length * 3], -30000);
+    assert.equal(packed.typeIds[source.length], 65_535);
+    sortPackedVoxelBlocks(packed);
+    assert.deepEqual(unpackVoxelBlocks(packed), source.slice().sort(compareBlocks));
+  }
+
+  const overflowOptions = { ...options, maxBlocks: 1, output: "packed" as const };
+  assert.deepEqual(
+    validateVoxelBuild({ version: "1.0", blocks: [], packed: packVoxelBlocks([
+      { x: 0, y: 0, z: 0, type: "stone" },
+      { x: 1, y: 0, z: 0, type: "stone" },
+    ]) }, overflowOptions),
+    { ok: false, error: "Too many blocks (2) > maxBlocks (1)" },
+  );
+  const require = createRequire(import.meta.url);
+  const memoryResult = spawnSync(
+    process.execPath,
+    ["--max-old-space-size=96", require.resolve("tsx/cli"), fileURLToPath(import.meta.url)],
+    { env: { ...process.env, [MEMORY_CHILD]: "1" }, encoding: "utf8" },
+  );
+  assert.equal(
+    memoryResult.status,
+    0,
+    `packed validation exceeded its heap envelope\n${memoryResult.stderr}`,
+  );
+  console.log(memoryResult.stdout.trim());
+  console.log("packed voxel validation checks passed");
+}
+
+const run = process.env[MEMORY_CHILD] === "1" ? Promise.resolve(validatePackedBox()) : main();
+run.catch((error) => {
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
Dense generations could exhaust the shared worker heap, and a lease-recovery transaction timeout could terminate the worker while other jobs were active. Run response execution and validation in disposable Node workers, retain packed blocks through canonical and viewer artifact creation, and retry transient queue errors while keeping active jobs alive.

Save raw responses before conversion and checkpoint OpenAI background response IDs on the leased job. Reclaimed jobs retrieve the same response; saved raw and canonical artifacts can complete without another provider request. Stream canonical recovery with checksum verification, preserve source bytes, and stop paid retries on memory or capacity failures. Expanded processing of 512-grid builds has a 16,777,216-cell capacity limit. GIF encoder startup and cancellation also release their pending work.

Validation: all 145 test files, ESLint, TypeScript, and the Next production build pass. Regression checks cover interrupted background responses, raw recovery without credentials, native worker heap failure and subsequent recovery, source identity, lease renewal, and encoder cleanup. A complete 256-grid fixture that previously aborted under a 640 MiB heap now completes; an 8.4-million-cell control retains identical canonical bytes while peak RSS falls from 1,009 MiB to 484 MiB in the local Node 22 pipeline.

*PR written by Codex*
