### PR TITLE
chore(analytics): remove redundant arena web events

### DIFF
--- a/app/api/arena/builds/[buildId]/route.ts
+++ b/app/api/arena/builds/[buildId]/route.ts
@@ -27,7 +27,6 @@ import { parseArenaBuildAccessToken } from "@/lib/arena/matchupToken";
 import { isLoopbackDatabaseUrl } from "@/lib/db/identity";
 import { prisma } from "@/lib/prisma";
 import { ServerTiming } from "@/lib/serverTiming";
-import { trackServerEvent } from "@/lib/analytics.server";
 import {
   getArenaBlockCountBucket,
   roundMetricMs,
@@ -93,13 +92,6 @@ function logArenaBuildDelivery(
   status: number,
 ) {
   const blockCountBucket = getArenaBlockCountBucket(observation.blockCount);
-  const path = [
-    observation.variant,
-    observation.requestedFormat,
-    observation.servedFormat,
-    observation.source,
-    observation.artifactOutcome,
-  ].join(":");
   const roundedStages = {
     tokenValidateMs: roundMetricMs(stages.token_validate),
     artifactResolveMs: roundMetricMs(stages.artifact_resolve),
@@ -121,32 +113,6 @@ function logArenaBuildDelivery(
     }),
   );
   emitArenaBuildCustomMetrics(observation, stages, status);
-
-  // Web Analytics Plus accepts at most eight properties per custom event
-  after(async () => {
-    await trackServerEvent("arena_build_server_timing", {
-      path,
-      blockCountBucket,
-      tokenMs: roundedStages.tokenValidateMs,
-      resolveMs: roundedStages.artifactResolveMs,
-      bodyReadyMs: roundedStages.bodyReadyMs,
-      totalMs: roundedStages.totalMs,
-      status,
-      optimized: observation.optimizedDelivered,
-    });
-    if (stages.artifact_fetch != null) {
-      await trackServerEvent("arena_artifact_server_timing", {
-        path,
-        cache: observation.artifactCacheStatus,
-        fetchMs: roundedStages.artifactFetchMs,
-        inflateMs: roundedStages.inflateMs,
-        rewriteMs: roundedStages.identityRewriteMs,
-        deflateMs: roundedStages.deflateMs,
-        transferBytes: observation.transferBytes,
-        decodedBytes: observation.decodedBytes,
-      });
-    }
-  });
 }
 
 // short process cache avoids rebuilding the same snapshot json

