### PR TITLE
fix(ui): unify controls and polish browsing

### DIFF
--- a/app/account/MediaExportSettings.tsx
+++ b/app/account/MediaExportSettings.tsx
@@ -40,14 +40,12 @@ const FRAMING_OPTIONS: ReadonlyArray<{
 
 function CreatorOptionGroup<T extends string>({
   legend,
-  name,
   value,
   options,
   disabled,
   onChange,
 }: {
   legend: string;
-  name: string;
   value: T;
   options: ReadonlyArray<{ value: T; label: string; detail: string }>;
   disabled: boolean;
@@ -56,30 +54,21 @@ function CreatorOptionGroup<T extends string>({
   return (
     <fieldset disabled={disabled}>
       <legend className="mb-2 text-xs font-medium text-muted">{legend}</legend>
-      <div className="grid grid-cols-2 overflow-hidden rounded-md border border-border/75">
-        {options.map((option, index) => {
+      <div data-stretch="true" className="mb-choice-group mb-choice-group-compact w-full">
+        {options.map((option) => {
           const selected = value === option.value;
           return (
-            <label key={option.value} className="cursor-pointer">
-              <input
-                type="radio"
-                name={name}
-                value={option.value}
-                checked={selected}
-                onChange={() => onChange(option.value)}
-                className="peer sr-only"
-              />
-              <span
-                className={`flex min-h-14 flex-col justify-center px-3 py-2 text-center transition-colors duration-200 peer-focus-visible:ring-2 peer-focus-visible:ring-inset peer-focus-visible:ring-accent/45 motion-reduce:transition-none ${
-                  index > 0 ? "border-l border-border/75" : ""
-                } ${selected ? "bg-fg text-bg" : "bg-transparent text-muted hover:text-fg"}`}
-              >
-                <span className="text-xs font-semibold">{option.label}</span>
-                <span className={`mt-0.5 text-[10px] ${selected ? "text-bg/70" : "text-muted"}`}>
-                  {option.detail}
-                </span>
-              </span>
-            </label>
+            <button
+              key={option.value}
+              type="button"
+              aria-pressed={selected}
+              aria-label={`${option.label}: ${option.detail}`}
+              disabled={disabled}
+              className="mb-choice-option mb-choice-option-stretch mb-choice-option-compact grid min-h-10 place-items-center text-center"
+              onClick={() => onChange(option.value)}
+            >
+              <span className="text-xs">{option.label}</span>
+            </button>
           );
         })}
       </div>
@@ -107,6 +96,8 @@ export function MediaExportSettings() {
   }
 
   const creator = preference.quality === "creator";
+  const selectedQuality = QUALITY_OPTIONS.find((option) => option.value === preference.quality)
+    ?? QUALITY_OPTIONS[0];
 
   return (
     <section
@@ -119,57 +110,26 @@ export function MediaExportSettings() {
       </h2>
       <p className="mt-2 text-sm text-muted">Saved on this device.</p>
 
-      <fieldset className="mt-5 space-y-2">
+      <fieldset className="mt-5">
         <legend className="sr-only">Export quality</legend>
-        {QUALITY_OPTIONS.map((option) => {
-          const selected = preference.quality === option.value;
-          return (
-            <label key={option.value} className="block cursor-pointer">
-              <input
-                type="radio"
-                name="media-export-quality"
-                value={option.value}
-                checked={selected}
-                onChange={() => save({ ...preference, quality: option.value })}
-                className="peer sr-only"
-              />
-              <span
-                className={`flex min-h-14 items-center justify-between gap-3 rounded-md border px-3 py-2.5 transition-[background-color,border-color,color] duration-200 ease-[cubic-bezier(0.22,1,0.36,1)] peer-focus-visible:ring-2 peer-focus-visible:ring-accent/45 motion-reduce:transition-none ${
-                  selected
-                    ? "border-accent/55 bg-accent/[0.07]"
-                    : "border-border/75 hover:border-border hover:bg-card/25"
-                }`}
+        <div data-stretch="true" className="mb-choice-group w-full">
+          {QUALITY_OPTIONS.map((option) => {
+            const selected = preference.quality === option.value;
+            return (
+              <button
+                key={option.value}
+                type="button"
+                aria-pressed={selected}
+                aria-label={`${option.label}: ${option.detail}`}
+                className="mb-choice-option mb-choice-option-stretch grid min-h-11 place-items-center text-center"
+                onClick={() => save({ ...preference, quality: option.value })}
               >
-                <span className="min-w-0">
-                  <span className="block text-sm font-semibold text-fg">{option.label}</span>
-                  <span className="mt-0.5 block text-xs text-muted">{option.detail}</span>
-                </span>
-                <span
-                  aria-hidden="true"
-                  className={`grid h-5 w-5 shrink-0 place-items-center rounded-full border transition-[background-color,border-color] duration-200 motion-reduce:transition-none ${
-                    selected ? "border-accent bg-accent text-bg" : "border-border text-transparent"
-                  }`}
-                >
-                  <svg
-                    viewBox="0 0 20 20"
-                    className={`h-3.5 w-3.5 transition-[opacity,transform] duration-200 ease-[cubic-bezier(0.22,1,0.36,1)] motion-reduce:transition-none ${
-                      selected ? "scale-100 opacity-100" : "scale-75 opacity-0"
-                    }`}
-                  >
-                    <path
-                      d="m5.25 10.25 3 3 6.5-6.5"
-                      fill="none"
-                      stroke="currentColor"
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      strokeWidth="2"
-                    />
-                  </svg>
-                </span>
-              </span>
-            </label>
-          );
-        })}
+                {option.label}
+              </button>
+            );
+          })}
+        </div>
+        <p className="mt-2 text-xs text-muted">{selectedQuality.detail}</p>
       </fieldset>
 
       <div
@@ -183,7 +143,6 @@ export function MediaExportSettings() {
           <div className="space-y-4 pt-4">
             <CreatorOptionGroup
               legend="Format"
-              name="media-export-file-type"
               value={preference.fileType}
               options={FILE_TYPE_OPTIONS}
               disabled={!creator}
@@ -191,7 +150,6 @@ export function MediaExportSettings() {
             />
             <CreatorOptionGroup
               legend="Framing"
-              name="media-export-framing"
               value={preference.framing}
               options={FRAMING_OPTIONS}
               disabled={!creator}

--- a/app/account/page.tsx
+++ b/app/account/page.tsx
@@ -55,33 +55,7 @@ export default async function AccountPage({
       ) : null}
 
       <div className="grid gap-12 lg:grid-cols-[minmax(0,1fr)_18rem] lg:items-start xl:gap-16">
-        <div className="min-w-0 space-y-12">
-          <section className="space-y-4" aria-labelledby="ranking-title">
-            <h2 id="ranking-title" className="text-xl font-semibold tracking-tight text-fg">
-              Your ranking
-            </h2>
-            <Suspense fallback={<PersonalRankingSkeleton />}>
-              <PersonalRanking userId={account.id} />
-            </Suspense>
-          </section>
-
-          <GalleryYours
-            initialItems={generations.items}
-            initialCursor={generations.nextCursor}
-            hasNickname={Boolean(account.publicNickname)}
-            suspended={Boolean(account.gallerySuspendedAt)}
-          />
-        </div>
-
-        <aside className="space-y-5 lg:sticky lg:top-24">
-          <GalleryAccountSettings
-            publicNickname={account.publicNickname}
-            suspendedAt={account.gallerySuspendedAt?.toISOString() ?? null}
-            suspensionReason={account.gallerySuspensionReason}
-          />
-
-          <MediaExportSettings />
-
+        <aside className="space-y-5 lg:order-2">
           <section className="rounded-md border border-border/80 bg-card/10 p-5" aria-labelledby="security-title">
             <p className="mb-eyebrow">Account</p>
             <h2 id="security-title" className="mt-2 text-lg font-semibold tracking-tight text-fg">
@@ -113,7 +87,33 @@ export default async function AccountPage({
               </form>
             </div>
           </section>
+
+          <GalleryAccountSettings
+            publicNickname={account.publicNickname}
+            suspendedAt={account.gallerySuspendedAt?.toISOString() ?? null}
+            suspensionReason={account.gallerySuspensionReason}
+          />
+
+          <MediaExportSettings />
         </aside>
+
+        <div className="min-w-0 space-y-12 lg:order-1">
+          <section className="space-y-4" aria-labelledby="ranking-title">
+            <h2 id="ranking-title" className="text-xl font-semibold tracking-tight text-fg">
+              Your ranking
+            </h2>
+            <Suspense fallback={<PersonalRankingSkeleton />}>
+              <PersonalRanking userId={account.id} />
+            </Suspense>
+          </section>
+
+          <GalleryYours
+            initialItems={generations.items}
+            initialCursor={generations.nextCursor}
+            hasNickname={Boolean(account.publicNickname)}
+            suspended={Boolean(account.gallerySuspendedAt)}
+          />
+        </div>
       </div>
     </div>
   );

--- a/app/gallery/[publicId]/loading.tsx
+++ b/app/gallery/[publicId]/loading.tsx
@@ -1,0 +1,40 @@
+export default function GalleryDetailLoading() {
+  return (
+    <article aria-busy="true" aria-label="Loading gallery prompt" className="mx-auto w-full max-w-7xl py-4 sm:py-8">
+      <div aria-hidden="true" className="animate-pulse motion-reduce:animate-none">
+        <div className="flex h-11 items-center justify-between gap-4">
+          <div className="h-4 w-20 rounded bg-border/30" />
+          <div className="h-11 w-[5.5rem] rounded-md border border-border/70 bg-card/10" />
+        </div>
+        <div className="mt-6 max-w-4xl sm:mt-8">
+          <div className="h-4 w-32 rounded bg-border/30" />
+          <div className="mt-3 h-10 w-4/5 rounded bg-border/45 sm:h-12" />
+          <div className="mt-6 flex gap-2">
+            <div className="h-11 w-16 rounded-md bg-border/30" />
+            <div className="h-11 w-28 rounded-md bg-border/30" />
+          </div>
+        </div>
+        <div className="mt-8 grid gap-6 sm:mt-10 lg:grid-cols-[minmax(0,1fr)_18rem] lg:items-start">
+          <div className="overflow-hidden rounded-md border border-border/70">
+            <div className="flex h-16 items-center px-4"><div className="h-4 w-36 rounded bg-border/30" /></div>
+            <div className="h-[300px] bg-card/25 sm:h-[360px] md:h-[420px] lg:h-[480px] xl:h-[520px]" />
+          </div>
+          <div className="min-w-0">
+            <div className="flex h-9 items-center"><div className="h-3 w-20 rounded bg-border/30" /></div>
+            <div className="mt-3 grid grid-cols-2 gap-2 lg:grid-cols-1">
+              {[0, 1].map((index) => (
+                <div key={index} className="overflow-hidden rounded-md border border-border/70">
+                  <div className="aspect-video bg-card/25" />
+                  <div className="space-y-2 p-3">
+                    <div className="h-4 w-3/4 rounded bg-border/30" />
+                    <div className="h-3 w-1/2 rounded bg-border/25" />
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      </div>
+    </article>
+  );
+}

--- a/app/gallery/[publicId]/loading.tsx
+++ b/app/gallery/[publicId]/loading.tsx
@@ -8,7 +8,10 @@ export default function GalleryDetailLoading() {
         </div>
         <div className="mt-6 max-w-4xl sm:mt-8">
           <div className="h-4 w-32 rounded bg-border/30" />
-          <div className="mt-3 h-10 w-4/5 rounded bg-border/45 sm:h-12" />
+          <div className="mt-3 h-32 space-y-3">
+            <div className="h-10 w-4/5 rounded bg-border/45 sm:h-12" />
+            <div className="h-7 w-3/5 rounded bg-border/30" />
+          </div>
           <div className="mt-6 flex gap-2">
             <div className="h-11 w-16 rounded-md bg-border/30" />
             <div className="h-11 w-28 rounded-md bg-border/30" />

--- a/app/gallery/[publicId]/page.tsx
+++ b/app/gallery/[publicId]/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { cookies } from "next/headers";
 import { notFound } from "next/navigation";
+import { cache } from "react";
 import { GalleryDetail } from "@/components/gallery/GalleryDetail";
 import { ARENA_SESSION_COOKIE } from "@/lib/arena/session";
 import { getGalleryCandidate, normalizeGallerySort } from "@/lib/gallery/service";
@@ -8,8 +9,26 @@ import { getCurrentAccount } from "@/lib/auth/account";
 
 export const dynamic = "force-dynamic";
 
-export async function generateMetadata({ params }: { params: Promise<{ publicId: string }> }): Promise<Metadata> {
-  const candidate = await getGalleryCandidate((await params).publicId);
+type GalleryPageProps = {
+  params: Promise<{ publicId: string }>;
+  searchParams: Promise<{ sort?: string }>;
+};
+
+const loadCandidate = cache(async (publicId: string, sort: ReturnType<typeof normalizeGallerySort>) => {
+  const [cookieStore, account] = await Promise.all([
+    cookies(),
+    getCurrentAccount().catch(() => null),
+  ]);
+  return getGalleryCandidate(publicId, {
+    sessionId: cookieStore.get(ARENA_SESSION_COOKIE)?.value ?? null,
+    userId: account?.id,
+    navigationSort: sort,
+  });
+});
+
+export async function generateMetadata({ params, searchParams }: GalleryPageProps): Promise<Metadata> {
+  const [route, query] = await Promise.all([params, searchParams]);
+  const candidate = await loadCandidate(route.publicId, normalizeGallerySort(query.sort));
   if (!candidate) return { title: "Gallery prompt not found", robots: { index: false, follow: false } };
   const description = candidate.prompt.length > 155 ? `${candidate.prompt.slice(0, 152)}…` : candidate.prompt;
   return {
@@ -23,22 +42,9 @@ export async function generateMetadata({ params }: { params: Promise<{ publicId:
 export default async function GalleryDetailPage({
   params,
   searchParams,
-}: {
-  params: Promise<{ publicId: string }>;
-  searchParams: Promise<{ sort?: string }>;
-}) {
-  const [route, query, cookieStore, account] = await Promise.all([
-    params,
-    searchParams,
-    cookies(),
-    getCurrentAccount().catch(() => null),
-  ]);
-  const sort = normalizeGallerySort(query.sort);
-  const candidate = await getGalleryCandidate(route.publicId, {
-    sessionId: cookieStore.get(ARENA_SESSION_COOKIE)?.value ?? null,
-    userId: account?.id,
-    navigationSort: sort,
-  });
+}: GalleryPageProps) {
+  const [route, query] = await Promise.all([params, searchParams]);
+  const candidate = await loadCandidate(route.publicId, normalizeGallerySort(query.sort));
   if (!candidate) notFound();
   return <GalleryDetail candidate={candidate} />;
 }

--- a/app/gallery/loading.tsx
+++ b/app/gallery/loading.tsx
@@ -15,9 +15,7 @@ export default function GalleryLoading() {
           <Link href="/account#builds" className="inline-flex min-h-11 items-center px-2 text-sm font-semibold text-muted transition-colors hover:text-fg motion-reduce:transition-none">
             Builds
           </Link>
-          <Link href="/sign-in?next=/gallery" className="mb-btn mb-btn-primary h-11">
-            Sign in
-          </Link>
+          <span aria-hidden="true" className="h-11 w-28 animate-pulse rounded-md bg-border/30 motion-reduce:animate-none" />
         </div>
       </header>
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -971,6 +971,45 @@
 
   /* Flip rather than rotate: a symmetric chevron passes through a flat line
      at the midpoint, which reads as the control inverting, not spinning. */
+  .mb-disclosure-toggle {
+    display: flex;
+    min-height: 2.75rem;
+    width: 100%;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+    border-radius: 0.375rem;
+    padding: 0.5rem 0.25rem;
+    text-align: left;
+    transition:
+      background-color 140ms ease-out,
+      color 140ms ease-out;
+  }
+
+  .mb-disclosure-toggle:hover {
+    background-color: hsl(var(--fg) / 0.04);
+    color: hsl(var(--fg));
+  }
+
+  .mb-disclosure-toggle:focus-visible {
+    outline: 2px solid hsl(var(--accent) / 0.45);
+    outline-offset: -2px;
+  }
+
+  summary.mb-disclosure-toggle {
+    cursor: pointer;
+    list-style: none;
+  }
+
+  summary.mb-disclosure-toggle::-webkit-details-marker {
+    display: none;
+  }
+
+  .mb-disclosure-toggle[aria-expanded="true"] .mb-disclosure-chevron,
+  details[open] > .mb-disclosure-toggle .mb-disclosure-chevron {
+    color: hsl(var(--accent));
+  }
+
   .mb-disclosure-chevron {
     transform: scaleY(1);
     transform-origin: center;
@@ -985,9 +1024,16 @@
     transform: scaleY(-1);
   }
 
+  .mb-disclosure-toggle[aria-expanded="true"] .mb-disclosure-chevron,
+  details[open] > .mb-disclosure-toggle .mb-disclosure-chevron {
+    transform: scaleY(-1);
+  }
+
   @media (prefers-reduced-motion: reduce) {
     .mb-prompt-reveal,
     .mb-prompt-reveal.is-open,
+    .mb-disclosure-toggle,
+    .mb-collapse-toggle,
     .mb-disclosure-chevron {
       transition: none;
       transform: none;
@@ -1108,13 +1154,37 @@
   }
 
   .mb-collapse-toggle {
-    @apply inline-flex items-center justify-center rounded-full bg-bg/60 px-3 py-1.5 text-xs font-semibold text-fg ring-1 ring-border/80 transition duration-200;
-    will-change: transform;
+    display: inline-flex;
+    min-height: 2.75rem;
+    width: auto;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+    border-radius: 0.375rem;
+    padding: 0.5rem 0.75rem;
+    color: hsl(var(--muted));
+    text-align: center;
+    font-size: 0.875rem;
+    font-weight: 600;
+    transition:
+      background-color 140ms ease-out,
+      color 140ms ease-out;
   }
 
-  .mb-collapse-toggle:hover {
-    --tw-ring-color: hsl(var(--accent) / 0.36);
-    background-color: hsl(var(--fg) / 0.05);
+  .mb-collapse-toggle:hover:not(:disabled):not([aria-disabled="true"]) {
+    background-color: hsl(var(--fg) / 0.04);
+    color: hsl(var(--fg));
+  }
+
+  .mb-collapse-toggle:focus-visible {
+    outline: 2px solid hsl(var(--accent) / 0.45);
+    outline-offset: -2px;
+  }
+
+  .mb-collapse-toggle:disabled,
+  .mb-collapse-toggle[aria-disabled="true"] {
+    cursor: not-allowed;
+    opacity: 0.48;
   }
 
   .mb-clamp-3 {
@@ -1697,37 +1767,85 @@
   .mb-efficiency-point, .mb-efficiency-dot, .mb-efficiency-row { transition: none; }
 }
 
-.mb-leaderboard-switch {
-  display: inline-flex;
-  max-width: 100%;
-  gap: 2px;
-  padding: 3px;
-  border-radius: 6px;
-  background: hsl(var(--fg) / 0.045);
-}
-.mb-leaderboard-option {
-  min-height: 44px;
-  padding: 0 16px;
-  border-radius: 4px;
-  color: hsl(var(--muted));
-  font-size: 14px;
-  font-weight: 500;
-  white-space: nowrap;
-  transition: background-color 140ms ease-out, color 140ms ease-out;
-}
-.mb-leaderboard-option:hover { color: hsl(var(--fg)); }
-.mb-leaderboard-option[aria-pressed="true"] {
-  color: hsl(var(--fg));
-  background: hsl(var(--fg) / 0.1);
-}
-.mb-leaderboard-option:focus-visible,
-.mb-efficiency-sort:focus-visible {
-  outline: 2px solid hsl(var(--accent));
-  outline-offset: -2px;
-}
-.mb-efficiency-sort:hover { color: hsl(var(--fg)); }
-.mb-efficiency-tooltip { animation: efficiency-detail 120ms ease-out; }
-@media (prefers-reduced-motion: reduce) {
-  .mb-leaderboard-row, .mb-efficiency-tooltip { animation: none; }
-  .mb-leaderboard-option { transition: none; }
+@layer components {
+  .mb-choice-group {
+    display: inline-flex;
+    max-width: 100%;
+    align-items: center;
+    align-content: center;
+    flex-wrap: wrap;
+    gap: 0.125rem;
+    padding: 0.25rem;
+    border: 1px solid hsl(var(--border) / 0.75);
+    border-radius: 0.375rem;
+    background: hsl(var(--bg) / 0.58);
+    color: hsl(var(--muted));
+  }
+
+  .mb-choice-group[data-stretch="true"] {
+    display: flex;
+  }
+
+  .mb-choice-option {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 2.5rem;
+    border-radius: 0.25rem;
+    padding: 0 0.75rem;
+    color: hsl(var(--muted));
+    font-size: 0.875rem;
+    font-weight: 600;
+    white-space: nowrap;
+    transition:
+      background-color 140ms ease-out,
+      box-shadow 140ms ease-out,
+      color 140ms ease-out;
+  }
+
+  .mb-choice-option-stretch {
+    flex: 1 1 auto;
+  }
+
+  .mb-choice-group-compact {
+    gap: 0.0625rem;
+    padding: 0.125rem;
+  }
+
+  .mb-choice-option-compact {
+    min-height: 1.75rem;
+    padding-inline: 0.375rem;
+  }
+
+  .mb-choice-option:hover:not(:disabled) {
+    color: hsl(var(--fg));
+    background: hsl(var(--fg) / 0.045);
+  }
+
+  .mb-choice-option[aria-pressed="true"],
+  .mb-choice-option[aria-current="page"] {
+    color: hsl(var(--fg));
+    background: hsl(var(--accent) / 0.12);
+    box-shadow: inset 0 0 0 1px hsl(var(--accent) / 0.35);
+  }
+
+  .mb-choice-option:disabled {
+    cursor: not-allowed;
+    opacity: 0.48;
+  }
+
+  .mb-choice-option:focus-visible,
+  .mb-efficiency-sort:focus-visible {
+    outline: 2px solid hsl(var(--accent) / 0.55);
+    outline-offset: -2px;
+  }
+
+  .mb-efficiency-sort:hover { color: hsl(var(--fg)); }
+
+  .mb-efficiency-tooltip { animation: efficiency-detail 120ms ease-out; }
+
+  @media (prefers-reduced-motion: reduce) {
+    .mb-leaderboard-row, .mb-efficiency-tooltip { animation: none; }
+    .mb-choice-option { transition: none; }
+  }
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -1822,8 +1822,7 @@
     background: hsl(var(--fg) / 0.045);
   }
 
-  .mb-choice-option[aria-pressed="true"],
-  .mb-choice-option[aria-current="page"] {
+  .mb-choice-option[aria-pressed="true"] {
     color: hsl(var(--fg));
     background: hsl(var(--accent) / 0.12);
     box-shadow: inset 0 0 0 1px hsl(var(--accent) / 0.35);

--- a/components/gallery/GalleryDetail.tsx
+++ b/components/gallery/GalleryDetail.tsx
@@ -177,11 +177,32 @@ export function GalleryDetail({ candidate }: { candidate: GalleryDetailPayload }
   const viewerRefs = useRef(new Map<string, RefObject<VoxelViewerHandle | null>>());
   const viewerControllers = useRef(new Map<string, AbortController>());
   const [reportOpen, setReportOpen] = useState(false);
+  const [promptOpen, setPromptOpen] = useState(false);
+  const promptRef = useRef<HTMLElement>(null);
+  const promptToggleRef = useRef<HTMLButtonElement>(null);
   const [removing, setRemoving] = useState(false);
   const [actionError, setActionError] = useState<string | null>(null);
   const examplesScrollRef = useRef<HTMLDivElement>(null);
   const [canScrollUp, setCanScrollUp] = useState(false);
   const [canScrollDown, setCanScrollDown] = useState(false);
+
+  useEffect(() => {
+    if (!promptOpen) return;
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== "Escape") return;
+      setPromptOpen(false);
+      promptToggleRef.current?.focus({ preventScroll: true });
+    };
+    const onPointerDown = (event: PointerEvent) => {
+      if (event.target instanceof Node && !promptRef.current?.contains(event.target)) setPromptOpen(false);
+    };
+    window.addEventListener("keydown", onKeyDown);
+    window.addEventListener("pointerdown", onPointerDown);
+    return () => {
+      window.removeEventListener("keydown", onKeyDown);
+      window.removeEventListener("pointerdown", onPointerDown);
+    };
+  }, [promptOpen]);
 
   const updateScrollState = useCallback(() => {
     const el = examplesScrollRef.current;
@@ -350,7 +371,7 @@ export function GalleryDetail({ candidate }: { candidate: GalleryDetailPayload }
   }, []);
 
   useEffect(() => {
-    if (!navigation || reportOpen) return;
+    if (!navigation || reportOpen || promptOpen) return;
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.defaultPrevented || event.repeat || event.isComposing) return;
       if (event.metaKey || event.ctrlKey || event.altKey || event.shiftKey) return;
@@ -370,7 +391,7 @@ export function GalleryDetail({ candidate }: { candidate: GalleryDetailPayload }
     };
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [navigation, reportOpen, router]);
+  }, [navigation, reportOpen, promptOpen, router]);
 
   function selectExample(event: React.MouseEvent<HTMLButtonElement>, exampleId: string) {
     const additive = event.metaKey || event.ctrlKey;
@@ -472,13 +493,24 @@ export function GalleryDetail({ candidate }: { candidate: GalleryDetailPayload }
         ) : null}
       </nav>
 
-      <header className="mt-6 max-w-4xl sm:mt-8">
+      <header ref={promptRef} className="relative mt-6 max-w-4xl sm:mt-8">
         <div className="flex flex-wrap items-center gap-3 text-xs uppercase tracking-[0.12em] text-muted"><span>By {candidate.attribution}</span>{candidate.selected ? <span className="text-accent">Official prompt</span> : null}</div>
-        <h1 className={`mt-3 text-balance font-display font-semibold leading-tight tracking-tight text-fg ${longPrompt ? "text-2xl sm:text-3xl lg:text-4xl" : "text-3xl sm:text-4xl lg:text-5xl"}`}>{candidate.prompt}</h1>
+        <h1 className={`mt-3 break-words text-balance font-display font-semibold leading-tight tracking-tight text-fg ${longPrompt ? "line-clamp-3 text-2xl sm:text-3xl" : "text-3xl sm:text-4xl lg:text-5xl"}`}>{candidate.prompt}</h1>
         <div className="mt-6 flex flex-wrap items-center gap-2">
           <GalleryVoteButton candidateId={candidate.id} initialCount={candidate.upvoteCount} initialUpvoted={candidate.upvoted} />
           <Link href={`/sandbox?mode=live&prompt=${encodeURIComponent(candidate.prompt)}`} className="mb-btn mb-btn-primary h-11">Use prompt</Link>
+          {longPrompt ? (
+            <button ref={promptToggleRef} type="button" aria-expanded={promptOpen} aria-controls={`gallery-prompt-${candidate.id}`} onClick={() => setPromptOpen((open) => !open)} className="inline-flex min-h-11 items-center gap-1.5 rounded-md px-2 text-sm font-medium text-muted transition-colors hover:text-fg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 motion-reduce:transition-none">
+              Full prompt
+              <svg aria-hidden="true" className={`mb-disclosure-chevron h-3.5 w-3.5 ${promptOpen ? "is-open" : ""}`} viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.75" strokeLinecap="round" strokeLinejoin="round"><path d="M4 6.5L8 10.5L12 6.5" /></svg>
+            </button>
+          ) : null}
         </div>
+        {longPrompt ? (
+          <div id={`gallery-prompt-${candidate.id}`} role="region" aria-label="Full prompt" aria-hidden={!promptOpen} tabIndex={promptOpen ? 0 : -1} className={`mb-prompt-reveal absolute inset-x-0 top-full z-30 mt-3 max-h-[min(45svh,22rem)] max-w-[70ch] overflow-y-auto overscroll-contain whitespace-pre-wrap break-words rounded-md border border-border bg-bg p-4 text-base leading-relaxed text-fg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 sm:p-5 ${promptOpen ? "is-open" : ""}`}>
+            {candidate.prompt}
+          </div>
+        ) : null}
       </header>
 
       {actionError ? <p role="alert" className="mt-5 text-sm text-danger">{actionError}</p> : null}

--- a/components/gallery/GalleryDetail.tsx
+++ b/components/gallery/GalleryDetail.tsx
@@ -4,7 +4,7 @@ import Image from "next/image";
 import Link from "next/link";
 import dynamic from "next/dynamic";
 import { useRouter } from "next/navigation";
-import { createRef, useCallback, useEffect, useRef, useState } from "react";
+import { createRef, useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
 import type { RefObject } from "react";
 import type { VoxelViewerHandle } from "@/components/voxel/VoxelViewer";
 import { VoxelViewerCard } from "@/components/voxel/VoxelViewerCard";
@@ -45,6 +45,19 @@ const RUN_DATE_FORMAT = new Intl.DateTimeFormat("en-US", {
   dateStyle: "medium",
   timeZone: "UTC",
 });
+
+export function fitGalleryPromptHeading(heading: HTMLHeadingElement) {
+  const container = heading.parentElement;
+  if (!heading.isConnected || !container?.clientHeight) return null;
+  const maximum = parseFloat(getComputedStyle(container).fontSize);
+  const rem = parseFloat(getComputedStyle(document.documentElement).fontSize);
+  for (const size of [3, 2.25, 1.875, 1.5, 1.25, 1.125]) {
+    if (size * rem > maximum) continue;
+    heading.style.fontSize = `${size}rem`;
+    if (heading.scrollHeight <= container.clientHeight) break;
+  }
+  return heading.scrollHeight > container.clientHeight;
+}
 
 function gallerySortHref(sort?: GallerySort) {
   return sort === "top" || !sort ? "/gallery" : `/gallery?sort=${sort}`;
@@ -178,13 +191,36 @@ export function GalleryDetail({ candidate }: { candidate: GalleryDetailPayload }
   const viewerControllers = useRef(new Map<string, AbortController>());
   const [reportOpen, setReportOpen] = useState(false);
   const [promptOpen, setPromptOpen] = useState(false);
+  const [promptTruncated, setPromptTruncated] = useState(false);
   const promptRef = useRef<HTMLElement>(null);
+  const promptTextRef = useRef<HTMLHeadingElement>(null);
   const promptToggleRef = useRef<HTMLButtonElement>(null);
   const [removing, setRemoving] = useState(false);
   const [actionError, setActionError] = useState<string | null>(null);
   const examplesScrollRef = useRef<HTMLDivElement>(null);
   const [canScrollUp, setCanScrollUp] = useState(false);
   const [canScrollDown, setCanScrollDown] = useState(false);
+
+  useLayoutEffect(() => {
+    const heading = promptTextRef.current;
+    const container = heading?.parentElement;
+    if (!heading || !container) return;
+    const fit = () => {
+      const truncated = fitGalleryPromptHeading(heading);
+      if (truncated === null) return;
+      setPromptTruncated(truncated);
+      if (!truncated) setPromptOpen(false);
+    };
+    fit();
+    const observer = new ResizeObserver(fit);
+    observer.observe(container);
+    window.addEventListener("resize", fit);
+    void document.fonts.ready.then(fit);
+    return () => {
+      observer.disconnect();
+      window.removeEventListener("resize", fit);
+    };
+  }, [candidate.prompt]);
 
   useEffect(() => {
     if (!promptOpen) return;
@@ -476,8 +512,6 @@ export function GalleryDetail({ candidate }: { candidate: GalleryDetailPayload }
         jsonBytes: example.jsonBytes,
       }))
     : [];
-  const longPrompt = candidate.prompt.length > 140;
-
   return (
     <article className="mb-fade-in mx-auto w-full max-w-7xl py-4 sm:py-8">
       <nav aria-label="Gallery navigation" className="flex items-center justify-between gap-4">
@@ -495,18 +529,20 @@ export function GalleryDetail({ candidate }: { candidate: GalleryDetailPayload }
 
       <header ref={promptRef} className="relative mt-6 max-w-4xl sm:mt-8">
         <div className="flex flex-wrap items-center gap-3 text-xs uppercase tracking-[0.12em] text-muted"><span>By {candidate.attribution}</span>{candidate.selected ? <span className="text-accent">Official prompt</span> : null}</div>
-        <h1 className={`mt-3 break-words text-balance font-display font-semibold leading-tight tracking-tight text-fg ${longPrompt ? "line-clamp-3 text-2xl sm:text-3xl" : "text-3xl sm:text-4xl lg:text-5xl"}`}>{candidate.prompt}</h1>
+        <div className="mt-3 h-32 overflow-hidden text-3xl sm:text-4xl lg:text-5xl">
+          <h1 ref={promptTextRef} className={`break-words font-display font-semibold leading-[1.2] tracking-tight text-fg ${promptTruncated ? "line-clamp-5" : ""}`}>{candidate.prompt}</h1>
+        </div>
         <div className="mt-6 flex flex-wrap items-center gap-2">
           <GalleryVoteButton candidateId={candidate.id} initialCount={candidate.upvoteCount} initialUpvoted={candidate.upvoted} />
           <Link href={`/sandbox?mode=live&prompt=${encodeURIComponent(candidate.prompt)}`} className="mb-btn mb-btn-primary h-11">Use prompt</Link>
-          {longPrompt ? (
+          {promptTruncated ? (
             <button ref={promptToggleRef} type="button" aria-expanded={promptOpen} aria-controls={`gallery-prompt-${candidate.id}`} onClick={() => setPromptOpen((open) => !open)} className="inline-flex min-h-11 items-center gap-1.5 rounded-md px-2 text-sm font-medium text-muted transition-colors hover:text-fg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 motion-reduce:transition-none">
               Full prompt
               <svg aria-hidden="true" className={`mb-disclosure-chevron h-3.5 w-3.5 ${promptOpen ? "is-open" : ""}`} viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.75" strokeLinecap="round" strokeLinejoin="round"><path d="M4 6.5L8 10.5L12 6.5" /></svg>
             </button>
           ) : null}
         </div>
-        {longPrompt ? (
+        {promptTruncated ? (
           <div id={`gallery-prompt-${candidate.id}`} role="region" aria-label="Full prompt" aria-hidden={!promptOpen} tabIndex={promptOpen ? 0 : -1} className={`mb-prompt-reveal absolute inset-x-0 top-full z-30 mt-3 max-h-[min(45svh,22rem)] max-w-[70ch] overflow-y-auto overscroll-contain whitespace-pre-wrap break-words rounded-md border border-border bg-bg p-4 text-base leading-relaxed text-fg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 sm:p-5 ${promptOpen ? "is-open" : ""}`}>
             {candidate.prompt}
           </div>

--- a/components/gallery/GalleryExplore.tsx
+++ b/components/gallery/GalleryExplore.tsx
@@ -11,35 +11,35 @@ import { formatBuildDuration, formatBuildJsonSize } from "@/lib/buildMetrics";
 
 type GallerySort = "top" | "new" | "official";
 
-export function GalleryCardSkeleton({ delayed = false }: { delayed?: boolean }) {
+export function GalleryCardSkeleton() {
   return (
     <article
       aria-hidden="true"
-      className={`flex min-w-0 flex-col overflow-hidden rounded-md border border-border/70 bg-card/10 ${delayed ? "mb-card-enter-delay" : ""}`}
+      className="flex min-w-0 animate-pulse flex-col overflow-hidden rounded-md border border-border/70 bg-card/10 motion-reduce:animate-none"
     >
       <div className="relative aspect-[4/3] overflow-hidden bg-bg/40">
-        <div className="absolute inset-0 animate-pulse bg-card/25" />
+        <div className="absolute inset-0 bg-card/25" />
       </div>
       <div className="flex flex-1 flex-col gap-3 p-5">
         <div className="flex items-center justify-between gap-3">
-          <div className="h-3 w-20 animate-pulse rounded bg-border/50" />
-          <div className="h-3 w-12 animate-pulse rounded bg-border/30" />
+          <div className="h-3 w-20 rounded bg-border/50" />
+          <div className="h-3 w-12 rounded bg-border/30" />
         </div>
         <div className="space-y-2">
-          <div className="h-5 w-4/5 animate-pulse rounded bg-border/45" />
-          <div className="h-5 w-3/5 animate-pulse rounded bg-border/35" />
+          <div className="h-5 w-4/5 rounded bg-border/45" />
+          <div className="h-5 w-3/5 rounded bg-border/35" />
         </div>
         <div className="mt-auto flex items-center gap-2 pt-3">
-          <div className="h-3.5 w-32 animate-pulse rounded bg-border/30" />
+          <div className="h-3.5 w-32 rounded bg-border/30" />
         </div>
         <div className="flex flex-wrap gap-x-3 gap-y-1">
-          <div className="h-3 w-16 animate-pulse rounded bg-border/25" />
-          <div className="h-3 w-14 animate-pulse rounded bg-border/25" />
+          <div className="h-3 w-16 rounded bg-border/25" />
+          <div className="h-3 w-14 rounded bg-border/25" />
         </div>
       </div>
       <div className="flex items-center justify-between border-t border-border/40 px-3 py-2">
-        <div className="h-7 w-12 animate-pulse rounded bg-border/30" />
-        <div className="h-7 w-20 animate-pulse rounded bg-border/30" />
+        <div className="h-7 w-12 rounded bg-border/30" />
+        <div className="h-7 w-20 rounded bg-border/30" />
       </div>
     </article>
   );
@@ -49,7 +49,7 @@ export function GallerySkeletonGrid({ count = 8 }: { count?: number }) {
   return (
     <div className="mt-7 grid grid-cols-1 gap-5 md:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4" aria-busy="true" aria-label="Loading gallery prompts">
       {Array.from({ length: count }, (_, i) => (
-        <GalleryCardSkeleton key={i} delayed={i % 2 === 1} />
+        <GalleryCardSkeleton key={i} />
       ))}
     </div>
   );
@@ -496,7 +496,7 @@ export function GalleryExplore({
             {items.map((candidate, index) => <GalleryCard key={candidate.id} candidate={candidate} delayed={index % 2 === 1} sort={activeSort} />)}
             {loadingMore ? (
               Array.from({ length: 4 }, (_, i) => (
-                <GalleryCardSkeleton key={`loading-more-${i}`} delayed={i % 2 === 1} />
+                <GalleryCardSkeleton key={`loading-more-${i}`} />
               ))
             ) : null}
           </div>

--- a/components/gallery/GalleryExplore.tsx
+++ b/components/gallery/GalleryExplore.tsx
@@ -3,7 +3,7 @@
 import Image from "next/image";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { Fragment, useEffect, useDeferredValue, useId, useRef, useState } from "react";
+import { Fragment, memo, useEffect, useDeferredValue, useId, useRef, useState } from "react";
 import type { GalleryCandidatePayload } from "@/lib/gallery/service";
 import { GalleryVoteButton } from "@/components/gallery/GalleryVoteButton";
 import { VoxelEmptyState } from "@/components/voxel/VoxelEmptyState";
@@ -140,7 +140,7 @@ function SubmissionDialog({
   );
 }
 
-function GalleryCard({
+const GalleryCard = memo(function GalleryCard({
   candidate,
   delayed,
   sort,
@@ -236,7 +236,7 @@ function GalleryCard({
       </article>
     </div>
   );
-}
+});
 
 export function GalleryExplore({
   initialItems,
@@ -522,8 +522,9 @@ export function GalleryExplore({
 
       {cursor && !loading && !searchPending ? (
         <div className="mt-12 flex justify-center">
-          <button type="button" className="mb-btn h-11 min-w-36" disabled={loadingMore} onClick={() => void loadMore()}>
-            {loadingMore ? "Loading…" : "More"}
+          <button type="button" className="mb-collapse-toggle" disabled={loadingMore} aria-busy={loadingMore} onClick={() => void loadMore()}>
+            <span>{loadingMore ? "Loading…" : "More"}</span>
+            <svg aria-hidden="true" className="mb-disclosure-chevron h-3.5 w-3.5" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.75" strokeLinecap="round" strokeLinejoin="round"><path d="M4 6.5L8 10.5L12 6.5" /></svg>
           </button>
         </div>
       ) : null}

--- a/components/gallery/GalleryYours.tsx
+++ b/components/gallery/GalleryYours.tsx
@@ -338,9 +338,9 @@ export function SavedBuildDialog({
           {downloadError ? <p role="status" className="mt-2 px-1 text-sm text-danger">{downloadError}</p> : null}
           {generation.retryReason ? (
             <details className="mt-3 w-full max-w-xl px-1 text-xs text-muted">
-              <summary className="flex cursor-pointer list-none items-center gap-1.5 rounded py-1 hover:text-fg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 [&::-webkit-details-marker]:hidden">
-                <span className="flex h-4 w-4 items-center justify-center rounded-full border border-current text-[9px] font-semibold">i</span>
-                Retry details
+              <summary className="mb-disclosure-toggle">
+                <span>Retry details</span>
+                <svg aria-hidden="true" className="mb-disclosure-chevron h-3 w-3 shrink-0" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.75" strokeLinecap="round" strokeLinejoin="round"><path d="M4 6.5L8 10.5L12 6.5" /></svg>
               </summary>
               <pre className="mt-2 max-h-48 overflow-y-auto overscroll-contain whitespace-pre-wrap rounded-md border border-border/70 bg-bg/45 p-3 font-mono text-[11px] leading-relaxed text-muted [overflow-wrap:anywhere]">
                 {generation.retryReason}
@@ -348,8 +348,11 @@ export function SavedBuildDialog({
             </details>
           ) : null}
           {generation.sha256 ? (
-            <details className="mt-3 w-fit px-1 text-xs text-muted">
-              <summary className="cursor-pointer list-none py-1 hover:text-fg">Build details</summary>
+            <details className="mt-3 w-full max-w-xl px-1 text-xs text-muted">
+              <summary className="mb-disclosure-toggle">
+                <span>Build details</span>
+                <svg aria-hidden="true" className="mb-disclosure-chevron h-3 w-3 shrink-0" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.75" strokeLinecap="round" strokeLinejoin="round"><path d="M4 6.5L8 10.5L12 6.5" /></svg>
+              </summary>
               <p className="mt-1 break-all font-mono">SHA-256 {generation.sha256}</p>
             </details>
           ) : null}
@@ -448,9 +451,9 @@ export function GalleryYours({
                 </button>
                 {generation.retryReason ? (
                   <details className="mt-3 w-full max-w-xl text-xs text-muted">
-                    <summary className="flex cursor-pointer list-none items-center gap-1.5 rounded py-1 hover:text-fg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 [&::-webkit-details-marker]:hidden">
-                      <span className="flex h-4 w-4 items-center justify-center rounded-full border border-current text-[9px] font-semibold">i</span>
-                      Details
+                    <summary className="mb-disclosure-toggle">
+                      <span>Details</span>
+                      <svg aria-hidden="true" className="mb-disclosure-chevron h-3 w-3 shrink-0" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.75" strokeLinecap="round" strokeLinejoin="round"><path d="M4 6.5L8 10.5L12 6.5" /></svg>
                     </summary>
                     <pre className="mt-2 max-h-48 overflow-y-auto overscroll-contain whitespace-pre-wrap rounded-md border border-border/70 bg-bg/45 p-3 font-mono text-[11px] leading-relaxed text-muted [overflow-wrap:anywhere]">
                       {generation.retryReason}
@@ -464,7 +467,7 @@ export function GalleryYours({
         ))}
         {items.length === 0 ? <div className="rounded-md border border-border/80 px-5 py-12 text-center"><p className="text-sm text-muted">No saved builds.</p></div> : null}
       </div>
-      {cursor ? <div className="mt-12 flex justify-center"><button type="button" disabled={loadingMore} className="mb-btn h-11 min-w-36" onClick={() => void loadMore()}>{loadingMore ? "Loading…" : "More"}</button></div> : null}
+      {cursor ? <div className="mt-12 flex justify-center"><button type="button" disabled={loadingMore} className="mb-collapse-toggle" onClick={() => void loadMore()}><span>{loadingMore ? "Loading…" : "More"}</span><svg aria-hidden="true" className="mb-disclosure-chevron h-3.5 w-3.5" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.75" strokeLinecap="round" strokeLinejoin="round"><path d="M4 6.5L8 10.5L12 6.5" /></svg></button></div> : null}
       {loadError ? <p role="status" className="mt-6 text-center text-sm text-danger">{loadError}</p> : null}
       {selected ? (
         <SavedBuildDialog

--- a/components/generation/RequestOverridesEditor.tsx
+++ b/components/generation/RequestOverridesEditor.tsx
@@ -118,7 +118,7 @@ export function RequestOverridesEditor({
       <button
         type="button"
         aria-expanded={open}
-        className="flex min-h-11 w-full items-center justify-between gap-3 rounded-sm px-1 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
+        className="mb-disclosure-toggle"
         onClick={() => setOpen((value) => !value)}
       >
         <span className="flex min-w-0 items-baseline gap-2">

--- a/components/leaderboard/Leaderboard.tsx
+++ b/components/leaderboard/Leaderboard.tsx
@@ -567,7 +567,7 @@ export function Leaderboard({
         </div>
       </div>
 
-      <div role="group" aria-label="Leaderboard view" className="mb-leaderboard-switch shrink-0 self-start">
+      <div role="group" aria-label="Leaderboard view" className="mb-choice-group shrink-0 self-start">
         {(["rankings", "efficiency"] as const).map((item) => (
           <button
             key={item}
@@ -575,7 +575,7 @@ export function Leaderboard({
             aria-pressed={view === item}
             aria-controls="leaderboard-models"
             onClick={() => setView(item)}
-            className="mb-leaderboard-option"
+            className="mb-choice-option"
           >
             {item === "rankings" ? "Rankings" : "Efficiency"}
           </button>

--- a/components/leaderboard/LeaderboardEfficiency.tsx
+++ b/components/leaderboard/LeaderboardEfficiency.tsx
@@ -78,11 +78,11 @@ export function LeaderboardEfficiency({ models, modelQuery }: {
     <section aria-labelledby={headingId} className="mb-efficiency-enter min-w-0 pb-5">
       <h2 id={headingId} className="sr-only">Model efficiency</h2>
       <div className="flex flex-wrap items-center justify-between gap-x-6 gap-y-2">
-        <div role="group" aria-label="Efficiency metric" className="mb-leaderboard-switch">
+        <div role="group" aria-label="Efficiency metric" className="mb-choice-group">
           {METRICS.map((item) => (
             <button key={item.key} type="button" aria-pressed={metric === item.key}
               onClick={() => { setMetric(item.key); setSort({ key: item.key, descending: false }); }}
-              className="mb-leaderboard-option">
+              className="mb-choice-option">
               {item.label}
             </button>
           ))}
@@ -184,9 +184,9 @@ export function LeaderboardEfficiency({ models, modelQuery }: {
         </aside>
       </div>
       <div className="mb-3 flex flex-wrap items-center justify-between gap-3">
-        <div role="group" aria-label="Comparison units" className="mb-leaderboard-switch">
-          <button type="button" aria-pressed={!perScore} className="mb-leaderboard-option" onClick={() => setPerScore(false)}>Per build</button>
-          <button type="button" aria-pressed={perScore} className="mb-leaderboard-option" onClick={() => setPerScore(true)}>Per score</button>
+        <div role="group" aria-label="Comparison units" className="mb-choice-group">
+          <button type="button" aria-pressed={!perScore} className="mb-choice-option" onClick={() => setPerScore(false)}>Per build</button>
+          <button type="button" aria-pressed={perScore} className="mb-choice-option" onClick={() => setPerScore(true)}>Per score</button>
         </div>
         <span className="text-xs text-muted">{perScore ? "Resource use per prompt-score point" : "Average resource use per build"}</span>
       </div>
@@ -230,7 +230,12 @@ export function LeaderboardEfficiency({ models, modelQuery }: {
         {modelQuery.trim() ? <span>Search highlights matches; the frontier still includes the full comparison.</span> : null}
       </div>
       <details className="mt-3 text-sm text-muted">
-        <summary className="min-h-11 cursor-pointer py-3 font-medium text-fg focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent">Methodology</summary>
+        <summary className="mb-disclosure-toggle py-3 font-medium text-fg">
+          <span>Methodology</span>
+          <svg aria-hidden="true" className="mb-disclosure-chevron h-3 w-3 shrink-0 text-muted" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.75" strokeLinecap="round" strokeLinejoin="round">
+            <path d="M4 6.5L8 10.5L12 6.5" />
+          </svg>
+        </summary>
         <div className="space-y-3 pb-3 leading-relaxed">
           <p>A model is on the Pareto frontier when no included model has an equal or higher rating with equal or lower resource use, with at least one strict improvement. The frontier follows point estimates; overlapping confidence intervals can mean the differences are uncertain.</p>
           <p>Per-score values divide average resource use by the observed prompt score on a 0–100 scale: wins count as 1, ties as 0.5, and losses as 0, averaged equally over prompts with at least two votes. Both-bad votes are excluded. These ratios depend on sampled opponents and prompts; they describe the evidence rather than replace the rating.</p>

--- a/components/leaderboard/ModelDetail.tsx
+++ b/components/leaderboard/ModelDetail.tsx
@@ -535,8 +535,59 @@ function topWeakest(prompts: ModelPromptBreakdown[]) {
     .slice(0, 6);
 }
 
-function topOpponents(opponents: ModelOpponentBreakdown[]) {
-  return [...opponents].sort((a, b) => b.votes - a.votes || b.averageScore - a.averageScore);
+function hasOpponentScore(opponent: ModelOpponentBreakdown) {
+  return opponent.votes > 0 && Number.isFinite(opponent.averageScore);
+}
+
+export function sortModelOpponentsForDetail(opponents: ModelOpponentBreakdown[]) {
+  return [...opponents].sort((a, b) => {
+    const aScored = hasOpponentScore(a);
+    const bScored = hasOpponentScore(b);
+    if (aScored !== bScored) return aScored ? -1 : 1;
+    if (!aScored) return a.displayName.localeCompare(b.displayName);
+    return (
+      a.averageScore - b.averageScore ||
+      b.votes - a.votes ||
+      a.displayName.localeCompare(b.displayName)
+    );
+  });
+}
+
+function DisclosureChevron({ open }: { open: boolean }) {
+  return (
+    <svg
+      aria-hidden="true"
+      className={`mb-disclosure-chevron h-3 w-3 shrink-0 text-muted ${open ? "is-open" : ""}`}
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.75"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="M4 6.5L8 10.5L12 6.5" />
+    </svg>
+  );
+}
+
+function FullContextToggle({
+  expanded,
+  onClick,
+}: {
+  expanded: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      aria-expanded={expanded}
+      className="mb-collapse-toggle"
+      onClick={onClick}
+    >
+      <span>{expanded ? "Hide full context" : "View full context"}</span>
+      <DisclosureChevron open={expanded} />
+    </button>
+  );
 }
 
 function buildCurve(values: number[]): {
@@ -959,7 +1010,7 @@ export function ModelDetail({ data }: { data: ModelDetailStats }) {
 
   const strongest = topStrongest(data.prompts);
   const weakest = topWeakest(data.prompts);
-  const opponents = topOpponents(data.opponents);
+  const opponents = useMemo(() => sortModelOpponentsForDetail(data.opponents), [data.opponents]);
 
   const promptCurveSource = useMemo(
     () =>
@@ -1806,14 +1857,10 @@ export function ModelDetail({ data }: { data: ModelDetailStats }) {
           </div>
           {hasHiddenOpponents ? (
             <div className="flex justify-center pt-0.5">
-              <button
-                type="button"
-                aria-expanded={showAllOpponents}
-                className="mb-collapse-toggle"
+              <FullContextToggle
+                expanded={showAllOpponents}
                 onClick={() => setShowAllOpponents((current) => !current)}
-              >
-                {showAllOpponents ? "Hide full context" : "View full context"}
-              </button>
+              />
             </div>
           ) : null}
         </div>
@@ -1941,14 +1988,10 @@ export function ModelDetail({ data }: { data: ModelDetailStats }) {
           </div>
           {hasHiddenPrompts ? (
             <div className="flex justify-center pt-0.5">
-              <button
-                type="button"
-                aria-expanded={showAllPrompts}
-                className="mb-collapse-toggle"
+              <FullContextToggle
+                expanded={showAllPrompts}
                 onClick={() => setShowAllPrompts((current) => !current)}
-              >
-                {showAllPrompts ? "Hide full context" : "View full context"}
-              </button>
+              />
             </div>
           ) : null}
         </div>

--- a/components/local/LocalLab.tsx
+++ b/components/local/LocalLab.tsx
@@ -3,7 +3,7 @@
 import { ReactNode, useEffect, useId, useMemo, useRef, useState } from "react";
 import { SandboxGifExportButton, type SandboxGifExportTarget } from "@/components/sandbox/SandboxGifExportButton";
 import { buildSystemPrompt, buildUserPrompt, buildWebPrompt } from "@/lib/ai/prompts";
-import { MAX_BLOCKS_BY_GRID, MIN_BLOCKS_BY_GRID } from "@/lib/ai/limits";
+import { MAX_BLOCKS_BY_GRID, MIN_BLOCKS_BY_GRID, GRID_SIZES, type GridSize } from "@/lib/ai/limits";
 import { extractBestVoxelBuildJson } from "@/lib/ai/jsonExtract";
 import { getPalette } from "@/lib/blocks/palettes";
 import { validateVoxelBuild } from "@/lib/voxel/validate";
@@ -13,7 +13,6 @@ import type { VoxelViewerHandle } from "@/components/voxel/VoxelViewer";
 import { formatVoxelLoadingMessage } from "@/components/voxel/VoxelLoadingHud";
 
 type Palette = "simple" | "advanced";
-type GridSize = 64 | 256 | 512;
 
 type LocalParseWorkerRequest =
   | {
@@ -173,31 +172,14 @@ function SegmentedControl({
   options: Array<{ value: string; label: ReactNode }>;
   className?: string;
 }) {
-  const safeCount = Math.max(1, options.length);
-  const activeIndex = Math.max(
-    0,
-    options.findIndex((option) => option.value === value),
-  );
-  const segmentWidth = `${100 / safeCount}%`;
-  const segmentTranslate = `${activeIndex * 100}%`;
-
   return (
     <div
+      data-stretch="true"
       className={cx(
-        "relative flex rounded-md bg-bg/60 p-1 ring-1 ring-border",
+        "mb-choice-group w-full",
         className,
       )}
     >
-      <div className="pointer-events-none absolute inset-1 rounded-lg">
-        <span
-          aria-hidden="true"
-          className="absolute inset-y-0 left-0 rounded-lg bg-accent/15 ring-1 ring-accent/40 transition-transform duration-200 ease-out"
-          style={{
-            width: segmentWidth,
-            transform: `translateX(${segmentTranslate})`,
-          }}
-        />
-      </div>
       {options.map((option) => {
         const active = option.value === value;
         return (
@@ -205,10 +187,7 @@ function SegmentedControl({
             key={option.value}
             type="button"
             aria-pressed={active}
-            className={cx(
-              "relative z-10 flex h-9 min-w-0 flex-1 items-center justify-center rounded-lg px-3 text-sm font-semibold transition-colors duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60 sm:h-10",
-              active ? "text-fg" : "text-muted hover:text-fg",
-            )}
+            className="mb-choice-option mb-choice-option-stretch"
             onClick={() => onChange(option.value)}
           >
             {option.label}
@@ -576,35 +555,15 @@ export function LocalLab() {
               <SegmentedControl
                 value={String(gridSize)}
                 onChange={(value) => setGridSize(Number(value) as GridSize)}
-                options={[
-                  {
-                    value: "64",
-                    label: (
-                      <span className="inline-flex items-start">
-                        <span>64</span>
-                        <span className="relative -top-[0.38em] ml-px text-[0.58em] font-semibold opacity-90">3</span>
-                      </span>
-                    ),
-                  },
-                  {
-                    value: "256",
-                    label: (
-                      <span className="inline-flex items-start">
-                        <span>256</span>
-                        <span className="relative -top-[0.38em] ml-px text-[0.58em] font-semibold opacity-90">3</span>
-                      </span>
-                    ),
-                  },
-                  {
-                    value: "512",
-                    label: (
-                      <span className="inline-flex items-start">
-                        <span>512</span>
-                        <span className="relative -top-[0.38em] ml-px text-[0.58em] font-semibold opacity-90">3</span>
-                      </span>
-                    ),
-                  },
-                ]}
+                options={GRID_SIZES.map((size) => ({
+                  value: String(size),
+                  label: (
+                    <span className="inline-flex items-start">
+                      <span>{size}</span>
+                      <span className="relative -top-[0.38em] ml-px text-[0.58em] font-semibold opacity-90">3</span>
+                    </span>
+                  ),
+                }))}
               />
             </SegmentedField>
             <SegmentedField

--- a/components/local/LocalLab.tsx
+++ b/components/local/LocalLab.tsx
@@ -552,19 +552,16 @@ export function LocalLab() {
               hint="Larger grids allow more detail."
               className="min-w-[220px] flex-1 sm:min-w-[240px]"
             >
-              <SegmentedControl
-                value={String(gridSize)}
-                onChange={(value) => setGridSize(Number(value) as GridSize)}
-                options={GRID_SIZES.map((size) => ({
-                  value: String(size),
-                  label: (
-                    <span className="inline-flex items-start">
-                      <span>{size}</span>
-                      <span className="relative -top-[0.38em] ml-px text-[0.58em] font-semibold opacity-90">3</span>
-                    </span>
-                  ),
-                }))}
-              />
+              <select
+                aria-label="Grid size"
+                className="mb-field h-12 w-full"
+                value={gridSize}
+                onChange={(event) => setGridSize(Number(event.target.value) as GridSize)}
+              >
+                {GRID_SIZES.map((size) => (
+                  <option key={size} value={size}>{size}³</option>
+                ))}
+              </select>
             </SegmentedField>
             <SegmentedField
               label="Block palette"

--- a/components/sandbox/Sandbox.tsx
+++ b/components/sandbox/Sandbox.tsx
@@ -33,30 +33,19 @@ function SandboxModeTabs({
     { value: "import", label: "Import" },
   ];
 
-  const activeIndex = Math.max(
-    0,
-    options.findIndex((option) => option.value === value),
-  );
-
   return (
     <nav
       aria-label="Sandbox modes"
-      className={`relative grid grid-cols-3 border-b border-border/70 ${className ?? ""}`}
+      data-stretch="true"
+      className={`mb-choice-group ${className ?? ""}`}
     >
-      <span
-        aria-hidden="true"
-        className="pointer-events-none absolute -bottom-px left-0 h-0.5 w-1/3 bg-accent transition-transform duration-200 ease-[cubic-bezier(0.22,1,0.36,1)] motion-reduce:transition-none"
-        style={{ transform: `translateX(${activeIndex * 100}%)` }}
-      />
       {options.map((option) => {
         const active = option.value === value;
         return (
           <a
             key={option.value}
             aria-current={active ? "page" : undefined}
-            className={`grid min-h-11 min-w-0 place-items-center px-3 text-sm font-semibold transition-colors duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-accent/50 motion-reduce:transition-none ${
-              active ? "text-fg" : "text-muted hover:text-fg"
-            }`}
+            className="mb-choice-option mb-choice-option-stretch"
             href={hrefFor(option.value)}
             onClick={(event) => {
               if (

--- a/components/sandbox/Sandbox.tsx
+++ b/components/sandbox/Sandbox.tsx
@@ -33,19 +33,30 @@ function SandboxModeTabs({
     { value: "import", label: "Import" },
   ];
 
+  const activeIndex = Math.max(
+    0,
+    options.findIndex((option) => option.value === value),
+  );
+
   return (
     <nav
       aria-label="Sandbox modes"
-      data-stretch="true"
-      className={`mb-choice-group ${className ?? ""}`}
+      className={`relative grid grid-cols-3 border-b border-border/70 ${className ?? ""}`}
     >
+      <span
+        aria-hidden="true"
+        className="pointer-events-none absolute -bottom-px left-0 h-0.5 w-1/3 bg-accent transition-transform duration-200 ease-[cubic-bezier(0.22,1,0.36,1)] motion-reduce:transition-none"
+        style={{ transform: `translateX(${activeIndex * 100}%)` }}
+      />
       {options.map((option) => {
         const active = option.value === value;
         return (
           <a
             key={option.value}
             aria-current={active ? "page" : undefined}
-            className="mb-choice-option mb-choice-option-stretch"
+            className={`grid min-h-11 min-w-0 place-items-center px-3 text-sm font-semibold transition-colors duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-accent/50 motion-reduce:transition-none ${
+              active ? "text-fg" : "text-muted hover:text-fg"
+            }`}
             href={hrefFor(option.value)}
             onClick={(event) => {
               if (

--- a/components/sandbox/SandboxGifExportButton.tsx
+++ b/components/sandbox/SandboxGifExportButton.tsx
@@ -1097,10 +1097,10 @@ function GifFormatSelector({
     <div
       role="group"
       aria-label="Export layout"
-      className={`inline-flex shrink-0 items-center rounded-full text-muted ${
+      className={`mb-choice-group mb-choice-group-compact shrink-0 ${
         embedded
-          ? "p-0"
-          : "border border-border/70 bg-bg/45 p-0.5 shadow-[0_12px_30px_-24px_rgba(4,11,31,0.9)] backdrop-blur-sm"
+          ? "border-0 bg-transparent p-0"
+          : "backdrop-blur-sm"
       } ${
         compact ? "h-7" : "h-8"
       }`}
@@ -1117,12 +1117,8 @@ function GifFormatSelector({
             aria-pressed={active}
             title={label}
             onClick={() => onChange(value)}
-            className={`grid place-items-center rounded-full transition-colors duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/55 motion-reduce:transition-none disabled:cursor-not-allowed disabled:opacity-45 ${
+            className={`mb-choice-option mb-choice-option-compact grid place-items-center ${
               compact ? "h-7 w-7" : "h-8 w-8"
-            } ${
-              active
-                ? "bg-accent/15 text-accent ring-1 ring-accent/40 shadow-[0_8px_20px_-16px_hsl(var(--accent)_/_0.7)]"
-                : "text-muted/75 hover:bg-fg/7 hover:text-fg"
             }`}
           >
             <FormatIcon format={value} />
@@ -1350,9 +1346,7 @@ export function SandboxGifExportButton({ targets, promptText, label, iconOnly, e
       title={iconOnly && !embedded ? undefined : buttonTitle}
       onClick={() => void handleExport()}
       disabled={isUnavailable}
-      className={`inline-flex select-none items-center justify-center font-semibold text-fg transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/35 motion-reduce:transition-none ${
-        embedded ? "mb-btn mb-btn-ghost rounded-md border border-border/70 bg-bg/55" : "rounded-full"
-      } ${
+      className={`mb-btn mb-btn-ghost rounded-md bg-bg/55 ${
         iconOnly
           ? "h-7 w-7 p-0 text-muted hover:bg-fg/7 hover:text-fg"
           : "h-8 gap-1.5 px-3 text-xs tracking-[0.01em] hover:bg-fg/7 sm:px-3.5 sm:text-sm"
@@ -1381,7 +1375,7 @@ export function SandboxGifExportButton({ targets, promptText, label, iconOnly, e
 
   if (!iconOnly) {
     return (
-      <div className="inline-flex h-9 items-center rounded-full border border-border/70 bg-bg/55 p-0.5 shadow-[0_18px_44px_-28px_rgba(4,11,31,0.95)] backdrop-blur-sm">
+      <div className="inline-flex h-9 items-center gap-1 rounded-md border border-border/70 bg-bg/55 p-0.5 backdrop-blur-sm">
         {formatSelector}
         {formatSelector ? <span className="mx-1 h-4 w-px bg-border/45" aria-hidden="true" /> : null}
         {button}
@@ -1390,12 +1384,12 @@ export function SandboxGifExportButton({ targets, promptText, label, iconOnly, e
   }
 
   return (
-    <div className="group/gif-export relative inline-flex h-8 items-center rounded-full border border-border/70 bg-bg/55 p-0.5 shadow-[0_18px_44px_-28px_rgba(4,11,31,0.95)] backdrop-blur-sm">
+    <div className="group/gif-export relative inline-flex h-8 items-center gap-1 rounded-md border border-border/70 bg-bg/55 p-0.5 backdrop-blur-sm">
       <div
         id={tooltipId}
         role="status"
         aria-live={busy ? "polite" : undefined}
-        className={`pointer-events-none absolute right-[calc(100%+0.55rem)] top-1/2 z-[40] w-max max-w-[min(16rem,calc(100vw-8rem))] -translate-y-1/2 rounded-full border border-border/80 bg-[linear-gradient(180deg,rgba(8,13,30,0.98),rgba(5,9,22,0.96))] px-3 py-1.5 text-right text-[11px] text-fg shadow-[0_18px_44px_-24px_rgba(4,11,31,0.9)] backdrop-blur-md transition duration-150 motion-reduce:transition-none ${shouldKeepTooltipVisible ? "translate-x-0 opacity-100" : "translate-x-1 opacity-0 group-hover/gif-export:translate-x-0 group-hover/gif-export:opacity-100 group-focus-within/gif-export:translate-x-0 group-focus-within/gif-export:opacity-100"}`}
+        className={`pointer-events-none absolute right-[calc(100%+0.55rem)] top-1/2 z-[40] w-max max-w-[min(16rem,calc(100vw-8rem))] -translate-y-1/2 rounded-md border border-border/80 bg-bg px-3 py-1.5 text-right text-[11px] text-fg backdrop-blur-md transition duration-150 motion-reduce:transition-none ${shouldKeepTooltipVisible ? "translate-x-0 opacity-100" : "translate-x-1 opacity-0 group-hover/gif-export:translate-x-0 group-hover/gif-export:opacity-100 group-focus-within/gif-export:translate-x-0 group-focus-within/gif-export:opacity-100"}`}
       >
         <span className="block truncate">{buttonTitle}</span>
       </div>

--- a/components/sandbox/SandboxLive.tsx
+++ b/components/sandbox/SandboxLive.tsx
@@ -1852,30 +1852,18 @@ export function SandboxLive({
         <section>
           <div className="mb-eyebrow">Build</div>
           <div className="mt-3 grid grid-cols-1 gap-3 sm:grid-cols-2">
-            <div className="flex min-w-0 flex-col gap-1">
-              <div id="sandbox-grid-size-label" className="text-xs font-medium text-muted">Size</div>
-              <div
-                role="group"
-                aria-labelledby="sandbox-grid-size-label"
-                data-stretch="true"
-                className="mb-choice-group w-full"
+            <label className="flex min-w-0 flex-col gap-1">
+              <div className="text-xs font-medium text-muted">Size</div>
+              <select
+                className="mb-field h-12 w-full"
+                value={gridSize}
+                onChange={(e) => setGridSize(Number(e.target.value) as GridSize)}
               >
-                {GRID_SIZES.map((value) => (
-                  <button
-                    key={value}
-                    type="button"
-                    aria-pressed={gridSize === value}
-                    className="mb-choice-option mb-choice-option-stretch"
-                    onClick={() => setGridSize(value)}
-                  >
-                    <span className="inline-flex items-start">
-                      <span>{value}</span>
-                      <span className="relative -top-[0.38em] ml-px text-[0.58em] font-semibold opacity-90">3</span>
-                    </span>
-                  </button>
+                {GRID_SIZES.map((size) => (
+                  <option key={size} value={size}>{size}³</option>
                 ))}
-              </div>
-            </div>
+              </select>
+            </label>
 
             <div className="flex min-w-0 flex-col gap-1">
               <div id="sandbox-palette-label" className="text-xs font-medium text-muted">Palette</div>

--- a/components/sandbox/SandboxLive.tsx
+++ b/components/sandbox/SandboxLive.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useMemo, useRef, useState } from "react";
+import { GRID_SIZES, type GridSize } from "@/lib/ai/limits";
 import Link from "next/link";
 import { MODEL_CATALOG, ModelKey } from "@/lib/ai/modelCatalog";
 import type { GenerateEvent, GenerateModelRequest, ProviderApiKeys } from "@/lib/ai/types";
@@ -41,7 +42,10 @@ import { enqueueVoxelMetric } from "@/lib/observability/clientMetrics";
 import type { SavedGenerationPayload } from "@/lib/generations/service";
 
 type Palette = "simple" | "advanced";
-type GridSize = 64 | 256 | 512;
+const PALETTE_OPTIONS: Array<{ value: Palette; label: string }> = [
+  { value: "simple", label: "Simple" },
+  { value: "advanced", label: "Advanced" },
+];
 type SelectedModelValue =
   | ModelKey
   | typeof OPENROUTER_MODEL_VALUE
@@ -1847,31 +1851,53 @@ export function SandboxLive({
 
         <section>
           <div className="mb-eyebrow">Build</div>
-          <div className="mt-3 grid grid-cols-2 gap-3">
-            <label className="flex min-w-0 flex-col gap-1">
-              <div className="text-xs font-medium text-muted">Size</div>
-              <select
-                className="mb-field h-10 w-full"
-                value={gridSize}
-                onChange={(e) => setGridSize(Number(e.target.value) as GridSize)}
+          <div className="mt-3 grid grid-cols-1 gap-3 sm:grid-cols-2">
+            <div className="flex min-w-0 flex-col gap-1">
+              <div id="sandbox-grid-size-label" className="text-xs font-medium text-muted">Size</div>
+              <div
+                role="group"
+                aria-labelledby="sandbox-grid-size-label"
+                data-stretch="true"
+                className="mb-choice-group w-full"
               >
-                <option value={64}>64</option>
-                <option value={256}>256</option>
-                <option value={512}>512</option>
-              </select>
-            </label>
+                {GRID_SIZES.map((value) => (
+                  <button
+                    key={value}
+                    type="button"
+                    aria-pressed={gridSize === value}
+                    className="mb-choice-option mb-choice-option-stretch"
+                    onClick={() => setGridSize(value)}
+                  >
+                    <span className="inline-flex items-start">
+                      <span>{value}</span>
+                      <span className="relative -top-[0.38em] ml-px text-[0.58em] font-semibold opacity-90">3</span>
+                    </span>
+                  </button>
+                ))}
+              </div>
+            </div>
 
-            <label className="flex min-w-0 flex-col gap-1">
-              <div className="text-xs font-medium text-muted">Palette</div>
-              <select
-                className="mb-field h-10 w-full"
-                value={palette}
-                onChange={(e) => setPalette(e.target.value as Palette)}
+            <div className="flex min-w-0 flex-col gap-1">
+              <div id="sandbox-palette-label" className="text-xs font-medium text-muted">Palette</div>
+              <div
+                role="group"
+                aria-labelledby="sandbox-palette-label"
+                data-stretch="true"
+                className="mb-choice-group w-full"
               >
-                <option value="simple">Simple</option>
-                <option value="advanced">Advanced</option>
-              </select>
-            </label>
+                {PALETTE_OPTIONS.map((option) => (
+                  <button
+                    key={option.value}
+                    type="button"
+                    aria-pressed={palette === option.value}
+                    className="mb-choice-option mb-choice-option-stretch"
+                    onClick={() => setPalette(option.value)}
+                  >
+                    {option.label}
+                  </button>
+                ))}
+              </div>
+            </div>
           </div>
         </section>
 
@@ -2139,7 +2165,7 @@ export function SandboxLive({
           type="button"
           aria-expanded={apiKeysOpen}
           aria-controls="sandbox-api-keys"
-          className="flex min-h-11 w-full items-center justify-between gap-3 rounded-sm px-1 py-2 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
+          className="mb-disclosure-toggle"
           onClick={() => setApiKeysOpen((open) => !open)}
         >
           <span className="flex min-w-0 items-baseline gap-2">
@@ -2209,7 +2235,7 @@ export function SandboxLive({
                 type="button"
                 aria-expanded={providerKeysOpen}
                 aria-controls="sandbox-provider-keys"
-                className="flex min-h-11 w-full items-center justify-between gap-3 rounded-sm px-1 text-left text-xs font-medium text-muted transition-colors hover:text-fg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 motion-reduce:transition-none"
+                className="mb-disclosure-toggle text-xs font-medium text-muted hover:text-fg"
                 onClick={() => setProviderKeysOpen((open) => !open)}
               >
                 Provider keys

--- a/components/voxel/VoxelViewerCard.tsx
+++ b/components/voxel/VoxelViewerCard.tsx
@@ -352,32 +352,25 @@ export function VoxelViewerCard({
 
             <div className="flex w-full shrink-0 flex-wrap items-center gap-2 sm:w-auto sm:justify-end">
               {showViewToggle ? (
-                <div className="relative flex w-[182px] rounded-full bg-bg/55 p-1 ring-1 ring-border/80 sm:w-[210px]">
-                  <div className="pointer-events-none absolute inset-1 rounded-full">
-                    <span
-                      aria-hidden="true"
-                      className="absolute inset-y-0 left-0 rounded-full border border-accent/55 bg-accent/24 shadow-[0_8px_20px_-14px_rgba(61,229,204,0.85)] transition-transform duration-300 ease-out"
-                      style={{
-                        width: "50%",
-                        transform: activeView === "json" ? "translateX(100%)" : "translateX(0%)",
-                      }}
-                    />
-                  </div>
+                <div
+                  role="group"
+                  aria-label="Viewer mode"
+                  data-stretch="true"
+                  className="mb-choice-group w-[182px] shrink-0 sm:w-[210px]"
+                >
                   <button
                     type="button"
+                    aria-pressed={activeView === "build"}
                     onClick={() => setPreferredView("build")}
-                    className={`relative z-10 h-9 flex-1 rounded-full px-3 text-xs font-medium transition-colors sm:px-4 sm:text-sm ${
-                      activeView === "build" ? "text-fg" : "text-muted hover:text-fg"
-                    }`}
+                    className="mb-choice-option mb-choice-option-stretch"
                   >
                     Build
                   </button>
                   <button
                     type="button"
+                    aria-pressed={activeView === "json"}
                     onClick={() => setPreferredView("json")}
-                    className={`relative z-10 h-9 flex-1 rounded-full px-3 text-xs font-medium transition-colors sm:px-4 sm:text-sm ${
-                      activeView === "json" ? "text-fg" : "text-muted hover:text-fg"
-                    }`}
+                    className="mb-choice-option mb-choice-option-stretch"
                   >
                     JSON
                   </button>

--- a/lib/ai/limits.ts
+++ b/lib/ai/limits.ts
@@ -2,7 +2,8 @@
 // Use the full grid volume as the ceiling for final builds: after validation and
 // dedupe, there can be at most one block per occupied cell.
 
-export type GridSize = 64 | 256 | 512;
+export const GRID_SIZES = [64, 256, 512] as const;
+export type GridSize = (typeof GRID_SIZES)[number];
 
 export const MAX_BLOCKS_BY_GRID: Record<GridSize, number> = {
   64: 64 ** 3,

--- a/tests/ui/gallery-actions.test.ts
+++ b/tests/ui/gallery-actions.test.ts
@@ -54,7 +54,7 @@ assert.ok(
     explore.includes('/faq#how-does-minebench-account-for-nondeterminism') &&
     detail.includes("gallerySortHref") &&
     detail.includes("longPrompt") &&
-    detail.includes("text-2xl sm:text-3xl lg:text-4xl") &&
+    detail.includes("line-clamp-3 text-2xl sm:text-3xl") &&
     galleryDetailPage.includes("navigationSort: sort"),
   "Gallery details should preserve their ordering and expose polished pointer and keyboard navigation",
 );

--- a/tests/ui/gallery-actions.test.ts
+++ b/tests/ui/gallery-actions.test.ts
@@ -53,8 +53,6 @@ assert.ok(
     explore.includes("Official prompts are part of the benchmark.") &&
     explore.includes('/faq#how-does-minebench-account-for-nondeterminism') &&
     detail.includes("gallerySortHref") &&
-    detail.includes("longPrompt") &&
-    detail.includes("line-clamp-3 text-2xl sm:text-3xl") &&
     galleryDetailPage.includes("navigationSort: sort"),
   "Gallery details should preserve their ordering and expose polished pointer and keyboard navigation",
 );
@@ -79,6 +77,8 @@ assert.ok(
     yours.includes("customHeaders: overrides.headers") &&
     yours.includes("customBody: overrides.body") &&
     !yours.includes("Add the required API key") &&
+    yours.includes("mb-disclosure-toggle") &&
+    yours.includes("mb-collapse-toggle") &&
     yours.includes("embedded"),
   "saved builds should open privately, reuse lifecycle placeholders, support retry, and expose owner verification details",
 );
@@ -182,9 +182,14 @@ assert.ok(
 assert.ok(
   account.includes("<GalleryYours") &&
     account.includes("lg:grid-cols-[minmax(0,1fr)_18rem]") &&
+    account.includes("lg:order-2") &&
+    account.includes("lg:order-1") &&
+    account.indexOf('id="security-title"') < account.indexOf("<GalleryAccountSettings") &&
+    account.indexOf('id="security-title"') < account.indexOf("<GalleryYours") &&
     yoursPage.includes('permanentRedirect("/account#builds")') &&
+    !account.includes("lg:sticky") &&
     !identity.includes("border-l-2"),
-  "Account should own saved builds, rankings, and its compact settings rail",
+  "Account should keep security actions first without a sticky settings rail",
 );
 assert.equal(
   [detail, explore, preflight].some((source) => source.includes("shadow-2xl")),

--- a/tests/ui/gallery-loading.test.ts
+++ b/tests/ui/gallery-loading.test.ts
@@ -1,0 +1,23 @@
+import assert from "node:assert/strict";
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import GalleryLoading from "../../app/gallery/loading";
+import GalleryDetailLoading from "../../app/gallery/[publicId]/loading";
+import { GallerySkeletonGrid } from "../../components/gallery/GalleryExplore";
+
+Object.assign(globalThis, { React });
+
+const detail = renderToStaticMarkup(React.createElement(GalleryDetailLoading));
+assert.match(detail, /aria-label="Loading gallery prompt"/,
+  "detail navigation must retain the prompt and viewer layout while loading");
+assert.doesNotMatch(detail, /Loading gallery prompts|Search prompts|Sign in/);
+
+const gallery = renderToStaticMarkup(React.createElement(GalleryLoading));
+assert.doesNotMatch(gallery, /Sign in|\/sign-in/,
+  "the loading fallback must not guess the account state");
+
+const grid = renderToStaticMarkup(React.createElement(GallerySkeletonGrid, { count: 24 }));
+assert.equal(grid.match(/animate-pulse/g)?.length, 24,
+  "loading cards should share one pulse per card");
+assert.equal(grid.match(/motion-reduce:animate-none/g)?.length, 24);
+console.log("Gallery loading checks passed");

--- a/tests/ui/gif-export-config.test.ts
+++ b/tests/ui/gif-export-config.test.ts
@@ -293,6 +293,9 @@ assert.ok(
     settingsSourceText.includes('value: "gif"') &&
     settingsSourceText.includes('value: "social-safe"') &&
     settingsSourceText.includes('value: "full"') &&
+    settingsSourceText.includes("mb-choice-group") &&
+    settingsSourceText.includes("mb-choice-option") &&
+    settingsSourceText.includes("selectedQuality.detail") &&
     settingsSourceText.includes("grid-rows-[1fr]") &&
     settingsSourceText.includes("motion-reduce:transition-none"),
   "Account should expose accessible Standard and Creator choices with a reduced-motion format reveal",

--- a/tests/unit/gallery/prompt-fit.test.ts
+++ b/tests/unit/gallery/prompt-fit.test.ts
@@ -1,0 +1,45 @@
+import assert from "node:assert/strict";
+import { fitGalleryPromptHeading } from "../../../components/gallery/GalleryDetail";
+
+const originalDocument = globalThis.document;
+const originalGetComputedStyle = globalThis.getComputedStyle;
+Object.assign(globalThis, {
+  document: { documentElement: { style: { fontSize: "16px" } } },
+  getComputedStyle: (element: HTMLElement) => element.style,
+});
+
+try {
+  let heightPerRem = 20;
+  const container = { clientHeight: 128, style: { fontSize: "48px" } };
+  const style = { fontSize: "" };
+  const heading = {
+    parentElement: container,
+    isConnected: true,
+    style,
+    get scrollHeight() { return parseFloat(style.fontSize) * heightPerRem; },
+  } as unknown as HTMLHeadingElement;
+
+  assert.equal(fitGalleryPromptHeading(heading), false);
+  assert.equal(heading.style.fontSize, "3rem", "short prompts keep the largest type");
+
+  heightPerRem = 80;
+  assert.equal(fitGalleryPromptHeading(heading), false);
+  assert.equal(heading.style.fontSize, "1.5rem", "medium prompts use the largest size that fits");
+
+  heightPerRem = 200;
+  assert.equal(fitGalleryPromptHeading(heading), true);
+  assert.equal(heading.style.fontSize, "1.125rem", "overflow stops shrinking at the readable minimum");
+
+  heightPerRem = 20;
+  container.style.fontSize = "30px";
+  assert.equal(fitGalleryPromptHeading(heading), false);
+  assert.equal(heading.style.fontSize, "1.875rem", "refitting respects the current responsive maximum");
+
+  container.clientHeight = 0;
+  assert.equal(fitGalleryPromptHeading(heading), null, "hidden routes retain their last fit");
+  assert.equal(heading.style.fontSize, "1.875rem");
+} finally {
+  Object.assign(globalThis, { document: originalDocument, getComputedStyle: originalGetComputedStyle });
+}
+
+console.log("Gallery prompt fitting checks passed");

--- a/tests/unit/leaderboard-model-detail-ui.test.ts
+++ b/tests/unit/leaderboard-model-detail-ui.test.ts
@@ -1,0 +1,45 @@
+import assert from "node:assert/strict";
+
+import { sortModelOpponentsForDetail } from "../../components/leaderboard/ModelDetail";
+import type { ModelOpponentBreakdown } from "../../lib/arena/stats";
+
+function opponent(
+  key: string,
+  averageScore: number,
+  votes: number,
+  bothBad = 0,
+): ModelOpponentBreakdown {
+  return {
+    key,
+    displayName: key,
+    votes,
+    averageScore,
+    wins: 0,
+    losses: 0,
+    draws: 0,
+    bothBad,
+  };
+}
+
+const ordered = sortModelOpponentsForDetail([
+  opponent("no scored votes", 0, 0, 4),
+  opponent("best", 0.78, 6),
+  opponent("same score less evidence", 0.5, 2),
+  opponent("worst", 0.18, 3),
+  opponent("same score more evidence", 0.5, 7),
+  opponent("bad score value", Number.NaN, 9),
+]);
+
+assert.deepEqual(
+  ordered.map((row) => row.key),
+  [
+    "worst",
+    "same score more evidence",
+    "same score less evidence",
+    "best",
+    "bad score value",
+    "no scored votes",
+  ],
+);
+
+console.log("leaderboard model detail UI checks passed");


### PR DESCRIPTION
Gallery detail navigation keeps its layout while loading, and prompt headings fit a fixed area before offering a full-text disclosure. Shared selection and disclosure styles make browsing consistent across Gallery, Sandbox, Leaderboard, and Account.

- Unify Rankings/Efficiency, Cost/Speed/Blocks, Build/JSON, palette, and export controls
- Use native dropdowns for grid sizes from the shared supported-size list
- Put account security actions first and let settings scroll naturally with the page
- Show weakest head-to-head matchups first, with unscored opponents last
- Match More and View full context controls with the same disclosure arrow
- Reuse Gallery detail data between metadata and page rendering, and skip unchanged card renders

Validation: lint, focused regression checks, and the Alpha merge's TypeScript check and production build. Visual review is available on [Alpha](https://alpha.minebench.ai/gallery).

*(PR written by Codex)*
