### PR TITLE
chore(analytics): sample speed insights at ten percent

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -151,7 +151,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
             </div>
           </div>
           <Analytics />
-          <SpeedInsights />
+          <SpeedInsights sampleRate={0.1} />
           <PublicPresence />
         </VoxelExplorerProvider>
       </body>


### PR DESCRIPTION
Set the existing Speed Insights integration to `sampleRate={0.1}`, reducing collection from every page load to a 10% sample. This lowers event volume before downgrading Speed Insights Plus; the subscription change remains a separate dashboard action after deployment.

Validation: targeted ESLint and `git diff --check` passed. The installed SDK supports the `sampleRate` prop.

*(PR written by Codex)*