--- a/app/api/arena/builds/[buildId]/stream/route.ts
+++ b/app/api/arena/builds/[buildId]/stream/route.ts
@@ -339,12 +339,6 @@ export async function GET(
       trackServerEventInBackground("arena_artifact_miss", {
         variant,
         deliveryClass: variant === "preview" ? shellHints.initialDeliveryClass : shellHints.deliveryClass,
-        estimatedBytes:
-          estimateArenaBuildVariantBytes(
-            shellHints,
-            variant,
-            variant === "preview" ? shellHints.previewBlockCount : shellHints.fullBlockCount,
-          ) ?? 0,
       });
     }
   } catch (err) {
@@ -352,12 +346,6 @@ export async function GET(
       trackServerEventInBackground("arena_artifact_fetch_error", {
         variant,
         deliveryClass: variant === "preview" ? shellHints.initialDeliveryClass : shellHints.deliveryClass,
-        estimatedBytes:
-          estimateArenaBuildVariantBytes(
-            shellHints,
-            variant,
-            variant === "preview" ? shellHints.previewBlockCount : shellHints.fullBlockCount,
-          ) ?? 0,
       });
       timing.add("artifact_error", ARTIFACT_FETCH_TIMEOUT_MS);
     }

--- a/app/api/arena/matchup/route.ts
+++ b/app/api/arena/matchup/route.ts
@@ -1090,14 +1090,7 @@ export async function GET(req: Request) {
   if (Number.isFinite(totalMs) && totalMs >= MATCHUP_SLOW_EVENT_MS) {
     trackServerEventInBackground("arena_matchup_slow", {
       ms: Math.round(totalMs),
-      eligibilityMs: Math.round(sampling.meta.eligibilityMs),
-      coverageMs: Math.round(sampling.meta.coverageMs),
-      buildMetaMs: Math.round(buildMetaMs),
-      prepareMs: Math.round(prepareMs),
-      txMs: Math.round(txMs),
       cacheStatus: sampling.meta.cacheStatus,
-      lane: picked.lane,
-      payloadMode,
     });
   }
 

--- a/components/arena/Arena.tsx
+++ b/components/arena/Arena.tsx
@@ -45,7 +45,6 @@ import { trackEvent } from "@/lib/analytics";
 import { hasSupabaseAuthCookie } from "@/lib/auth/cookies";
 import {
   getArenaBlockCountBucket,
-  getArenaLatencyBucket,
   roundMetricMs,
 } from "@/lib/observability/arenaMetrics";
 import {
@@ -142,16 +141,6 @@ async function fetchMatchupOnce(promptId?: string, signal?: AbortSignal): Promis
     const laneBBlocks = getArenaBlockCountBucket(voxelBuildBlockCount(packedMatchup.b.build));
     const mode: "random" | "forced" = promptId ? "forced" : "random";
     setMatchupRequestMode(packedMatchup.id, mode);
-    trackEvent("arena_matchup_received", {
-      path: `${mode}:adaptive`,
-      samplingLane: matchup.samplingLane ?? "unknown",
-      laneABlocks,
-      laneBBlocks,
-      headersMs,
-      bodyMs,
-      totalMs: roundMetricMs(totalMs),
-      latency: getArenaLatencyBucket(totalMs),
-    });
     enqueueClientMetric({
       kind: "matchup",
       mode,
@@ -190,7 +179,6 @@ async function fetchMatchup(
         lastError = new Error("Matchup request timed out");
         if (attempt >= maxAttempts) {
           trackEvent("arena_matchup_timeout", {
-            timeoutMs: MATCHUP_REQUEST_TIMEOUT_MS,
             attempts: maxAttempts,
             promptMode: promptId ? "forced" : "random",
           });
@@ -297,16 +285,6 @@ async function readMeasuredBuildVariantPayload(
   return result;
 }
 
-function normalizeBuildDeliveryClass(response: Response): ArenaBuildDeliveryClass | "unknown" {
-  const value = response.headers.get("x-build-delivery-class");
-  return value === "inline" ||
-    value === "snapshot" ||
-    value === "stream-live" ||
-    value === "stream-artifact"
-    ? value
-    : "unknown";
-}
-
 function reportBuildDeliveryMetrics(opts: {
   metrics: BuildDeliveryMetrics;
   ref: ArenaBuildRef;
@@ -319,10 +297,8 @@ function reportBuildDeliveryMetrics(opts: {
 }) {
   const { metrics } = opts;
   const source = normalizeDeliverySource(opts.response);
-  const deliveryClass = normalizeBuildDeliveryClass(opts.response);
   const blockCount = voxelBuildBlockCount(opts.payload.voxelBuild);
   const blockCountBucket = getArenaBlockCountBucket(blockCount);
-  const path = `${metrics.purpose}:${opts.ref.variant}:${metrics.transport}`;
   const totalMs =
     metrics.trace.measure("total", metrics.startStage, "payload_ready") ?? 0;
   const optimized =
@@ -346,27 +322,6 @@ function reportBuildDeliveryMetrics(opts: {
     metrics.trace.measure("decode", "inflate_complete", "decode_complete"),
   );
 
-  // Web Analytics Plus accepts at most eight properties per custom event
-  trackEvent("arena_build_delivery", {
-    path,
-    requestedFormat: opts.requestedFormat,
-    servedFormat: opts.servedFormat,
-    source,
-    deliveryClass,
-    optimized,
-    blockCountBucket,
-    gzip: opts.compressed,
-  });
-  trackEvent("arena_build_delivery_timing", {
-    path: `${path}:${opts.servedFormat}`,
-    blockCountBucket,
-    headersMs,
-    bodyMs,
-    inflateMs,
-    decodeMs,
-    totalMs: roundMetricMs(totalMs),
-    bodyBytes: opts.bodyBytes,
-  });
   enqueueClientMetric({
     kind: "delivery",
     surface: "arena",
@@ -392,27 +347,6 @@ function reportBuildRenderMetrics(
   variant: ArenaBuildVariant,
   metrics: VoxelViewerBuildMetrics,
 ) {
-  const path = `${variant}:${metrics.strategy}:${metrics.cacheStatus}`;
-  const blockCountBucket = getArenaBlockCountBucket(metrics.inputBlockCount);
-  trackEvent("arena_build_mesh_timing", {
-    path,
-    blockCountBucket,
-    queueMs: roundMetricMs(metrics.queueMs),
-    atlasMs: roundMetricMs(metrics.atlasMs),
-    payloadMs: roundMetricMs(metrics.payloadMs),
-    groupMs: roundMetricMs(metrics.groupMs),
-    meshMs: roundMetricMs(metrics.meshMs),
-    totalMs: roundMetricMs(metrics.totalMs),
-  });
-  trackEvent("arena_build_render_timing", {
-    path,
-    blockCountBucket,
-    renderedBlockCountBucket: getArenaBlockCountBucket(metrics.renderedBlockCount),
-    firstRenderMs: roundMetricMs(metrics.firstRenderMs),
-    revealMs: roundMetricMs(metrics.revealMs),
-    totalMs: roundMetricMs(metrics.totalMs),
-    animated: metrics.animated,
-  });
   enqueueVoxelMetric("arena", variant, metrics);
 }
 
@@ -2043,8 +1977,6 @@ export function Arena() {
         trackEvent("arena_full_hydration_slow", {
           ms: Math.round(hydrationMs),
           deliveryClass: lane.buildLoadHints?.deliveryClass ?? "unknown",
-          initialVariant: lane.buildLoadHints?.initialVariant ?? "unknown",
-          side,
         });
       }
     } catch (err: unknown) {
@@ -2865,11 +2797,6 @@ export function Arena() {
         laneBBlocks: voxelBuildBlockCount(matchup.b.build),
         durationMs: elapsedMs,
       });
-      trackEvent("arena_matchup_stage", {
-        stage: "preview_ready",
-        mode,
-        durationMs: elapsedMs,
-      });
     }
 
     if (!matchupBuildLoading && !stages.voteReadyReported) {
@@ -2879,11 +2806,6 @@ export function Arena() {
         mode,
         laneABlocks: voxelBuildBlockCount(matchup.a.build),
         laneBBlocks: voxelBuildBlockCount(matchup.b.build),
-        durationMs: elapsedMs,
-      });
-      trackEvent("arena_matchup_stage", {
-        stage: "vote_ready",
-        mode,
         durationMs: elapsedMs,
       });
     }

--- a/lib/observability/clientMetrics.ts
+++ b/lib/observability/clientMetrics.ts
@@ -32,6 +32,13 @@ function flushClientMetrics() {
   }
 }
 
+if (typeof window !== "undefined") {
+  window.addEventListener("pagehide", flushClientMetrics);
+  document.addEventListener("visibilitychange", () => {
+    if (document.visibilityState === "hidden") flushClientMetrics();
+  });
+}
+
 export function enqueueClientMetric(sample: ClientMetricSample) {
   if (typeof window === "undefined") return;
   pendingSamples.push(sample);

--- a/tests/unit/observability/client-metrics.test.ts
+++ b/tests/unit/observability/client-metrics.test.ts
@@ -1,0 +1,56 @@
+import assert from "node:assert/strict";
+import type { ClientMetricSample } from "../../../lib/observability/customMetrics";
+
+async function main() {
+  const originalWindow = Object.getOwnPropertyDescriptor(globalThis, "window");
+  const originalDocument = Object.getOwnPropertyDescriptor(globalThis, "document");
+  const originalFetch = globalThis.fetch;
+  const browser = new EventTarget();
+  const page = Object.assign(new EventTarget(), { visibilityState: "visible" });
+  const requests: RequestInit[] = [];
+  Object.defineProperty(globalThis, "window", { configurable: true, value: browser });
+  Object.defineProperty(globalThis, "document", { configurable: true, value: page });
+  globalThis.fetch = async (url, options) => {
+    assert.equal(url, "/api/observability/client-metrics");
+    requests.push(options!);
+    return new Response(null, { status: 204 });
+  };
+
+  try {
+    const { enqueueClientMetric } = await import("../../../lib/observability/clientMetrics");
+    const sample: ClientMetricSample = {
+      kind: "matchup", mode: "random", laneABlocks: "under-8k", laneBBlocks: "under-8k",
+      headersMs: 10, bodyMs: 5, totalMs: 15,
+    };
+    enqueueClientMetric(sample);
+    page.dispatchEvent(new Event("visibilitychange"));
+    assert.equal(requests.length, 0, "Visible pages should retain the normal batching delay");
+    page.visibilityState = "hidden";
+    page.dispatchEvent(new Event("visibilitychange"));
+    assert.equal(requests.length, 1, "Hiding the page must send pending metrics before the timer fires");
+    browser.dispatchEvent(new Event("pagehide"));
+    assert.equal(requests.length, 1, "Pagehide after visibilitychange must not duplicate samples");
+
+    page.visibilityState = "visible";
+    page.dispatchEvent(new Event("visibilitychange"));
+    enqueueClientMetric(sample);
+    browser.dispatchEvent(new Event("pagehide"));
+    assert.equal(requests.length, 2, "Pagehide must also flush after the page is restored");
+    await new Promise(resolve => setTimeout(resolve, 1100));
+    assert.equal(requests.length, 2, "Canceled flush timers must not resend samples");
+    for (const request of requests) {
+      assert.equal(request.keepalive, true);
+      assert.equal(request.method, "POST");
+      assert.deepEqual(JSON.parse(String(request.body)), { samples: [sample] });
+    }
+  } finally {
+    globalThis.fetch = originalFetch;
+    if (originalWindow) Object.defineProperty(globalThis, "window", originalWindow);
+    else Reflect.deleteProperty(globalThis, "window");
+    if (originalDocument) Object.defineProperty(globalThis, "document", originalDocument);
+    else Reflect.deleteProperty(globalThis, "document");
+  }
+  console.log("Client metrics lifecycle checks passed");
+}
+
+main().catch(error => { console.error(error); process.exit(1); });


### PR DESCRIPTION
Routine Arena requests and renders emit performance data both as Web Analytics events and as numeric Custom Metrics. Remove the eight routine Web Analytics event types to reduce billable event volume while retaining pageview analytics, Custom Metrics, structured delivery logs, and Server-Timing.

Keep the six exceptional diagnostic events and reduce their payloads to at most two properties so they remain compatible with standard Pro Web Analytics. The removed events' visitor associations and extra diagnostic properties are no longer collected. Web Analytics Plus can be downgraded after deployment if its extended history and UTM reporting are not needed.

Flush pending client metrics when the page becomes hidden or exits, using the existing keepalive request so the final batching window is not lost on navigation.

Validation:
- Targeted ESLint and TypeScript (`tsc --noEmit --incremental false`) passed
- Arena metrics, Custom Metrics contracts, and client lifecycle regression tests passed (3 test files); the lifecycle test failed before the exit-time flush was added
- TypeScript AST audit confirmed all eight routine event types are absent and all six remaining diagnostics use at most two properties
- `git diff --check` passed

*(PR written by Codex)*
